### PR TITLE
[codex] Add Pi remote preflight command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Remote Pi workflow:
 
 ```bash
 uv run python scripts/pi_remote.py status
+uv run python scripts/pi_remote.py preflight --branch main --with-mopidy --with-voip
 uv run python scripts/pi_remote.py sync --branch main
 uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip
 ```

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -8,6 +8,7 @@ The repo now has a clear hardware smoke path, but developers still need a quick 
 
 - sync a branch onto the Raspberry Pi
 - inspect remote status
+- run one combined preflight before manual app startup
 - run the Pi smoke checks
 - launch the production app
 
@@ -88,6 +89,27 @@ uv run python scripts/pi_remote.py smoke --with-mopidy --mopidy-timeout 10
 uv run python scripts/pi_remote.py smoke --with-voip --voip-timeout 15 --verbose
 ```
 
+### Run the full preflight in one command
+
+```bash
+uv run python scripts/pi_remote.py preflight --branch main --with-mopidy --with-voip
+```
+
+What it does:
+
+1. runs local `compileall`
+2. runs local `uv run pytest -q`
+3. syncs the chosen branch to the Raspberry Pi
+4. runs the Raspberry Pi smoke pass
+
+Useful variations:
+
+```bash
+uv run python scripts/pi_remote.py preflight --branch main --skip-local
+uv run python scripts/pi_remote.py preflight --branch main --skip-sync --with-voip
+uv run python scripts/pi_remote.py preflight --branch main --skip-uv-sync --with-mopidy --with-voip
+```
+
 ### Launch the production app remotely
 
 ```bash
@@ -105,20 +127,16 @@ uv run python scripts/pi_remote.py run --app-arg=--your-extra-flag
 
 1. Run local checks: `uv run pytest -q`
 2. Push your branch
-3. Sync the target branch to the Raspberry Pi:
-   `uv run python scripts/pi_remote.py sync --branch <branch>`
-4. Run the hardware smoke pass:
-   `uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip`
-5. Launch the app:
+3. Run the combined preflight:
+   `uv run python scripts/pi_remote.py preflight --branch <branch> --with-mopidy --with-voip`
+4. Launch the app:
    `uv run python scripts/pi_remote.py run`
 
 ## Release / Pre-Merge Checklist
 
 - Local branch is green with `uv run pytest -q`
 - Branch is pushed and reviewed
-- Raspberry Pi has the intended branch checked out
-- `uv run python scripts/pi_remote.py smoke` passes
-- `uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip` passes when services are expected
+- `uv run python scripts/pi_remote.py preflight --branch <branch> --with-mopidy --with-voip` passes
 - `uv run python scripts/pi_remote.py run` starts cleanly
 - Manual sanity:
   - display renders correctly
@@ -130,5 +148,6 @@ uv run python scripts/pi_remote.py run --app-arg=--your-extra-flag
 ## Notes
 
 - `pi_remote.py run` uses an interactive SSH session so you can stop the remote app with `Ctrl+C`.
+- `pi_remote.py preflight` is intentionally non-interactive. It validates but does not launch the app.
 - The helper does not kill existing remote processes for you. If the Pi already has a stale YoyoPod or `linphonec` process, stop it first.
 - For deeper hardware debugging, use `docs/RPI_SMOKE_VALIDATION.md`.

--- a/scripts/pi_remote.py
+++ b/scripts/pi_remote.py
@@ -9,6 +9,7 @@ import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
+from typing import Sequence
 
 
 @dataclass
@@ -94,6 +95,53 @@ def build_parser() -> argparse.ArgumentParser:
         help="VoIP registration timeout in seconds (default: 10)",
     )
 
