### PR TITLE
Remove legacy state machine from app path

### DIFF
--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -1,4 +1,4 @@
-"""Coordinator tests for the Phase 1 event bus and split FSM refactor."""
+"""Coordinator tests for the event bus and split FSM orchestration path."""
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ import pytest
 from yoyopy.app import YoyoPodApp
 from yoyopy.app_context import AppContext
 from yoyopy.connectivity import CallState, RegistrationState
+from yoyopy.coordinators.runtime import AppRuntimeState
 from yoyopy.events import (
     CallEndedEvent,
     CallStateChangedEvent,
@@ -17,8 +18,13 @@ from yoyopy.events import (
     RegistrationChangedEvent,
     TrackChangedEvent,
 )
-from yoyopy.fsm import CallSessionState, MusicState
-from yoyopy.state_machine import AppState, StateMachine
+from yoyopy.fsm import (
+    CallFSM,
+    CallInterruptionPolicy,
+    CallSessionState,
+    MusicFSM,
+    MusicState,
+)
 
 
 class FakeScreen:
@@ -96,10 +102,9 @@ def _build_app(playback_state: str = "stopped", auto_resume: bool = True) -> tup
 ]:
     app = YoyoPodApp(simulate=True)
     app.context = AppContext()
-    app.state_machine = StateMachine(app.context)
-    app.music_fsm = app.state_machine.music_fsm
-    app.call_fsm = app.state_machine.call_fsm
-    app.call_interruption_policy = app.state_machine.call_interruption_policy
+    app.music_fsm = MusicFSM()
+    app.call_fsm = CallFSM()
+    app.call_interruption_policy = CallInterruptionPolicy()
     app.auto_resume_after_call = auto_resume
     app.voip_registered = False
 
@@ -123,7 +128,7 @@ def _build_app(playback_state: str = "stopped", auto_resume: bool = True) -> tup
     )
     app.screen_manager = screen_manager
     app.screen_manager.push_screen("menu")
-    app.state_machine.set_ui_state(AppState.MENU, trigger="test_setup")
+    app._ui_state = AppRuntimeState.MENU
 
     app._setup_event_subscriptions()
     app.call_coordinator.start_ringing = lambda: None
@@ -135,7 +140,7 @@ def test_incoming_call_pauses_playing_music_once() -> None:
     """Incoming call events should pause active playback exactly once."""
     app, mopidy, screen_manager = _build_app(playback_state="playing")
     app.music_fsm.transition("play")
