### PR TITLE
Phase 3a typed VoIP backend

### DIFF
--- a/tests/test_voip_backend.py
+++ b/tests/test_voip_backend.py
@@ -1,0 +1,118 @@
+"""Unit tests for the VoIP backend abstraction and manager facade."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from yoyopy.connectivity import (
+    CallState,
+    CallStateChanged,
+    IncomingCallDetected,
+    LinphonecBackend,
+    MockVoIPBackend,
+    RegistrationState,
+    RegistrationStateChanged,
+    VoIPConfig,
+    VoIPManager,
+)
+
+
+class FakeConfigManager:
+    """Minimal contact lookup double for VoIP manager tests."""
+
+    def __init__(self, contacts: dict[str, str] | None = None) -> None:
+        self.contacts = contacts or {}
+
+    def get_contact_by_address(self, sip_address: str):
+        """Return a fake contact object when the address is known."""
+
+        contact_name = self.contacts.get(sip_address)
+        if contact_name is None:
+            return None
+        return SimpleNamespace(name=contact_name)
+
+
+def build_config() -> VoIPConfig:
+    """Create a small test configuration."""
+
+    return VoIPConfig(
+        sip_server="sip.example.com",
+        sip_username="alice",
+        sip_password_ha1="hash",
+        sip_identity="sip:alice@sip.example.com",
+        linphonec_path="/usr/bin/linphonec",
+    )
+
+
+def test_linphone_backend_parses_registration_and_incoming_call_events() -> None:
+    """The Linphone backend should translate stdout lines into typed events."""
+
+    backend = LinphonecBackend(build_config())
+
+    assert backend._parse_output_line("LinphoneRegistrationOk, reason none") == [
+        RegistrationStateChanged(state=RegistrationState.OK)
+    ]
+    assert backend._parse_output_line("New incoming call from [sip:parent@example.com]") == [
+        CallStateChanged(state=CallState.INCOMING),
+        IncomingCallDetected(caller_address="sip:parent@example.com"),
+    ]
+
+
+def test_voip_manager_applies_backend_events_and_resolves_contact_names() -> None:
+    """VoIPManager should stay app-facing while backend events remain typed and low-level."""
+
+    backend = MockVoIPBackend()
+    config_manager = FakeConfigManager({"sip:parent@example.com": "Parent"})
+    manager = VoIPManager(build_config(), config_manager=config_manager, backend=backend)
+
+    registration_states: list[RegistrationState] = []
+    call_states: list[CallState] = []
+    incoming_calls: list[tuple[str, str]] = []
+
+    manager.on_registration_change(registration_states.append)
+    manager.on_call_state_change(call_states.append)
+    manager.on_incoming_call(lambda address, name: incoming_calls.append((address, name)))
+
+    assert manager.start()
+
+    backend.emit(RegistrationStateChanged(state=RegistrationState.OK))
+    backend.emit(CallStateChanged(state=CallState.INCOMING))
+    backend.emit(IncomingCallDetected(caller_address="sip:parent@example.com"))
+
+    assert manager.registered
+    assert registration_states == [RegistrationState.OK]
+    assert call_states == [CallState.INCOMING]
+    assert incoming_calls == [("sip:parent@example.com", "Parent")]
+    assert manager.get_caller_info()["display_name"] == "Parent"
+
+
+def test_voip_manager_delegates_outgoing_commands_to_backend() -> None:
+    """Outgoing call commands should be delegated through the backend boundary."""
+
+    backend = MockVoIPBackend()
+    manager = VoIPManager(build_config(), backend=backend)
+
+    backend.emit(RegistrationStateChanged(state=RegistrationState.OK))
+
+    assert manager.make_call("sip:bob@example.com", contact_name="Bob")
+    assert backend.commands == ["call sip:bob@example.com"]
+    assert manager.get_caller_info()["display_name"] == "Bob"
+
+
+def test_voip_manager_resets_call_state_after_release() -> None:
+    """Releasing a call should stop timers and clear caller metadata."""
+
+    backend = MockVoIPBackend()
+    manager = VoIPManager(build_config(), backend=backend)
+    manager.caller_address = "sip:bob@example.com"
+    manager.caller_name = "Bob"
+
+    backend.emit(CallStateChanged(state=CallState.CONNECTED))
+    assert manager.call_start_time is not None
+
+    backend.emit(CallStateChanged(state=CallState.RELEASED))
+
+    assert manager.call_state == CallState.RELEASED
+    assert manager.call_start_time is None
+    assert manager.call_duration == 0
+    assert manager.get_caller_info()["display_name"] == "Unknown"

--- a/yoyopy/connectivity/__init__.py
+++ b/yoyopy/connectivity/__init__.py
@@ -3,16 +3,34 @@ Connectivity module for YoyoPod.
 Manages 4G/LTE connection, WiFi fallback, network status, and VoIP calling.
 """
 
