### PR TITLE
Phase 3b schema-driven config models

### DIFF
--- a/scripts/pi_smoke.py
+++ b/scripts/pi_smoke.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import yaml
 from loguru import logger
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -19,7 +18,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from yoyopy.audio.mopidy_client import MopidyClient
-from yoyopy.config import ConfigManager
+from yoyopy.config import ConfigManager, YoyoPodConfig, config_to_dict, load_config_model_from_yaml
 from yoyopy.connectivity import VoIPConfig, VoIPManager
 from yoyopy.ui.display import Display, detect_hardware
 from yoyopy.ui.input import get_input_manager
@@ -49,10 +48,7 @@ def load_app_config(config_dir: Path) -> dict[str, Any]:
     config_file = config_dir / "yoyopod_config.yaml"
     if not config_file.exists():
         logger.warning(f"App config not found: {config_file}")
-        return {}
-
-    with open(config_file, "r", encoding="utf-8") as handle:
-        return yaml.safe_load(handle) or {}
+    return config_to_dict(load_config_model_from_yaml(YoyoPodConfig, config_file))
 
 
 def environment_check() -> CheckResult:

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Tests for typed YAML-plus-env configuration models."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from yoyopy.config import ConfigManager, YoyoPodConfig, load_config_model_from_yaml
+
+
+def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> None:
+    """Missing yoyopod_config.yaml should resolve to typed defaults in memory."""
+
+    monkeypatch.delenv("YOYOPOD_MOPIDY_HOST", raising=False)
+    monkeypatch.delenv("YOYOPOD_MOPIDY_PORT", raising=False)
+    monkeypatch.delenv("YOYOPOD_AUTO_RESUME_AFTER_CALL", raising=False)
+    monkeypatch.delenv("YOYOPOD_DISPLAY", raising=False)
+
+    config_file = tmp_path / "yoyopod_config.yaml"
+    settings = load_config_model_from_yaml(YoyoPodConfig, config_file)
+
+    assert not config_file.exists()
+    assert settings.audio.mopidy_host == "localhost"
+    assert settings.audio.mopidy_port == 6680
+    assert settings.audio.auto_resume_after_call is True
+    assert settings.audio.speaker_test_path == "speaker-test"
+    assert settings.display.hardware == "auto"
+
+
+def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) -> None:
+    """Environment variables should override YAML while preserving other values."""
+
+    config_file = tmp_path / "yoyopod_config.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "audio": {
+                    "mopidy_host": "mopidy.local",
+                    "mopidy_port": 7000,
+                    "auto_resume_after_call": True,
+                },
+                "display": {
+                    "hardware": "pimoroni",
+                },
+                "logging": {
+                    "level": "DEBUG",
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("YOYOPOD_MOPIDY_PORT", "7788")
+    monkeypatch.setenv("YOYOPOD_AUTO_RESUME_AFTER_CALL", "false")
+    monkeypatch.setenv("YOYOPOD_DISPLAY", "whisplay")
+
+    config_manager = ConfigManager(config_dir=str(tmp_path))
+    settings = config_manager.get_app_settings()
+    config_dict = config_manager.get_app_config_dict()
+
+    assert config_manager.app_config_loaded is True
+    assert settings.audio.mopidy_host == "mopidy.local"
+    assert settings.audio.mopidy_port == 7788
+    assert settings.audio.auto_resume_after_call is False
+    assert settings.display.hardware == "whisplay"
+    assert settings.logging.level == "DEBUG"
+    assert config_dict["audio"]["mopidy_port"] == 7788
+    assert config_dict["display"]["hardware"] == "whisplay"
+
+
+def test_config_manager_keeps_typed_voip_audio_settings(tmp_path, monkeypatch) -> None:
+    """VoIP settings should stay typed while preserving existing getter behavior."""
+
+    monkeypatch.setenv("YOYOPOD_PLAYBACK_DEVICE", "ALSA: default")
+    monkeypatch.setenv("YOYOPOD_RING_OUTPUT_DEVICE", "default")
+
+    config_manager = ConfigManager(config_dir=str(tmp_path))
+
+    assert config_manager.voip_settings.audio.playback_device_id == "ALSA: default"
+    assert config_manager.get_playback_device_id() == "ALSA: default"
+    assert config_manager.get_ring_output_device() == "default"

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -9,14 +9,13 @@ from __future__ import annotations
 import threading
 import time
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 from loguru import logger
 
 from yoyopy.app_context import AppContext
 from yoyopy.audio.mopidy_client import MopidyClient
-from yoyopy.config import ConfigManager
+from yoyopy.config import ConfigManager, YoyoPodConfig
 from yoyopy.connectivity import VoIPConfig, VoIPManager
 from yoyopy.coordinators import (
     CallCoordinator,
@@ -66,6 +65,7 @@ class YoyoPodApp:
         self.display: Optional[Display] = None
         self.context: Optional[AppContext] = None
         self.config_manager: Optional[ConfigManager] = None
+        self.app_settings: Optional[YoyoPodConfig] = None
         self.state_machine: Optional[StateMachine] = None
         self.screen_manager: Optional[ScreenManager] = None
         self.input_manager: Optional[InputManager] = None
@@ -168,60 +168,20 @@ class YoyoPodApp:
 
         try:
             self.config_manager = ConfigManager(config_dir=self.config_dir)
-            config_file = Path(self.config_dir) / "yoyopod_config.yaml"
+            self.app_settings = self.config_manager.get_app_settings()
+            self.config = self.config_manager.get_app_config_dict()
 
-            if config_file.exists():
-                import yaml
-
-                with open(config_file, "r") as handle:
-                    self.config = yaml.safe_load(handle) or {}
-                logger.info(f"Loaded configuration from {config_file}")
+            if self.config_manager.app_config_loaded:
+                logger.info(f"Loaded configuration from {self.config_manager.app_config_file}")
             else:
-                logger.warning(f"Config file not found: {config_file}")
-                logger.info("Using default configuration")
-                self.config = self._get_default_config()
+                logger.info("Using default application configuration")
 
-            self.auto_resume_after_call = self.config.get("audio", {}).get(
-                "auto_resume_after_call",
-                True,
-            )
+            self.auto_resume_after_call = self.app_settings.audio.auto_resume_after_call
             logger.info(f"  Auto-resume after call: {self.auto_resume_after_call}")
             return True
         except Exception as exc:
             logger.error(f"Failed to load configuration: {exc}")
             return False
-
-    def _get_default_config(self) -> Dict[str, Any]:
-        """Return the default YoyoPod configuration."""
-        return {
-            "app": {
-                "name": "YoyoPod",
-                "version": "1.0.0",
-                "simulate": self.simulate,
-            },
-            "audio": {
-                "mopidy_host": "localhost",
-                "mopidy_port": 6680,
-                "auto_resume_after_call": True,
-                "default_volume": 70,
-                "ring_output_device": "",
-                "speaker_test_path": "speaker-test",
-            },
-            "voip": {
-                "config_file": "config/voip_config.yaml",
-                "priority_over_music": True,
-                "auto_answer": False,
-                "ring_duration_seconds": 30,
-            },
-            "ui": {
-                "theme": "dark",
-                "show_album_art": True,
-                "screen_timeout_seconds": 300,
-            },
-            "logging": {
-                "level": "INFO",
-            },
-        }
 
     def _init_core_components(self) -> bool:
         """Initialize display, context, state machine, input, and screen manager."""
@@ -229,7 +189,9 @@ class YoyoPodApp:
 
         try:
             logger.info("  - Display")
-            display_hardware = self.config.get("display", {}).get("hardware", "auto")
+            display_hardware = (
+                self.app_settings.display.hardware if self.app_settings else "auto"
+            )
             logger.info(f"    Hardware: {display_hardware}")
             self.display = Display(hardware=display_hardware, simulate=self.simulate)
             logger.info(f"    Dimensions: {self.display.WIDTH}x{self.display.HEIGHT}")
@@ -298,8 +260,10 @@ class YoyoPodApp:
                 logger.warning("    ⚠ VoIP failed to start (music-only mode)")
 
             logger.info("  - MopidyClient")
-            mopidy_host = self.config.get("audio", {}).get("mopidy_host", "localhost")
-            mopidy_port = self.config.get("audio", {}).get("mopidy_port", 6680)
+            mopidy_host = (
+                self.app_settings.audio.mopidy_host if self.app_settings else "localhost"
+            )
+            mopidy_port = self.app_settings.audio.mopidy_port if self.app_settings else 6680
             self.mopidy_client = MopidyClient(host=mopidy_host, port=mopidy_port)
             if self.mopidy_client.connect():
                 logger.info("    ✓ Mopidy connected successfully")

--- a/yoyopy/config/__init__.py
+++ b/yoyopy/config/__init__.py
@@ -4,8 +4,18 @@ Handles VoIP settings and contacts.
 """
 
 from yoyopy.config.config_manager import ConfigManager, Contact
+from yoyopy.config.models import (
+    VoIPFileConfig,
+    YoyoPodConfig,
+    config_to_dict,
+    load_config_model_from_yaml,
+)
 
 __all__ = [
-    'ConfigManager',
-    'Contact'
+    "ConfigManager",
+    "Contact",
+    "YoyoPodConfig",
+    "VoIPFileConfig",
+    "load_config_model_from_yaml",
+    "config_to_dict",
 ]

--- a/yoyopy/config/config_manager.py
+++ b/yoyopy/config/config_manager.py
@@ -1,20 +1,30 @@
 """
 Configuration Manager for YoyoPod.
 
-Manages VoIP settings and contacts from YAML configuration files.
+Manages typed app/VoIP settings and contacts from YAML configuration files.
 """
 
-import os
+from __future__ import annotations
+
 import yaml
-from pathlib import Path
-from typing import List, Optional, Dict, Any
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
 from loguru import logger
+
+from yoyopy.config.models import (
+    VoIPFileConfig,
+    YoyoPodConfig,
+    config_to_dict,
+    load_config_model_from_yaml,
+)
 
 
 @dataclass
 class Contact:
     """Represents a VoIP contact."""
+
     name: str
     sip_address: str
     favorite: bool = False
@@ -28,53 +38,86 @@ class ConfigManager:
     """
     Manages application configuration.
 
-    Loads VoIP settings and contacts from YAML files.
+    Loads typed application and VoIP settings plus contacts from YAML files.
     """
 
     def __init__(self, config_dir: str = "config") -> None:
-        """
-        Initialize configuration manager.
-
-        Args:
-            config_dir: Directory containing configuration files
-        """
         self.config_dir = Path(config_dir)
+        self.app_config_file = self.config_dir / "yoyopod_config.yaml"
         self.voip_config_file = self.config_dir / "voip_config.yaml"
         self.contacts_file = self.config_dir / "contacts.yaml"
 
-        self.voip_config: Dict[str, Any] = {}
-        self.contacts: List[Contact] = []
-        self.speed_dial: Dict[int, str] = {}
+        self.app_settings = YoyoPodConfig()
+        self.voip_settings = VoIPFileConfig()
+        self.app_config: dict[str, Any] = config_to_dict(self.app_settings)
+        self.voip_config: dict[str, Any] = config_to_dict(self.voip_settings)
+        self.contacts: list[Contact] = []
+        self.speed_dial: dict[int, str] = {}
+
+        self.app_config_loaded = False
+        self.voip_config_loaded = False
+        self.contacts_loaded = False
 
         logger.info(f"ConfigManager initialized (config_dir: {config_dir})")
 
-        # Load configurations
+        self.load_app_config()
         self.load_voip_config()
         self.load_contacts()
 
-    def load_voip_config(self) -> bool:
+    def load_app_config(self) -> bool:
         """
-        Load VoIP configuration from file.
+        Load typed application configuration from yoyopod_config.yaml.
 
         Returns:
-            True if loaded successfully, False otherwise
+            True if loaded from file, False if defaults were used.
         """
-        if not self.voip_config_file.exists():
-            logger.warning(f"VoIP config file not found: {self.voip_config_file}")
-            self._create_default_voip_config()
+
+        self.app_config_loaded = self.app_config_file.exists()
+        try:
+            self.app_settings = load_config_model_from_yaml(YoyoPodConfig, self.app_config_file)
+            self.app_config = config_to_dict(self.app_settings)
+
+            if self.app_config_loaded:
+                logger.info("App configuration loaded successfully")
+            else:
+                logger.warning(f"App config file not found: {self.app_config_file}")
+                logger.info("Using default app configuration")
+
+            logger.debug(f"Mopidy host: {self.app_settings.audio.mopidy_host}")
+            logger.debug(f"Display hardware: {self.app_settings.display.hardware}")
+            return self.app_config_loaded
+        except Exception as exc:
+            logger.error(f"Error loading app config: {exc}")
+            self.app_settings = YoyoPodConfig()
+            self.app_config = config_to_dict(self.app_settings)
+            self.app_config_loaded = False
             return False
 
+    def load_voip_config(self) -> bool:
+        """
+        Load typed VoIP configuration from file.
+
+        Returns:
+            True if loaded from file, False if a default file was created.
+        """
+
+        self.voip_config_loaded = self.voip_config_file.exists()
+        if not self.voip_config_loaded:
+            logger.warning(f"VoIP config file not found: {self.voip_config_file}")
+            self._create_default_voip_config()
+
         try:
-            with open(self.voip_config_file, 'r') as f:
-                self.voip_config = yaml.safe_load(f) or {}
+            self.voip_settings = load_config_model_from_yaml(VoIPFileConfig, self.voip_config_file)
+            self.voip_config = config_to_dict(self.voip_settings)
 
             logger.info("VoIP configuration loaded successfully")
             logger.debug(f"SIP Server: {self.get_sip_server()}")
             logger.debug(f"SIP Identity: {self.get_sip_identity()}")
-            return True
-
-        except Exception as e:
-            logger.error(f"Error loading VoIP config: {e}")
+            return self.voip_config_loaded
+        except Exception as exc:
+            logger.error(f"Error loading VoIP config: {exc}")
+            self.voip_settings = VoIPFileConfig()
+            self.voip_config = config_to_dict(self.voip_settings)
             return False
 
     def load_contacts(self) -> bool:
@@ -82,36 +125,34 @@ class ConfigManager:
         Load contacts from file.
 
         Returns:
-            True if loaded successfully, False otherwise
+            True if loaded successfully, False otherwise.
         """
-        if not self.contacts_file.exists():
+
+        self.contacts_loaded = self.contacts_file.exists()
+        if not self.contacts_loaded:
             logger.warning(f"Contacts file not found: {self.contacts_file}")
             self._create_default_contacts()
             return False
 
         try:
-            with open(self.contacts_file, 'r') as f:
-                data = yaml.safe_load(f) or {}
+            with open(self.contacts_file, "r", encoding="utf-8") as handle:
+                data = yaml.safe_load(handle) or {}
 
-            # Load contacts
-            self.contacts = []
-            for contact_data in data.get('contacts', []):
-                contact = Contact(
-                    name=contact_data.get('name', ''),
-                    sip_address=contact_data.get('sip_address', ''),
-                    favorite=contact_data.get('favorite', False),
-                    notes=contact_data.get('notes', '')
+            self.contacts = [
+                Contact(
+                    name=contact_data.get("name", ""),
+                    sip_address=contact_data.get("sip_address", ""),
+                    favorite=contact_data.get("favorite", False),
+                    notes=contact_data.get("notes", ""),
                 )
-                self.contacts.append(contact)
-
-            # Load speed dial
-            self.speed_dial = data.get('speed_dial', {})
+                for contact_data in data.get("contacts", [])
+            ]
+            self.speed_dial = data.get("speed_dial", {})
 
             logger.info(f"Loaded {len(self.contacts)} contacts")
             return True
-
-        except Exception as e:
-            logger.error(f"Error loading contacts: {e}")
+        except Exception as exc:
+            logger.error(f"Error loading contacts: {exc}")
             return False
 
     def save_contacts(self) -> bool:
@@ -119,187 +160,159 @@ class ConfigManager:
         Save contacts to file.
 
         Returns:
-            True if saved successfully, False otherwise
+            True if saved successfully, False otherwise.
         """
+
         try:
             data = {
-                'contacts': [
+                "contacts": [
                     {
-                        'name': c.name,
-                        'sip_address': c.sip_address,
-                        'favorite': c.favorite,
-                        'notes': c.notes
+                        "name": contact.name,
+                        "sip_address": contact.sip_address,
+                        "favorite": contact.favorite,
+                        "notes": contact.notes,
                     }
-                    for c in self.contacts
+                    for contact in self.contacts
                 ],
-                'speed_dial': self.speed_dial
+                "speed_dial": self.speed_dial,
             }
 
-            with open(self.contacts_file, 'w') as f:
-                yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+            with open(self.contacts_file, "w", encoding="utf-8") as handle:
+                yaml.dump(data, handle, default_flow_style=False, sort_keys=False)
 
             logger.info("Contacts saved successfully")
             return True
-
-        except Exception as e:
-            logger.error(f"Error saving contacts: {e}")
+        except Exception as exc:
+            logger.error(f"Error saving contacts: {exc}")
             return False
 
     def _create_default_voip_config(self) -> None:
-        """Create default VoIP configuration file."""
+        """Create a default typed VoIP configuration file."""
+
         logger.info("Creating default VoIP configuration...")
         self.config_dir.mkdir(parents=True, exist_ok=True)
 
-        default_config = {
-            'account': {
-                'sip_server': 'sip.linphone.org',
-                'sip_username': '',
-                'sip_password': '',
-                'sip_identity': '',
-                'transport': 'tcp',
-                'display_name': 'YoyoPod'
-            },
-            'network': {
-                'stun_server': 'stun.linphone.org',
-                'enable_ice': True
-            },
-            'audio': {
-                'preferred_codec': 'opus',
-                'echo_cancellation': True,
-                'mic_gain': 80,
-                'speaker_volume': 80,
-                'playback_device_id': 'ALSA: plughw:1',
-                'ringer_device_id': 'ALSA: plughw:1',
-                'capture_device_id': 'ALSA: plughw:1',
-                'media_device_id': 'ALSA: plughw:1',
-                'ring_output_device': 'plughw:1'
-            },
-            'linphonec_path': '/usr/bin/linphonec',
-            'auto_answer': False,
-            'call_timeout': 60
-        }
+        default_config = config_to_dict(VoIPFileConfig())
+        with open(self.voip_config_file, "w", encoding="utf-8") as handle:
+            yaml.dump(default_config, handle, default_flow_style=False, sort_keys=False)
 
-        with open(self.voip_config_file, 'w') as f:
-            yaml.dump(default_config, f, default_flow_style=False, sort_keys=False)
-
+        self.voip_settings = VoIPFileConfig()
         self.voip_config = default_config
 
     def _create_default_contacts(self) -> None:
-        """Create default contacts file."""
+        """Create a default contacts file."""
+
         logger.info("Creating default contacts file...")
         self.config_dir.mkdir(parents=True, exist_ok=True)
 
         default_contacts = {
-            'contacts': [
+            "contacts": [
                 {
-                    'name': 'Echo Test Service',
-                    'sip_address': 'sip:echo@sip.linphone.org',
-                    'favorite': True,
-                    'notes': 'Linphone echo test'
+                    "name": "Echo Test Service",
+                    "sip_address": "sip:echo@sip.linphone.org",
+                    "favorite": True,
+                    "notes": "Linphone echo test",
                 }
             ],
-            'speed_dial': {
-                1: 'sip:echo@sip.linphone.org'
-            }
+            "speed_dial": {
+                1: "sip:echo@sip.linphone.org",
+            },
         }
 
-        with open(self.contacts_file, 'w') as f:
-            yaml.dump(default_contacts, f, default_flow_style=False, sort_keys=False)
+        with open(self.contacts_file, "w", encoding="utf-8") as handle:
+            yaml.dump(default_contacts, handle, default_flow_style=False, sort_keys=False)
 
         self.load_contacts()
 
-    # VoIP Configuration Getters
+    def get_app_settings(self) -> YoyoPodConfig:
+        """Return the typed application configuration model."""
+
+        return self.app_settings
+
+    def get_app_config_dict(self) -> dict[str, Any]:
+        """Return the plain-dict form of the application configuration."""
+
+        return config_to_dict(self.app_settings)
 
     def get_sip_server(self) -> str:
         """Get SIP server address."""
-        return self.voip_config.get('account', {}).get('sip_server', '')
+
+        return self.voip_settings.account.sip_server
 
     def get_sip_username(self) -> str:
         """Get SIP username."""
-        return self.voip_config.get('account', {}).get('sip_username', '')
+
+        return self.voip_settings.account.sip_username
 
     def get_sip_password(self) -> str:
         """Get SIP password."""
-        return self.voip_config.get('account', {}).get('sip_password', '')
+
+        return self.voip_settings.account.sip_password
 
     def get_sip_password_ha1(self) -> str:
         """Get SIP password HA1 hash."""
-        return self.voip_config.get('account', {}).get('sip_password_ha1', '')
+
+        return self.voip_settings.account.sip_password_ha1
 
     def get_sip_identity(self) -> str:
         """Get SIP identity."""
-        return self.voip_config.get('account', {}).get('sip_identity', '')
+
+        return self.voip_settings.account.sip_identity
 
     def get_transport(self) -> str:
         """Get transport protocol."""
-        return self.voip_config.get('account', {}).get('transport', 'tcp')
+
+        return self.voip_settings.account.transport
 
     def get_display_name(self) -> str:
         """Get display name."""
-        return self.voip_config.get('account', {}).get('display_name', 'YoyoPod')
+
+        return self.voip_settings.account.display_name
 
     def get_stun_server(self) -> str:
         """Get STUN server address."""
-        return self.voip_config.get('network', {}).get('stun_server', '')
+
+        return self.voip_settings.network.stun_server
 
     def get_linphonec_path(self) -> str:
         """Get linphonec executable path."""
-        return self.voip_config.get('linphonec_path', '/usr/bin/linphonec')
+
+        return self.voip_settings.linphonec_path
 
     def get_auto_answer(self) -> bool:
         """Get auto-answer setting."""
-        return self.voip_config.get('auto_answer', False)
+
+        return self.voip_settings.auto_answer
 
     def get_call_timeout(self) -> int:
         """Get call timeout in seconds."""
-        return self.voip_config.get('call_timeout', 60)
 
-    def _get_audio_setting(self, key: str, env_var: str, default: str = "") -> str:
-        """Get an audio setting from env override, config, or default."""
-        env_value = os.getenv(env_var)
-        if env_value:
-            return env_value
-        return self.voip_config.get('audio', {}).get(key, default)
+        return self.voip_settings.call_timeout
 
     def get_playback_device_id(self) -> str:
         """Get the ALSA playback device id for Linphone."""
-        return self._get_audio_setting(
-            'playback_device_id',
-            'YOYOPOD_PLAYBACK_DEVICE',
-            'ALSA: plughw:1',
-        )
+
+        return self.voip_settings.audio.playback_device_id
 
     def get_ringer_device_id(self) -> str:
         """Get the ALSA ringer device id for Linphone."""
-        return self._get_audio_setting(
-            'ringer_device_id',
-            'YOYOPOD_RINGER_DEVICE',
-            self.get_playback_device_id(),
-        )
+
+        return self.voip_settings.audio.ringer_device_id or self.get_playback_device_id()
 
     def get_capture_device_id(self) -> str:
         """Get the ALSA capture device id for Linphone."""
-        return self._get_audio_setting(
-            'capture_device_id',
-            'YOYOPOD_CAPTURE_DEVICE',
-            'ALSA: plughw:1',
-        )
+
+        return self.voip_settings.audio.capture_device_id
 
     def get_media_device_id(self) -> str:
         """Get the ALSA media device id for Linphone."""
-        return self._get_audio_setting(
-            'media_device_id',
-            'YOYOPOD_MEDIA_DEVICE',
-            self.get_playback_device_id(),
-        )
+
+        return self.voip_settings.audio.media_device_id or self.get_playback_device_id()
 
     def get_ring_output_device(self) -> str:
         """Get the output device for the speaker-test ring tone helper."""
-        ring_output = self._get_audio_setting(
-            'ring_output_device',
-            'YOYOPOD_RING_OUTPUT_DEVICE',
-            '',
-        )
+
+        ring_output = self.voip_settings.audio.ring_output_device
         if ring_output:
             return ring_output
 
@@ -308,71 +321,43 @@ class ConfigManager:
             return playback_device.split(":", 1)[1].strip()
         return playback_device or "default"
 
-    # Contact Management
+    def get_contacts(self, favorites_only: bool = False) -> list[Contact]:
+        """Get the current contact list."""
 
-    def get_contacts(self, favorites_only: bool = False) -> List[Contact]:
-        """
-        Get list of contacts.
-
-        Args:
-            favorites_only: If True, return only favorite contacts
-
-        Returns:
-            List of contacts
-        """
         if favorites_only:
-            return [c for c in self.contacts if c.favorite]
+            return [contact for contact in self.contacts if contact.favorite]
         return self.contacts
 
     def get_contact_by_name(self, name: str) -> Optional[Contact]:
-        """
-        Get contact by name.
+        """Get a contact by display name."""
 
-        Args:
-            name: Contact name
-
-        Returns:
-            Contact if found, None otherwise
-        """
         for contact in self.contacts:
             if contact.name.lower() == name.lower():
                 return contact
         return None
 
     def get_contact_by_address(self, sip_address: str) -> Optional[Contact]:
-        """
-        Get contact by SIP address.
+        """Get a contact by SIP address."""
 
-        Args:
-            sip_address: SIP address
-
-        Returns:
-            Contact if found, None otherwise
-        """
         for contact in self.contacts:
             if contact.sip_address == sip_address:
                 return contact
         return None
 
-    def add_contact(self, name: str, sip_address: str,
-                   favorite: bool = False, notes: str = "") -> Contact:
-        """
-        Add a new contact.
+    def add_contact(
+        self,
+        name: str,
+        sip_address: str,
+        favorite: bool = False,
+        notes: str = "",
+    ) -> Contact:
+        """Add a new contact and persist it to disk."""
 
-        Args:
-            name: Contact name
-            sip_address: SIP address
-            favorite: Mark as favorite
-            notes: Additional notes
-
-        Returns:
-            Created contact
-        """
         contact = Contact(
             name=name,
             sip_address=sip_address,
             favorite=favorite,
-            notes=notes
+            notes=notes,
         )
         self.contacts.append(contact)
         self.save_contacts()
@@ -380,70 +365,48 @@ class ConfigManager:
         return contact
 
     def remove_contact(self, name: str) -> bool:
-        """
-        Remove a contact by name.
+        """Remove a contact by name."""
 
-        Args:
-            name: Contact name
-
-        Returns:
-            True if removed, False if not found
-        """
         contact = self.get_contact_by_name(name)
-        if contact:
-            self.contacts.remove(contact)
-            self.save_contacts()
-            logger.info(f"Removed contact: {contact}")
-            return True
-        return False
+        if contact is None:
+            return False
+
+        self.contacts.remove(contact)
+        self.save_contacts()
+        logger.info(f"Removed contact: {contact}")
+        return True
 
     def update_contact(self, name: str, **kwargs) -> bool:
-        """
-        Update contact properties.
+        """Update a contact by name."""
 
-        Args:
-            name: Contact name
-            **kwargs: Properties to update
-
-        Returns:
-            True if updated, False if not found
-        """
         contact = self.get_contact_by_name(name)
-        if contact:
-            for key, value in kwargs.items():
-                if hasattr(contact, key):
-                    setattr(contact, key, value)
-            self.save_contacts()
-            logger.info(f"Updated contact: {contact}")
-            return True
-        return False
+        if contact is None:
+            return False
+
+        for key, value in kwargs.items():
+            if hasattr(contact, key):
+                setattr(contact, key, value)
+
+        self.save_contacts()
+        logger.info(f"Updated contact: {contact}")
+        return True
 
     def get_speed_dial_address(self, number: int) -> Optional[str]:
-        """
-        Get SIP address for speed dial number.
+        """Get SIP address for a speed dial number."""
 
-        Args:
-            number: Speed dial number
-
-        Returns:
-            SIP address if found, None otherwise
-        """
         return self.speed_dial.get(number)
 
     def set_speed_dial(self, number: int, sip_address: str) -> None:
-        """
-        Set speed dial number.
+        """Assign a SIP address to a speed dial number."""
 
-        Args:
-            number: Speed dial number
-            sip_address: SIP address to assign
-        """
         self.speed_dial[number] = sip_address
         self.save_contacts()
         logger.info(f"Set speed dial {number} to {sip_address}")
 
     def reload(self) -> None:
-        """Reload all configuration from files."""
+        """Reload all configuration from disk."""
+
         logger.info("Reloading configuration...")
+        self.load_app_config()
         self.load_voip_config()
         self.load_contacts()

--- a/yoyopy/config/models.py
+++ b/yoyopy/config/models.py
@@ -1,0 +1,268 @@
+"""Typed configuration models and YAML/env loading helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import MISSING, asdict, dataclass, field, fields, is_dataclass
+from pathlib import Path
+from types import UnionType
+from typing import Any, TypeVar, Union, get_args, get_origin, get_type_hints
+
+import yaml
+
+T = TypeVar("T")
+
+
+def config_value(*, default: Any = MISSING, default_factory: Any = MISSING, env: str | None = None):
+    """Create a dataclass field with optional environment override metadata."""
+
+    metadata: dict[str, Any] = {}
+    if env is not None:
+        metadata["env"] = env
+
+    if default is not MISSING:
+        return field(default=default, metadata=metadata)
+    if default_factory is not MISSING:
+        return field(default_factory=default_factory, metadata=metadata)
+    return field(metadata=metadata)
+
+
+def load_config_model_from_yaml(model_cls: type[T], path: Path) -> T:
+    """Load a typed config model from YAML with env-var overlays."""
+
+    data: dict[str, Any] = {}
+    if path.exists():
+        with open(path, "r", encoding="utf-8") as handle:
+            loaded = yaml.safe_load(handle) or {}
+            if isinstance(loaded, dict):
+                data = loaded
+    return build_config_model(model_cls, data)
+
+
+def build_config_model(model_cls: type[T], data: dict[str, Any] | None = None) -> T:
+    """Build a config dataclass from raw YAML data plus environment overrides."""
+
+    payload = data if isinstance(data, dict) else {}
+    kwargs: dict[str, Any] = {}
+    type_hints = get_type_hints(model_cls)
+
+    for model_field in fields(model_cls):
+        field_type = type_hints.get(model_field.name, model_field.type)
+        env_name = model_field.metadata.get("env")
+        env_value = os.getenv(env_name) if env_name else None
+
+        if env_name and env_value not in (None, ""):
+            kwargs[model_field.name] = _coerce_value(env_value, field_type)
+            continue
+
+        raw_value = payload.get(model_field.name, MISSING)
+        nested_type = _unwrap_optional(field_type)
+        if raw_value is not MISSING:
+            if _is_dataclass_type(nested_type):
+                nested_payload = raw_value if isinstance(raw_value, dict) else {}
+                kwargs[model_field.name] = build_config_model(nested_type, nested_payload)
+            else:
+                kwargs[model_field.name] = _coerce_value(raw_value, field_type)
+            continue
+
+        if _is_dataclass_type(nested_type):
+            kwargs[model_field.name] = build_config_model(nested_type, {})
+        elif model_field.default is not MISSING:
+            kwargs[model_field.name] = model_field.default
+        elif model_field.default_factory is not MISSING:
+            kwargs[model_field.name] = model_field.default_factory()
+        else:
+            raise TypeError(f"Missing required config field: {model_field.name}")
+
+    return model_cls(**kwargs)
+
+
+def config_to_dict(model: Any) -> dict[str, Any]:
+    """Convert a config dataclass to a plain dictionary."""
+
+    return asdict(model)
+
+
+def _unwrap_optional(field_type: Any) -> Any:
+    """Return the concrete type inside an Optional/Union type when possible."""
+
+    origin = get_origin(field_type)
+    if origin in (UnionType, Union):
+        args = [arg for arg in get_args(field_type) if arg is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return field_type
+
+
+def _is_dataclass_type(field_type: Any) -> bool:
+    """Return True when the provided type is a dataclass class."""
+
+    return isinstance(field_type, type) and is_dataclass(field_type)
+
+
+def _coerce_value(value: Any, field_type: Any) -> Any:
+    """Coerce YAML/env values into the annotated field type."""
+
+    target_type = _unwrap_optional(field_type)
+    origin = get_origin(target_type)
+
+    if target_type is Any or value is None:
+        return value
+    if origin in (list, dict, tuple, set):
+        return value
+    if target_type is bool:
+        if isinstance(value, bool):
+            return value
+        normalized = str(value).strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        raise ValueError(f"Cannot coerce {value!r} to bool")
+    if target_type is int:
+        return int(value)
+    if target_type is float:
+        return float(value)
+    if target_type is str:
+        return str(value)
+    if target_type is Path:
+        return Path(value)
+    return value
+
+
+@dataclass(slots=True)
+class AppMetadataConfig:
+    """Top-level application identity settings."""
+
+    name: str = "YoyoPod"
+    version: str = "1.0.0"
+    simulate: bool = config_value(default=False, env="YOYOPOD_SIMULATE")
+
+
+@dataclass(slots=True)
+class AppAudioConfig:
+    """Audio and Mopidy integration settings."""
+
+    mopidy_host: str = config_value(default="localhost", env="YOYOPOD_MOPIDY_HOST")
+    mopidy_port: int = config_value(default=6680, env="YOYOPOD_MOPIDY_PORT")
+    auto_resume_after_call: bool = config_value(
+        default=True,
+        env="YOYOPOD_AUTO_RESUME_AFTER_CALL",
+    )
+    fade_out_duration_ms: int = config_value(default=0, env="YOYOPOD_FADE_OUT_DURATION_MS")
+    fade_in_duration_ms: int = config_value(default=0, env="YOYOPOD_FADE_IN_DURATION_MS")
+    default_volume: int = config_value(default=70, env="YOYOPOD_DEFAULT_VOLUME")
+    ring_output_device: str = config_value(default="", env="YOYOPOD_RING_OUTPUT_DEVICE")
+    speaker_test_path: str = config_value(default="speaker-test", env="YOYOPOD_SPEAKER_TEST_PATH")
+
+
+@dataclass(slots=True)
+class AppVoIPConfig:
+    """App-level VoIP coordination settings."""
+
+    config_file: str = config_value(default="config/voip_config.yaml", env="YOYOPOD_VOIP_CONFIG_FILE")
+    priority_over_music: bool = config_value(default=True, env="YOYOPOD_PRIORITY_OVER_MUSIC")
+    auto_answer: bool = config_value(default=False)
+    ring_duration_seconds: int = config_value(default=30, env="YOYOPOD_RING_DURATION_SECONDS")
+
+
+@dataclass(slots=True)
+class AppUiConfig:
+    """Display/UI behavior settings."""
+
+    theme: str = "dark"
+    show_album_art: bool = True
+    screen_timeout_seconds: int = 300
+    button_debounce_ms: int = 50
+
+
+@dataclass(slots=True)
+class AppDisplayConfig:
+    """Display hardware configuration."""
+
+    hardware: str = config_value(default="auto", env="YOYOPOD_DISPLAY")
+    brightness: int = 80
+    rotation: int = 0
+    backlight_timeout_seconds: int = 60
+
+
+@dataclass(slots=True)
+class AppLoggingConfig:
+    """Logging configuration."""
+
+    level: str = config_value(default="INFO", env="YOYOPOD_LOG_LEVEL")
+    file: str = "logs/yoyopod.log"
+    max_size_mb: int = 10
+    backup_count: int = 3
+
+
+@dataclass(slots=True)
+class YoyoPodConfig:
+    """Root application configuration model loaded from yoyopod_config.yaml."""
+
+    app: AppMetadataConfig = config_value(default_factory=AppMetadataConfig)
+    audio: AppAudioConfig = config_value(default_factory=AppAudioConfig)
+    voip: AppVoIPConfig = config_value(default_factory=AppVoIPConfig)
+    ui: AppUiConfig = config_value(default_factory=AppUiConfig)
+    display: AppDisplayConfig = config_value(default_factory=AppDisplayConfig)
+    logging: AppLoggingConfig = config_value(default_factory=AppLoggingConfig)
+
+
+@dataclass(slots=True)
+class VoIPAccountConfig:
+    """VoIP account and SIP identity settings."""
+
+    sip_server: str = config_value(default="sip.linphone.org", env="YOYOPOD_SIP_SERVER")
+    sip_username: str = config_value(default="", env="YOYOPOD_SIP_USERNAME")
+    sip_password: str = config_value(default="", env="YOYOPOD_SIP_PASSWORD")
+    sip_password_ha1: str = config_value(default="", env="YOYOPOD_SIP_PASSWORD_HA1")
+    sip_identity: str = config_value(default="", env="YOYOPOD_SIP_IDENTITY")
+    transport: str = config_value(default="tcp", env="YOYOPOD_SIP_TRANSPORT")
+    display_name: str = "YoyoPod"
+
+
+@dataclass(slots=True)
+class VoIPNetworkConfig:
+    """VoIP network and NAT traversal settings."""
+
+    stun_server: str = config_value(default="stun.linphone.org", env="YOYOPOD_STUN_SERVER")
+    enable_ice: bool = True
+
+
+@dataclass(slots=True)
+class VoIPAudioConfig:
+    """VoIP audio and device settings."""
+
+    preferred_codec: str = "opus"
+    echo_cancellation: bool = True
+    mic_gain: int = 80
+    speaker_volume: int = 80
+    playback_device_id: str = config_value(
+        default="ALSA: plughw:1",
+        env="YOYOPOD_PLAYBACK_DEVICE",
+    )
+    ringer_device_id: str = config_value(
+        default="ALSA: plughw:1",
+        env="YOYOPOD_RINGER_DEVICE",
+    )
+    capture_device_id: str = config_value(
+        default="ALSA: plughw:1",
+        env="YOYOPOD_CAPTURE_DEVICE",
+    )
+    media_device_id: str = config_value(
+        default="ALSA: plughw:1",
+        env="YOYOPOD_MEDIA_DEVICE",
+    )
+    ring_output_device: str = config_value(default="", env="YOYOPOD_RING_OUTPUT_DEVICE")
+
+
+@dataclass(slots=True)
+class VoIPFileConfig:
+    """Root VoIP configuration model loaded from voip_config.yaml."""
+
+    account: VoIPAccountConfig = config_value(default_factory=VoIPAccountConfig)
+    network: VoIPNetworkConfig = config_value(default_factory=VoIPNetworkConfig)
+    audio: VoIPAudioConfig = config_value(default_factory=VoIPAudioConfig)
+    linphonec_path: str = config_value(default="/usr/bin/linphonec", env="YOYOPOD_LINPHONEC_PATH")
+    auto_answer: bool = False
+    call_timeout: int = 60


### PR DESCRIPTION
## Summary
- add typed app and VoIP config models with a shared YAML plus env overlay loader
- rework ConfigManager and YoyoPodApp to use the typed config path while preserving existing getter compatibility
- align the Raspberry Pi smoke helper with the new config loader and add coverage for config precedence

## Testing
- python -m compileall yoyopy tests scripts/pi_smoke.py
- uv run pytest -q