### PR TITLE
Phase 2b declarative screen routing

### DIFF
--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Routing-focused tests for the declarative screen navigation layer."""
+
+from __future__ import annotations
+
+import pytest
+
+from yoyopy.app_context import AppContext
+from yoyopy.ui.display import Display
+from yoyopy.ui.input import InputAction, InputManager
+from yoyopy.ui.screens import HomeScreen, MenuScreen, NavigationRequest, Screen, ScreenManager, ScreenRouter
+
+
+class RoutableStubScreen(Screen):
+    """Minimal screen double that can emit simple route requests."""
+
+    def __init__(self, display: Display, context: AppContext | None = None) -> None:
+        super().__init__(display, context, "RoutableStub")
+
+    def render(self) -> None:
+        """No-op render used by routing tests."""
+
+    def on_back(self, data=None) -> None:
+        """Request a standard back route."""
+        self.request_route("back")
+
+
+@pytest.fixture
+def display() -> Display:
+    """Create a simulation display and clean it up after the test."""
+    test_display = Display(simulate=True)
+    try:
+        yield test_display
+    finally:
+        test_display.cleanup()
+
+
+def test_screen_router_covers_live_menu_labels() -> None:
+    """The router should cover the menu labels used by the app and demos."""
+    router = ScreenRouter()
+    expected_routes = {
+        "Back": NavigationRequest.pop(),
+        "Load Playlist": NavigationRequest.push("playlists"),
+        "Music": NavigationRequest.push("now_playing"),
+        "Now Playing": NavigationRequest.push("now_playing"),
+        "Browse Playlists": NavigationRequest.push("playlists"),
+        "Playlists": NavigationRequest.push("playlists"),
+        "VoIP Status": NavigationRequest.push("call"),
+        "Call Contact": NavigationRequest.push("contacts"),
+        "Contacts": NavigationRequest.push("contacts"),
+    }
+
+    for label, expected_request in expected_routes.items():
+        assert router.resolve("menu", "select", payload=label) == expected_request
+
+
+def test_screen_manager_routes_menu_labels_through_stack(display: Display) -> None:
+    """Menu labels should resolve through the router and preserve stack navigation."""
+    context = AppContext()
+    input_manager = InputManager()
+    screen_manager = ScreenManager(display, input_manager)
+
+    home = HomeScreen(display, context)
+    menu = MenuScreen(display, context, items=["Load Playlist", "Back"])
+    playlists = RoutableStubScreen(display, context)
+
+    screen_manager.register_screen("home", home)
+    screen_manager.register_screen("menu", menu)
+    screen_manager.register_screen("playlists", playlists)
+
+    screen_manager.replace_screen("home")
+    assert screen_manager.current_screen is home
+
+    input_manager.simulate_action(InputAction.SELECT)
+    assert screen_manager.current_screen is menu
+
+    input_manager.simulate_action(InputAction.SELECT)
+    assert screen_manager.current_screen is playlists
+
+    input_manager.simulate_action(InputAction.BACK)
+    assert screen_manager.current_screen is menu
+
+    menu.selected_index = 1
+    input_manager.simulate_action(InputAction.SELECT)
+    assert screen_manager.current_screen is home

--- a/yoyopy/ui/screens/__init__.py
+++ b/yoyopy/ui/screens/__init__.py
@@ -14,6 +14,7 @@ from yoyopy.ui.screens.base import Screen
 
 # Screen manager
 from yoyopy.ui.screens.manager import ScreenManager
+from yoyopy.ui.screens.router import NavigationRequest, ScreenRouter
 
 # Navigation screens
 from yoyopy.ui.screens.navigation import HomeScreen, MenuScreen
@@ -34,6 +35,8 @@ __all__ = [
     # Base & Manager
     'Screen',
     'ScreenManager',
+    'NavigationRequest',
+    'ScreenRouter',
     # Navigation
     'HomeScreen',
     'MenuScreen',

--- a/yoyopy/ui/screens/base.py
+++ b/yoyopy/ui/screens/base.py
@@ -10,10 +10,12 @@ from typing import Optional, Any, TYPE_CHECKING
 from loguru import logger
 
 from yoyopy.ui.display import Display
+from yoyopy.ui.screens.router import NavigationRequest
 
 if TYPE_CHECKING:
     from yoyopy.ui.screens.manager import ScreenManager
     from yoyopy.app_context import AppContext
+    from yoyopy.ui.input import InputAction
 
 
 class Screen(ABC):
@@ -42,15 +44,51 @@ class Screen(ABC):
         self.context = context
         self.name = name
         self.screen_manager: Optional['ScreenManager'] = None
+        self.route_name: Optional[str] = None
+        self._pending_navigation: Optional[NavigationRequest] = None
         logger.debug(f"Screen '{name}' initialized")
 
     def set_screen_manager(self, manager: 'ScreenManager') -> None:
         """Set the screen manager for navigation."""
         self.screen_manager = manager
 
+    def set_route_name(self, route_name: str) -> None:
+        """Set the registered route name for this screen."""
+        self.route_name = route_name
+
     def set_context(self, context: 'AppContext') -> None:
         """Set the application context."""
         self.context = context
+
+    def request_navigation(self, request: NavigationRequest) -> None:
+        """Queue a navigation request for the screen manager to resolve."""
+        self._pending_navigation = request
+
+    def request_route(self, route_name: str, payload: Optional[Any] = None) -> None:
+        """Request navigation via the declarative router."""
+        self.request_navigation(NavigationRequest.route(route_name, payload=payload))
+
+    def request_push(self, target: str) -> None:
+        """Request a direct push transition."""
+        self.request_navigation(NavigationRequest.push(target))
+
+    def request_pop(self) -> None:
+        """Request a stack pop."""
+        self.request_navigation(NavigationRequest.pop())
+
+    def consume_navigation_request(self) -> Optional[NavigationRequest]:
+        """Return and clear the current pending navigation request."""
+        request = self._pending_navigation
+        self._pending_navigation = None
+        return request
+
+    def handle_action(self, action: "InputAction", data: Optional[Any] = None) -> None:
+        """Dispatch a semantic input action to the matching handler method."""
+        handler = getattr(self, f"on_{action.value}", None)
+        if handler is None:
+            logger.debug(f"Screen '{self.name}' does not handle {action.value}")
+            return
+        handler(data)
 
     @abstractmethod
     def render(self) -> None:

--- a/yoyopy/ui/screens/manager.py
+++ b/yoyopy/ui/screens/manager.py
@@ -1,14 +1,15 @@
 """
 Screen management and navigation for YoyoPod.
 