-from yoyopy.connectivity.voip_manager import (
-    VoIPManager,
-    VoIPConfig,
+from yoyopy.connectivity.voip_backend import (
+    LinphonecBackend,
+    MockVoIPBackend,
+    VoIPBackend,
+)
+from yoyopy.connectivity.voip_manager import VoIPManager
+from yoyopy.connectivity.voip_types import (
+    BackendStopped,
+    CallState,
+    CallStateChanged,
+    IncomingCallDetected,
     RegistrationState,
-    CallState
+    RegistrationStateChanged,
+    VoIPConfig,
+    VoIPEvent,
 )
 
 __all__ = [
-    'VoIPManager',
-    'VoIPConfig',
-    'RegistrationState',
-    'CallState'
+    "VoIPManager",
+    "VoIPBackend",
+    "LinphonecBackend",
+    "MockVoIPBackend",
+    "VoIPConfig",
+    "RegistrationState",
+    "CallState",
+    "RegistrationStateChanged",
+    "CallStateChanged",
+    "IncomingCallDetected",
+    "BackendStopped",
+    "VoIPEvent",
 ]

--- a/yoyopy/connectivity/voip_backend.py
+++ b/yoyopy/connectivity/voip_backend.py
@@ -1,0 +1,473 @@
+"""VoIP backend protocol and Linphone-backed implementation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+import time
+from typing import Callable, Optional, Protocol
+
+from loguru import logger
+
+from yoyopy.connectivity.voip_types import (
+    BackendStopped,
+    CallState,
+    CallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged,
+    VoIPConfig,
+    VoIPEvent,
+)
+
+
+class VoIPBackend(Protocol):
+    """Backend contract for SIP implementations used by VoIPManager."""
+
+    def start(self) -> bool:
+        """Start the backend process and begin emitting events."""
+
+    def stop(self) -> None:
+        """Stop the backend and release any resources."""
+
+    def make_call(self, sip_address: str) -> bool:
+        """Initiate an outgoing call."""
+
+    def answer_call(self) -> bool:
+        """Answer the current incoming call."""
+
+    def reject_call(self) -> bool:
+        """Reject the current incoming call."""
+
+    def hangup(self) -> bool:
+        """Terminate the current call."""
+
+    def mute(self) -> bool:
+        """Mute the current call microphone."""
+
+    def unmute(self) -> bool:
+        """Unmute the current call microphone."""
+
+    def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
+        """Register a typed backend-event listener."""
+
+
+class LinphonecBackend:
+    """Production VoIP backend that drives the linphonec subprocess."""
+
+    def __init__(self, config: VoIPConfig) -> None:
+        self.config = config
+        self.process: Optional[subprocess.Popen] = None
+        self.running = False
+        self.monitor_thread: Optional[threading.Thread] = None
+        self.event_callbacks: list[Callable[[VoIPEvent], None]] = []
+
+    def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
+        """Register a backend event callback."""
+
+        self.event_callbacks.append(callback)
+
+    def start(self) -> bool:
+        """Start linphonec and begin monitoring its output."""
+
+        if self.running:
+            logger.warning("Linphone backend already running")
+            return True
+
+        try:
+            if not self._generate_linphonerc():
+                logger.warning(
+                    "Failed to generate .linphonerc, attempting to use existing Linphone config"
+                )
+
+            logger.info("Starting linphonec backend...")
+            self.process = subprocess.Popen(
+                [self.config.linphonec_path, "-d", "6"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+            self.running = True
+            self.monitor_thread = threading.Thread(target=self._monitor_output, daemon=True)
+            self.monitor_thread.start()
+
+            time.sleep(2)
+            self._send_command("status register")
+            logger.info("Linphone backend started successfully")
+            return True
+        except Exception as exc:
+            logger.error(f"Failed to start linphone backend: {exc}")
+            self.running = False
+            if self.process is not None:
+                try:
+                    self.process.terminate()
+                    self.process.wait(timeout=1)
+                except Exception:
+                    pass
+                finally:
+                    self.process = None
+            return False
+
+    def stop(self) -> None:
+        """Stop the linphonec backend."""
+
+        self.running = False
+
+        if self.process is not None:
+            try:
+                self._send_command("quit")
+                self.process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.process.terminate()
+                self.process.wait(timeout=1)
+            except Exception as exc:
+                logger.error(f"Error stopping linphone backend: {exc}")
+            finally:
+                self.process = None
+
+        if self.monitor_thread is not None:
+            self.monitor_thread.join(timeout=2)
+            self.monitor_thread = None
+
+    def make_call(self, sip_address: str) -> bool:
+        """Initiate an outgoing call through linphonec."""
+
+        return self._send_command(f"call {sip_address}")
+
+    def answer_call(self) -> bool:
+        """Answer the current call."""
+
+        return self._send_command("answer")
+
+    def reject_call(self) -> bool:
+        """Reject the current incoming call."""
+
+        return self._send_command("decline")
+
+    def hangup(self) -> bool:
+        """Terminate the current call."""
+
+        return self._send_command("terminate")
+
+    def mute(self) -> bool:
+        """Mute the current call."""
+
+        return self._send_command("mute")
+
+    def unmute(self) -> bool:
+        """Unmute the current call."""
+
+        return self._send_command("unmute")
+
+    def _emit(self, event: VoIPEvent) -> None:
+        """Publish a typed event to registered backend listeners."""
+
+        for callback in self.event_callbacks:
+            try:
+                callback(event)
+            except Exception as exc:
+                logger.error(f"Error in VoIP backend callback: {exc}")
+
+    def _monitor_output(self) -> None:
+        """Monitor linphonec output and emit typed backend events."""
+
+        logger.debug("Linphone backend output monitor started")
+
+        while self.running and self.process is not None:
+            try:
+                if self.process.stdout is None:
+                    break
+
+                line = self.process.stdout.readline()
+                if not line:
+                    if self.running and self.process.poll() is not None:
+                        logger.warning("Linphone backend process terminated")
+                        self.running = False
+                        self._emit(BackendStopped(reason="process_terminated"))
+                        break
+                    continue
+
+                line = line.strip()
+                if not line:
+                    continue
+
+                for event in self._parse_output_line(line):
+                    self._emit(event)
+            except Exception as exc:
+                logger.error(f"Error monitoring linphone output: {exc}")
+                break
+
+        logger.debug("Linphone backend output monitor stopped")
+
+    def _parse_output_line(self, line: str) -> list[VoIPEvent]:
+        """Parse one linphonec output line into typed events."""
+
+        logger.debug(f"Linphone: {line}")
+        events: list[VoIPEvent] = []
+
+        registration_state = self._match_registration_state(line)
+        if registration_state is not None:
+            events.append(RegistrationStateChanged(state=registration_state))
+
+        line_lower = line.lower()
+        if "call" not in line_lower and "callsession" not in line_lower:
+            return events
+
+        caller_address = self._extract_caller_address(line)
+        if "LinphoneCallIncoming" in line or "incoming" in line_lower:
+            events.append(CallStateChanged(state=CallState.INCOMING))
+            if caller_address:
+                events.append(IncomingCallDetected(caller_address=caller_address))
+        elif "outgoing" in line_lower:
+            events.append(CallStateChanged(state=CallState.OUTGOING))
+        elif (
+            "connected" in line_lower
+            or "streams running" in line_lower
+            or "LinphoneCallConnected" in line
+        ):
+            events.append(CallStateChanged(state=CallState.CONNECTED))
+        elif (
+            "released" in line_lower
+            or "ended" in line_lower
+            or "LinphoneCallReleased" in line
+        ):
+            events.append(CallStateChanged(state=CallState.RELEASED))
+
+        return events
+
+    def _match_registration_state(self, line: str) -> Optional[RegistrationState]:
+        """Match a linphone output line to a registration state."""
+
+        if "Registration on" in line and "successful" in line:
+            return RegistrationState.OK
+        if "Registration on" in line and "failed" in line:
+            return RegistrationState.FAILED
+        if "Registration on" in line and "cleared" in line:
+            return RegistrationState.CLEARED
+        if "LinphoneRegistrationOk" in line or (
+            "Registration successful" in line and "reason" in line
+        ):
+            return RegistrationState.OK
+        if "LinphoneRegistrationProgress" in line:
+            return RegistrationState.PROGRESS
+        if "LinphoneRegistrationFailed" in line or (
+            "Registration failed" in line and "reason" in line
+        ):
+            return RegistrationState.FAILED
+        if "LinphoneRegistrationCleared" in line:
+            return RegistrationState.CLEARED
+        return None
+
+    def _extract_caller_address(self, line: str) -> Optional[str]:
+        """Extract a SIP caller address from a linphone output line."""
+
+        if "[sip:" in line:
+            start = line.find("[sip:")
+            end = line.find("]", start)
+            if start != -1 and end != -1:
+                return line[start + 1:end]
+
+        if "<sip:" in line:
+            start = line.find("<sip:")
+            end = line.find(">", start)
+            if start != -1 and end != -1:
+                return line[start + 1:end]
+
+        line_lower = line.lower()
+        if "from" not in line_lower or "sip:" not in line_lower:
+            return None
+
+        from_index = line_lower.find("from")
+        if from_index == -1:
+            return None
+
+        after_from = line[from_index + len("from") :].strip()
+        sip_index = after_from.lower().find("sip:")
+        if sip_index == -1:
+            return None
+
+        candidate = after_from[sip_index:]
+        end_pos = len(candidate)
+        for marker in (" ", ",", "\t", "\n"):
+            pos = candidate.find(marker)
+            if pos != -1:
+                end_pos = min(end_pos, pos)
+        return candidate[:end_pos]
+
+    def _generate_linphonerc(self) -> bool:
+        """Generate the runtime linphonerc from the configured SIP settings."""
+
+        if not self.config.sip_password_ha1 or not self.config.sip_identity:
+            logger.warning("Cannot generate .linphonerc: missing HA1 hash or identity")
+            return False
+
+        try:
+            linphonerc_path = os.path.expanduser("~/.linphonerc")
+            config_content = f"""# Generated by YoyoPod LinphonecBackend
+[sip]
+sip_port=-1
+sip_tcp_port=-1
+sip_tls_port=-1
+default_proxy=0
+register_only_when_network_is_up=1
+register_only_when_upnp_is_ok=0
+guess_hostname=1
+inc_timeout=30
+in_call_timeout=0
+delayed_timeout=4
+use_info=0
+use_rfc2833=1
+use_ipv6=0
+record_aware=0
+media_encryption=srtp
+
+[auth_info_0]
+username={self.config.sip_username}
+userid={self.config.sip_username}
+ha1={self.config.sip_password_ha1}
+realm={self.config.sip_server}
+domain={self.config.sip_server}
+algorithm=SHA-256
+available_algorithms=SHA-256
+
+[proxy_0]
+reg_proxy=<sip:{self.config.sip_server};transport={self.config.transport}>
+reg_identity={self.config.sip_identity}
+reg_expires=3600
+reg_sendregister=1
+publish=0
+dial_escape_plus=0
+nat_policy_ref=ice_nat_policy
+
+[nat_policy_0]
+ref=ice_nat_policy
+stun_server={self.config.stun_server if self.config.stun_server else 'stun.linphone.org'}
+ice_enabled=1
+turn_enabled=0
+upnp_enabled=0
+
+[rtp]
+audio_rtp_port=7076-7100
+video_rtp_port=9076-9100
+audio_jitt_comp=60
+video_jitt_comp=60
+nortp_timeout=30
+audio_adaptive_jitt_comp_enabled=1
+video_adaptive_jitt_comp_enabled=1
+
+[net]
+download_bw=380
+upload_bw=60
+adaptive_rate_control=1
+mtu=1300
+
+[sound]
+playback_dev_id={self.config.playback_dev_id}
+ringer_dev_id={self.config.ringer_dev_id}
+capture_dev_id={self.config.capture_dev_id}
+media_dev_id={self.config.media_dev_id}
+echocancellation=1
+mic_gain_db=10.0
+"""
+
+            with open(linphonerc_path, "w", encoding="utf-8") as handle:
+                handle.write(config_content)
+
+            logger.info(f"Generated .linphonerc at {linphonerc_path}")
+            return True
+        except Exception as exc:
+            logger.error(f"Failed to generate .linphonerc: {exc}")
+            return False
+
+    def _send_command(self, command: str) -> bool:
+        """Send a raw command to the linphonec process."""
+
+        if self.process is None or self.process.stdin is None:
+            logger.error("Cannot send command: linphone backend not running")
+            return False
+
+        try:
+            self.process.stdin.write(f"{command}\n")
+            self.process.stdin.flush()
+            logger.debug(f"Sent command: {command}")
+            return True
+        except Exception as exc:
+            logger.error(f"Failed to send command '{command}': {exc}")
+            return False
+
+
+class MockVoIPBackend:
+    """Simple in-memory backend used for fast unit tests."""
+
+    def __init__(self, start_result: bool = True) -> None:
+        self.start_result = start_result
+        self.running = False
+        self.commands: list[str] = []
+        self.event_callbacks: list[Callable[[VoIPEvent], None]] = []
+        self.make_call_result = True
+        self.answer_result = True
+        self.reject_result = True
+        self.hangup_result = True
+        self.mute_result = True
+        self.unmute_result = True
+
+    def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
+        """Register a backend event callback."""
+
+        self.event_callbacks.append(callback)
+
+    def emit(self, event: VoIPEvent) -> None:
+        """Emit a synthetic backend event to registered listeners."""
+
+        for callback in self.event_callbacks:
+            callback(event)
+
+    def start(self) -> bool:
+        """Mark the backend as started."""
+
+        self.running = self.start_result
+        return self.start_result
+
+    def stop(self) -> None:
+        """Mark the backend as stopped."""
+
+        self.running = False
+
+    def make_call(self, sip_address: str) -> bool:
+        """Record an outgoing call command."""
+
+        self.commands.append(f"call {sip_address}")
+        return self.make_call_result
+
+    def answer_call(self) -> bool:
+        """Record an answer command."""
+
+        self.commands.append("answer")
+        return self.answer_result
+
+    def reject_call(self) -> bool:
+        """Record a reject command."""
+
+        self.commands.append("decline")
+        return self.reject_result
+
+    def hangup(self) -> bool:
+        """Record a hangup command."""
+
+        self.commands.append("terminate")
+        return self.hangup_result
+
+    def mute(self) -> bool:
+        """Record a mute command."""
+
+        self.commands.append("mute")
+        return self.mute_result
+
+    def unmute(self) -> bool:
+        """Record an unmute command."""
+
+        self.commands.append("unmute")
+        return self.unmute_result

--- a/yoyopy/connectivity/voip_manager.py
+++ b/yoyopy/connectivity/voip_manager.py
@@ -1,735 +1,320 @@
-"""
-VoIP Manager for YoyoPod using Linphone.
+"""App-facing VoIP facade built on top of typed backend events."""
 
-Provides SIP/VoIP calling capability by interfacing with linphonec CLI.
-Handles registration, call management, and status monitoring.
-"""
+from __future__ import annotations
 
-import subprocess
 import threading
 import time
-from enum import Enum
-from typing import Optional, Callable, List
-from dataclasses import dataclass
+from typing import Callable, Optional
+
 from loguru import logger
 
-
-class RegistrationState(Enum):
-    """SIP registration states."""
-    NONE = "none"
-    PROGRESS = "progress"
-    OK = "ok"
-    CLEARED = "cleared"
-    FAILED = "failed"
-
-
-class CallState(Enum):
-    """Call states."""
-    IDLE = "idle"
-    INCOMING = "incoming"
-    OUTGOING = "outgoing_init"
-    OUTGOING_PROGRESS = "outgoing_progress"
-    OUTGOING_RINGING = "outgoing_ringing"
-    OUTGOING_EARLY_MEDIA = "outgoing_early_media"
-    CONNECTED = "connected"
-    STREAMS_RUNNING = "streams_running"
-    PAUSED = "paused"
-    PAUSED_BY_REMOTE = "paused_by_remote"
-    UPDATED_BY_REMOTE = "updated_by_remote"
-    RELEASED = "released"
-    ERROR = "error"
-    END = "end"
-
-
-@dataclass
-class VoIPConfig:
-    """VoIP configuration."""
-    sip_server: str = "sip.linphone.org"
-    sip_username: str = ""
-    sip_password: str = ""
-    sip_password_ha1: str = ""  # HA1 hash (SHA-256) for SIP authentication
-    sip_identity: str = ""  # sip:username@server
-    transport: str = "tcp"  # tcp, udp, tls
-    stun_server: str = ""
-    linphonec_path: str = "/usr/bin/linphonec"
-    playback_dev_id: str = "ALSA: plughw:1"
-    ringer_dev_id: str = "ALSA: plughw:1"
-    capture_dev_id: str = "ALSA: plughw:1"
-    media_dev_id: str = "ALSA: plughw:1"
-
-    @staticmethod
-    def from_config_manager(config_manager) -> 'VoIPConfig':
-        """
-        Create VoIPConfig from ConfigManager.
-
-        Args:
-            config_manager: ConfigManager instance
-
-        Returns:
-            VoIPConfig instance
-        """
-        return VoIPConfig(
-            sip_server=config_manager.get_sip_server(),
-            sip_username=config_manager.get_sip_username(),
-            sip_password=config_manager.get_sip_password(),
-            sip_password_ha1=config_manager.get_sip_password_ha1(),
-            sip_identity=config_manager.get_sip_identity(),
-            transport=config_manager.get_transport(),
-            stun_server=config_manager.get_stun_server(),
-            linphonec_path=config_manager.get_linphonec_path(),
-            playback_dev_id=config_manager.get_playback_device_id(),
-            ringer_dev_id=config_manager.get_ringer_device_id(),
-            capture_dev_id=config_manager.get_capture_device_id(),
-            media_dev_id=config_manager.get_media_device_id(),
-        )
+from yoyopy.connectivity.voip_backend import LinphonecBackend, VoIPBackend
+from yoyopy.connectivity.voip_types import (
+    BackendStopped,
+    CallState,
+    CallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged,
+    VoIPConfig,
+    VoIPEvent,
+)
 
 
 class VoIPManager:
-    """
-    VoIP Manager using Linphone CLI.
+    """Application-facing VoIP facade that delegates subprocess work to a backend."""
 
-    Manages SIP registration and call handling through linphonec subprocess.
-    """
-
-    def __init__(self, config: VoIPConfig, config_manager=None) -> None:
-        """
-        Initialize VoIP manager.
-
-        Args:
-            config: VoIP configuration
-            config_manager: Optional ConfigManager for contact name lookup
-        """
+    def __init__(
+        self,
+        config: VoIPConfig,
+        config_manager=None,
+        backend: Optional[VoIPBackend] = None,
+    ) -> None:
         self.config = config
-        self.config_manager = config_manager  # For contact lookup
-        self.process: Optional[subprocess.Popen] = None
+        self.config_manager = config_manager
+        self.backend = backend or LinphonecBackend(config)
         self.running = False
         self.registered = False
         self.registration_state = RegistrationState.NONE
         self.call_state = CallState.IDLE
         self.current_call_id: Optional[str] = None
-        self.caller_address: Optional[str] = None  # SIP address of caller/callee
-        self.caller_name: Optional[str] = None  # Display name of caller/callee
-        self.call_duration: int = 0  # Call duration in seconds
-        self.call_start_time: Optional[float] = None  # Time when call became active
-        self.is_muted: bool = False  # Microphone mute state
+        self.caller_address: Optional[str] = None
+        self.caller_name: Optional[str] = None
+        self.call_duration: int = 0
+        self.call_start_time: Optional[float] = None
+        self.is_muted = False
 
-        # Callbacks
-        self.registration_callbacks: List[Callable[[RegistrationState], None]] = []
-        self.call_state_callbacks: List[Callable[[CallState], None]] = []
-        self.incoming_call_callbacks: List[Callable[[str, str], None]] = []  # (address, name)
+        self.registration_callbacks: list[Callable[[RegistrationState], None]] = []
+        self.call_state_callbacks: list[Callable[[CallState], None]] = []
+        self.incoming_call_callbacks: list[Callable[[str, str], None]] = []
 
-        # Monitor thread
-        self.monitor_thread: Optional[threading.Thread] = None
-        self.monitor_event = threading.Event()
-
-        # Call duration tracking thread
         self.duration_thread: Optional[threading.Thread] = None
         self.duration_stop_event = threading.Event()
 
+        self.backend.on_event(self._handle_backend_event)
         logger.info(f"VoIPManager initialized (server: {config.sip_server})")
 
-    def _generate_linphonerc(self) -> bool:
-        """
-        Generate .linphonerc configuration file from config.
-
-        Returns:
-            True if generated successfully, False otherwise
-        """
-        if not self.config.sip_password_ha1 or not self.config.sip_identity:
-            logger.warning("Cannot generate .linphonerc: missing HA1 hash or identity")
-            return False
-
-        try:
-            import os
-            linphonerc_path = os.path.expanduser("~/.linphonerc")
-
-            # Linphonerc configuration
-            config_content = f"""# Generated by YoyoPod VoIPManager
-[sip]
-sip_port=-1
-sip_tcp_port=-1
-sip_tls_port=-1
-default_proxy=0
-register_only_when_network_is_up=1
-register_only_when_upnp_is_ok=0
-guess_hostname=1
-inc_timeout=30
-in_call_timeout=0
-delayed_timeout=4
-use_info=0
-use_rfc2833=1
-use_ipv6=0
-record_aware=0
-media_encryption=srtp
-
-[auth_info_0]
-username={self.config.sip_username}
-userid={self.config.sip_username}
-ha1={self.config.sip_password_ha1}
-realm={self.config.sip_server}
-domain={self.config.sip_server}
-algorithm=SHA-256
-available_algorithms=SHA-256
-
-[proxy_0]
-reg_proxy=<sip:{self.config.sip_server};transport={self.config.transport}>
-reg_identity={self.config.sip_identity}
-reg_expires=3600
-reg_sendregister=1
-publish=0
-dial_escape_plus=0
-nat_policy_ref=ice_nat_policy
-
-[nat_policy_0]
-ref=ice_nat_policy
-stun_server={self.config.stun_server if self.config.stun_server else 'stun.linphone.org'}
-ice_enabled=1
-turn_enabled=0
-upnp_enabled=0
-
-[rtp]
-audio_rtp_port=7076-7100
-video_rtp_port=9076-9100
-audio_jitt_comp=60
-video_jitt_comp=60
-nortp_timeout=30
-audio_adaptive_jitt_comp_enabled=1
-video_adaptive_jitt_comp_enabled=1
-
-[net]
-download_bw=380
-upload_bw=60
-adaptive_rate_control=1
-mtu=1300
-
-[sound]
-playback_dev_id={self.config.playback_dev_id}
-ringer_dev_id={self.config.ringer_dev_id}
-capture_dev_id={self.config.capture_dev_id}
-media_dev_id={self.config.media_dev_id}
-echocancellation=1
-mic_gain_db=10.0
-"""
-
-            with open(linphonerc_path, 'w') as f:
-                f.write(config_content)
-
-            logger.info(f"Generated .linphonerc at {linphonerc_path}")
-            return True
-
-        except Exception as e:
-            logger.error(f"Failed to generate .linphonerc: {e}")
-            return False
-
     def start(self) -> bool:
-        """
-        Start linphonec process and begin monitoring.
+        """Start the configured VoIP backend."""
 
-        Returns:
-            True if started successfully, False otherwise
-        """
         if self.running:
             logger.warning("VoIP manager already running")
             return True
 
-        try:
-            # Generate .linphonerc configuration file
-            if not self._generate_linphonerc():
-                logger.warning("Failed to generate .linphonerc, will try to use existing configuration")
-
-            logger.info("Starting linphonec...")
-
-            # Start linphonec in daemon mode with pipe interface
-            self.process = subprocess.Popen(
-                [self.config.linphonec_path, "-d", "6"],  # -d 6 = debug level
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                bufsize=1
-            )
-
-            self.running = True
-
-            # Start monitor thread
-            self.monitor_thread = threading.Thread(
-                target=self._monitor_output,
-                daemon=True
-            )
-            self.monitor_thread.start()
-
-            logger.info("Linphonec started successfully")
-
-            # Give it a moment to initialize
-            time.sleep(2)
-
-            # Check registration status
-            self._send_command("status register")
-
-            return True
-
-        except Exception as e:
-            logger.error(f"Failed to start linphonec: {e}")
-            self.running = False
-            return False
+        self.running = self.backend.start()
+        return self.running
 
     def stop(self) -> None:
-        """Stop linphonec process and monitoring."""
-        if not self.running:
-            return
+        """Stop the backend and clean up manager-owned state."""
 
         logger.info("Stopping VoIP manager...")
-
+        self._stop_call_timer()
+        self.backend.stop()
         self.running = False
-        self.monitor_event.set()
-
-        # Terminate linphonec
-        if self.process:
-            try:
-                self._send_command("quit")
-                self.process.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                self.process.terminate()
-                self.process.wait(timeout=1)
-            except Exception as e:
-                logger.error(f"Error stopping linphonec: {e}")
-            finally:
-                self.process = None
-
-        # Wait for monitor thread
-        if self.monitor_thread:
-            self.monitor_thread.join(timeout=2)
-            self.monitor_thread = None
-
         logger.info("VoIP manager stopped")
 
-    def _send_command(self, command: str) -> bool:
-        """
-        Send command to linphonec.
+    def make_call(self, sip_address: str, contact_name: str | None = None) -> bool:
+        """Initiate an outgoing call."""
 
-        Args:
-            command: Command to send
-
-        Returns:
-            True if command sent successfully
-        """
-        if not self.process or not self.process.stdin:
-            logger.error("Cannot send command: linphonec not running")
-            return False
-
-        try:
-            self.process.stdin.write(f"{command}\n")
-            self.process.stdin.flush()
-            logger.debug(f"Sent command: {command}")
-            return True
-        except Exception as e:
-            logger.error(f"Failed to send command '{command}': {e}")
-            return False
-
-    def _monitor_output(self) -> None:
-        """Monitor linphonec output for events."""
-        logger.debug("Output monitor started")
-
-        while self.running and self.process:
-            try:
-                if not self.process.stdout:
-                    break
-
-                line = self.process.stdout.readline()
-                if not line:
-                    if self.process.poll() is not None:
-                        logger.warning("Linphonec process terminated")
-                        self.running = False
-                        break
-                    continue
-
-                line = line.strip()
-                if line:
-                    self._parse_output(line)
-
-            except Exception as e:
-                logger.error(f"Error monitoring output: {e}")
-                break
-
-        logger.debug("Output monitor stopped")
-
-    def _parse_output(self, line: str) -> None:
-        """
-        Parse linphonec output line.
-
-        Args:
-            line: Output line to parse
-        """
-        logger.debug(f"Linphone: {line}")
-
-        # Parse registration state
-        if "Registration on" in line and "successful" in line:
-            self._update_registration_state(RegistrationState.OK)
-        elif "Registration on" in line and "failed" in line:
-            self._update_registration_state(RegistrationState.FAILED)
-        elif "Registration on" in line and "cleared" in line:
-            self._update_registration_state(RegistrationState.CLEARED)
-        elif "Refreshing" in line and "registration" in line:
-            logger.debug("Registration refresh in progress")
-        # New pattern for Linphone 5.x
-        elif "LinphoneRegistrationOk" in line or ("Registration successful" in line and "reason" in line):
-            self._update_registration_state(RegistrationState.OK)
-        elif "LinphoneRegistrationProgress" in line:
-            self._update_registration_state(RegistrationState.PROGRESS)
-        elif "LinphoneRegistrationFailed" in line or ("Registration failed" in line and "reason" in line):
-            self._update_registration_state(RegistrationState.FAILED)
-        elif "LinphoneRegistrationCleared" in line:
-            self._update_registration_state(RegistrationState.CLEARED)
-
-        # Parse call state and extract caller info
-        # Look for lines containing call information (case-insensitive)
-        line_lower = line.lower()
-        if "call" in line_lower or "callsession" in line_lower:
-            # Try to extract SIP address from line
-            # Linphone format examples:
-            # - Linphone 5.x: "New incoming call from [sip:user@domain]"
-            # - Linphone 4.x: "Receiving new incoming call from <sip:user@domain>"
-            # - Linphone 4.x: "Call from <sip:user@domain>"
-            if "from" in line_lower:
-                # Try Linphone 5.x format with square brackets [sip:...]
-                if "[sip:" in line:
-                    start = line.find("[sip:")
-                    end = line.find("]", start)
-                    if start != -1 and end != -1:
-                        self.caller_address = line[start+1:end]  # Remove [ ]
-                        self.caller_name = self._lookup_contact_name(self.caller_address)
-                        logger.debug(f"Extracted caller address: {self.caller_address}, name: {self.caller_name}")
-                # Try Linphone 4.x format with angle brackets <sip:...>
-                elif "<sip:" in line:
-                    start = line.find("<sip:")
-                    end = line.find(">", start)
-                    if start != -1 and end != -1:
-                        self.caller_address = line[start+1:end]  # Remove < >
-                        self.caller_name = self._lookup_contact_name(self.caller_address)
-                        logger.debug(f"Extracted caller address: {self.caller_address}, name: {self.caller_name}")
-                # Fallback: try to extract plain sip: address
-                elif "sip:" in line.lower():
-                    # Extract from "from sip:user@domain" or similar
-                    parts = line.lower().split("from")
-                    if len(parts) > 1:
-                        # Get everything after "from"
-                        after_from = parts[1].strip()
-                        # Extract sip address
-                        if after_from.startswith("sip:"):
-                            # Find end of SIP address (space, comma, or end of line)
-                            end_chars = [' ', ',', '\t', '\n']
-                            end_pos = len(after_from)
-                            for char in end_chars:
-                                pos = after_from.find(char)
-                                if pos != -1 and pos < end_pos:
-                                    end_pos = pos
-                            self.caller_address = after_from[:end_pos]
-                            self.caller_name = self._lookup_contact_name(self.caller_address)
-                            logger.debug(f"Extracted caller address (fallback): {self.caller_address}, name: {self.caller_name}")
-
-            # Linphone 5.x pattern: "LinphoneCallIncoming"
-            if "LinphoneCallIncoming" in line or "incoming" in line.lower():
-                self._update_call_state(CallState.INCOMING)
-                # Fire incoming call callbacks
-                if self.caller_address:
-                    for callback in self.incoming_call_callbacks:
-                        try:
-                            callback(self.caller_address, self.caller_name or self._extract_username(self.caller_address))
-                        except Exception as e:
-                            logger.error(f"Error in incoming call callback: {e}")
-            elif "outgoing" in line.lower():
-                self._update_call_state(CallState.OUTGOING)
-            elif "connected" in line.lower() or "streams running" in line.lower() or "LinphoneCallConnected" in line:
-                self._update_call_state(CallState.CONNECTED)
-                if not self.call_start_time:
-                    self._start_call_timer()
-            elif "released" in line.lower() or "ended" in line.lower() or "LinphoneCallReleased" in line:
-                self._update_call_state(CallState.RELEASED)
-                self._stop_call_timer()
-                self.current_call_id = None
-                self.caller_address = None
-                self.caller_name = None
-
-    def _update_registration_state(self, state: RegistrationState) -> None:
-        """
-        Update registration state and fire callbacks.
-
-        Args:
-            state: New registration state
-        """
-        if state != self.registration_state:
-            old_state = self.registration_state
-            self.registration_state = state
-            self.registered = (state == RegistrationState.OK)
-
-            logger.info(f"Registration state: {old_state.value} -> {state.value}")
-
-            for callback in self.registration_callbacks:
-                try:
-                    callback(state)
-                except Exception as e:
-                    logger.error(f"Error in registration callback: {e}")
-
-    def _update_call_state(self, state: CallState) -> None:
-        """
-        Update call state and fire callbacks.
-
-        Args:
-            state: New call state
-        """
-        if state != self.call_state:
-            old_state = self.call_state
-            self.call_state = state
-
-            logger.info(f"Call state: {old_state.value} -> {state.value}")
-
-            for callback in self.call_state_callbacks:
-                try:
-                    callback(state)
-                except Exception as e:
-                    logger.error(f"Error in call state callback: {e}")
-
-    def make_call(self, sip_address: str, contact_name: str = None) -> bool:
-        """
-        Initiate outgoing call.
-
-        Args:
-            sip_address: SIP address to call (e.g., sip:user@domain)
-            contact_name: Optional contact name (will be looked up if not provided)
-
-        Returns:
-            True if call initiated successfully
-        """
         if not self.registered:
             logger.error("Cannot make call: not registered")
             return False
 
-        # Store caller info for outgoing call
         self.caller_address = sip_address
         self.caller_name = contact_name or self._lookup_contact_name(sip_address)
-
         logger.info(f"Making call to: {self.caller_name} ({sip_address})")
-        return self._send_command(f"call {sip_address}")
+        return self.backend.make_call(sip_address)
 
     def answer_call(self) -> bool:
-        """
-        Answer incoming call.
+        """Answer an incoming call."""
 
-        Returns:
-            True if answered successfully
-        """
         logger.info("Answering call")
-        return self._send_command("answer")
+        return self.backend.answer_call()
 
     def hangup(self) -> bool:
-        """
-        Hangup current call.
+        """Hang up the current call."""
 
-        Returns:
-            True if hangup command sent successfully
-        """
         logger.info("Hanging up call")
-        return self._send_command("terminate")
+        return self.backend.hangup()
+
+    def reject_call(self) -> bool:
+        """Reject an incoming call."""
+
+        logger.info("Rejecting call")
+        return self.backend.reject_call()
+
+    def mute(self) -> bool:
+        """Mute the current call microphone."""
+
+        if self.is_muted:
+            return False
+        logger.info("Muting microphone")
+        if self.backend.mute():
+            self.is_muted = True
+            return True
+        return False
+
+    def unmute(self) -> bool:
+        """Unmute the current call microphone."""
+
+        if not self.is_muted:
+            return False
+        logger.info("Unmuting microphone")
+        if self.backend.unmute():
+            self.is_muted = False
+            return True
+        return False
+
+    def toggle_mute(self) -> bool:
+        """Toggle microphone mute state."""
+
+        if self.is_muted:
+            self.unmute()
+            return False
+        self.mute()
+        return True
 
     def get_status(self) -> dict:
-        """
-        Get current VoIP status.
+        """Return the current VoIP status."""
 
-        Returns:
-            Status dictionary
-        """
         return {
             "running": self.running,
             "registered": self.registered,
             "registration_state": self.registration_state.value,
             "call_state": self.call_state.value,
             "call_id": self.current_call_id,
-            "sip_identity": self.config.sip_identity
+            "sip_identity": self.config.sip_identity,
         }
 
     def on_registration_change(self, callback: Callable[[RegistrationState], None]) -> None:
-        """
-        Register callback for registration state changes.
+        """Register a callback for SIP registration changes."""
 
-        Args:
-            callback: Function to call on state change
-        """
         self.registration_callbacks.append(callback)
 
     def on_call_state_change(self, callback: Callable[[CallState], None]) -> None:
-        """
-        Register callback for call state changes.
+        """Register a callback for call-state changes."""
 
-        Args:
-            callback: Function to call on state change
-        """
         self.call_state_callbacks.append(callback)
 
-    def mute(self) -> bool:
-        """
-        Mute microphone.
+    def on_incoming_call(self, callback: Callable[[str, str], None]) -> None:
+        """Register a callback for incoming call notifications."""
 
-        Returns:
-            True if muted successfully
-        """
-        if not self.is_muted:
-            logger.info("Muting microphone")
-            if self._send_command("mute"):
-                self.is_muted = True
-                return True
-        return False
-
-    def unmute(self) -> bool:
-        """
-        Unmute microphone.
-
-        Returns:
-            True if unmuted successfully
-        """
-        if self.is_muted:
-            logger.info("Unmuting microphone")
-            if self._send_command("unmute"):
-                self.is_muted = False
-                return True
-        return False
-
-    def toggle_mute(self) -> bool:
-        """
-        Toggle microphone mute state.
-
-        Returns:
-            True if now muted, False if unmuted
-        """
-        if self.is_muted:
-            self.unmute()
-            return False
-        else:
-            self.mute()
-            return True
-
-    def reject_call(self) -> bool:
-        """
-        Reject incoming call.
-
-        Returns:
-            True if rejected successfully
-        """
-        logger.info("Rejecting call")
-        return self._send_command("decline")
+        self.incoming_call_callbacks.append(callback)
 
     def get_call_duration(self) -> int:
-        """
-        Get current call duration in seconds.
+        """Return the current call duration in seconds."""
 
-        Returns:
-            Duration in seconds, or 0 if no active call
-        """
-        if self.call_start_time and self.call_state in [CallState.CONNECTED, CallState.STREAMS_RUNNING]:
+        if self.call_start_time and self.call_state in (
+            CallState.CONNECTED,
+            CallState.STREAMS_RUNNING,
+        ):
             return int(time.time() - self.call_start_time)
         return 0
 
     def get_caller_info(self) -> dict:
-        """
-        Get information about current caller/callee.
+        """Return information about the active caller or callee."""
 
-        Returns:
-            Dictionary with caller information
-        """
-        # If we have an address but no name, look it up
         if self.caller_address and not self.caller_name:
             self.caller_name = self._lookup_contact_name(self.caller_address)
 
         return {
             "address": self.caller_address,
             "name": self.caller_name or self.caller_address,
-            "display_name": self.caller_name or self._lookup_contact_name(self.caller_address)
+            "display_name": self.caller_name or self._lookup_contact_name(self.caller_address),
         }
 
+    def cleanup(self) -> None:
+        """Clean up all VoIP resources."""
+
+        self._stop_call_timer()
+        self.stop()
+        logger.info("VoIP manager cleaned up")
+
+    def _handle_backend_event(self, event: VoIPEvent) -> None:
+        """Apply a typed backend event to the manager state and callbacks."""
+
+        if isinstance(event, RegistrationStateChanged):
+            self._update_registration_state(event.state)
+            return
+        if isinstance(event, CallStateChanged):
+            self._update_call_state(event.state)
+            return
+        if isinstance(event, IncomingCallDetected):
+            self._handle_incoming_call_event(event.caller_address)
+            return
+        if isinstance(event, BackendStopped):
+            logger.warning(f"VoIP backend stopped unexpectedly: {event.reason or 'unknown'}")
+            self.running = False
+
+    def _handle_incoming_call_event(self, caller_address: str) -> None:
+        """Resolve caller metadata and notify incoming-call callbacks."""
+
+        self.caller_address = caller_address
+        self.caller_name = self._lookup_contact_name(caller_address)
+
+        for callback in self.incoming_call_callbacks:
+            try:
+                callback(
+                    caller_address,
+                    self.caller_name or self._extract_username(caller_address),
+                )
+            except Exception as exc:
+                logger.error(f"Error in incoming call callback: {exc}")
+
+    def _update_registration_state(self, state: RegistrationState) -> None:
+        """Update registration state and fire callbacks when it changes."""
+
+        if state == self.registration_state:
+            return
+
+        old_state = self.registration_state
+        self.registration_state = state
+        self.registered = state == RegistrationState.OK
+
+        logger.info(f"Registration state: {old_state.value} -> {state.value}")
+        for callback in self.registration_callbacks:
+            try:
+                callback(state)
+            except Exception as exc:
+                logger.error(f"Error in registration callback: {exc}")
+
+    def _update_call_state(self, state: CallState) -> None:
+        """Update call state and fire callbacks when it changes."""
+
+        if state == self.call_state:
+            return
+
+        old_state = self.call_state
+        self.call_state = state
+        logger.info(f"Call state: {old_state.value} -> {state.value}")
+
+        if state == CallState.CONNECTED and self.call_start_time is None:
+            self._start_call_timer()
+        elif state == CallState.RELEASED:
+            self._stop_call_timer()
+            self.current_call_id = None
+            self.caller_address = None
+            self.caller_name = None
+            self.is_muted = False
+
+        for callback in self.call_state_callbacks:
+            try:
+                callback(state)
+            except Exception as exc:
+                logger.error(f"Error in call state callback: {exc}")
+
     def _extract_username(self, sip_address: Optional[str]) -> str:
-        """
-        Extract username from SIP address.
+        """Extract a displayable username from a SIP address."""
 
-        Args:
-            sip_address: SIP URI (e.g., sip:user@domain)
-
-        Returns:
-            Username or full address if parsing fails
-        """
         if not sip_address:
             return "Unknown"
 
-        # Extract username from sip:username@domain
         if "@" in sip_address:
-            username_part = sip_address.split("@")[0]
+            username_part = sip_address.split("@", 1)[0]
             if ":" in username_part:
                 return username_part.split(":")[-1]
             return username_part
         return sip_address
 
     def _lookup_contact_name(self, sip_address: Optional[str]) -> str:
-        """
-        Look up contact name from SIP address.
+        """Look up a contact name for a SIP address."""
 
-        Args:
-            sip_address: SIP URI to look up
-
-        Returns:
-            Contact name if found, otherwise extracted username
-        """
         if not sip_address:
             return "Unknown"
 
-        # Try to look up contact in config_manager
-        if self.config_manager:
+        if self.config_manager is not None:
             contact = self.config_manager.get_contact_by_address(sip_address)
             if contact:
                 logger.debug(f"Found contact: {contact.name} for {sip_address}")
                 return contact.name
 
-        # Fall back to extracting username from SIP address
         return self._extract_username(sip_address)
 
     def _start_call_timer(self) -> None:
-        """Start tracking call duration."""
+        """Start tracking the duration of the active call."""
+
         self.call_start_time = time.time()
         self.call_duration = 0
-
-        # Start duration tracking thread
         self.duration_stop_event.clear()
-        self.duration_thread = threading.Thread(
-            target=self._track_duration,
-            daemon=True
-        )
+        self.duration_thread = threading.Thread(target=self._track_duration, daemon=True)
         self.duration_thread.start()
         logger.debug("Call duration timer started")
 
     def _stop_call_timer(self) -> None:
         """Stop tracking call duration."""
+
         self.duration_stop_event.set()
-        if self.duration_thread:
+        if self.duration_thread is not None:
             self.duration_thread.join(timeout=1)
             self.duration_thread = None
         self.call_start_time = None
+        self.call_duration = 0
         logger.debug("Call duration timer stopped")
 
     def _track_duration(self) -> None:
-        """Background thread to track call duration."""
+        """Background loop that updates the active call duration."""
+
         while not self.duration_stop_event.is_set():
-            if self.call_start_time:
+            if self.call_start_time is not None:
                 self.call_duration = int(time.time() - self.call_start_time)
             time.sleep(1)
-
-    def on_incoming_call(self, callback: Callable[[str, str], None]) -> None:
-        """
-        Register callback for incoming calls.
-
-        Args:
-            callback: Function to call with (caller_address, caller_name)
-        """
-        self.incoming_call_callbacks.append(callback)
-
-    def cleanup(self) -> None:
-        """Clean up resources."""
-        self._stop_call_timer()
-        self.stop()
-        logger.info("VoIP manager cleaned up")

--- a/yoyopy/connectivity/voip_types.py
+++ b/yoyopy/connectivity/voip_types.py
@@ -1,0 +1,109 @@
+"""Shared VoIP models and typed backend events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TypeAlias
+
+
+class RegistrationState(Enum):
+    """SIP registration states."""
+
+    NONE = "none"
+    PROGRESS = "progress"
+    OK = "ok"
+    CLEARED = "cleared"
+    FAILED = "failed"
+
+
+class CallState(Enum):
+    """Call states."""
+
+    IDLE = "idle"
+    INCOMING = "incoming"
+    OUTGOING = "outgoing_init"
+    OUTGOING_PROGRESS = "outgoing_progress"
+    OUTGOING_RINGING = "outgoing_ringing"
+    OUTGOING_EARLY_MEDIA = "outgoing_early_media"
+    CONNECTED = "connected"
+    STREAMS_RUNNING = "streams_running"
+    PAUSED = "paused"
+    PAUSED_BY_REMOTE = "paused_by_remote"
+    UPDATED_BY_REMOTE = "updated_by_remote"
+    RELEASED = "released"
+    ERROR = "error"
+    END = "end"
+
+
+@dataclass(slots=True)
+class VoIPConfig:
+    """VoIP configuration."""
+
+    sip_server: str = "sip.linphone.org"
+    sip_username: str = ""
+    sip_password: str = ""
+    sip_password_ha1: str = ""
+    sip_identity: str = ""
+    transport: str = "tcp"
+    stun_server: str = ""
+    linphonec_path: str = "/usr/bin/linphonec"
+    playback_dev_id: str = "ALSA: plughw:1"
+    ringer_dev_id: str = "ALSA: plughw:1"
+    capture_dev_id: str = "ALSA: plughw:1"
+    media_dev_id: str = "ALSA: plughw:1"
+
+    @staticmethod
+    def from_config_manager(config_manager) -> "VoIPConfig":
+        """Create a VoIPConfig from the current config manager."""
+
+        return VoIPConfig(
+            sip_server=config_manager.get_sip_server(),
+            sip_username=config_manager.get_sip_username(),
+            sip_password=config_manager.get_sip_password(),
+            sip_password_ha1=config_manager.get_sip_password_ha1(),
+            sip_identity=config_manager.get_sip_identity(),
+            transport=config_manager.get_transport(),
+            stun_server=config_manager.get_stun_server(),
+            linphonec_path=config_manager.get_linphonec_path(),
+            playback_dev_id=config_manager.get_playback_device_id(),
+            ringer_dev_id=config_manager.get_ringer_device_id(),
+            capture_dev_id=config_manager.get_capture_device_id(),
+            media_dev_id=config_manager.get_media_device_id(),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RegistrationStateChanged:
+    """Typed event emitted when SIP registration changes."""
+
+    state: RegistrationState
+
+
+@dataclass(frozen=True, slots=True)
+class CallStateChanged:
+    """Typed event emitted when the active call state changes."""
+
+    state: CallState
+
+
+@dataclass(frozen=True, slots=True)
+class IncomingCallDetected:
+    """Typed event emitted when an incoming call address is detected."""
+
+    caller_address: str
+
+
+@dataclass(frozen=True, slots=True)
+class BackendStopped:
+    """Typed event emitted when the backend process exits unexpectedly."""
+
+    reason: str = ""
+
+
+VoIPEvent: TypeAlias = (
+    RegistrationStateChanged
+    | CallStateChanged
+    | IncomingCallDetected
+    | BackendStopped
+)


### PR DESCRIPTION
## Summary
- extract shared VoIP models and typed backend events into dedicated modules
- move linphonec subprocess and stdout parsing behind a LinphonecBackend protocol boundary
- keep VoIPManager as the app-facing facade and add focused backend/manager tests

## Testing
- python -m compileall yoyopy tests
- uv run pytest -q