### PR TITLE
Phase 1: event bus and split orchestration FSMs

### DIFF
--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -1,0 +1,254 @@
+"""Coordinator tests for the Phase 1 event bus and split FSM refactor."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from yoyopy.app import YoyoPodApp
+from yoyopy.app_context import AppContext
+from yoyopy.connectivity import CallState, RegistrationState
+from yoyopy.events import (
+    CallEndedEvent,
+    CallStateChangedEvent,
+    IncomingCallEvent,
+    PlaybackStateChangedEvent,
+    RegistrationChangedEvent,
+    TrackChangedEvent,
+)
+from yoyopy.fsm import CallSessionState, MusicState
+from yoyopy.state_machine import AppState, StateMachine
+
+
+class FakeScreen:
+    """Minimal screen double for coordinator tests."""
+
+    def __init__(self) -> None:
+        self.render_calls = 0
+
+    def render(self) -> None:
+        self.render_calls += 1
+
+
+class FakeIncomingCallScreen(FakeScreen):
+    """Incoming call screen double with mutable caller fields."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.caller_address = ""
+        self.caller_name = "Unknown"
+        self.ring_animation_frame = 0
+
+
+class FakeScreenManager:
+    """Simple stack-based screen manager double."""
+
+    def __init__(self, screen_lookup: dict[str, object]) -> None:
+        self.screen_lookup = screen_lookup
+        self.screen_stack: list[object] = []
+        self.current_screen: object | None = None
+
+    def push_screen(self, name: str) -> None:
+        screen = self.screen_lookup[name]
+        self.screen_stack.append(screen)
+        self.current_screen = screen
+
+    def pop_screen(self) -> None:
+        if self.screen_stack:
+            self.screen_stack.pop()
+        self.current_screen = self.screen_stack[-1] if self.screen_stack else None
+
+
+class FakeMopidyClient:
+    """Minimal Mopidy double used by the coordinator tests."""
+
+    def __init__(self, playback_state: str) -> None:
+        self.playback_state = playback_state
+        self.pause_calls = 0
+        self.play_calls = 0
+        self.is_connected = True
+
+    def get_playback_state(self) -> str:
+        return self.playback_state
+
+    def pause(self) -> bool:
+        self.pause_calls += 1
+        self.playback_state = "paused"
+        return True
+
+    def play(self) -> bool:
+        self.play_calls += 1
+        self.playback_state = "playing"
+        return True
+
+
+def _publish_from_worker(app: YoyoPodApp, event: object) -> None:
+    worker = threading.Thread(target=lambda: app.event_bus.publish(event))
+    worker.start()
+    worker.join()
+
+
+def _build_app(playback_state: str = "stopped", auto_resume: bool = True) -> tuple[
+    YoyoPodApp,
+    FakeMopidyClient,
+    FakeScreenManager,
+]:
+    app = YoyoPodApp(simulate=True)
+    app.context = AppContext()
+    app.state_machine = StateMachine(app.context)
+    app.music_fsm = app.state_machine.music_fsm
+    app.call_fsm = app.state_machine.call_fsm
+    app.call_interruption_policy = app.state_machine.call_interruption_policy
+    app.auto_resume_after_call = auto_resume
+    app.voip_registered = False
+
+    mopidy = FakeMopidyClient(playback_state=playback_state)
+    app.mopidy_client = mopidy
+
+    app.menu_screen = FakeScreen()
+    app.now_playing_screen = FakeScreen()
+    app.call_screen = FakeScreen()
+    app.incoming_call_screen = FakeIncomingCallScreen()
+    app.outgoing_call_screen = FakeScreen()
+    app.in_call_screen = FakeScreen()
+
+    screen_manager = FakeScreenManager(
+        {
+            "menu": app.menu_screen,
+            "incoming_call": app.incoming_call_screen,
+            "outgoing_call": app.outgoing_call_screen,
+            "in_call": app.in_call_screen,
+        }
+    )
+    app.screen_manager = screen_manager
+    app.screen_manager.push_screen("menu")
+    app.state_machine.set_ui_state(AppState.MENU, trigger="test_setup")
+
+    app._start_ringing = lambda: None
+    app._stop_ringing = lambda: None
+
+    app._setup_event_subscriptions()
+    return app, mopidy, screen_manager
+
+
+def test_incoming_call_pauses_playing_music_once() -> None:
+    """Incoming call events should pause active playback exactly once."""
+    app, mopidy, screen_manager = _build_app(playback_state="playing")
+    app.music_fsm.transition("play")
+    app.state_machine.sync_from_models("playback_playing")
+
+    _publish_from_worker(
+        app,
+        IncomingCallEvent(caller_address="sip:alice@example.com", caller_name="Alice"),
+    )
+
+    assert mopidy.pause_calls == 0
+    assert app.event_bus.drain() == 1
+    assert mopidy.pause_calls == 1
+    assert app.music_fsm.state == MusicState.PAUSED
+    assert app.call_fsm.state == CallSessionState.INCOMING
+    assert app.call_interruption_policy.music_interrupted_by_call
+    assert screen_manager.current_screen is app.incoming_call_screen
+    assert app.incoming_call_screen.caller_name == "Alice"
+
+    _publish_from_worker(
+        app,
+        IncomingCallEvent(caller_address="sip:alice@example.com", caller_name="Alice"),
+    )
+
+    assert app.event_bus.drain() == 1
+    assert mopidy.pause_calls == 1
+    assert len(screen_manager.screen_stack) == 2
+
+
+def test_call_end_auto_resumes_only_when_enabled() -> None:
+    """Call end should auto-resume only when playback was interrupted and enabled."""
+    app, mopidy, screen_manager = _build_app(playback_state="paused", auto_resume=True)
+    app.music_fsm.sync(MusicState.PAUSED)
+    app.call_fsm.sync(CallSessionState.ACTIVE)
+    app.call_interruption_policy.music_interrupted_by_call = True
+    screen_manager.push_screen("incoming_call")
+    screen_manager.push_screen("in_call")
+
+    _publish_from_worker(app, CallEndedEvent())
+
+    assert mopidy.play_calls == 0
+    assert app.event_bus.drain() == 1
+    assert mopidy.play_calls == 1
+    assert app.music_fsm.state == MusicState.PLAYING
+    assert app.call_fsm.state == CallSessionState.IDLE
+    assert not app.call_interruption_policy.music_interrupted_by_call
+    assert screen_manager.current_screen is app.menu_screen
+
+
+def test_call_end_keeps_music_paused_when_auto_resume_disabled() -> None:
+    """Call end should leave playback paused when auto-resume is off."""
+    app, mopidy, screen_manager = _build_app(playback_state="paused", auto_resume=False)
+    app.music_fsm.sync(MusicState.PAUSED)
+    app.call_fsm.sync(CallSessionState.ACTIVE)
+    app.call_interruption_policy.music_interrupted_by_call = True
+    screen_manager.push_screen("incoming_call")
+    screen_manager.push_screen("in_call")
+
+    _publish_from_worker(app, CallEndedEvent())
+
+    assert app.event_bus.drain() == 1
+    assert mopidy.play_calls == 0
+    assert app.music_fsm.state == MusicState.PAUSED
+    assert app.call_fsm.state == CallSessionState.IDLE
+    assert not app.call_interruption_policy.music_interrupted_by_call
+    assert screen_manager.current_screen is app.menu_screen
+
+
+@pytest.mark.parametrize(
+    ("music_state", "playback_state"),
+    [
+        (MusicState.IDLE, "stopped"),
+        (MusicState.PAUSED, "paused"),
+    ],
+)
+def test_outgoing_call_does_not_change_idle_or_paused_music(
+    music_state: MusicState,
+    playback_state: str,
+) -> None:
+    """Outgoing call state changes should not mutate paused or idle music state."""
+    app, _, _ = _build_app(playback_state=playback_state)
+    app.music_fsm.sync(music_state)
+
+    _publish_from_worker(app, CallStateChangedEvent(state=CallState.OUTGOING))
+
+    assert app.event_bus.drain() == 1
+    assert app.call_fsm.state == CallSessionState.OUTGOING
+    assert app.music_fsm.state == music_state
+
+
+def test_background_events_wait_for_drain_before_mutating_state() -> None:
+    """Registration and playback events should not mutate coordinator state until drained."""
+    app, _, _ = _build_app(playback_state="stopped")
+
+    _publish_from_worker(app, RegistrationChangedEvent(state=RegistrationState.OK))
+    _publish_from_worker(app, PlaybackStateChangedEvent(state="playing"))
+
+    assert not app.voip_registered
+    assert app.music_fsm.state == MusicState.IDLE
+
+    assert app.event_bus.drain() == 2
+    assert app.voip_registered
+    assert app.music_fsm.state == MusicState.PLAYING
+    assert app.state_machine.current_state == AppState.PLAYING_WITH_VOIP
+
+
+def test_track_event_refreshes_now_playing_screen_when_visible() -> None:
+    """Track events should refresh the current now playing screen through the bus."""
+    app, _, screen_manager = _build_app(playback_state="playing")
+    screen_manager.current_screen = app.now_playing_screen
+    app.music_fsm.transition("play")
+    app.state_machine.sync_from_models("playback_playing")
+
+    _publish_from_worker(app, TrackChangedEvent(track=None))
+
+    assert app.now_playing_screen.render_calls == 0
+    assert app.event_bus.drain() == 1
+    assert app.now_playing_screen.render_calls == 1
+    assert app.music_fsm.state == MusicState.IDLE

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,44 @@
+"""Tests for the coordinator-thread event bus."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+from yoyopy.event_bus import EventBus
+
+
+@dataclass(frozen=True, slots=True)
+class DemoEvent:
+    """Simple event used to validate bus behavior."""
+
+    value: str
+
+
+def test_main_thread_publish_dispatches_inline() -> None:
+    """Publishing on the main thread should dispatch immediately."""
+    bus = EventBus()
+    seen_thread_ids: list[int] = []
+
+    bus.subscribe(DemoEvent, lambda event: seen_thread_ids.append(threading.get_ident()))
+
+    bus.publish(DemoEvent(value="inline"))
+
+    assert seen_thread_ids == [bus.main_thread_id]
+    assert bus.drain() == 0
+
+
+def test_background_publish_is_queued_until_drain() -> None:
+    """Background publishes should wait for the coordinator thread to drain them."""
+    bus = EventBus()
+    seen_thread_ids: list[int] = []
+
+    bus.subscribe(DemoEvent, lambda event: seen_thread_ids.append(threading.get_ident()))
+
+    worker = threading.Thread(target=lambda: bus.publish(DemoEvent(value="queued")))
+    worker.start()
+    worker.join()
+
+    assert seen_thread_ids == []
+    assert bus.drain() == 1
+    assert seen_thread_ids == [bus.main_thread_id]

--- a/tests/test_phase1_state_machine.py
+++ b/tests/test_phase1_state_machine.py
@@ -1,153 +1,112 @@
-#!/usr/bin/env python3
-"""
-Test Phase 1 State Machine Enhancements
-
-Validates that the new VoIP + music integration states and transitions
-work correctly without requiring hardware.
-"""
-
-import sys
-from loguru import logger
-
-logger.remove()
-logger.add(
-    sys.stderr,
-    format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <level>{message}</level>",
-    level="INFO"
-)
+"""Tests for the split FSM orchestration layer and compatibility bridge."""
 
 from yoyopy.app_context import AppContext
-from yoyopy.state_machine import StateMachine, AppState
+from yoyopy.fsm import CallFSM, CallInterruptionPolicy, CallSessionState, MusicFSM, MusicState
+from yoyopy.state_machine import AppState, StateMachine
 
 
-def test_state_machine():
-    """Test state machine with new Phase 5 states."""
-    logger.info("=" * 60)
-    logger.info("Testing Phase 5 State Machine Enhancements")
-    logger.info("=" * 60)
+def test_music_fsm_transitions() -> None:
+    """MusicFSM should support play, pause, and stop transitions."""
+    fsm = MusicFSM()
 
-    # Initialize
-    context = AppContext()
-    sm = StateMachine(context)
-
-    logger.info(f"\n✓ Initial state: {sm.get_state_name()}")
-
-    # Test 1: Music playback with VoIP ready
-    logger.info("\n--- Test 1: Music Playback with VoIP Ready ---")
-    assert sm.transition_to(AppState.MENU, "open_menu"), "Failed to go to MENU"
-    logger.info(f"  State: {sm.get_state_name()}")
-
-    assert sm.transition_to(AppState.PLAYING_WITH_VOIP, "select_media_with_voip"), \
-        "Failed to start music with VoIP"
-    logger.info(f"  State: {sm.get_state_name()}")
-    assert sm.is_playing_with_voip(), "Should be in PLAYING_WITH_VOIP"
-    assert sm.is_music_playing(), "Should report music playing"
-    logger.info("  ✓ Music playing with VoIP ready")
-
-    # Test 2: Incoming call pauses music
-    logger.info("\n--- Test 2: Incoming Call Pauses Music ---")
-    assert sm.transition_to(AppState.PAUSED_BY_CALL, "auto_pause_for_call"), \
-        "Failed to auto-pause for call"
-    logger.info(f"  State: {sm.get_state_name()}")
-    assert sm.is_music_paused_by_call(), "Should be paused by call"
-    logger.info("  ✓ Music auto-paused for call")
-
-    assert sm.transition_to(AppState.CALL_INCOMING, "incoming_call_ringing"), \
-        "Failed to transition to CALL_INCOMING"
-    logger.info(f"  State: {sm.get_state_name()}")
-    assert sm.is_in_call(), "Should be in call state"
-    logger.info("  ✓ Incoming call ringing")
-
-    # Test 3: Answer call with music paused
-    logger.info("\n--- Test 3: Answer Call (Music Paused in Background) ---")
-    assert sm.transition_to(AppState.CALL_ACTIVE_MUSIC_PAUSED, "answer_call_resume_after"), \
-        "Failed to answer call"
-    logger.info(f"  State: {sm.get_state_name()}")
-    assert sm.is_in_call(), "Should still be in call"
-    assert sm.has_paused_music_for_call(), "Should have paused music"
-    logger.info("  ✓ In active call with music paused")
-
-    # Test 4: Call ends, music auto-resumes
-    logger.info("\n--- Test 4: Call Ends, Music Auto-Resumes ---")
-    assert sm.transition_to(AppState.PLAYING_WITH_VOIP, "call_ended_auto_resume"), \
-        "Failed to auto-resume music"
-    logger.info(f"  State: {sm.get_state_name()}")
-    assert sm.is_playing_with_voip(), "Should be back to playing with VoIP"
-    assert sm.is_music_playing(), "Music should be playing"
-    logger.info("  ✓ Music auto-resumed after call")
-
-    # Test 5: Call ends, music stays paused
-    logger.info("\n--- Test 5: Alternative Flow - Call Ends, Music Stays Paused ---")
-    # Start from music playing again
-    assert sm.transition_to(AppState.PAUSED_BY_CALL, "auto_pause_for_call"), \
-        "Failed to pause for call"
-    assert sm.transition_to(AppState.CALL_INCOMING, "incoming_call_ringing"), \
-        "Failed to ring"
-    assert sm.transition_to(AppState.CALL_ACTIVE_MUSIC_PAUSED, "answer_call_resume_after"), \
-        "Failed to answer"
-    logger.info(f"  State: {sm.get_state_name()}")
-
-    # End call but stay paused
-    assert sm.transition_to(AppState.PAUSED, "call_ended_stay_paused"), \
-        "Failed to stay paused"
-    logger.info(f"  State: {sm.get_state_name()}")
-    assert sm.current_state == AppState.PAUSED, "Should be in PAUSED state"
-    logger.info("  ✓ Music stayed paused after call (user preference)")
-
-    # Test 6: Outgoing call from music screen
-    logger.info("\n--- Test 6: Outgoing Call from Music Screen ---")
-    assert sm.transition_to(AppState.PLAYING_WITH_VOIP, "resume"), \
-        "Failed to resume music"
-    assert sm.transition_to(AppState.CALL_OUTGOING, "make_call_pause_music"), \
-        "Failed to make outgoing call"
-    logger.info(f"  State: {sm.get_state_name()}")
-    assert sm.is_in_call(), "Should be in call state"
-    logger.info("  ✓ Outgoing call initiated")
-
-    assert sm.transition_to(AppState.CALL_ACTIVE_MUSIC_PAUSED, "call_connected_music_paused"), \
-        "Failed to connect call"
-    logger.info(f"  State: {sm.get_state_name()}")
-    assert sm.has_paused_music_for_call(), "Should have paused music for call"
-    logger.info("  ✓ Outgoing call connected")
-
-    # Test 7: Invalid transitions should fail
-    logger.info("\n--- Test 7: Invalid Transitions ---")
-    current = sm.current_state
-    # Try to go directly to IDLE from CALL_ACTIVE_MUSIC_PAUSED (should fail)
-    result = sm.transition_to(AppState.IDLE, "invalid_trigger")
-    assert not result, "Should reject invalid transition"
-    assert sm.current_state == current, "State should not change on invalid transition"
-    logger.info("  ✓ Invalid transitions correctly rejected")
-
-    # Test 8: State helper methods
-    logger.info("\n--- Test 8: State Helper Methods ---")
-    sm.transition_to(AppState.PLAYING_WITH_VOIP, "call_ended_auto_resume")
-    assert sm.is_playing_with_voip(), "is_playing_with_voip() should work"
-    assert sm.is_music_playing(), "is_music_playing() should work"
-    assert not sm.is_music_paused_by_call(), "is_music_paused_by_call() should be False"
-    assert not sm.is_in_call(), "is_in_call() should be False"
-    logger.info("  ✓ Helper methods work correctly")
-
-    logger.info("\n" + "=" * 60)
-    logger.info("✓ ALL TESTS PASSED!")
-    logger.info("=" * 60)
-    logger.info("\nPhase 1 State Machine:")
-    logger.info("  ✓ New states: PLAYING_WITH_VOIP, PAUSED_BY_CALL, CALL_ACTIVE_MUSIC_PAUSED")
-    logger.info("  ✓ New transitions: Call interruption flows")
-    logger.info("  ✓ Helper methods: State checking utilities")
-    logger.info("\nReady for Phase 2: Screen Integration")
-    logger.info("")
+    assert fsm.state == MusicState.IDLE
+    assert fsm.transition("play")
+    assert fsm.state == MusicState.PLAYING
+    assert fsm.transition("pause")
+    assert fsm.state == MusicState.PAUSED
+    assert fsm.transition("play")
+    assert fsm.state == MusicState.PLAYING
+    assert fsm.transition("stop")
+    assert fsm.state == MusicState.IDLE
+    assert not fsm.transition("pause")
 
 
-if __name__ == "__main__":
-    try:
-        test_state_machine()
-        sys.exit(0)
-    except AssertionError as e:
-        logger.error(f"\n✗ TEST FAILED: {e}")
-        sys.exit(1)
-    except Exception as e:
-        logger.error(f"\n✗ ERROR: {e}")
-        import traceback
-        traceback.print_exc()
-        sys.exit(1)
+def test_call_fsm_transitions() -> None:
+    """CallFSM should model incoming, outgoing, connect, and end flows."""
+    fsm = CallFSM()
+
+    assert fsm.state == CallSessionState.IDLE
+    assert fsm.transition("incoming")
+    assert fsm.state == CallSessionState.INCOMING
+    assert fsm.transition("connect")
+    assert fsm.state == CallSessionState.ACTIVE
+    assert fsm.transition("end")
+    assert fsm.state == CallSessionState.IDLE
+    assert fsm.transition("dial")
+    assert fsm.state == CallSessionState.OUTGOING
+    assert fsm.transition("end")
+    assert fsm.state == CallSessionState.IDLE
+    assert not fsm.transition("connect")
+
+
+def test_call_interruption_policy_pauses_and_resumes_music() -> None:
+    """The interruption policy should remember whether playback was interrupted."""
+    music_fsm = MusicFSM()
+    policy = CallInterruptionPolicy()
+
+    assert not policy.pause_for_call(music_fsm)
+    assert not policy.should_auto_resume(auto_resume=True)
+
+    assert music_fsm.transition("play")
+    assert policy.pause_for_call(music_fsm)
+    assert music_fsm.state == MusicState.PAUSED
+    assert policy.should_auto_resume(auto_resume=True)
+    assert not policy.should_auto_resume(auto_resume=False)
+
+    policy.clear()
+    assert not policy.music_interrupted_by_call
+
+
+def test_compatibility_state_machine_derives_legacy_state_from_split_fsms() -> None:
+    """The compatibility facade should derive legacy AppState values from the new FSMs."""
+    state_machine = StateMachine(AppContext())
+
+    state_machine.set_ui_state(AppState.MENU, trigger="test_menu")
+    assert state_machine.current_state == AppState.MENU
+
+    state_machine.music_fsm.transition("play")
+    state_machine.sync_from_models("playback_playing")
+    assert state_machine.current_state == AppState.PLAYING
+
+    state_machine.set_voip_ready(True)
+    assert state_machine.current_state == AppState.PLAYING_WITH_VOIP
+    assert state_machine.is_playing_with_voip()
+
+    state_machine.call_interruption_policy.pause_for_call(state_machine.music_fsm)
+    state_machine.sync_from_models("auto_pause_for_call")
+    assert state_machine.current_state == AppState.PAUSED_BY_CALL
+    assert state_machine.is_music_paused_by_call()
+
+    state_machine.call_fsm.transition("incoming")
+    state_machine.sync_from_models("incoming_call")
+    assert state_machine.current_state == AppState.CALL_INCOMING
+    assert state_machine.is_in_call()
+
+    state_machine.call_fsm.transition("connect")
+    state_machine.sync_from_models("call_connected")
+    assert state_machine.current_state == AppState.CALL_ACTIVE_MUSIC_PAUSED
+    assert state_machine.has_paused_music_for_call()
+
+    state_machine.call_fsm.transition("end")
+    state_machine.music_fsm.transition("play")
+    state_machine.call_interruption_policy.clear()
+    state_machine.sync_from_models("call_ended")
+    assert state_machine.current_state == AppState.PLAYING_WITH_VOIP
+
+
+def test_legacy_transition_api_still_supports_existing_phase1_flow() -> None:
+    """The old transition_to API should still work during the bridge period."""
+    state_machine = StateMachine(AppContext())
+
+    assert state_machine.transition_to(AppState.MENU, "open_menu")
+    assert state_machine.transition_to(AppState.PLAYING_WITH_VOIP, "select_media_with_voip")
+    assert state_machine.transition_to(AppState.PAUSED_BY_CALL, "auto_pause_for_call")
+    assert state_machine.transition_to(AppState.CALL_INCOMING, "incoming_call_ringing")
+    assert state_machine.transition_to(
+        AppState.CALL_ACTIVE_MUSIC_PAUSED,
+        "answer_call_resume_after",
+    )
+    assert state_machine.transition_to(AppState.PLAYING_WITH_VOIP, "call_ended_auto_resume")
+
+    assert state_machine.is_playing_with_voip()
+    assert state_machine.is_music_playing()

--- a/yoyopy/__init__.py
+++ b/yoyopy/__init__.py
@@ -4,5 +4,31 @@ YoyoPod package.
 Integrated Raspberry Pi application for button-driven music playback and SIP calling.
 """
 
