### PR TITLE
[codex] Add Raspberry Pi developer workflow helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The current codebase supports three display/input modes:
 - `yoyopy/main.py`: package entry point for installed console scripts
 - `yoyopy/app.py`: `YoyoPodApp` coordinator
 - `scripts/pi_smoke.py`: Raspberry Pi smoke validator for hardware and optional service checks
+- `scripts/pi_remote.py`: SSH helper for Raspberry Pi sync, smoke, status, and run loops
 - `yoyopy/state_machine.py`: application state machine for music and call flows
 - `yoyopy/audio/mopidy_client.py`: Mopidy JSON-RPC client
 - `yoyopy/connectivity/voip_manager.py`: `linphonec` subprocess integration
@@ -89,6 +90,14 @@ Raspberry Pi smoke:
 ```bash
 uv run python scripts/pi_smoke.py
 uv run python scripts/pi_smoke.py --with-mopidy --with-voip
+```
+
+Remote Pi workflow:
+
+```bash
+uv run python scripts/pi_remote.py status
+uv run python scripts/pi_remote.py sync --branch main
+uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip
 ```
 
 ## Running
@@ -164,6 +173,7 @@ yoyopy/
 - `docs/DISPLAY_HAL_ARCHITECTURE.md`: current display HAL design
 - `docs/INPUT_HAL_ARCHITECTURE.md`: current input HAL design and compatibility notes
 - `docs/RPI_SMOKE_VALIDATION.md`: Raspberry Pi smoke checklist and manual follow-up drills
+- `docs/PI_DEV_WORKFLOW.md`: SSH-based Raspberry Pi sync/run workflow and release checklist
 - `docs/UI_RESTRUCTURE_PROPOSAL.md`: refactor status and remaining cleanup
 - `docs/PHASE2_SUMMARY.md`: historical screen-integration summary, updated to current file paths
 

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -1,0 +1,134 @@
+# Raspberry Pi Dev Workflow
+
+This guide gives the day-to-day remote workflow for YoyoPod development once code is already in Git.
+
+## What This Solves
+
+The repo now has a clear hardware smoke path, but developers still need a quick way to:
+
+- sync a branch onto the Raspberry Pi
+- inspect remote status
+- run the Pi smoke checks
+- launch the production app
+
+Use `scripts/pi_remote.py` for that loop.
+
+## Setup
+
+Make sure your dev machine can SSH into the Raspberry Pi with an alias or reachable host name.
+
+Examples:
+
+```bash
+ssh rpi-zero
+ssh tifo@192.168.1.42
+```
+
+Optional environment defaults:
+
+```bash
+export YOYOPOD_PI_HOST=rpi-zero
+export YOYOPOD_PI_PROJECT_DIR=~/yoyo-py
+export YOYOPOD_PI_BRANCH=main
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:YOYOPOD_PI_HOST="rpi-zero"
+$env:YOYOPOD_PI_PROJECT_DIR="~/yoyo-py"
+$env:YOYOPOD_PI_BRANCH="main"
+```
+
+## Common Commands
+
+### Check remote status
+
+```bash
+uv run python scripts/pi_remote.py status
+```
+
+Shows:
+
+- remote branch and commit
+- dirty working tree state
+- Mopidy user-service state
+- top memory processes
+
+### Sync branch to the Raspberry Pi
+
+```bash
+uv run python scripts/pi_remote.py sync --branch main
+```
+
+By default this will:
+
+1. `git fetch origin`
+2. `git checkout <branch>`
+3. `git pull --ff-only origin <branch>`
+4. `uv sync --extra dev`
+
+Skip dependency refresh if you only need the Git update:
+
+```bash
+uv run python scripts/pi_remote.py sync --branch main --skip-uv-sync
+```
+
+### Run smoke validation remotely
+
+```bash
+uv run python scripts/pi_remote.py smoke
+uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip
+```
+
+Useful variations:
+
+```bash
+uv run python scripts/pi_remote.py smoke --with-mopidy --mopidy-timeout 10
+uv run python scripts/pi_remote.py smoke --with-voip --voip-timeout 15 --verbose
+```
+
+### Launch the production app remotely
+
+```bash
+uv run python scripts/pi_remote.py run
+```
+
+Pass extra args through when needed:
+
+```bash
+uv run python scripts/pi_remote.py run --simulate
+uv run python scripts/pi_remote.py run --app-arg=--your-extra-flag
+```
+
+## Suggested Daily Loop
+
+1. Run local checks: `uv run pytest -q`
+2. Push your branch
+3. Sync the target branch to the Raspberry Pi:
+   `uv run python scripts/pi_remote.py sync --branch <branch>`
+4. Run the hardware smoke pass:
+   `uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip`
+5. Launch the app:
+   `uv run python scripts/pi_remote.py run`
+
+## Release / Pre-Merge Checklist
+
+- Local branch is green with `uv run pytest -q`
+- Branch is pushed and reviewed
+- Raspberry Pi has the intended branch checked out
+- `uv run python scripts/pi_remote.py smoke` passes
+- `uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip` passes when services are expected
+- `uv run python scripts/pi_remote.py run` starts cleanly
+- Manual sanity:
+  - display renders correctly
+  - input works on target hardware
+  - music playback works
+  - SIP registration succeeds
+  - incoming/outgoing call flow still behaves correctly
+
+## Notes
+
+- `pi_remote.py run` uses an interactive SSH session so you can stop the remote app with `Ctrl+C`.
+- The helper does not kill existing remote processes for you. If the Pi already has a stale YoyoPod or `linphonec` process, stop it first.
+- For deeper hardware debugging, use `docs/RPI_SMOKE_VALIDATION.md`.