-Handles screen transitions and the navigation stack.
+Handles screen transitions, route resolution, and the navigation stack.
 """
 
-from typing import Optional, Dict, Type, TYPE_CHECKING
+from typing import Optional, Dict, TYPE_CHECKING
 from loguru import logger
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.router import NavigationRequest, ScreenRouter
 
 # Import InputManager from new input HAL
 if TYPE_CHECKING:
@@ -30,7 +31,12 @@ class ScreenManager:
     handles screen lifecycle (enter/exit).
     """
 
-    def __init__(self, display: Display, input_manager: Optional['InputManager'] = None) -> None:
+    def __init__(
+        self,
+        display: Display,
+        input_manager: Optional['InputManager'] = None,
+        router: Optional[ScreenRouter] = None,
+    ) -> None:
         """
         Initialize the screen manager.
 
@@ -43,6 +49,7 @@ class ScreenManager:
         self.current_screen: Optional[Screen] = None
         self.screen_stack: list[Screen] = []
         self.screens: Dict[str, Screen] = {}
+        self.router = router or ScreenRouter()
 
         logger.info("ScreenManager initialized")
 
@@ -56,6 +63,7 @@ class ScreenManager:
         """
         self.screens[name] = screen
         screen.set_screen_manager(self)
+        screen.set_route_name(name)
         logger.debug(f"Registered screen: {name}")
 
     def push_screen(self, screen_name: str) -> None:
