### PR TITLE
[codex] Add main-thread app event queue and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests
+        run: uv run pytest -q

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ The current codebase supports three display/input modes:
 - VoIP and music integration is implemented in the production app
 - The UI package has been refactored into display, input, and screen subpackages
 - Hardware abstraction layers exist for display and input
-- Some older demos and tests still need migration to the new UI/HAL APIs
+- Demo scripts and tests have been migrated to the current UI/HAL APIs
+- Background VoIP and Mopidy callbacks are coordinated through the app's main loop
+- GitHub Actions CI validates `uv sync --extra dev` and `uv run pytest -q`
 
 ## Main Runtime Components
 
@@ -29,22 +31,19 @@ The current codebase supports three display/input modes:
 
 ## Hardware Notes
 
-The current implementation assumes a Raspberry Pi environment and still contains some device-specific assumptions:
+The current implementation assumes a Raspberry Pi environment, but the main hardware-specific paths and audio devices can now be overridden:
 
-- Whisplay driver discovery currently checks `/home/tifo/Whisplay/Driver/WhisPlay.py`
-- Ring tone playback and Linphone audio default to `plughw:1`
+- Whisplay driver discovery can be overridden with `YOYOPOD_WHISPLAY_DRIVER`
+- Linphone audio devices can be overridden with `YOYOPOD_PLAYBACK_DEVICE`, `YOYOPOD_RINGER_DEVICE`, `YOYOPOD_CAPTURE_DEVICE`, and `YOYOPOD_MEDIA_DEVICE`
+- Ring tone output can be overridden with `YOYOPOD_RING_OUTPUT_DEVICE` or `config/yoyopod_config.yaml`
 - Simulation mode starts a Flask-SocketIO web server on `http://localhost:5000`