--- a/scripts/pi_remote.py
+++ b/scripts/pi_remote.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Developer helper for common YoyoPod Raspberry Pi workflows over SSH."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class RemoteConfig:
+    """Connection details for the Raspberry Pi host."""
+
+    host: str
+    project_dir: str
+    branch: str
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run common YoyoPod Raspberry Pi development tasks over SSH. "
+            "Defaults can be provided with YOYOPOD_PI_HOST, "
+            "YOYOPOD_PI_PROJECT_DIR, and YOYOPOD_PI_BRANCH."
+        )
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("YOYOPOD_PI_HOST", ""),
+        help="SSH host or alias for the Raspberry Pi",
+    )
+    parser.add_argument(
+        "--project-dir",
+        default=os.getenv("YOYOPOD_PI_PROJECT_DIR", "~/yoyo-py"),
+        help="Project directory on the Raspberry Pi (default: ~/yoyo-py)",
+    )
+    parser.add_argument(
+        "--branch",
+        default=os.getenv("YOYOPOD_PI_BRANCH", "main"),
+        help="Git branch to sync on the Raspberry Pi (default: main)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser(
+        "status",
+        help="Show remote repo, Mopidy, and process status",
+    )
+
+    sync_parser = subparsers.add_parser(
+        "sync",
+        help="Fetch, checkout, pull, and optionally run uv sync on the Raspberry Pi",
+    )
+    sync_parser.add_argument(
+        "--skip-uv-sync",
+        action="store_true",
+        help="Skip `uv sync --extra dev` after pulling",
+    )
+
+    smoke_parser = subparsers.add_parser(
+        "smoke",
+        help="Run the Raspberry Pi smoke validator remotely",
+    )
+    smoke_parser.add_argument(
+        "--with-mopidy",
+        action="store_true",
+        help="Include Mopidy connectivity checks",
+    )
+    smoke_parser.add_argument(
+        "--with-voip",
+        action="store_true",
+        help="Include SIP registration checks",
+    )
+    smoke_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose smoke-script logging",
+    )
+    smoke_parser.add_argument(
+        "--mopidy-timeout",
+        type=int,
+        default=5,
+        help="Mopidy request timeout in seconds (default: 5)",
+    )
+    smoke_parser.add_argument(
+        "--voip-timeout",
+        type=float,
+        default=10.0,
+        help="VoIP registration timeout in seconds (default: 10)",
+    )
+
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Start the production app on the Raspberry Pi",
+    )
+    run_parser.add_argument(
+        "--simulate",
+        action="store_true",
+        help="Run the app in simulation mode instead of hardware mode",
+    )
+    run_parser.add_argument(
+        "--app-arg",
+        action="append",
+        default=[],
+        help="Extra argument to pass through to yoyopod.py (repeatable)",
+    )
+
+    return parser
+
+
+def validate_config(config: RemoteConfig) -> None:
+    """Ensure required connection details are present."""
+    if not config.host:
+        raise SystemExit(
+            "Missing Raspberry Pi host. Pass --host or set YOYOPOD_PI_HOST."
+        )
+
+
+def quote_remote_project_dir(project_dir: str) -> str:
+    """Quote the remote project path while preserving `~` expansion."""
+    if project_dir == "~":
+        return '"$HOME"'
+
+    if project_dir.startswith("~/"):
+        suffix = project_dir[2:].replace('"', '\\"')
+        return f'"$HOME/{suffix}"'
+
+    return shlex.quote(project_dir)
+
+
+def run_remote(config: RemoteConfig, remote_command: str, tty: bool = False) -> int:
+    """Execute one command on the Raspberry Pi via SSH."""
+    wrapped_command = (
+        f"cd {quote_remote_project_dir(config.project_dir)} && {remote_command}"
+    )
+    ssh_command = ["ssh"]
+    if tty:
+        ssh_command.append("-t")
+    ssh_command.extend([config.host, f"bash -lc {shlex.quote(wrapped_command)}"])
+
+    print("")
+    print(f"[pi-remote] host={config.host}")
+    print(f"[pi-remote] dir={config.project_dir}")
+    print(f"[pi-remote] cmd={remote_command}")
+    print("")
+
+    completed = subprocess.run(ssh_command, check=False)
+    return completed.returncode
+
+
+def build_status_command() -> str:
+    """Create the remote status command."""
+    return " && ".join(
+        [
+            "echo '== Git ==' ",
+            "git branch --show-current",
+            "git rev-parse --short HEAD",
+            "git status --short",
+            "echo",
+            "echo '== Mopidy ==' ",
+            "systemctl --user is-active mopidy || true",
+            "echo",
+            "echo '== Top Processes ==' ",
+            "ps -eo pid,comm,%mem,%cpu --sort=-%mem | head -15",
+        ]
+    )
+
+
+def build_sync_command(config: RemoteConfig, skip_uv_sync: bool) -> str:
+    """Create the remote sync command."""
+    commands = [
+        "git fetch origin",
+        f"git checkout {shlex.quote(config.branch)}",
+        f"git pull --ff-only origin {shlex.quote(config.branch)}",
+    ]
+    if not skip_uv_sync:
+        commands.append("uv sync --extra dev")
+    return " && ".join(commands)
+
+
+def build_smoke_command(args: argparse.Namespace) -> str:
+    """Create the remote smoke-validation command."""
+    parts = ["uv run python scripts/pi_smoke.py"]
+    if args.with_mopidy:
+        parts.append("--with-mopidy")
+    if args.with_voip:
+        parts.append("--with-voip")
+    if args.verbose:
+        parts.append("--verbose")
+    if args.mopidy_timeout != 5:
+        parts.extend(["--mopidy-timeout", str(args.mopidy_timeout)])
+    if args.voip_timeout != 10.0:
+        parts.extend(["--voip-timeout", str(args.voip_timeout)])
+    return " ".join(parts)
+
+
+def build_run_command(args: argparse.Namespace) -> str:
+    """Create the remote production-app command."""
+    parts = ["uv run python yoyopod.py"]
+    if args.simulate:
+        parts.append("--simulate")
+    for app_arg in args.app_arg:
+        parts.append(shlex.quote(app_arg))
+    return " ".join(parts)
+
+
+def main() -> int:
+    """Program entry point."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    config = RemoteConfig(
+        host=args.host,
+        project_dir=args.project_dir,
+        branch=args.branch,
+    )
+    validate_config(config)
+
+    if args.command == "status":
+        return run_remote(config, build_status_command())
+
+    if args.command == "sync":
+        return run_remote(config, build_sync_command(config, args.skip_uv_sync))
+
+    if args.command == "smoke":
+        return run_remote(config, build_smoke_command(args))
+
+    if args.command == "run":
+        return run_remote(config, build_run_command(args), tty=True)
+
+    parser.error(f"Unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -1,0 +1,30 @@
+"""Tests for Raspberry Pi remote workflow helpers."""
+
+from scripts.pi_remote import (
+    RemoteConfig,
+    build_sync_command,
+    quote_remote_project_dir,
+)
+
+
+def test_quote_remote_project_dir_preserves_home_expansion() -> None:
+    """Tilde-based project paths should still expand on the remote shell."""
+    assert quote_remote_project_dir("~") == '"$HOME"'
+    assert quote_remote_project_dir("~/yoyo-py") == '"$HOME/yoyo-py"'
+
+
+def test_quote_remote_project_dir_quotes_plain_paths() -> None:
+    """Non-tilde paths should still be shell-escaped safely."""
+    assert quote_remote_project_dir("/home/tifo/yoyo py") == "'/home/tifo/yoyo py'"
+
+
+def test_build_sync_command_includes_uv_sync_by_default() -> None:
+    """Remote sync should refresh dependencies unless explicitly skipped."""
+    config = RemoteConfig(
+        host="rpi-zero",
+        project_dir="~/yoyo-py",
+        branch="main",
+    )
+
+    assert "uv sync --extra dev" in build_sync_command(config, skip_uv_sync=False)
+    assert "uv sync --extra dev" not in build_sync_command(config, skip_uv_sync=True)


### PR DESCRIPTION
## What changed
- added `scripts/pi_remote.py` as an SSH helper for Raspberry Pi `status`, `sync`, `smoke`, and `run` workflows
- added `docs/PI_DEV_WORKFLOW.md` with the day-to-day remote loop and a concise pre-merge/release checklist
- updated the README to point at the new Pi remote workflow
- added tests for helper path quoting and sync-command behavior

## Why
The repo already had a solid CI lane and a clear Raspberry Pi smoke-validation path, but the day-to-day remote workflow from a developer machine was still manual and easy to drift. This adds one explicit helper for the high-frequency Pi tasks so deployment and validation are easier to repeat.

## Impact
- shortens the local-to-Pi feedback loop for sync, status, smoke, and run tasks
- makes the expected remote workflow discoverable from the repo root
- adds a lightweight checklist so hardware validation is easier to hand off and repeat
- keeps the helper safe by default: no process killing, explicit branch sync, interactive app run

## Validation
- `python -m compileall yoyopy tests scripts/pi_smoke.py scripts/pi_remote.py`
- `uv run pytest -q`
- `uv run python scripts/pi_remote.py --help`

## Notes
The SSH helper was not exercised against a live Raspberry Pi from this environment, so the actual remote session path still needs one on-device sanity pass.