@@ -146,6 +154,37 @@ class ScreenManager:
         if self.current_screen:
             self.current_screen.render()
 
+    def apply_navigation_request(
+        self,
+        request: NavigationRequest,
+        source_screen: Optional[Screen] = None,
+    ) -> bool:
+        """Apply a direct or routed navigation request."""
+        resolved_request = request
+        if request.operation == "route":
+            if source_screen is None or source_screen.route_name is None:
+                logger.warning("Cannot resolve route without a source screen")
+                return False
+            resolved_request = self.router.resolve(
+                source_screen.route_name,
+                request.route_name or "",
+                payload=request.payload,
+            )
+            if resolved_request is None:
+                return False
+
+        if resolved_request.operation == "push" and resolved_request.target:
+            self.push_screen(resolved_request.target)
+            return True
+        if resolved_request.operation == "replace" and resolved_request.target:
+            self.replace_screen(resolved_request.target)
+            return True
+        if resolved_request.operation == "pop":
+            return self.pop_screen()
+
+        logger.warning(f"Unsupported navigation request: {resolved_request}")
+        return False
+
     def _connect_inputs(self) -> None:
         """Connect input action handlers for the current screen."""
         if not self.current_screen:
@@ -161,44 +200,24 @@ class ScreenManager:
             logger.warning("InputAction not available - cannot connect inputs")
             return
 
-        # Helper function to wrap action handlers with auto-refresh
-        def wrap_with_refresh(handler):
+        # Helper function to dispatch an action and then refresh or route
+        def wrap_with_refresh(action: "InputAction"):
             """Wrap action handler to automatically refresh display after execution."""
             def wrapper(data=None):
                 previous_screen = self.current_screen
-                handler(data)
+                if previous_screen is None:
+                    return
+
+                previous_screen.handle_action(action, data)
+                navigation_request = previous_screen.consume_navigation_request()
+                if navigation_request is not None:
+                    self.apply_navigation_request(navigation_request, source_screen=previous_screen)
                 if self.current_screen is previous_screen:
                     self.refresh_current_screen()
             return wrapper
 
-        # Register semantic action callbacks with input manager
-        # These are hardware-independent actions that screens understand
-        # Each callback is wrapped to auto-refresh the display after execution
-        self.input_manager.on_action(InputAction.SELECT, wrap_with_refresh(self.current_screen.on_select))
-        self.input_manager.on_action(InputAction.BACK, wrap_with_refresh(self.current_screen.on_back))
-        self.input_manager.on_action(InputAction.UP, wrap_with_refresh(self.current_screen.on_up))
-        self.input_manager.on_action(InputAction.DOWN, wrap_with_refresh(self.current_screen.on_down))
-        self.input_manager.on_action(InputAction.LEFT, wrap_with_refresh(self.current_screen.on_left))
-        self.input_manager.on_action(InputAction.RIGHT, wrap_with_refresh(self.current_screen.on_right))
-        self.input_manager.on_action(InputAction.MENU, wrap_with_refresh(self.current_screen.on_menu))
-        self.input_manager.on_action(InputAction.HOME, wrap_with_refresh(self.current_screen.on_home))
-
-        # Playback actions
-        self.input_manager.on_action(InputAction.PLAY_PAUSE, wrap_with_refresh(self.current_screen.on_play_pause))
-        self.input_manager.on_action(InputAction.NEXT_TRACK, wrap_with_refresh(self.current_screen.on_next_track))
-        self.input_manager.on_action(InputAction.PREV_TRACK, wrap_with_refresh(self.current_screen.on_prev_track))
-
-        # VoIP actions
-        self.input_manager.on_action(InputAction.CALL_ANSWER, wrap_with_refresh(self.current_screen.on_call_answer))
-        self.input_manager.on_action(InputAction.CALL_REJECT, wrap_with_refresh(self.current_screen.on_call_reject))
-        self.input_manager.on_action(InputAction.CALL_HANGUP, wrap_with_refresh(self.current_screen.on_call_hangup))
-
-        # PTT actions
-        self.input_manager.on_action(InputAction.PTT_PRESS, wrap_with_refresh(self.current_screen.on_ptt_press))
-        self.input_manager.on_action(InputAction.PTT_RELEASE, wrap_with_refresh(self.current_screen.on_ptt_release))
-
-        # Voice actions
-        self.input_manager.on_action(InputAction.VOICE_COMMAND, wrap_with_refresh(self.current_screen.on_voice_command))
+        for action in InputAction:
+            self.input_manager.on_action(action, wrap_with_refresh(action))
 
         logger.debug(f"Connected input actions for {self.current_screen.name}")
 