-    app.state_machine.sync_from_models("playback_playing")
+    app.coordinator_runtime.sync_app_state("playback_playing")
 
     _publish_from_worker(
         app,
@@ -167,6 +172,7 @@ def test_call_end_auto_resumes_only_when_enabled() -> None:
     app.music_fsm.sync(MusicState.PAUSED)
     app.call_fsm.sync(CallSessionState.ACTIVE)
     app.call_interruption_policy.music_interrupted_by_call = True
+    app.coordinator_runtime.sync_app_state("test_setup")
     screen_manager.push_screen("incoming_call")
     screen_manager.push_screen("in_call")
 
@@ -187,6 +193,7 @@ def test_call_end_keeps_music_paused_when_auto_resume_disabled() -> None:
     app.music_fsm.sync(MusicState.PAUSED)
     app.call_fsm.sync(CallSessionState.ACTIVE)
     app.call_interruption_policy.music_interrupted_by_call = True
+    app.coordinator_runtime.sync_app_state("test_setup")
     screen_manager.push_screen("incoming_call")
     screen_manager.push_screen("in_call")
 
@@ -214,6 +221,7 @@ def test_outgoing_call_does_not_change_idle_or_paused_music(
     """Outgoing call state changes should not mutate paused or idle music state."""
     app, _, _ = _build_app(playback_state=playback_state)
     app.music_fsm.sync(music_state)
+    app.coordinator_runtime.sync_app_state("test_setup")
 
     _publish_from_worker(app, CallStateChangedEvent(state=CallState.OUTGOING))
 
@@ -235,7 +243,7 @@ def test_background_events_wait_for_drain_before_mutating_state() -> None:
     assert app.event_bus.drain() == 2
     assert app.voip_registered
     assert app.music_fsm.state == MusicState.PLAYING
-    assert app.state_machine.current_state == AppState.PLAYING_WITH_VOIP
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.PLAYING_WITH_VOIP
 
 
 def test_track_event_refreshes_now_playing_screen_when_visible() -> None:
@@ -243,7 +251,7 @@ def test_track_event_refreshes_now_playing_screen_when_visible() -> None:
     app, _, screen_manager = _build_app(playback_state="playing")
     screen_manager.current_screen = app.now_playing_screen
     app.music_fsm.transition("play")
-    app.state_machine.sync_from_models("playback_playing")
+    app.coordinator_runtime.sync_app_state("playback_playing")
 
     _publish_from_worker(app, TrackChangedEvent(track=None))
 

--- a/tests/test_phase1_state_machine.py
+++ b/tests/test_phase1_state_machine.py
@@ -1,8 +1,31 @@
-"""Tests for the split FSM orchestration layer and compatibility bridge."""
+"""Tests for the split FSM orchestration layer and derived runtime state."""
 
-from yoyopy.app_context import AppContext
-from yoyopy.fsm import CallFSM, CallInterruptionPolicy, CallSessionState, MusicFSM, MusicState
-from yoyopy.state_machine import AppState, StateMachine
+from yoyopy.coordinators.runtime import AppRuntimeState, CoordinatorRuntime
+from yoyopy.fsm import (
+    CallFSM,
+    CallInterruptionPolicy,
+    CallSessionState,
+    MusicFSM,
+    MusicState,
+)
+
+
+def _build_runtime() -> CoordinatorRuntime:
+    """Create a minimal coordinator runtime for state-derivation tests."""
+    return CoordinatorRuntime(
+        music_fsm=MusicFSM(),
+        call_fsm=CallFSM(),
+        call_interruption_policy=CallInterruptionPolicy(),
+        screen_manager=None,
+        mopidy_client=None,
+        now_playing_screen=None,
+        call_screen=None,
+        incoming_call_screen=None,
+        outgoing_call_screen=None,
+        in_call_screen=None,
+        config={},
+        config_manager=None,
+    )
 
 
 def test_music_fsm_transitions() -> None:
@@ -57,56 +80,58 @@ def test_call_interruption_policy_pauses_and_resumes_music() -> None:
     assert not policy.music_interrupted_by_call
 
 
-def test_compatibility_state_machine_derives_legacy_state_from_split_fsms() -> None:
-    """The compatibility facade should derive legacy AppState values from the new FSMs."""
-    state_machine = StateMachine(AppContext())
+def test_runtime_state_is_derived_from_split_fsms() -> None:
+    """CoordinatorRuntime should derive app state from music and call FSMs."""
+    runtime = _build_runtime()
 
-    state_machine.set_ui_state(AppState.MENU, trigger="test_menu")
-    assert state_machine.current_state == AppState.MENU
+    state_change = runtime.set_ui_state(AppRuntimeState.MENU, trigger="test_menu")
+    assert state_change.entered(AppRuntimeState.MENU)
+    assert runtime.current_app_state == AppRuntimeState.MENU
 
-    state_machine.music_fsm.transition("play")
-    state_machine.sync_from_models("playback_playing")
-    assert state_machine.current_state == AppState.PLAYING
+    runtime.music_fsm.transition("play")
+    state_change = runtime.sync_app_state("playback_playing")
+    assert state_change.entered(AppRuntimeState.PLAYING)
+    assert runtime.current_app_state == AppRuntimeState.PLAYING
 
-    state_machine.set_voip_ready(True)
-    assert state_machine.current_state == AppState.PLAYING_WITH_VOIP
-    assert state_machine.is_playing_with_voip()
+    state_change = runtime.set_voip_ready(True)
+    assert state_change.entered(AppRuntimeState.PLAYING_WITH_VOIP)
+    assert runtime.current_app_state == AppRuntimeState.PLAYING_WITH_VOIP
 
-    state_machine.call_interruption_policy.pause_for_call(state_machine.music_fsm)
-    state_machine.sync_from_models("auto_pause_for_call")
-    assert state_machine.current_state == AppState.PAUSED_BY_CALL
-    assert state_machine.is_music_paused_by_call()
+    runtime.call_interruption_policy.pause_for_call(runtime.music_fsm)
+    state_change = runtime.sync_app_state("auto_pause_for_call")
+    assert state_change.entered(AppRuntimeState.PAUSED_BY_CALL)
+    assert runtime.current_app_state == AppRuntimeState.PAUSED_BY_CALL
 
-    state_machine.call_fsm.transition("incoming")
-    state_machine.sync_from_models("incoming_call")
-    assert state_machine.current_state == AppState.CALL_INCOMING
-    assert state_machine.is_in_call()
+    runtime.call_fsm.transition("incoming")
+    state_change = runtime.sync_app_state("incoming_call")
+    assert state_change.entered(AppRuntimeState.CALL_INCOMING)
+    assert runtime.current_app_state == AppRuntimeState.CALL_INCOMING
 
-    state_machine.call_fsm.transition("connect")
-    state_machine.sync_from_models("call_connected")
-    assert state_machine.current_state == AppState.CALL_ACTIVE_MUSIC_PAUSED
-    assert state_machine.has_paused_music_for_call()
+    runtime.call_fsm.transition("connect")
+    state_change = runtime.sync_app_state("call_connected")
+    assert state_change.entered(AppRuntimeState.CALL_ACTIVE_MUSIC_PAUSED)
+    assert runtime.current_app_state == AppRuntimeState.CALL_ACTIVE_MUSIC_PAUSED
 
-    state_machine.call_fsm.transition("end")
-    state_machine.music_fsm.transition("play")
-    state_machine.call_interruption_policy.clear()
-    state_machine.sync_from_models("call_ended")
-    assert state_machine.current_state == AppState.PLAYING_WITH_VOIP
+    runtime.call_fsm.transition("end")
+    runtime.music_fsm.transition("play")
+    runtime.call_interruption_policy.clear()
+    state_change = runtime.sync_app_state("call_ended")
+    assert state_change.entered(AppRuntimeState.PLAYING_WITH_VOIP)
+    assert runtime.current_app_state == AppRuntimeState.PLAYING_WITH_VOIP
 
 
-def test_legacy_transition_api_still_supports_existing_phase1_flow() -> None:
-    """The old transition_to API should still work during the bridge period."""
-    state_machine = StateMachine(AppContext())
+def test_runtime_returns_to_base_ui_state_when_music_and_calls_are_idle() -> None:
+    """The derived app state should fall back to the current base UI state."""
+    runtime = _build_runtime()
 
-    assert state_machine.transition_to(AppState.MENU, "open_menu")
-    assert state_machine.transition_to(AppState.PLAYING_WITH_VOIP, "select_media_with_voip")
-    assert state_machine.transition_to(AppState.PAUSED_BY_CALL, "auto_pause_for_call")
-    assert state_machine.transition_to(AppState.CALL_INCOMING, "incoming_call_ringing")
-    assert state_machine.transition_to(
-        AppState.CALL_ACTIVE_MUSIC_PAUSED,
-        "answer_call_resume_after",
-    )
-    assert state_machine.transition_to(AppState.PLAYING_WITH_VOIP, "call_ended_auto_resume")
+    runtime.set_ui_state(AppRuntimeState.PLAYLIST_BROWSER, trigger="browse_playlists")
+    assert runtime.current_app_state == AppRuntimeState.PLAYLIST_BROWSER
 
-    assert state_machine.is_playing_with_voip()
-    assert state_machine.is_music_playing()
+    runtime.music_fsm.transition("play")
+    runtime.sync_app_state("load_playlist")
+    assert runtime.current_app_state == AppRuntimeState.PLAYING
+
+    runtime.music_fsm.transition("stop")
+    state_change = runtime.sync_app_state("stop")
+    assert state_change.entered(AppRuntimeState.PLAYLIST_BROWSER)
+    assert runtime.current_app_state == AppRuntimeState.PLAYLIST_BROWSER

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -18,13 +18,14 @@ from yoyopy.audio.mopidy_client import MopidyClient
 from yoyopy.config import ConfigManager, YoyoPodConfig
 from yoyopy.connectivity import VoIPConfig, VoIPManager
 from yoyopy.coordinators import (
+    AppRuntimeState,
     CallCoordinator,
     CoordinatorRuntime,
     PlaybackCoordinator,
     ScreenCoordinator,
 )
 from yoyopy.event_bus import EventBus
-from yoyopy.state_machine import AppState, StateMachine
+from yoyopy.fsm import CallFSM, CallInterruptionPolicy, MusicFSM
 from yoyopy.ui.display import Display
 from yoyopy.ui.input import InputManager, get_input_manager
 from yoyopy.ui.screens import (
@@ -66,7 +67,6 @@ class YoyoPodApp:
         self.context: Optional[AppContext] = None
         self.config_manager: Optional[ConfigManager] = None
         self.app_settings: Optional[YoyoPodConfig] = None
-        self.state_machine: Optional[StateMachine] = None
         self.screen_manager: Optional[ScreenManager] = None
         self.input_manager: Optional[InputManager] = None
 
@@ -86,13 +86,14 @@ class YoyoPodApp:
         self.in_call_screen: Optional[InCallScreen] = None
 
         # Split orchestration models
-        self.music_fsm = None
-        self.call_fsm = None
-        self.call_interruption_policy = None
+        self.music_fsm: Optional[MusicFSM] = None
+        self.call_fsm: Optional[CallFSM] = None
+        self.call_interruption_policy: Optional[CallInterruptionPolicy] = None
 
         # Integration state
         self.auto_resume_after_call = True
         self._voip_registered = False
+        self._ui_state = AppRuntimeState.IDLE
 
         # Configuration
         self.config: Dict[str, Any] = {}
@@ -151,10 +152,10 @@ class YoyoPodApp:
                 return False
 
             self._ensure_coordinators()
+            self.coordinator_runtime.set_ui_state(AppRuntimeState.MENU, trigger="initial_screen")
             self._setup_event_subscriptions()
             self._setup_voip_callbacks()
             self._setup_music_callbacks()
-            self._setup_state_callbacks()
 
             logger.info("✓ YoyoPod setup complete")
             return True
@@ -184,7 +185,7 @@ class YoyoPodApp:
             return False
 
     def _init_core_components(self) -> bool:
-        """Initialize display, context, state machine, input, and screen manager."""
+        """Initialize display, context, orchestration models, input, and screen manager."""
         logger.info("Initializing core components...")
 
         try:
@@ -210,11 +211,10 @@ class YoyoPodApp:
             logger.info("  - AppContext")
             self.context = AppContext()
 
-            logger.info("  - StateMachine")
-            self.state_machine = StateMachine(self.context)
-            self.music_fsm = self.state_machine.music_fsm
-            self.call_fsm = self.state_machine.call_fsm
-            self.call_interruption_policy = self.state_machine.call_interruption_policy
+            logger.info("  - Orchestration Models")
+            self.music_fsm = MusicFSM()
+            self.call_fsm = CallFSM()
+            self.call_interruption_policy = CallInterruptionPolicy()
 
             logger.info("  - InputManager")
             self.input_manager = get_input_manager(
@@ -348,7 +348,7 @@ class YoyoPodApp:
             logger.info("    - Navigation: home, menu")
 
             self.screen_manager.push_screen("menu")
-            self.state_machine.set_ui_state(AppState.MENU, trigger="initial_screen")
+            self._ui_state = AppRuntimeState.MENU
             logger.info("  ✓ Initial screen set to menu")
             return True
         except Exception as exc:
@@ -393,17 +393,8 @@ class YoyoPodApp:
         logger.info("  ✓ Event subscriptions registered")
 
     def _setup_state_callbacks(self) -> None:
-        """Register state-machine callbacks."""
-        logger.info("Setting up state callbacks...")
-        self._ensure_coordinators()
-        self.state_machine.on_enter(
-            AppState.PLAYING_WITH_VOIP,
-            self.playback_coordinator.on_enter_playing_with_voip,
-        )
-        self.state_machine.on_enter(
-            AppState.CALL_ACTIVE_MUSIC_PAUSED,
-            self.call_coordinator.on_enter_call_active_music_paused,
-        )
+        """Legacy no-op retained for compatibility."""
+        return None
         logger.info("  ✓ State callbacks registered")
 
     def _run_on_main_thread(self, description: str, callback: Callable[[], None]) -> None:
@@ -425,7 +416,6 @@ class YoyoPodApp:
             return
 
         self.coordinator_runtime = CoordinatorRuntime(
-            state_machine=self.state_machine,
             music_fsm=self.music_fsm,
             call_fsm=self.call_fsm,
             call_interruption_policy=self.call_interruption_policy,
@@ -438,6 +428,8 @@ class YoyoPodApp:
             in_call_screen=self.in_call_screen,
             config=self.config,
             config_manager=self.config_manager,
+            ui_state=self._ui_state,
+            voip_ready=self._voip_registered,
         )
         self.screen_coordinator = ScreenCoordinator(self.coordinator_runtime)
         self.call_coordinator = CallCoordinator(
@@ -477,8 +469,8 @@ class YoyoPodApp:
         logger.info("YoyoPod Running")
         logger.info("=" * 60)
         logger.info("")
-        logger.info("State Machine Status:")
-        logger.info(f"  Current state: {self.state_machine.get_state_name()}")
+        logger.info("Coordinator Status:")
+        logger.info(f"  Current state: {self.coordinator_runtime.get_state_name()}")
         logger.info("")
         logger.info("VoIP Status:")
         if self.voip_manager:
@@ -570,7 +562,7 @@ class YoyoPodApp:
     def get_status(self) -> Dict[str, Any]:
         """Return the current application status."""
         return {
-            "state": self.state_machine.get_state_name(),
+            "state": self.coordinator_runtime.get_state_name(),
             "voip_registered": self.voip_registered,
             "music_was_playing": self.call_interruption_policy.music_interrupted_by_call,
             "auto_resume": self.auto_resume_after_call,

--- a/yoyopy/coordinators/__init__.py
+++ b/yoyopy/coordinators/__init__.py
@@ -4,10 +4,11 @@ Coordinator modules for YoyoPod orchestration.
 
 from yoyopy.coordinators.call import CallCoordinator
 from yoyopy.coordinators.playback import PlaybackCoordinator
-from yoyopy.coordinators.runtime import CoordinatorRuntime
+from yoyopy.coordinators.runtime import AppRuntimeState, CoordinatorRuntime
 from yoyopy.coordinators.screen import ScreenCoordinator
 
 __all__ = [
+    "AppRuntimeState",
     "CallCoordinator",
     "PlaybackCoordinator",
     "CoordinatorRuntime",

--- a/yoyopy/coordinators/call.py
+++ b/yoyopy/coordinators/call.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from loguru import logger
 
-from yoyopy.coordinators.runtime import CoordinatorRuntime
+from yoyopy.coordinators.runtime import AppRuntimeState, CoordinatorRuntime
 from yoyopy.coordinators.screen import ScreenCoordinator
 from yoyopy.event_bus import EventBus
 from yoyopy.events import (
@@ -159,7 +159,7 @@ class CallCoordinator:
                 self.runtime.mopidy_client.pause()
 
         self.runtime.call_fsm.transition("incoming")
-        self.runtime.state_machine.sync_from_models("incoming_call")
+        self.runtime.sync_app_state("incoming_call")
 
         self.screen_coordinator.show_incoming_call(caller_address, caller_name)
         self.start_ringing()
@@ -175,17 +175,19 @@ class CallCoordinator:
             CallState.OUTGOING_EARLY_MEDIA,
         ):
             self.runtime.call_fsm.transition("dial")
-            self.runtime.state_machine.sync_from_models("call_outgoing")
+            self.runtime.sync_app_state("call_outgoing")
             return
 
         if state == CallState.INCOMING:
             self.runtime.call_fsm.transition("incoming")
-            self.runtime.state_machine.sync_from_models("call_incoming_state")
+            self.runtime.sync_app_state("call_incoming_state")
             return
 
         if state in (CallState.CONNECTED, CallState.STREAMS_RUNNING):
             self.runtime.call_fsm.transition("connect")
-            self.runtime.state_machine.sync_from_models("call_connected")
+            state_change = self.runtime.sync_app_state("call_connected")
+            if state_change.entered(AppRuntimeState.CALL_ACTIVE_MUSIC_PAUSED):
+                logger.info("In call (music paused in background)")
             self.screen_coordinator.show_in_call()
             self.stop_ringing()
 
@@ -215,14 +217,14 @@ class CallCoordinator:
             logger.info("  No music to resume")
 
         self.runtime.call_interruption_policy.clear()
-        self.runtime.state_machine.sync_from_models("call_ended")
+        self.runtime.sync_app_state("call_ended")
 
     def handle_registration_change(self, state: RegistrationState) -> None:
         """Coordinate registration updates and VoIP availability state."""
         logger.info(f"📞 VoIP registration: {state.value}")
 
         self.voip_registered = state == RegistrationState.OK
-        self.runtime.state_machine.set_voip_ready(self.voip_registered)
+        self.runtime.set_voip_ready(self.voip_registered)
 
         if state == RegistrationState.OK:
             logger.info("  ✓ VoIP ready to receive calls")

--- a/yoyopy/coordinators/playback.py
+++ b/yoyopy/coordinators/playback.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from loguru import logger
 
 from yoyopy.audio.mopidy_client import MopidyTrack
-from yoyopy.coordinators.runtime import CoordinatorRuntime
+from yoyopy.coordinators.runtime import AppRuntimeState, CoordinatorRuntime
 from yoyopy.coordinators.screen import ScreenCoordinator
 from yoyopy.event_bus import EventBus
 from yoyopy.events import PlaybackStateChangedEvent, TrackChangedEvent
@@ -68,7 +68,7 @@ class PlaybackCoordinator:
             logger.info("🎵 Playback stopped")
             if not self.runtime.call_fsm.is_active:
                 self.runtime.music_fsm.transition("stop")
-                self.runtime.state_machine.sync_from_models("track_stopped")
+                self.runtime.sync_app_state("track_stopped")
 
         self.screen_coordinator.refresh_now_playing_screen()
 
@@ -87,5 +87,7 @@ class PlaybackCoordinator:
         elif playback_state == "stopped":
             self.runtime.music_fsm.transition("stop")
 
-        self.runtime.state_machine.sync_from_models(f"playback_{playback_state}")
+        state_change = self.runtime.sync_app_state(f"playback_{playback_state}")
+        if state_change.entered(AppRuntimeState.PLAYING_WITH_VOIP):
+            logger.info("Music playing with VoIP ready")
         self.screen_coordinator.refresh_now_playing_screen()

--- a/yoyopy/coordinators/runtime.py
+++ b/yoyopy/coordinators/runtime.py
@@ -4,18 +4,64 @@ Shared runtime references for YoyoPod coordinators.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
-from yoyopy.fsm import CallFSM, CallInterruptionPolicy, MusicFSM
-from yoyopy.state_machine import StateMachine
+from loguru import logger
+
+from yoyopy.fsm import (
+    CallFSM,
+    CallInterruptionPolicy,
+    CallSessionState,
+    MusicFSM,
+    MusicState,
+)
+
+
+class AppRuntimeState(Enum):
+    """Derived application state used by the production coordinator path."""
+
+    IDLE = "idle"
+    MENU = "menu"
+    PLAYING = "playing"
+    PAUSED = "paused"
+    SETTINGS = "settings"
+    PLAYLIST = "playlist"
+    PLAYLIST_BROWSER = "playlist_browser"
+    CALL_IDLE = "call_idle"
+    CALL_INCOMING = "call_incoming"
+    CALL_OUTGOING = "call_outgoing"
+    CALL_ACTIVE = "call_active"
+    CONNECTING = "connecting"
+    ERROR = "error"
+    PLAYING_WITH_VOIP = "playing_with_voip"
+    PAUSED_BY_CALL = "paused_by_call"
+    CALL_ACTIVE_MUSIC_PAUSED = "call_active_music_paused"
+
+
+@dataclass(frozen=True, slots=True)
+class AppStateChange:
+    """Describe a derived app-state refresh."""
+
+    previous_state: AppRuntimeState
+    current_state: AppRuntimeState
+    trigger: str
+
+    @property
+    def changed(self) -> bool:
+        """Return True when the derived app state changed."""
+        return self.previous_state != self.current_state
+
+    def entered(self, state: AppRuntimeState) -> bool:
+        """Return True when this refresh entered the provided state."""
+        return self.changed and self.current_state == state
 
 
 @dataclass(slots=True)
 class CoordinatorRuntime:
     """Shared app runtime references used by coordinator modules."""
 
-    state_machine: StateMachine
     music_fsm: MusicFSM
     call_fsm: CallFSM
     call_interruption_policy: CallInterruptionPolicy
@@ -28,3 +74,99 @@ class CoordinatorRuntime:
     in_call_screen: Any
     config: dict[str, Any]
     config_manager: Any
+    ui_state: AppRuntimeState = AppRuntimeState.IDLE
+    voip_ready: bool = False
+    current_app_state: AppRuntimeState = field(init=False)
+    previous_app_state: AppRuntimeState | None = field(init=False, default=None)
+    state_history: list[AppRuntimeState] = field(init=False, default_factory=list)
+
+    _UI_STATES = {
+        AppRuntimeState.IDLE,
+        AppRuntimeState.MENU,
+        AppRuntimeState.SETTINGS,
+        AppRuntimeState.PLAYLIST,
+        AppRuntimeState.PLAYLIST_BROWSER,
+        AppRuntimeState.CALL_IDLE,
+        AppRuntimeState.CONNECTING,
+        AppRuntimeState.ERROR,
+    }
+
+    def __post_init__(self) -> None:
+        self.current_app_state = self._derive_state()
+        self.state_history = [self.current_app_state]
+
+    def _derive_state(self) -> AppRuntimeState:
+        """Derive the current application state from the split FSMs."""
+        if self.call_fsm.state == CallSessionState.INCOMING:
+            return AppRuntimeState.CALL_INCOMING
+
+        if self.call_fsm.state == CallSessionState.OUTGOING:
+            return AppRuntimeState.CALL_OUTGOING
+
+        if self.call_fsm.state == CallSessionState.ACTIVE:
+            if self.call_interruption_policy.music_interrupted_by_call:
+                return AppRuntimeState.CALL_ACTIVE_MUSIC_PAUSED
+            return AppRuntimeState.CALL_ACTIVE
+
+        if (
+            self.call_interruption_policy.music_interrupted_by_call
+            and self.music_fsm.state == MusicState.PAUSED
+        ):
+            return AppRuntimeState.PAUSED_BY_CALL
+
+        if self.music_fsm.state == MusicState.PLAYING:
+            if self.voip_ready:
+                return AppRuntimeState.PLAYING_WITH_VOIP
+            return AppRuntimeState.PLAYING
+
+        if self.music_fsm.state == MusicState.PAUSED:
+            return AppRuntimeState.PAUSED
+
+        return self.ui_state
+
+    def sync_app_state(self, trigger: str = "sync") -> AppStateChange:
+        """Refresh the derived app state after coordinator mutations."""
+        previous_state = self.current_app_state
+        current_state = self._derive_state()
+
+        if current_state != previous_state:
+            self.previous_app_state = previous_state
+            self.current_app_state = current_state
+            self.state_history.append(current_state)
+            if len(self.state_history) > 50:
+                self.state_history = self.state_history[-50:]
+
+            logger.info(
+                "Coordinator state: {} -> {} (trigger: {})",
+                previous_state.value,
+                current_state.value,
+                trigger,
+            )
+
+        return AppStateChange(
+            previous_state=previous_state,
+            current_state=self.current_app_state,
+            trigger=trigger,
+        )
+
+    def set_ui_state(
+        self,
+        state: AppRuntimeState,
+        trigger: str = "ui_state",
+    ) -> AppStateChange:
+        """Update the base UI state used when music and calls are idle."""
+        if state not in self._UI_STATES:
+            raise ValueError(f"{state.value} is not a base UI state")
+
+        self.ui_state = state
+        return self.sync_app_state(trigger)
+
+    def set_voip_ready(self, ready: bool, trigger: str = "voip_ready") -> AppStateChange:
+        """Store whether VoIP is ready and refresh the derived state."""
+        self.voip_ready = ready
+        actual_trigger = trigger if ready else "voip_unavailable"
+        return self.sync_app_state(actual_trigger)
+
+    def get_state_name(self) -> str:
+        """Return the current derived app-state name."""
+        return self.current_app_state.value


### PR DESCRIPTION
## Summary
- remove the StateMachine compatibility facade from the production app/coordinator runtime path
- add a derived AppRuntimeState layer on CoordinatorRuntime for status and state refreshes
- rewrite orchestration and FSM tests to target the split FSM runtime directly while keeping state_machine.py for the legacy demo only

## Testing
- python -m compileall yoyopy tests
- uv run pytest -q