-
-These are known repo constraints, not hidden requirements.
 
 ## Installation
 
 ### Python Environment
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+uv sync --extra dev
 ```
 
 ### System Dependencies
@@ -75,6 +74,12 @@ Important settings:
 - `config/yoyopod_config.yaml`: display hardware selection, Mopidy host/port, auto-resume behavior
 - `config/voip_config.yaml`: SIP account, transport, STUN, `linphonec` path
 - `config/contacts.yaml`: contact list and speed dial entries
+
+### Verification
+
+```bash
+uv run pytest -q
+```
 
 ## Running
 
@@ -153,7 +158,5 @@ yoyopy/
 
 ## Current Gaps
 
-- Several demos still import removed pre-refactor UI modules
-- Some tests still target deleted interfaces
-- Screen code still relies partly on legacy `on_button_*` handlers through a compatibility bridge
-- Hardware paths and audio device selection still need to become more configurable
+- Full end-to-end validation still requires Raspberry Pi hardware, Mopidy, and a reachable SIP service
+- CI currently covers the Python test suite, not hardware-in-the-loop scenarios

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,6 @@ python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_app_queue.py
+++ b/tests/test_app_queue.py
@@ -1,0 +1,39 @@
+"""Tests for coordinator-thread event dispatch in YoyoPodApp."""
+
+import threading
+
+from yoyopy.app import YoyoPodApp
+
+
+def test_main_thread_action_runs_immediately() -> None:
+    """Callbacks scheduled on the coordinator thread should run inline."""
+    app = YoyoPodApp(simulate=True)
+    seen_thread_ids: list[int] = []
+
+    app._run_on_main_thread(
+        "immediate action",
+        lambda: seen_thread_ids.append(threading.get_ident()),
+    )
+
+    assert seen_thread_ids == [app._main_thread_id]
+    assert app._process_pending_main_thread_actions() == 0
+
+
+def test_background_thread_action_is_queued_until_drained() -> None:
+    """Callbacks from worker threads should wait for the main loop to drain them."""
+    app = YoyoPodApp(simulate=True)
+    seen_thread_ids: list[int] = []
+
+    def worker() -> None:
+        app._run_on_main_thread(
+            "queued action",
+            lambda: seen_thread_ids.append(threading.get_ident()),
+        )
+
+    worker_thread = threading.Thread(target=worker)
+    worker_thread.start()
+    worker_thread.join()
+
+    assert seen_thread_ids == []
+    assert app._process_pending_main_thread_actions() == 1
+    assert seen_thread_ids == [app._main_thread_id]

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -5,12 +5,15 @@ Main application coordinator that integrates VoIP calling and music streaming
 into a seamless iPod-inspired experience.
 """
 
+import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
-from typing import Optional, Dict, Any
+from queue import Empty, Queue
+from typing import Any, Callable, Dict, Optional
+
 from loguru import logger
-import subprocess
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens import ScreenManager
@@ -89,6 +92,11 @@ class YoyoPodApp:
 
         # Configuration
         self.config: Dict[str, Any] = {}
+
+        # Coordinate callback work through the main app loop so UI and state
+        # changes do not run from background manager threads.
+        self._main_thread_id = threading.get_ident()
+        self._main_thread_actions: Queue[tuple[str, Callable[[], None]]] = Queue()
 
         logger.info("=" * 60)
         logger.info("YoyoPod Application Initializing")
@@ -440,9 +448,24 @@ class YoyoPodApp:
             logger.warning("  VoIPManager not available, skipping callbacks")
             return
 
-        self.voip_manager.on_incoming_call(self._handle_incoming_call)
-        self.voip_manager.on_call_state_change(self._handle_call_state_change)
-        self.voip_manager.on_registration_change(self._handle_registration_change)
+        self.voip_manager.on_incoming_call(
+            lambda caller_address, caller_name: self._run_on_main_thread(
+                f"incoming call from {caller_name or caller_address}",
+                lambda: self._handle_incoming_call(caller_address, caller_name),
+            )
+        )
+        self.voip_manager.on_call_state_change(
+            lambda state: self._run_on_main_thread(
+                f"call state change to {state.value}",
+                lambda: self._handle_call_state_change(state),
+            )
+        )
+        self.voip_manager.on_registration_change(
+            lambda state: self._run_on_main_thread(
+                f"registration state change to {state.value}",
+                lambda: self._handle_registration_change(state),
+            )
+        )
 
         logger.info("  ✓ VoIP callbacks registered")
 
@@ -454,8 +477,18 @@ class YoyoPodApp:
             logger.warning("  MopidyClient not available, skipping callbacks")
             return
 
-        self.mopidy_client.on_track_change(self._handle_track_change)
-        self.mopidy_client.on_playback_state_change(self._handle_playback_state_change)
+        self.mopidy_client.on_track_change(
+            lambda track: self._run_on_main_thread(
+                "track change",
+                lambda: self._handle_track_change(track),
+            )
+        )
+        self.mopidy_client.on_playback_state_change(
+            lambda playback_state: self._run_on_main_thread(
+                f"playback state change to {playback_state}",
+                lambda: self._handle_playback_state_change(playback_state),
+            )
+        )
 
         logger.info("  ✓ Music callbacks registered")
 
@@ -478,6 +511,52 @@ class YoyoPodApp:
     # ========================================================================
     # Helper Methods
     # ========================================================================
+
+    def _run_on_main_thread(
+        self,
+        description: str,
+        callback: Callable[[], None],
+    ) -> None:
+        """
+        Run work on the coordinator thread.
+
+        Background manager threads enqueue callbacks here so UI mutations and
+        state transitions happen from the main application loop.
+        """
+        if threading.get_ident() == self._main_thread_id:
+            callback()
+            return
+
+        self._main_thread_actions.put((description, callback))
+        logger.debug(f"Queued main-thread action: {description}")
+
+    def _process_pending_main_thread_actions(self, limit: Optional[int] = None) -> int:
+        """
+        Drain queued actions that were scheduled by background threads.
+
+        Args:
+            limit: Optional maximum number of actions to process.
+
+        Returns:
+            Number of processed actions.
+        """
+        processed = 0
+
+        while limit is None or processed < limit:
+            try:
+                description, callback = self._main_thread_actions.get_nowait()
+            except Empty:
+                break
+
+            try:
+                logger.debug(f"Processing main-thread action: {description}")
+                callback()
+            except Exception as e:
+                logger.error(f"Error processing main-thread action '{description}': {e}")
+
+            processed += 1
+
+        return processed
 
     def _pop_call_screens(self) -> None:
         """
@@ -911,6 +990,9 @@ class YoyoPodApp:
 
         try:
             # Main loop
+            last_screen_update = time.time()
+            screen_update_interval = 1.0  # Update every second
+
             if self.simulate:
                 # Simulation mode: just keep alive
                 logger.info("")
@@ -919,17 +1001,19 @@ class YoyoPodApp:
                 logger.info("")
 
                 while True:
-                    time.sleep(1)
-                    # Update NowPlayingScreen if visible to animate progress bar
-                    self._update_now_playing_if_needed()
+                    time.sleep(0.1)
+                    self._process_pending_main_thread_actions()
+
+                    current_time = time.time()
+                    if current_time - last_screen_update >= screen_update_interval:
+                        self._update_now_playing_if_needed()
+                        last_screen_update = current_time
             else:
                 # Hardware mode: input handler manages button events
                 # Also update NowPlayingScreen periodically for progress animation
-                last_screen_update = time.time()
-                screen_update_interval = 1.0  # Update every second
-
                 while True:
                     time.sleep(0.1)
+                    self._process_pending_main_thread_actions()
 
                     # Check if it's time to update the screen
                     current_time = time.time()
@@ -961,6 +1045,10 @@ class YoyoPodApp:
         if self.input_manager:
             logger.info("  - Stopping input manager")
             self.input_manager.stop()
+
+        pending_actions = self._process_pending_main_thread_actions()
+        if pending_actions:
+            logger.info(f"  - Processed {pending_actions} queued app events during shutdown")
 
         # Clear display
         if self.display:

--- a/yoyopy/ui/display/adapters/pimoroni.py
+++ b/yoyopy/ui/display/adapters/pimoroni.py
@@ -24,9 +24,12 @@ from loguru import logger
 try:
     from displayhatmini import DisplayHATMini
     HAS_HARDWARE = True
-except ImportError:
+except Exception as e:
     HAS_HARDWARE = False
-    logger.warning("DisplayHATMini library not available - adapter will run in simulation mode")
+    logger.warning(
+        f"DisplayHATMini library unavailable or unusable ({e}) - "
+        "adapter will run in simulation mode"
+    )
 
 
 class PimoroniDisplayAdapter(DisplayHAL):

--- a/yoyopy/ui/display/display_factory.py
+++ b/yoyopy/ui/display/display_factory.py
@@ -14,13 +14,12 @@ Author: YoyoPod Team
 Date: 2025-11-30
 """
 
-from yoyopy.ui.display.display_hal import DisplayHAL
-from yoyopy.ui.display.adapters.pimoroni import PimoroniDisplayAdapter
-from yoyopy.ui.display.adapters.whisplay import WhisplayDisplayAdapter
-from yoyopy.ui.display.adapters.simulation import SimulationDisplayAdapter
-from yoyopy.ui.display.whisplay_paths import find_whisplay_driver
-from loguru import logger
 import os
+
+from loguru import logger
+
+from yoyopy.ui.display.display_hal import DisplayHAL
+from yoyopy.ui.display.whisplay_paths import find_whisplay_driver
 
 
 def detect_hardware() -> str:
@@ -62,8 +61,8 @@ def detect_hardware() -> str:
         import displayhatmini
         logger.info("Detected Pimoroni Display HAT Mini (library imported successfully)")
         return "pimoroni"
-    except ImportError:
-        pass
+    except Exception as e:
+        logger.debug(f"DisplayHATMini import failed during detection: {e}")
 
     # Priority 4: No hardware detected, default to simulation
     logger.warning("No display hardware detected - defaulting to simulation mode")
@@ -128,15 +127,21 @@ def get_display(hardware: str = "auto", simulate: bool = False) -> DisplayHAL:
     # Create appropriate adapter
     if hardware == "whisplay":
         logger.info("Creating Whisplay display adapter (240×280 portrait)")
+        from yoyopy.ui.display.adapters.whisplay import WhisplayDisplayAdapter
+
         return WhisplayDisplayAdapter(simulate=simulate)
 
     elif hardware == "pimoroni":
         logger.info("Creating Pimoroni display adapter (320×240 landscape)")
+        from yoyopy.ui.display.adapters.pimoroni import PimoroniDisplayAdapter
+
         return PimoroniDisplayAdapter(simulate=simulate)
 
     elif hardware == "simulation":
         logger.info("Creating simulation display adapter (240×280 portrait)")
         # Use dedicated simulation adapter with web server support
+        from yoyopy.ui.display.adapters.simulation import SimulationDisplayAdapter
+
         adapter = SimulationDisplayAdapter(simulate=True)
 
         # Start web server for browser display

--- a/yoyopy/ui/input/adapters/four_button.py
+++ b/yoyopy/ui/input/adapters/four_button.py
@@ -16,9 +16,12 @@ from yoyopy.ui.input.input_hal import InputHAL, InputAction
 try:
     from displayhatmini import DisplayHATMini
     HAS_BUTTONS = True
-except ImportError:
+except Exception as e:
     HAS_BUTTONS = False
-    logger.warning("DisplayHATMini not available - button input will be simulated")
+    logger.warning(
+        f"DisplayHATMini unavailable or unusable ({e}) - "
+        "button input will be simulated"
+    )
 
 
 class Button(Enum):

--- a/yoyopy/ui/input/input_factory.py
+++ b/yoyopy/ui/input/input_factory.py
@@ -9,9 +9,6 @@ from typing import Dict, Any, Optional
 from loguru import logger
 
 from yoyopy.ui.input.input_manager import InputManager
-from yoyopy.ui.input.adapters.four_button import FourButtonInputAdapter
-from yoyopy.ui.input.adapters.ptt_button import PTTInputAdapter
-from yoyopy.ui.input.adapters.keyboard import get_keyboard_adapter
 
 
 def get_input_manager(
@@ -67,6 +64,8 @@ def get_input_manager(
 
         if display_device or simulate:
             # Create 4-button adapter
+            from yoyopy.ui.input.adapters.four_button import FourButtonInputAdapter
+
             button_adapter = FourButtonInputAdapter(
                 display_device=display_device,
                 simulate=simulate
@@ -88,6 +87,8 @@ def get_input_manager(
 
         if whisplay_device or simulate:
             # Create PTT button adapter
+            from yoyopy.ui.input.adapters.ptt_button import PTTInputAdapter
+
             ptt_adapter = PTTInputAdapter(
                 whisplay_device=whisplay_device,
                 enable_navigation=enable_navigation,
@@ -112,6 +113,8 @@ def get_input_manager(
         logger.info("  Detected Simulation Display Adapter")
 
         # Add keyboard input adapter
+        from yoyopy.ui.input.adapters.keyboard import get_keyboard_adapter
+
         keyboard_adapter = get_keyboard_adapter()
         manager.add_adapter(keyboard_adapter)
         logger.info("  → Added keyboard input (Enter, Esc, Arrow keys)")


### PR DESCRIPTION
## What changed
- routed VoIP and Mopidy callback side effects through a coordinator-thread queue in `YoyoPodApp`
- drained queued app events from the main loop and during shutdown so screen updates and state transitions stay on one thread
- added focused tests for immediate vs queued app-event execution
- added a lightweight GitHub Actions workflow that runs `uv sync --extra dev` and `uv run pytest -q`
- refreshed the README to match the current demos/tests status, config overrides, and verification flow

## Why
VoIP and Mopidy events were coming from background threads and could mutate screen state directly. That is fragile on a Pi-class UI app because screen rendering, stack transitions, and state-machine updates are safer when coordinated by the main application loop.

## Impact
- reduces threading risk around call/music state changes and screen navigation
- keeps simulation-mode event latency low by draining queued work every 100ms
- gives the repo a simple CI gate for dependency install + test execution
- makes the README consistent with the current codebase

## Validation
- `python -m compileall yoyopy tests`
- `uv run pytest -q`