--- a/yoyopy/ui/screens/music/now_playing.py
+++ b/yoyopy/ui/screens/music/now_playing.py
@@ -249,8 +249,7 @@ class NowPlayingScreen(Screen):
 
     def on_back(self, data=None) -> None:
         """Go back to the previous screen."""
-        if self.screen_manager:
-            self.screen_manager.pop_screen()
+        self.request_route("back")
 
     def on_up(self, data=None) -> None:
         """Go to the previous track."""

--- a/yoyopy/ui/screens/music/playlist.py
+++ b/yoyopy/ui/screens/music/playlist.py
@@ -335,9 +335,7 @@ class PlaylistScreen(Screen):
         try:
             if self.mopidy_client.load_playlist(playlist.uri):
                 logger.info(f"Successfully loaded playlist: {playlist.name}")
-                # Navigate to now playing screen
-                if self.screen_manager:
-                    self.screen_manager.push_screen("now_playing")
+                self.request_route("playlist_loaded")
             else:
                 logger.error(f"Failed to load playlist: {playlist.name}")
                 self.error_message = "Failed to load"
@@ -353,8 +351,7 @@ class PlaylistScreen(Screen):
 
     def on_back(self, data=None) -> None:
         """Go back to the previous screen."""
-        if self.screen_manager:
-            self.screen_manager.pop_screen()
+        self.request_route("back")
 
     def on_up(self, data=None) -> None:
         """Move selection up."""

--- a/yoyopy/ui/screens/navigation/home.py
+++ b/yoyopy/ui/screens/navigation/home.py
@@ -99,6 +99,5 @@ class HomeScreen(Screen):
 
     def on_select(self, data=None) -> None:
         """Open the main menu."""
-        if self.screen_manager:
-            self.screen_manager.push_screen("menu")
+        self.request_route("select")
 

--- a/yoyopy/ui/screens/navigation/menu.py
+++ b/yoyopy/ui/screens/navigation/menu.py
@@ -145,24 +145,14 @@ class MenuScreen(Screen):
         """Select the current item."""
         selected_item = self.get_selected()
         logger.info(f"Menu item selected: {selected_item}")
-
-        # Navigate to appropriate screen based on selection
-        if self.screen_manager:
-            if selected_item == "Music" or selected_item == "Podcasts" or selected_item == "Audiobooks":
-                self.screen_manager.push_screen("now_playing")
-            elif selected_item == "Browse Playlists" or selected_item == "Playlists":
-                self.screen_manager.push_screen("playlists")
-            elif selected_item == "Call Parent" or selected_item == "Call" or selected_item == "Call Contact":
-                self.screen_manager.push_screen("contacts")
-            elif selected_item == "VoIP Status":
-                self.screen_manager.push_screen("call")
-            elif selected_item == "Settings":
-                logger.info("Settings not implemented yet")
+        if selected_item == "Settings":
+            logger.info("Settings not implemented yet")
+            return
+        self.request_route("select", payload=selected_item)
 
     def on_back(self, data=None) -> None:
         """Go back to the previous screen."""