+    preflight_parser = subparsers.add_parser(
+        "preflight",
+        help="Run local checks, sync the Pi, and execute the Pi smoke pass",
+    )
+    preflight_parser.add_argument(
+        "--skip-local",
+        action="store_true",
+        help="Skip local compile/test verification before remote work",
+    )
+    preflight_parser.add_argument(
+        "--skip-sync",
+        action="store_true",
+        help="Skip the remote git pull and dependency sync step",
+    )
+    preflight_parser.add_argument(
+        "--skip-uv-sync",
+        action="store_true",
+        help="Skip `uv sync --extra dev` during the remote sync step",
+    )
+    preflight_parser.add_argument(
+        "--with-mopidy",
+        action="store_true",
+        help="Include Mopidy connectivity checks in the remote smoke pass",
+    )
+    preflight_parser.add_argument(
+        "--with-voip",
+        action="store_true",
+        help="Include SIP registration checks in the remote smoke pass",
+    )
+    preflight_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose smoke-script logging",
+    )
+    preflight_parser.add_argument(
+        "--mopidy-timeout",
+        type=int,
+        default=5,
+        help="Mopidy request timeout in seconds (default: 5)",
+    )
+    preflight_parser.add_argument(
+        "--voip-timeout",
+        type=float,
+        default=10.0,
+        help="VoIP registration timeout in seconds (default: 10)",
+    )
+
     run_parser = subparsers.add_parser(
         "run",
         help="Start the production app on the Raspberry Pi",
@@ -153,6 +201,17 @@ def run_remote(config: RemoteConfig, remote_command: str, tty: bool = False) -> 
     return completed.returncode
 
 
+def run_local(command: Sequence[str], label: str) -> int:
+    """Execute one local command and stream its output."""
+    print("")
+    print(f"[pi-remote] local={label}")
+    print(f"[pi-remote] cmd={shlex.join(command)}")
+    print("")
+
+    completed = subprocess.run(list(command), check=False)
+    return completed.returncode
+
+
 def build_status_command() -> str:
     """Create the remote status command."""
     return " && ".join(
@@ -209,6 +268,47 @@ def build_run_command(args: argparse.Namespace) -> str:
     return " ".join(parts)
 
 
+def build_local_preflight_commands() -> list[tuple[str, list[str]]]:
+    """Create the local verification commands for preflight."""
+    return [
+        (
+            "compileall",
+            [
+                sys.executable,
+                "-m",
+                "compileall",
+                "yoyopy",
+                "tests",
+                "scripts/pi_smoke.py",
+                "scripts/pi_remote.py",
+            ],
+        ),
+        (
+            "pytest",
+            ["uv", "run", "pytest", "-q"],
+        ),
+    ]
+
+
+def run_preflight(config: RemoteConfig, args: argparse.Namespace) -> int:
+    """Run the combined local + remote preflight flow."""
+    if not args.skip_local:
+        for label, command in build_local_preflight_commands():
+            exit_code = run_local(command, label)
+            if exit_code != 0:
+                return exit_code
+
+    if not args.skip_sync:
+        exit_code = run_remote(
+            config,
+            build_sync_command(config, args.skip_uv_sync),
+        )
+        if exit_code != 0:
+            return exit_code
+
+    return run_remote(config, build_smoke_command(args))
+
+
 def main() -> int:
     """Program entry point."""
     parser = build_parser()
@@ -229,6 +329,9 @@ def main() -> int:
 
     if args.command == "smoke":
         return run_remote(config, build_smoke_command(args))
+
+    if args.command == "preflight":
+        return run_preflight(config, args)
 
     if args.command == "run":
         return run_remote(config, build_run_command(args), tty=True)

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -2,9 +2,12 @@
 
 from scripts.pi_remote import (
     RemoteConfig,
+    build_local_preflight_commands,
+    build_smoke_command,
     build_sync_command,
     quote_remote_project_dir,
 )
+from argparse import Namespace
 
 
 def test_quote_remote_project_dir_preserves_home_expansion() -> None:
@@ -28,3 +31,32 @@ def test_build_sync_command_includes_uv_sync_by_default() -> None:
 
     assert "uv sync --extra dev" in build_sync_command(config, skip_uv_sync=False)
     assert "uv sync --extra dev" not in build_sync_command(config, skip_uv_sync=True)
+
+
+def test_build_smoke_command_adds_optional_checks() -> None:
+    """Smoke command should include optional service-check flags when requested."""
+    args = Namespace(
+        with_mopidy=True,
+        with_voip=True,
+        verbose=True,
+        mopidy_timeout=10,
+        voip_timeout=15.0,
+    )
+
+    command = build_smoke_command(args)
+
+    assert command.startswith("uv run python scripts/pi_smoke.py")
+    assert "--with-mopidy" in command
+    assert "--with-voip" in command
+    assert "--verbose" in command
+    assert "--mopidy-timeout 10" in command
+    assert "--voip-timeout 15.0" in command
+
+
+def test_build_local_preflight_commands_cover_compile_and_pytest() -> None:
+    """Preflight should run both compileall and pytest locally."""
+    commands = build_local_preflight_commands()
+
+    assert commands[0][0] == "compileall"
+    assert commands[0][1][1:3] == ["-m", "compileall"]
+    assert commands[1] == ("pytest", ["uv", "run", "pytest", "-q"])


### PR DESCRIPTION
## What changed
- added a `preflight` subcommand to `scripts/pi_remote.py`
- `preflight` runs local `compileall`, local `uv run pytest -q`, optional remote sync, and the Raspberry Pi smoke pass in one flow
- updated `docs/PI_DEV_WORKFLOW.md` and `README.md` to point at the new one-command preflight path
- added tests covering smoke-command construction and local preflight commands

## Why
The Pi developer workflow already had the individual pieces for sync, smoke, and run, but the most common confidence-building path was still manual. This change adds one non-interactive command for the repeatable pre-app loop so developers can validate a branch faster and with less drift.

## Impact
- shortens the branch-to-Pi validation loop
- keeps the preflight path consistent with the existing smoke-validation flow
- preserves manual app launch as a separate explicit step
- makes the release checklist easier to follow and hand off

## Validation
- `python -m compileall yoyopy tests scripts/pi_smoke.py scripts/pi_remote.py`
- `uv run pytest -q`
- `uv run python scripts/pi_remote.py preflight --help`

## Notes
The new `preflight` command was not executed against a live Raspberry Pi from this environment, so the remote end-to-end path still needs one on-device sanity pass.