+from yoyopy.event_bus import EventBus
+from yoyopy.events import (
+    CallEndedEvent,
+    CallStateChangedEvent,
+    IncomingCallEvent,
+    PlaybackStateChangedEvent,
+    RegistrationChangedEvent,
+    TrackChangedEvent,
+)
+from yoyopy.fsm import CallFSM, CallInterruptionPolicy, CallSessionState, MusicFSM, MusicState
+
 __version__ = "0.1.0"
 __author__ = "YoyoPod Team"
+
+__all__ = [
+    "EventBus",
+    "IncomingCallEvent",
+    "CallStateChangedEvent",
+    "CallEndedEvent",
+    "RegistrationChangedEvent",
+    "TrackChangedEvent",
+    "PlaybackStateChangedEvent",
+    "MusicFSM",
+    "MusicState",
+    "CallFSM",
+    "CallSessionState",
+    "CallInterruptionPolicy",
+]

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -9,12 +9,22 @@ import subprocess
 import sys
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
-from queue import Empty, Queue
 from typing import Any, Callable, Dict, Optional
 
 from loguru import logger
 
+from yoyopy.event_bus import EventBus
+from yoyopy.events import (
+    CallEndedEvent,
+    CallStateChangedEvent,
+    IncomingCallEvent,
+    PlaybackStateChangedEvent,
+    RegistrationChangedEvent,
+    TrackChangedEvent,
+)
+from yoyopy.fsm import CallSessionState, MusicState
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens import ScreenManager
 from yoyopy.ui.input import get_input_manager, InputManager