-        if self.screen_manager:
-            self.screen_manager.pop_screen()
+        self.request_route("back")
 
     def on_up(self, data=None) -> None:
         """Move selection up."""

--- a/yoyopy/ui/screens/router.py
+++ b/yoyopy/ui/screens/router.py
@@ -1,0 +1,117 @@
+"""
+Declarative screen routing for YoyoPod.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from loguru import logger
+
+
+@dataclass(frozen=True, slots=True)
+class NavigationRequest:
+    """Represents a pending navigation request emitted by a screen."""
+
+    operation: str
+    target: Optional[str] = None
+    route_name: Optional[str] = None
+    payload: Optional[Any] = None
+
+    @classmethod
+    def push(cls, target: str) -> "NavigationRequest":
+        return cls(operation="push", target=target)
+
+    @classmethod
+    def pop(cls) -> "NavigationRequest":
+        return cls(operation="pop")
+
+    @classmethod
+    def replace(cls, target: str) -> "NavigationRequest":
+        return cls(operation="replace", target=target)
+
+    @classmethod
+    def route(cls, route_name: str, payload: Optional[Any] = None) -> "NavigationRequest":
+        return cls(operation="route", route_name=route_name, payload=payload)
+
+
+class ScreenRouter:
+    """Resolve route names into concrete screen-stack navigation operations."""
+
+    def __init__(self, routes: Optional[Dict[str, Dict[str, NavigationRequest]]] = None) -> None:
+        self.routes = routes or self._default_routes()
+
+    def resolve(
+        self,
+        screen_name: str,
+        route_name: str,
+        payload: Optional[Any] = None,
+    ) -> Optional[NavigationRequest]:
+        """Resolve a named route from a screen into a concrete navigation request."""
+        screen_routes = self.routes.get(screen_name, {})
+        route_key = self._route_key(route_name, payload)
+
+        if route_key in screen_routes:
+            return screen_routes[route_key]
+
+        if route_name in screen_routes:
+            return screen_routes[route_name]
+
+        logger.warning(f"No route found for {screen_name}.{route_key}")
+        return None
+
+    def _default_routes(self) -> Dict[str, Dict[str, NavigationRequest]]:
+        """Return the default route map for current YoyoPod screens."""
+        return {
+            "home": {
+                "select": NavigationRequest.push("menu"),
+            },
+            "menu": {
+                "back": NavigationRequest.pop(),
+                "select:Back": NavigationRequest.pop(),
+                "select:Load Playlist": NavigationRequest.push("playlists"),
+                "select:Music": NavigationRequest.push("now_playing"),
+                "select:Podcasts": NavigationRequest.push("now_playing"),
+                "select:Audiobooks": NavigationRequest.push("now_playing"),
+                "select:Now Playing": NavigationRequest.push("now_playing"),
+                "select:Browse Playlists": NavigationRequest.push("playlists"),
+                "select:Playlists": NavigationRequest.push("playlists"),
+                "select:VoIP Status": NavigationRequest.push("call"),
+                "select:Call Parent": NavigationRequest.push("contacts"),
+                "select:Call": NavigationRequest.push("contacts"),
+                "select:Call Contact": NavigationRequest.push("contacts"),
+                "select:Contacts": NavigationRequest.push("contacts"),
+            },
+            "now_playing": {
+                "back": NavigationRequest.pop(),
+            },
+            "playlists": {
+                "back": NavigationRequest.pop(),
+                "playlist_loaded": NavigationRequest.push("now_playing"),
+            },
+            "call": {
+                "back": NavigationRequest.pop(),
+            },
+            "contacts": {
+                "back": NavigationRequest.pop(),
+                "call_started": NavigationRequest.push("outgoing_call"),
+            },
+            "incoming_call": {
+                "call_answered": NavigationRequest.push("in_call"),
+                "call_rejected": NavigationRequest.pop(),
+            },
+            "in_call": {
+                "call_hangup": NavigationRequest.pop(),
+            },
+            "outgoing_call": {
+                "call_hangup": NavigationRequest.pop(),
+            },
+        }
+
+    @staticmethod
+    def _route_key(route_name: str, payload: Optional[Any]) -> str:
+        """Create a lookup key for payload-sensitive routes."""
+        if payload is None:
+            return route_name
+        return f"{route_name}:{payload}"

--- a/yoyopy/ui/screens/voip/call.py
+++ b/yoyopy/ui/screens/voip/call.py
@@ -198,8 +198,7 @@ class CallScreen(Screen):
 
     def on_back(self, data=None) -> None:
         """Go back to the previous screen."""
-        if self.screen_manager:
-            self.screen_manager.pop_screen()
+        self.request_route("back")
 
     def on_up(self, data=None) -> None:
         """Reserved for dial pad."""

--- a/yoyopy/ui/screens/voip/contact_list.py
+++ b/yoyopy/ui/screens/voip/contact_list.py
@@ -263,9 +263,7 @@ class ContactListScreen(Screen):
         # Make the call with contact name
         if self.voip_manager.make_call(contact.sip_address, contact_name=contact.name):
             logger.info(f"Call initiated to {contact.name}")
-            # Navigate to outgoing call screen
-            if self.screen_manager:
-                self.screen_manager.push_screen("outgoing_call")
+            self.request_route("call_started")
         else:
             logger.error(f"Failed to initiate call to {contact.name}")
 
@@ -275,8 +273,7 @@ class ContactListScreen(Screen):
 
     def on_back(self, data=None) -> None:
         """Go back to the previous screen."""
-        if self.screen_manager:
-            self.screen_manager.pop_screen()
+        self.request_route("back")
 
     def on_up(self, data=None) -> None:
         """Move selection up."""

--- a/yoyopy/ui/screens/voip/in_call.py
+++ b/yoyopy/ui/screens/voip/in_call.py
@@ -224,8 +224,7 @@ class InCallScreen(Screen):
         if self.voip_manager:
             if self.voip_manager.hangup():
                 logger.info("Call ended, going back")
-                if self.screen_manager:
-                    self.screen_manager.pop_screen()
+                self.request_route("call_hangup")
             else:
                 logger.error("Failed to end call")
 

--- a/yoyopy/ui/screens/voip/incoming_call.py
+++ b/yoyopy/ui/screens/voip/incoming_call.py
@@ -196,8 +196,7 @@ class IncomingCallScreen(Screen):
         if self.voip_manager:
             if self.voip_manager.answer_call():
                 logger.info("Call answered, transitioning to InCall screen")
-                if self.screen_manager:
-                    self.screen_manager.push_screen("in_call")
+                self.request_route("call_answered")
             else:
                 logger.error("Failed to answer call")
 
@@ -207,8 +206,7 @@ class IncomingCallScreen(Screen):
         if self.voip_manager:
             if self.voip_manager.reject_call():
                 logger.info("Call rejected, going back")
-                if self.screen_manager:
-                    self.screen_manager.pop_screen()
+                self.request_route("call_rejected")
             else:
                 logger.error("Failed to reject call")
 

--- a/yoyopy/ui/screens/voip/outgoing_call.py
+++ b/yoyopy/ui/screens/voip/outgoing_call.py
@@ -218,8 +218,7 @@ class OutgoingCallScreen(Screen):
         if self.voip_manager:
             if self.voip_manager.hangup():
                 logger.info("Call canceled, going back")
-                if self.screen_manager:
-                    self.screen_manager.pop_screen()
+                self.request_route("call_hangup")
             else:
                 logger.error("Failed to cancel call")
 


### PR DESCRIPTION
## Summary
- add a declarative screen router and screen-level navigation requests
- route semantic input through Screen.handle_action instead of per-action manager wiring
- convert screens to emit navigation intents and cover the new paths with routing tests

## Testing
- python -m compileall yoyopy tests
- uv run pytest -q