@@ -34,6 +44,14 @@ from yoyopy.state_machine import StateMachine, AppState
 from yoyopy.connectivity import VoIPManager, VoIPConfig, RegistrationState, CallState
 from yoyopy.config import ConfigManager
 from yoyopy.audio.mopidy_client import MopidyClient, MopidyTrack
+
+
+@dataclass(slots=True)
+class _MainThreadCallbackEvent:
+    """Compatibility event used by existing app queue helpers."""
+
+    description: str
+    callback: Callable[[], None]
 
 
 class YoyoPodApp:
@@ -84,7 +102,6 @@ class YoyoPodApp:
         self.in_call_screen: Optional[InCallScreen] = None
 
         # Integration state tracking
-        self.music_was_playing_before_call = False
         self.auto_resume_after_call = True  # Will be loaded from config
         self.voip_registered = False
         self.handling_incoming_call = False  # Prevent callback spam
@@ -96,7 +113,8 @@ class YoyoPodApp:
         # Coordinate callback work through the main app loop so UI and state
         # changes do not run from background manager threads.
         self._main_thread_id = threading.get_ident()
-        self._main_thread_actions: Queue[tuple[str, Callable[[], None]]] = Queue()
+        self.event_bus = EventBus(main_thread_id=self._main_thread_id)
+        self.event_bus.subscribe(_MainThreadCallbackEvent, self._handle_main_thread_callback_event)
 
         logger.info("=" * 60)
         logger.info("YoyoPod Application Initializing")
@@ -129,6 +147,9 @@ class YoyoPodApp:
             if not self._setup_screens():
                 logger.error("Failed to setup screens")
                 return False
+
+            # Setup event bus subscriptions
+            self._setup_event_subscriptions()
 
             # Setup callbacks
             self._setup_voip_callbacks()
@@ -252,6 +273,9 @@ class YoyoPodApp:
             # Initialize state machine
             logger.info("  - StateMachine")
             self.state_machine = StateMachine(self.context)
+            self.music_fsm = self.state_machine.music_fsm
+            self.call_fsm = self.state_machine.call_fsm
+            self.call_interruption_policy = self.state_machine.call_interruption_policy
 
             # Initialize input manager with hardware auto-detection
             logger.info("  - InputManager")
@@ -432,6 +456,7 @@ class YoyoPodApp:
 
             # Set initial screen to menu
             self.screen_manager.push_screen("menu")
+            self.state_machine.set_ui_state(AppState.MENU, trigger="initial_screen")
             logger.info("  ✓ Initial screen set to menu")
 
             return True
@@ -449,22 +474,18 @@ class YoyoPodApp:
             return
 
         self.voip_manager.on_incoming_call(
-            lambda caller_address, caller_name: self._run_on_main_thread(
-                f"incoming call from {caller_name or caller_address}",
-                lambda: self._handle_incoming_call(caller_address, caller_name),
+            lambda caller_address, caller_name: self.event_bus.publish(
+                IncomingCallEvent(
+                    caller_address=caller_address,
+                    caller_name=caller_name,
+                )
             )
         )
         self.voip_manager.on_call_state_change(
-            lambda state: self._run_on_main_thread(
-                f"call state change to {state.value}",
-                lambda: self._handle_call_state_change(state),
-            )
+            self._publish_call_state_events
         )
         self.voip_manager.on_registration_change(
-            lambda state: self._run_on_main_thread(
-                f"registration state change to {state.value}",
-                lambda: self._handle_registration_change(state),
-            )
+            lambda state: self.event_bus.publish(RegistrationChangedEvent(state=state))
         )
 
         logger.info("  ✓ VoIP callbacks registered")
@@ -478,19 +499,46 @@ class YoyoPodApp:
             return
 
         self.mopidy_client.on_track_change(
-            lambda track: self._run_on_main_thread(
-                "track change",
-                lambda: self._handle_track_change(track),
-            )
+            lambda track: self.event_bus.publish(TrackChangedEvent(track=track))
         )
         self.mopidy_client.on_playback_state_change(
-            lambda playback_state: self._run_on_main_thread(
-                f"playback state change to {playback_state}",
-                lambda: self._handle_playback_state_change(playback_state),
+            lambda playback_state: self.event_bus.publish(
+                PlaybackStateChangedEvent(state=playback_state)
             )
         )
 
         logger.info("  ✓ Music callbacks registered")
+
+    def _setup_event_subscriptions(self) -> None:
+        """Subscribe coordinator handlers to typed app events."""
+        logger.info("Setting up event subscriptions...")
+
+        self.event_bus.subscribe(
+            IncomingCallEvent,
+            lambda event: self._handle_incoming_call(event.caller_address, event.caller_name),
+        )
+        self.event_bus.subscribe(
+            CallStateChangedEvent,
+            lambda event: self._handle_call_state_change(event.state),
+        )
+        self.event_bus.subscribe(
+            CallEndedEvent,
+            lambda event: self._handle_call_ended(),
+        )
+        self.event_bus.subscribe(
+            RegistrationChangedEvent,
+            lambda event: self._handle_registration_change(event.state),
+        )
+        self.event_bus.subscribe(
+            TrackChangedEvent,
+            lambda event: self._handle_track_change(event.track),
+        )
+        self.event_bus.subscribe(
+            PlaybackStateChangedEvent,
+            lambda event: self._handle_playback_state_change(event.state),
+        )
+
+        logger.info("  ✓ Event subscriptions registered")
 
     def _setup_state_callbacks(self) -> None:
         """Register state machine callbacks."""
@@ -523,12 +571,9 @@ class YoyoPodApp:
         Background manager threads enqueue callbacks here so UI mutations and
         state transitions happen from the main application loop.
         """
-        if threading.get_ident() == self._main_thread_id:
-            callback()
-            return
-
-        self._main_thread_actions.put((description, callback))
-        logger.debug(f"Queued main-thread action: {description}")
+        self.event_bus.publish(
+            _MainThreadCallbackEvent(description=description, callback=callback)
+        )
 
     def _process_pending_main_thread_actions(self, limit: Optional[int] = None) -> int:
         """
@@ -540,23 +585,18 @@ class YoyoPodApp:
         Returns:
             Number of processed actions.
         """
-        processed = 0
+        return self.event_bus.drain(limit)
 
-        while limit is None or processed < limit:
-            try:
-                description, callback = self._main_thread_actions.get_nowait()
-            except Empty:
-                break
+    def _handle_main_thread_callback_event(self, event: _MainThreadCallbackEvent) -> None:
+        """Execute a compatibility callback event on the coordinator thread."""
+        logger.debug(f"Processing main-thread action: {event.description}")
+        event.callback()
 
-            try:
-                logger.debug(f"Processing main-thread action: {description}")
-                callback()
-            except Exception as e:
-                logger.error(f"Error processing main-thread action '{description}': {e}")
-
-            processed += 1
-
-        return processed
+    def _publish_call_state_events(self, state: CallState) -> None:
+        """Publish call state events onto the bus."""
+        self.event_bus.publish(CallStateChangedEvent(state=state))
+        if state == CallState.RELEASED:
+            self.event_bus.publish(CallEndedEvent())
 
     def _pop_call_screens(self) -> None:
         """
@@ -662,32 +702,15 @@ class YoyoPodApp:
         playback_state = self.mopidy_client.get_playback_state() if self.mopidy_client else "stopped"
 
         if playback_state == "playing":
-            self.music_was_playing_before_call = True
             logger.info("  🎵 Auto-pausing music for incoming call")
+
+            self.call_interruption_policy.pause_for_call(self.music_fsm)
 
             # Pause music
             if self.mopidy_client:
                 self.mopidy_client.pause()
-
-            # Transition to paused-by-call state (if we're in a music state)
-            if self.state_machine.is_music_playing():
-                self.state_machine.transition_to(
-                    AppState.PAUSED_BY_CALL,
-                    "auto_pause_for_call"
-                )
-
-        # Transition to incoming call state using the correct trigger for the
-        # current music/call context.
-        if self.state_machine.current_state == AppState.PAUSED_BY_CALL:
-            self.state_machine.transition_to(
-                AppState.CALL_INCOMING,
-                "incoming_call_ringing"
-            )
-        else:
-            self.state_machine.transition_to(
-                AppState.CALL_INCOMING,
-                "incoming_call"
-            )
+        self.call_fsm.transition("incoming")
+        self.state_machine.sync_from_models("incoming_call")
 
         # Update and push incoming call screen
         self.incoming_call_screen.caller_address = caller_address
@@ -711,29 +734,24 @@ class YoyoPodApp:
         """
         logger.info(f"📞 Call state changed: {state.value}")
 
-        if state == CallState.CONNECTED or state == CallState.STREAMS_RUNNING:
-            current_state = self.state_machine.current_state
+        if state in (
+            CallState.OUTGOING,
+            CallState.OUTGOING_PROGRESS,
+            CallState.OUTGOING_RINGING,
+            CallState.OUTGOING_EARLY_MEDIA,
+        ):
+            self.call_fsm.transition("dial")
+            self.state_machine.sync_from_models("call_outgoing")
+            return
 
-            if current_state == AppState.PAUSED_BY_CALL:
-                self.state_machine.transition_to(
-                    AppState.CALL_ACTIVE_MUSIC_PAUSED,
-                    "call_answered"
-                )
-            elif current_state == AppState.CALL_INCOMING and self.music_was_playing_before_call:
-                self.state_machine.transition_to(
-                    AppState.CALL_ACTIVE_MUSIC_PAUSED,
-                    "answer_call_resume_after"
-                )
-            elif current_state == AppState.CALL_OUTGOING and self.music_was_playing_before_call:
-                self.state_machine.transition_to(
-                    AppState.CALL_ACTIVE_MUSIC_PAUSED,
-                    "call_connected_music_paused"
-                )
-            else:
-                self.state_machine.transition_to(
-                    AppState.CALL_ACTIVE,
-                    "call_connected"
-                )
+        if state == CallState.INCOMING:
+            self.call_fsm.transition("incoming")
+            self.state_machine.sync_from_models("call_incoming_state")
+            return
+
+        if state == CallState.CONNECTED or state == CallState.STREAMS_RUNNING:
+            self.call_fsm.transition("connect")
+            self.state_machine.sync_from_models("call_connected")
 
             # Push in-call screen
             if self.screen_manager.current_screen != self.in_call_screen:
@@ -742,10 +760,6 @@ class YoyoPodApp:
 
             # Stop ring tone when call is answered
             self._stop_ringing()
-
-        elif state == CallState.RELEASED:
-            # Call ended
-            self._handle_call_ended()
 
     def _handle_call_ended(self) -> None:
         """Handle call end - restore music if needed."""
@@ -760,56 +774,34 @@ class YoyoPodApp:
         # Pop all call screens
         self._pop_call_screens()
 
-        current_state = self.state_machine.current_state
+        should_resume = self.call_interruption_policy.should_auto_resume(
+            self.auto_resume_after_call
+        )
+
+        self.call_fsm.transition("end")
 
         # Check if we should resume music
-        if self.music_was_playing_before_call and self.auto_resume_after_call:
+        if should_resume:
             logger.info("  🎵 Auto-resuming music after call")
 
             # Resume music playback
             if self.mopidy_client:
                 self.mopidy_client.play()
-
-            if current_state in (AppState.CALL_ACTIVE_MUSIC_PAUSED, AppState.CALL_INCOMING):
-                self.state_machine.transition_to(
-                    AppState.PLAYING_WITH_VOIP,
-                    "call_ended_auto_resume"
-                )
-            elif current_state == AppState.PAUSED_BY_CALL:
-                self.state_machine.transition_to(
-                    AppState.PLAYING_WITH_VOIP,
-                    "call_rejected_resume"
-                )
+            self.music_fsm.transition("play")
 
             # Refresh NowPlayingScreen if visible to show play icon
             if self.screen_manager.current_screen == self.now_playing_screen:
                 self.now_playing_screen.render()
                 logger.debug("  → Now playing screen refreshed (showing play icon)")
 
-        elif self.music_was_playing_before_call:
+        elif self.call_interruption_policy.music_interrupted_by_call:
             logger.info("  🎵 Music stays paused (auto-resume disabled)")
-            if current_state == AppState.CALL_ACTIVE_MUSIC_PAUSED:
-                self.state_machine.transition_to(
-                    AppState.PAUSED,
-                    "call_ended_stay_paused"
-                )
-            elif current_state in (AppState.CALL_INCOMING, AppState.PAUSED_BY_CALL):
-                self.state_machine.transition_to(
-                    AppState.PAUSED,
-                    "reject_call_stay_paused"
-                )
-
+            self.music_fsm.transition("pause")
         else:
-            # No music was playing, return to idle or menu
             logger.info("  No music to resume")
-            if self.state_machine.current_state == AppState.CALL_ACTIVE:
-                self.state_machine.transition_to(
-                    AppState.CALL_IDLE,
-                    "call_ended"
-                )
 
-        # Reset flag
-        self.music_was_playing_before_call = False
+        self.call_interruption_policy.clear()
+        self.state_machine.sync_from_models("call_ended")
 
     def _handle_registration_change(self, state: RegistrationState) -> None:
         """
@@ -821,15 +813,10 @@ class YoyoPodApp:
         logger.info(f"📞 VoIP registration: {state.value}")
 
         self.voip_registered = (state == RegistrationState.OK)
+        self.state_machine.set_voip_ready(self.voip_registered)
 
         if state == RegistrationState.OK:
             logger.info("  ✓ VoIP ready to receive calls")
-            # If music is playing, upgrade to PLAYING_WITH_VOIP
-            if self.state_machine.current_state == AppState.PLAYING:
-                self.state_machine.transition_to(
-                    AppState.PLAYING_WITH_VOIP,
-                    "voip_ready"
-                )
         elif state == RegistrationState.FAILED:
             logger.warning("  ⚠ VoIP registration failed")
 
@@ -853,15 +840,9 @@ class YoyoPodApp:
             logger.info(f"🎵 Track changed: {track.name} - {track.get_artist_string()}")
         else:
             logger.info("🎵 Playback stopped")
-
-            # If we're in PLAYING_WITH_VOIP and track is None, music may have stopped
-            if self.state_machine.is_music_playing():
-                logger.warning("  Track is None but state is playing - music may have stopped")
-                # Transition to paused to reflect reality
-                self.state_machine.transition_to(
-                    AppState.PAUSED,
-                    "pause"
-                )
+            if not self.call_fsm.is_active:
+                self.music_fsm.transition("stop")
+                self.state_machine.sync_from_models("track_stopped")
 
         # Update now playing screen if visible
         if self.screen_manager.current_screen == self.now_playing_screen:
@@ -881,48 +862,18 @@ class YoyoPodApp:
 
         # Only sync state machine if we're not in a call
         # (during calls, call logic handles music states)
-        if self.state_machine.is_call_active():
+        if self.call_fsm.is_active:
             logger.debug("  → In call, state machine managed by call logic")
             return
 
-        # Sync state machine with actual playback state
-        current_state = self.state_machine.current_state
-
         if playback_state == "playing":
-            if self.voip_registered:
-                if current_state == AppState.PAUSED:
-                    self.state_machine.transition_to(
-                        AppState.PLAYING_WITH_VOIP,
-                        "resume"
-                    )
-                elif current_state == AppState.PLAYING:
-                    self.state_machine.transition_to(
-                        AppState.PLAYING_WITH_VOIP,
-                        "voip_ready"
-                    )
-                elif current_state == AppState.MENU:
-                    self.state_machine.transition_to(
-                        AppState.PLAYING_WITH_VOIP,
-                        "select_media_with_voip"
-                    )
-            else:
-                if current_state == AppState.PAUSED:
-                    self.state_machine.transition_to(
-                        AppState.PLAYING,
-                        "resume"
-                    )
-                elif current_state == AppState.MENU:
-                    self.state_machine.transition_to(
-                        AppState.PLAYING,
-                        "select_media"
-                    )
+            self.music_fsm.transition("play")
+        elif playback_state == "paused":
+            self.music_fsm.transition("pause")
+        elif playback_state == "stopped":
+            self.music_fsm.transition("stop")
 
-        elif playback_state in ("paused", "stopped"):
-            if self.state_machine.is_music_playing() and current_state != AppState.PAUSED:
-                self.state_machine.transition_to(
-                    AppState.PAUSED,
-                    "pause"
-                )
+        self.state_machine.sync_from_models(f"playback_{playback_state}")
 
         # Refresh NowPlayingScreen if visible to reflect new state
         if self.screen_manager.current_screen == self.now_playing_screen:
@@ -1076,7 +1027,7 @@ class YoyoPodApp:
         return {
             'state': self.state_machine.get_state_name(),
             'voip_registered': self.voip_registered,
-            'music_was_playing': self.music_was_playing_before_call,
+            'music_was_playing': self.call_interruption_policy.music_interrupted_by_call,
             'auto_resume': self.auto_resume_after_call,
             'voip_available': self.voip_manager is not None,
             'music_available': self.mopidy_client is not None and self.mopidy_client.is_connected

--- a/yoyopy/event_bus.py
+++ b/yoyopy/event_bus.py
@@ -1,0 +1,79 @@
+"""
+Thread-safe typed event bus for YoyoPod orchestration.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import defaultdict
+from queue import Empty, Queue
+from typing import Any, Callable, DefaultDict
+
+from loguru import logger
+
+
+EventHandler = Callable[[Any], None]
+
+
+class EventBus:
+    """
+    Dispatch typed events on the coordinator thread.
+
+    Background threads enqueue events, while the main loop drains and dispatches
+    them to subscribed handlers in publish order.
+    """
+
+    def __init__(self, main_thread_id: int | None = None) -> None:
+        self.main_thread_id = main_thread_id or threading.get_ident()
+        self._subscribers: DefaultDict[type[Any], list[EventHandler]] = defaultdict(list)
+        self._queue: Queue[Any] = Queue()
+
+    def subscribe(self, event_type: type[Any], handler: EventHandler) -> None:
+        """Register a handler for a specific event type."""
+        self._subscribers[event_type].append(handler)
+        logger.debug(f"Subscribed handler for {event_type.__name__}")
+
+    def publish(self, event: Any) -> None:
+        """Publish an event, queueing it if called off the main thread."""
+        if threading.get_ident() == self.main_thread_id:
+            self._dispatch(event)
+            return
+
+        self._queue.put(event)
+        logger.debug(f"Queued event: {event.__class__.__name__}")
+
+    def drain(self, limit: int | None = None) -> int:
+        """
+        Drain queued events on the main thread.
+
+        Args:
+            limit: Optional maximum number of events to process.
+
+        Returns:
+            Number of drained events.
+        """
+        processed = 0
+
+        while limit is None or processed < limit:
+            try:
+                event = self._queue.get_nowait()
+            except Empty:
+                break
+
+            self._dispatch(event)
+            processed += 1
+
+        return processed
+
+    def _dispatch(self, event: Any) -> None:
+        """Dispatch an event to all compatible subscribers."""
+        handlers: list[EventHandler] = []
+        for event_type, subscribers in self._subscribers.items():
+            if isinstance(event, event_type):
+                handlers.extend(subscribers)
+
+        for handler in handlers:
+            try:
+                handler(event)
+            except Exception as exc:
+                logger.error(f"Error handling {event.__class__.__name__}: {exc}")

--- a/yoyopy/events.py
+++ b/yoyopy/events.py
@@ -1,0 +1,54 @@
+"""
+Typed application events for YoyoPod orchestration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from yoyopy.audio.mopidy_client import MopidyTrack
+from yoyopy.connectivity.voip_manager import CallState, RegistrationState
+
+
+@dataclass(frozen=True, slots=True)
+class IncomingCallEvent:
+    """Published when the VoIP stack reports an incoming call."""
+
+    caller_address: str
+    caller_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class CallStateChangedEvent:
+    """Published when the VoIP call state changes."""
+
+    state: CallState
+
+
+@dataclass(frozen=True, slots=True)
+class CallEndedEvent:
+    """Published when a call is released."""
+
+    reason: str = "released"
+
+
+@dataclass(frozen=True, slots=True)
+class RegistrationChangedEvent:
+    """Published when SIP registration changes."""
+
+    state: RegistrationState
+
+
+@dataclass(frozen=True, slots=True)
+class TrackChangedEvent:
+    """Published when the current Mopidy track changes."""
+
+    track: Optional[MopidyTrack]
+
+
+@dataclass(frozen=True, slots=True)
+class PlaybackStateChangedEvent:
+    """Published when Mopidy playback changes state."""
+
+    state: str

--- a/yoyopy/fsm.py
+++ b/yoyopy/fsm.py
@@ -1,0 +1,163 @@
+"""
+Focused finite-state machines for YoyoPod orchestration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from loguru import logger
+
+
+class MusicState(Enum):
+    """Music playback state."""
+
+    IDLE = "idle"
+    PLAYING = "playing"
+    PAUSED = "paused"
+
+
+class CallSessionState(Enum):
+    """High-level call session state."""
+
+    IDLE = "idle"
+    INCOMING = "incoming"
+    OUTGOING = "outgoing"
+    ACTIVE = "active"
+
+
+class MusicFSM:
+    """Small FSM for music playback orchestration."""
+
+    _TRANSITIONS = {
+        MusicState.IDLE: {"play": MusicState.PLAYING, "stop": MusicState.IDLE},
+        MusicState.PLAYING: {
+            "play": MusicState.PLAYING,
+            "pause": MusicState.PAUSED,
+            "stop": MusicState.IDLE,
+        },
+        MusicState.PAUSED: {
+            "play": MusicState.PLAYING,
+            "pause": MusicState.PAUSED,
+            "stop": MusicState.IDLE,
+        },
+    }
+
+    def __init__(self, initial_state: MusicState = MusicState.IDLE) -> None:
+        self.state = initial_state
+        self.previous_state: Optional[MusicState] = None
+
+    def transition(self, trigger: str) -> bool:
+        """Transition using a small trigger vocabulary."""
+        target = self._TRANSITIONS.get(self.state, {}).get(trigger)
+        if target is None:
+            logger.warning(f"Invalid music transition: {self.state.value} -> {trigger}")
+            return False
+
+        if target == self.state:
+            return True
+
+        self.previous_state = self.state
+        self.state = target
+        logger.debug(f"MusicFSM: {self.previous_state.value} -> {self.state.value} ({trigger})")
+        return True
+
+    def sync(self, state: MusicState) -> None:
+        """Force-sync to a known state."""
+        if self.state == state:
+            return
+
+        self.previous_state = self.state
+        self.state = state
+        logger.debug(f"MusicFSM synced to {self.state.value}")
+
+
+class CallFSM:
+    """Small FSM for call orchestration."""
+
+    _TRANSITIONS = {
+        CallSessionState.IDLE: {
+            "incoming": CallSessionState.INCOMING,
+            "dial": CallSessionState.OUTGOING,
+            "reset": CallSessionState.IDLE,
+        },
+        CallSessionState.INCOMING: {
+            "incoming": CallSessionState.INCOMING,
+            "connect": CallSessionState.ACTIVE,
+            "end": CallSessionState.IDLE,
+            "reset": CallSessionState.IDLE,
+        },
+        CallSessionState.OUTGOING: {
+            "dial": CallSessionState.OUTGOING,
+            "connect": CallSessionState.ACTIVE,
+            "end": CallSessionState.IDLE,
+            "reset": CallSessionState.IDLE,
+        },
+        CallSessionState.ACTIVE: {
+            "connect": CallSessionState.ACTIVE,
+            "end": CallSessionState.IDLE,
+            "reset": CallSessionState.IDLE,
+        },
+    }
+
+    def __init__(self, initial_state: CallSessionState = CallSessionState.IDLE) -> None:
+        self.state = initial_state
+        self.previous_state: Optional[CallSessionState] = None
+
+    def transition(self, trigger: str) -> bool:
+        """Transition using a small trigger vocabulary."""
+        target = self._TRANSITIONS.get(self.state, {}).get(trigger)
+        if target is None:
+            logger.warning(f"Invalid call transition: {self.state.value} -> {trigger}")
+            return False
+
+        if target == self.state:
+            return True
+
+        self.previous_state = self.state
+        self.state = target
+        logger.debug(f"CallFSM: {self.previous_state.value} -> {self.state.value} ({trigger})")
+        return True
+
+    def sync(self, state: CallSessionState) -> None:
+        """Force-sync to a known state."""
+        if self.state == state:
+            return
+
+        self.previous_state = self.state
+        self.state = state
+        logger.debug(f"CallFSM synced to {self.state.value}")
+
+    @property
+    def is_active(self) -> bool:
+        """Return True when any call is in progress."""
+        return self.state != CallSessionState.IDLE
+
+
+@dataclass
+class CallInterruptionPolicy:
+    """Track whether a call interrupted playback and owns resume policy."""
+
+    music_interrupted_by_call: bool = False
+
+    def pause_for_call(self, music_fsm: MusicFSM) -> bool:
+        """
+        Mark and pause music if the call interrupted active playback.
+
+        Returns:
+            True if music was actively playing and is now paused for the call.
+        """
+        self.music_interrupted_by_call = music_fsm.state == MusicState.PLAYING
+        if self.music_interrupted_by_call:
+            music_fsm.transition("pause")
+        return self.music_interrupted_by_call
+
+    def should_auto_resume(self, auto_resume: bool) -> bool:
+        """Return True if interrupted playback should resume after call end."""
+        return self.music_interrupted_by_call and auto_resume
+
+    def clear(self) -> None:
+        """Reset call interruption tracking after a call completes."""
+        self.music_interrupted_by_call = False

--- a/yoyopy/state_machine.py
+++ b/yoyopy/state_machine.py
@@ -1,226 +1,181 @@
 """
-State machine for YoyoPod application.
+Compatibility state machine for YoyoPod.
 
-Manages application states and transitions with validation
-and context tracking.
+This module keeps the legacy AppState API alive while delegating playback and
+call orchestration to separate MusicFSM and CallFSM instances.
 """
 
-from enum import Enum
-from typing import Optional, Callable, Dict, List, Set
+from __future__ import annotations
+
 from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Dict, List, Optional
+
 from loguru import logger
 
 from yoyopy.app_context import AppContext
+from yoyopy.fsm import CallFSM, CallInterruptionPolicy, CallSessionState, MusicFSM, MusicState
 
 
 class AppState(Enum):
-    """Application states."""
-    IDLE = "idle"                    # Home screen, ready to start
-    MENU = "menu"                    # Main menu navigation
-    PLAYING = "playing"              # Playing audio content
-    PAUSED = "paused"                # Playback paused
-    SETTINGS = "settings"            # Settings screen
-    PLAYLIST = "playlist"            # Playlist/library view
-    PLAYLIST_BROWSER = "playlist_browser"  # Browsing Mopidy playlists
-    CALL_IDLE = "call_idle"          # VoIP ready, no active call
-    CALL_INCOMING = "call_incoming"  # Incoming call ringing
-    CALL_OUTGOING = "call_outgoing"  # Outgoing call dialing
-    CALL_ACTIVE = "call_active"      # Call connected and active
-    CALLING = "calling"              # Active VoIP call (outgoing/incoming/connected) - legacy
-    CONNECTING = "connecting"        # Network connection setup
-    ERROR = "error"                  # Error state
+    """Legacy application states."""
 
-    # VoIP + Music Integration States
-    PLAYING_WITH_VOIP = "playing_with_voip"  # Music playing, VoIP ready to receive calls
-    PAUSED_BY_CALL = "paused_by_call"        # Music auto-paused for incoming/active call
-    CALL_ACTIVE_MUSIC_PAUSED = "call_active_music_paused"  # In call, music paused in background
+    IDLE = "idle"
+    MENU = "menu"
+    PLAYING = "playing"
+    PAUSED = "paused"
+    SETTINGS = "settings"
+    PLAYLIST = "playlist"
+    PLAYLIST_BROWSER = "playlist_browser"
+    CALL_IDLE = "call_idle"
+    CALL_INCOMING = "call_incoming"
+    CALL_OUTGOING = "call_outgoing"
+    CALL_ACTIVE = "call_active"
+    CALLING = "calling"
+    CONNECTING = "connecting"
+    ERROR = "error"
+    PLAYING_WITH_VOIP = "playing_with_voip"
+    PAUSED_BY_CALL = "paused_by_call"
+    CALL_ACTIVE_MUSIC_PAUSED = "call_active_music_paused"
 
 
 @dataclass
 class StateTransition:
-    """Represents a state transition."""
+    """Represents a legacy compatibility transition."""
+
     from_state: AppState
     to_state: AppState
     trigger: str
-    guard: Optional[Callable[[], bool]] = None  # Optional condition check
+    guard: Optional[Callable[[], bool]] = None
 
 
 class StateMachine:
     """
-    Manages application state transitions.
+    Compatibility facade over split playback and call state machines.
 
-    Provides state management with validation, history tracking,
-    and callback hooks for state changes.
+    Legacy callers can still transition with AppState values while new code can
+    mutate `music_fsm`, `call_fsm`, and `call_interruption_policy` directly, then
+    call `sync_from_models()` to refresh the derived AppState view.
     """
 
-    def __init__(self, context: AppContext) -> None:
-        """
-        Initialize the state machine.
+    _UI_STATES = {
+        AppState.IDLE,
+        AppState.MENU,
+        AppState.SETTINGS,
+        AppState.PLAYLIST,
+        AppState.PLAYLIST_BROWSER,
+        AppState.CALL_IDLE,
+        AppState.CONNECTING,
+        AppState.ERROR,
+    }
 
-        Args:
-            context: Application context instance
-        """
+    def __init__(self, context: AppContext) -> None:
         self.context = context
+        self.music_fsm = MusicFSM()
+        self.call_fsm = CallFSM()
+        self.call_interruption_policy = CallInterruptionPolicy()
+        self.voip_ready = False
+        self.ui_state = AppState.IDLE
+
         self.current_state = AppState.IDLE
         self.previous_state: Optional[AppState] = None
         self.state_history: List[AppState] = [AppState.IDLE]
 
-        # Callbacks for state changes
-        self.on_enter_callbacks: Dict[AppState, List[Callable]] = {
+        self.on_enter_callbacks: Dict[AppState, List[Callable[[], None]]] = {
             state: [] for state in AppState
         }
-        self.on_exit_callbacks: Dict[AppState, List[Callable]] = {
+        self.on_exit_callbacks: Dict[AppState, List[Callable[[], None]]] = {
             state: [] for state in AppState
         }
-
-        # Define valid transitions
-        self.transitions: List[StateTransition] = self._define_transitions()
+        self.transitions = self._define_transitions()
 
         logger.info(f"StateMachine initialized in {self.current_state.value} state")
 
     def _define_transitions(self) -> List[StateTransition]:
-        """
-        Define valid state transitions.
-
-        Returns:
-            List of valid transitions
-        """
+        """Retain the legacy transition table for compatibility validation."""
         return [
-            # From IDLE
             StateTransition(AppState.IDLE, AppState.MENU, "open_menu"),
             StateTransition(AppState.IDLE, AppState.SETTINGS, "open_settings"),
             StateTransition(AppState.IDLE, AppState.CONNECTING, "connect"),
-            StateTransition(AppState.IDLE, AppState.CALL_INCOMING, "incoming_call"),  # Allow calls while idle
-
-            # From MENU
+            StateTransition(AppState.IDLE, AppState.CALL_INCOMING, "incoming_call"),
             StateTransition(AppState.MENU, AppState.IDLE, "back"),
             StateTransition(AppState.MENU, AppState.PLAYING, "select_media"),
             StateTransition(AppState.MENU, AppState.PLAYLIST, "select_playlist"),
             StateTransition(AppState.MENU, AppState.PLAYLIST_BROWSER, "browse_playlists"),
             StateTransition(AppState.MENU, AppState.CALL_IDLE, "open_voip"),
             StateTransition(AppState.MENU, AppState.SETTINGS, "select_settings"),
-
-            # From PLAYING
             StateTransition(AppState.PLAYING, AppState.PAUSED, "pause"),
             StateTransition(AppState.PLAYING, AppState.MENU, "back"),
             StateTransition(AppState.PLAYING, AppState.IDLE, "stop"),
-
-            # From PAUSED
             StateTransition(AppState.PAUSED, AppState.PLAYING, "resume"),
-            StateTransition(AppState.PAUSED, AppState.PLAYING_WITH_VOIP, "resume"),  # Resume with VoIP
+            StateTransition(AppState.PAUSED, AppState.PLAYING_WITH_VOIP, "resume"),
             StateTransition(AppState.PAUSED, AppState.MENU, "back"),
             StateTransition(AppState.PAUSED, AppState.IDLE, "stop"),
-
-            # From PLAYLIST
             StateTransition(AppState.PLAYLIST, AppState.MENU, "back"),
             StateTransition(AppState.PLAYLIST, AppState.PLAYING, "select_track"),
-
-            # From PLAYLIST_BROWSER
             StateTransition(AppState.PLAYLIST_BROWSER, AppState.MENU, "back"),
             StateTransition(AppState.PLAYLIST_BROWSER, AppState.PLAYING, "load_playlist"),
-
-            # From CALL_IDLE
             StateTransition(AppState.CALL_IDLE, AppState.MENU, "back"),
             StateTransition(AppState.CALL_IDLE, AppState.CALL_OUTGOING, "make_call"),
             StateTransition(AppState.CALL_IDLE, AppState.CALL_INCOMING, "incoming_call"),
-            StateTransition(AppState.CALL_IDLE, AppState.CALLING, "make_call"),  # Legacy
-            StateTransition(AppState.CALL_IDLE, AppState.CALLING, "incoming_call"),  # Legacy
-
-            # From CALL_INCOMING
+            StateTransition(AppState.CALL_IDLE, AppState.CALLING, "make_call"),
+            StateTransition(AppState.CALL_IDLE, AppState.CALLING, "incoming_call"),
             StateTransition(AppState.CALL_INCOMING, AppState.CALL_ACTIVE, "answer_call"),
-            StateTransition(AppState.CALL_INCOMING, AppState.CALL_ACTIVE, "call_connected"),  # VoIP manager uses this trigger
+            StateTransition(AppState.CALL_INCOMING, AppState.CALL_ACTIVE, "call_connected"),
             StateTransition(AppState.CALL_INCOMING, AppState.CALL_IDLE, "reject_call"),
             StateTransition(AppState.CALL_INCOMING, AppState.CALL_IDLE, "call_ended"),
-
-            # From CALL_OUTGOING
             StateTransition(AppState.CALL_OUTGOING, AppState.CALL_ACTIVE, "call_connected"),
             StateTransition(AppState.CALL_OUTGOING, AppState.CALL_IDLE, "cancel_call"),
             StateTransition(AppState.CALL_OUTGOING, AppState.CALL_IDLE, "call_failed"),
-
-            # From CALL_ACTIVE
             StateTransition(AppState.CALL_ACTIVE, AppState.CALL_IDLE, "end_call"),
             StateTransition(AppState.CALL_ACTIVE, AppState.CALL_IDLE, "call_ended"),
-
-            # From CALLING (Legacy - keep for backward compatibility)
             StateTransition(AppState.CALLING, AppState.CALL_IDLE, "call_ended"),
             StateTransition(AppState.CALLING, AppState.MENU, "back"),
-
-            # From SETTINGS
             StateTransition(AppState.SETTINGS, AppState.MENU, "back"),
             StateTransition(AppState.SETTINGS, AppState.IDLE, "home"),
-
-            # From CONNECTING
             StateTransition(AppState.CONNECTING, AppState.IDLE, "cancel"),
             StateTransition(AppState.CONNECTING, AppState.MENU, "connected"),
-
-            # From ERROR - can go to idle
             StateTransition(AppState.ERROR, AppState.IDLE, "reset"),
-
-            # VoIP + Music Integration Transitions
-            # Music to VoIP-ready music
             StateTransition(AppState.PLAYING, AppState.PLAYING_WITH_VOIP, "voip_ready"),
             StateTransition(AppState.PLAYLIST_BROWSER, AppState.PLAYING_WITH_VOIP, "load_playlist_with_voip"),
             StateTransition(AppState.MENU, AppState.PLAYING_WITH_VOIP, "select_media_with_voip"),
-
-            # From PLAYING_WITH_VOIP (music playing, VoIP ready)
             StateTransition(AppState.PLAYING_WITH_VOIP, AppState.PAUSED, "pause"),
             StateTransition(AppState.PLAYING_WITH_VOIP, AppState.MENU, "back"),
             StateTransition(AppState.PLAYING_WITH_VOIP, AppState.IDLE, "stop"),
             StateTransition(AppState.PLAYING_WITH_VOIP, AppState.PAUSED_BY_CALL, "auto_pause_for_call"),
             StateTransition(AppState.PLAYING_WITH_VOIP, AppState.CALL_INCOMING, "incoming_call"),
-
-            # From PAUSED_BY_CALL (music paused for call)
             StateTransition(AppState.PAUSED_BY_CALL, AppState.CALL_INCOMING, "incoming_call_ringing"),
             StateTransition(AppState.PAUSED_BY_CALL, AppState.CALL_ACTIVE_MUSIC_PAUSED, "call_answered"),
             StateTransition(AppState.PAUSED_BY_CALL, AppState.PLAYING_WITH_VOIP, "call_rejected_resume"),
             StateTransition(AppState.PAUSED_BY_CALL, AppState.PAUSED, "call_rejected_stay_paused"),
-
-            # From CALL_INCOMING with music in background
             StateTransition(AppState.CALL_INCOMING, AppState.CALL_ACTIVE_MUSIC_PAUSED, "answer_call_resume_after"),
             StateTransition(AppState.CALL_INCOMING, AppState.PAUSED, "reject_call_stay_paused"),
             StateTransition(AppState.CALL_INCOMING, AppState.PLAYING_WITH_VOIP, "reject_call_resume"),
-            StateTransition(AppState.CALL_INCOMING, AppState.PLAYING_WITH_VOIP, "call_ended_auto_resume"),  # Call ends before answer
-
-            # From CALL_ACTIVE_MUSIC_PAUSED (in call, music paused)
+            StateTransition(AppState.CALL_INCOMING, AppState.PLAYING_WITH_VOIP, "call_ended_auto_resume"),
             StateTransition(AppState.CALL_ACTIVE_MUSIC_PAUSED, AppState.PLAYING_WITH_VOIP, "call_ended_auto_resume"),
             StateTransition(AppState.CALL_ACTIVE_MUSIC_PAUSED, AppState.PAUSED, "call_ended_stay_paused"),
             StateTransition(AppState.CALL_ACTIVE_MUSIC_PAUSED, AppState.MENU, "call_ended_stop_music"),
-
-            # Outgoing call from music screen
             StateTransition(AppState.PLAYING_WITH_VOIP, AppState.CALL_OUTGOING, "make_call_pause_music"),
             StateTransition(AppState.CALL_OUTGOING, AppState.CALL_ACTIVE_MUSIC_PAUSED, "call_connected_music_paused"),
         ]
 
     def can_transition(self, to_state: AppState, trigger: str = "manual") -> bool:
-        """
-        Check if transition to new state is valid.
-
-        Args:
-            to_state: Target state
-            trigger: Trigger name (for logging)
-
-        Returns:
-            True if transition is valid, False otherwise
-        """
-        # Find matching transition
-        for transition in self.transitions:
-            if (transition.from_state == self.current_state and
-                transition.to_state == to_state and
-                transition.trigger == trigger):
-
-                # Check guard condition if present
-                if transition.guard and not transition.guard():
-                    logger.warning(
-                        f"Transition {self.current_state.value} -> {to_state.value} "
-                        f"blocked by guard"
-                    )
-                    return False
-
-                return True
-
-        # Check if it's the same state (always allowed)
+        """Check if a legacy transition is currently allowed."""
         if to_state == self.current_state:
             return True
+
+        for transition in self.transitions:
+            if (
+                transition.from_state == self.current_state
+                and transition.to_state == to_state
+                and transition.trigger == trigger
+            ):
+                if transition.guard and not transition.guard():
+                    logger.warning(
+                        f"Transition {self.current_state.value} -> {to_state.value} blocked by guard"
+                    )
+                    return False
+                return True
 
         logger.warning(
             f"Invalid transition: {self.current_state.value} -> {to_state.value} "
@@ -229,129 +184,193 @@ class StateMachine:
         return False
 
     def transition_to(self, new_state: AppState, trigger: str = "manual") -> bool:
-        """
-        Transition to a new state.
-
-        Args:
-            new_state: Target state
-            trigger: Trigger name
-
-        Returns:
-            True if transition succeeded, False otherwise
-        """
-        # Check if transition is valid
+        """Perform a legacy transition and keep the new FSMs aligned."""
         if not self.can_transition(new_state, trigger):
             logger.error(
-                f"Cannot transition from {self.current_state.value} "
-                f"to {new_state.value}"
+                f"Cannot transition from {self.current_state.value} to {new_state.value}"
             )
             return False
 
-        # Don't do anything if already in target state
         if new_state == self.current_state:
             logger.debug(f"Already in {new_state.value} state")
             return True
 
-        old_state = self.current_state
+        self._apply_legacy_state(new_state, trigger)
+        self._set_state(new_state, trigger)
+        return True
 
-        # Exit current state
+    def _apply_legacy_state(self, new_state: AppState, trigger: str) -> None:
+        """Update the split FSMs to reflect a legacy transition."""
+        if trigger == "voip_ready":
+            self.voip_ready = True
+
+        if new_state in self._UI_STATES:
+            self.ui_state = new_state
+
+        if new_state == AppState.IDLE:
+            self.music_fsm.sync(MusicState.IDLE)
+            self.call_fsm.sync(CallSessionState.IDLE)
+            self.call_interruption_policy.clear()
+            self.voip_ready = False if trigger == "reset" else self.voip_ready
+            return
+
+        if new_state in (AppState.PLAYING, AppState.PLAYING_WITH_VOIP):
+            self.music_fsm.sync(MusicState.PLAYING)
+            self.call_fsm.sync(CallSessionState.IDLE)
+            self.call_interruption_policy.clear()
+            if new_state == AppState.PLAYING_WITH_VOIP:
+                self.voip_ready = True
+            return
+
+        if new_state == AppState.PAUSED:
+            self.music_fsm.sync(MusicState.PAUSED)
+            if trigger not in {"auto_pause_for_call", "call_answered", "answer_call_resume_after"}:
+                self.call_interruption_policy.clear()
+            return
+
+        if new_state == AppState.PAUSED_BY_CALL:
+            self.music_fsm.sync(MusicState.PAUSED)
+            self.call_fsm.sync(CallSessionState.IDLE)
+            self.call_interruption_policy.music_interrupted_by_call = True
+            return
+
+        if new_state == AppState.CALL_INCOMING:
+            self.call_fsm.sync(CallSessionState.INCOMING)
+            return
+
+        if new_state == AppState.CALL_OUTGOING:
+            self.call_fsm.sync(CallSessionState.OUTGOING)
+            return
+
+        if new_state in (AppState.CALL_ACTIVE, AppState.CALLING):
+            self.call_fsm.sync(CallSessionState.ACTIVE)
+            if new_state == AppState.CALL_ACTIVE:
+                self.call_interruption_policy.clear()
+            return
+
+        if new_state == AppState.CALL_ACTIVE_MUSIC_PAUSED:
+            self.music_fsm.sync(MusicState.PAUSED)
+            self.call_fsm.sync(CallSessionState.ACTIVE)
+            self.call_interruption_policy.music_interrupted_by_call = True
+
+    def _set_state(self, new_state: AppState, trigger: str) -> None:
+        """Update the current legacy state and fire callbacks."""
+        old_state = self.current_state
         logger.info(f"Exiting state: {old_state.value}")
         self._fire_callbacks(self.on_exit_callbacks[old_state])
 
-        # Update state
         self.previous_state = old_state
         self.current_state = new_state
         self.state_history.append(new_state)
-
-        # Limit history size
         if len(self.state_history) > 50:
             self.state_history = self.state_history[-50:]
 
-        # Enter new state
         logger.info(f"Entering state: {new_state.value} (trigger: {trigger})")
         self._fire_callbacks(self.on_enter_callbacks[new_state])
 
-        return True
-
-    def go_back(self) -> bool:
+    def sync_from_models(self, trigger: str = "sync") -> AppState:
         """
-        Go back to the previous state.
+        Refresh the legacy AppState view from the split FSMs.
 
         Returns:
-            True if successful, False otherwise
+            The newly derived AppState.
         """
+        derived_state = self._derive_state()
+        if derived_state == self.current_state:
+            return derived_state
+
+        self._set_state(derived_state, trigger)
+        return derived_state
+
+    def _derive_state(self) -> AppState:
+        """Derive the compatibility AppState from the split FSMs."""
+        if self.call_fsm.state == CallSessionState.INCOMING:
+            return AppState.CALL_INCOMING
+
+        if self.call_fsm.state == CallSessionState.OUTGOING:
+            return AppState.CALL_OUTGOING
+
+        if self.call_fsm.state == CallSessionState.ACTIVE:
+            if self.call_interruption_policy.music_interrupted_by_call:
+                return AppState.CALL_ACTIVE_MUSIC_PAUSED
+            return AppState.CALL_ACTIVE
+
+        if (
+            self.call_interruption_policy.music_interrupted_by_call
+            and self.music_fsm.state == MusicState.PAUSED
+        ):
+            return AppState.PAUSED_BY_CALL
+
+        if self.music_fsm.state == MusicState.PLAYING:
+            return AppState.PLAYING_WITH_VOIP if self.voip_ready else AppState.PLAYING
+
+        if self.music_fsm.state == MusicState.PAUSED:
+            return AppState.PAUSED
+
+        return self.ui_state
+
+    def set_ui_state(self, state: AppState, trigger: str = "ui_state") -> AppState:
+        """Update the base UI state used when music/calls are idle."""
+        if state not in self._UI_STATES:
+            raise ValueError(f"{state.value} is not a base UI state")
+
+        self.ui_state = state
+        return self.sync_from_models(trigger)
+
+    def set_voip_ready(self, ready: bool, trigger: str = "voip_ready") -> AppState:
+        """Set whether VoIP is ready to receive calls and refresh derived state."""
+        self.voip_ready = ready
+        actual_trigger = trigger if ready else "voip_unavailable"
+        return self.sync_from_models(actual_trigger)
+
+    def go_back(self) -> bool:
+        """Go back to the previous legacy state."""
         if len(self.state_history) < 2:
             logger.warning("Cannot go back: no previous state")
             return False
 
-        # Get the state before current
-        # state_history[-1] is current, [-2] is previous
         previous = self.state_history[-2]
+        return self.transition_to(previous, "back")
 
-        # Determine trigger based on current state
-        trigger = "back"
-
-        return self.transition_to(previous, trigger)
-
-    def on_enter(self, state: AppState, callback: Callable) -> None:
-        """
-        Register callback for entering a state.
-
-        Args:
-            state: State to register callback for
-            callback: Function to call when entering state
-        """
+    def on_enter(self, state: AppState, callback: Callable[[], None]) -> None:
+        """Register an on-enter callback."""
         self.on_enter_callbacks[state].append(callback)
         logger.debug(f"Registered on_enter callback for {state.value}")
 
-    def on_exit(self, state: AppState, callback: Callable) -> None:
-        """
-        Register callback for exiting a state.
-
-        Args:
-            state: State to register callback for
-            callback: Function to call when exiting state
-        """
+    def on_exit(self, state: AppState, callback: Callable[[], None]) -> None:
+        """Register an on-exit callback."""
         self.on_exit_callbacks[state].append(callback)
         logger.debug(f"Registered on_exit callback for {state.value}")
 
-    def _fire_callbacks(self, callbacks: List[Callable]) -> None:
-        """
-        Fire all callbacks in a list.
-
-        Args:
-            callbacks: List of callbacks to fire
-        """
+    def _fire_callbacks(self, callbacks: List[Callable[[], None]]) -> None:
+        """Fire a callback list safely."""
         for callback in callbacks:
             try:
                 callback()
-            except Exception as e:
-                logger.error(f"Error in state callback: {e}")
+            except Exception as exc:
+                logger.error(f"Error in state callback: {exc}")
 
     def get_valid_transitions(self) -> List[AppState]:
-        """
-        Get list of valid states that can be transitioned to from current state.
-
-        Returns:
-            List of valid target states
-        """
-        valid_states = []
+        """Return legacy target states allowed from the current compatibility state."""
+        valid_states: List[AppState] = []
         for transition in self.transitions:
             if transition.from_state == self.current_state:
-                # Check guard if present
                 if not transition.guard or transition.guard():
                     if transition.to_state not in valid_states:
                         valid_states.append(transition.to_state)
         return valid_states
 
     def reset(self) -> None:
-        """Reset state machine to initial state."""
+        """Reset to the initial idle state."""
         logger.info("Resetting state machine")
-        self.transition_to(AppState.IDLE, "reset")
+        self.music_fsm.sync(MusicState.IDLE)
+        self.call_fsm.sync(CallSessionState.IDLE)
+        self.call_interruption_policy.clear()
+        self.voip_ready = False
+        self.ui_state = AppState.IDLE
+        self._set_state(AppState.IDLE, "reset")
         self.state_history = [AppState.IDLE]
         self.previous_state = None
-
-    # Convenience methods for common transitions
 
     def open_menu(self) -> bool:
         """Transition to MENU state."""
@@ -386,81 +405,57 @@ class StateMachine:
         return False
 
     def toggle_playback(self) -> bool:
-        """
-        Toggle between playing and paused states.
-
-        Returns:
-            True if now playing, False if paused
-        """
-        if self.current_state == AppState.PLAYING:
+        """Toggle between playing and paused states."""
+        if self.music_fsm.state == MusicState.PLAYING:
             self.pause_playback()
             return False
-        elif self.current_state == AppState.PAUSED:
+        if self.music_fsm.state == MusicState.PAUSED:
             self.resume_playback()
             return True
-        else:
-            # Start playback from other states
-            self.start_playback()
-            return True
+
+        self.start_playback()
+        return True
 
     def open_settings(self) -> bool:
         """Transition to SETTINGS state."""
         return self.transition_to(AppState.SETTINGS, "select_settings")
 
     def get_state_name(self) -> str:
-        """Get the current state name."""
+        """Get the current legacy state name."""
         return self.current_state.value
 
     def is_playing(self) -> bool:
-        """Check if currently in PLAYING state."""
-        return self.current_state == AppState.PLAYING
+        """Check whether music is actively playing."""
+        return self.music_fsm.state == MusicState.PLAYING
 
     def is_idle(self) -> bool:
-        """Check if currently in IDLE state."""
-        return self.current_state == AppState.IDLE
-
-    # VoIP + Music Integration helper methods
+        """Check whether the app is idle."""
+        return (
+            self.music_fsm.state == MusicState.IDLE
+            and self.call_fsm.state == CallSessionState.IDLE
+            and self.current_state == AppState.IDLE
+        )
 
     def is_playing_with_voip(self) -> bool:
-        """Check if currently playing music with VoIP ready."""
-        return self.current_state == AppState.PLAYING_WITH_VOIP
+        """Check whether music is playing while VoIP is ready."""
+        return self.music_fsm.state == MusicState.PLAYING and self.voip_ready
 
     def is_music_paused_by_call(self) -> bool:
-        """Check if music is paused due to call."""
-        return self.current_state in [
-            AppState.PAUSED_BY_CALL,
-            AppState.CALL_ACTIVE_MUSIC_PAUSED
-        ]
+        """Check whether music is paused because of call interruption."""
+        return self.call_interruption_policy.music_interrupted_by_call
 
     def is_in_call(self) -> bool:
-        """Check if currently in any call state."""
-        return self.current_state in [
-            AppState.CALL_INCOMING,
-            AppState.CALL_OUTGOING,
-            AppState.CALL_ACTIVE,
-            AppState.CALL_ACTIVE_MUSIC_PAUSED,
-            AppState.CALLING  # Legacy
-        ]
+        """Check if any call session is in progress."""
+        return self.call_fsm.is_active
 
     def is_music_playing(self) -> bool:
-        """Check if music is currently playing (any music state)."""
-        return self.current_state in [
-            AppState.PLAYING,
-            AppState.PLAYING_WITH_VOIP
-        ]
+        """Check whether music is currently playing."""
+        return self.music_fsm.state == MusicState.PLAYING
 
     def has_paused_music_for_call(self) -> bool:
-        """Check if we have music paused that should resume after call."""
-        return self.current_state in [
-            AppState.PAUSED_BY_CALL,
-            AppState.CALL_ACTIVE_MUSIC_PAUSED
-        ]
+        """Check whether the policy is holding paused music for a call."""
+        return self.call_interruption_policy.music_interrupted_by_call
 
     def is_call_active(self) -> bool:
-        """Check if there is currently an active call (any call state)."""
-        return self.current_state in [
-            AppState.CALL_INCOMING,
-            AppState.CALL_OUTGOING,
-            AppState.CALL_ACTIVE,
-            AppState.CALL_ACTIVE_MUSIC_PAUSED
-        ]
+        """Check if a call is in progress."""
+        return self.call_fsm.is_active


### PR DESCRIPTION
## Summary
- add a typed coordinator-thread event bus and typed app events
- split orchestration into MusicFSM, CallFSM, and CallInterruptionPolicy
- keep StateMachine as a compatibility facade while moving YoyoPodApp onto the new orchestration model
- replace the old phase-1 script test with focused FSM, event bus, and coordinator tests

## Verification
- python -m compileall yoyopy tests
- uv run pytest -q