### PR TITLE
Sync runtime state with screen navigation

### DIFF
--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -32,6 +32,7 @@ class FakeScreen:
 
     def __init__(self) -> None:
         self.render_calls = 0
+        self.route_name: str | None = None
 
     def render(self) -> None:
         self.render_calls += 1
@@ -54,16 +55,30 @@ class FakeScreenManager:
         self.screen_lookup = screen_lookup
         self.screen_stack: list[object] = []
         self.current_screen: object | None = None
+        self.on_screen_changed = None
+
+        for name, screen in screen_lookup.items():
+            setattr(screen, "route_name", name)
 
     def push_screen(self, name: str) -> None:
         screen = self.screen_lookup[name]
         self.screen_stack.append(screen)
         self.current_screen = screen
+        self._notify_screen_changed(name)
 
     def pop_screen(self) -> None:
         if self.screen_stack:
             self.screen_stack.pop()
         self.current_screen = self.screen_stack[-1] if self.screen_stack else None
+        route_name = getattr(self.current_screen, "route_name", None)
+        self._notify_screen_changed(route_name)
+
+    def get_current_screen(self) -> object | None:
+        return self.current_screen
+
+    def _notify_screen_changed(self, route_name: str | None) -> None:
+        if self.on_screen_changed is not None:
+            self.on_screen_changed(route_name)
 
 
 class FakeMopidyClient:
@@ -113,7 +128,9 @@ def _build_app(playback_state: str = "stopped", auto_resume: bool = True) -> tup
 
     app.menu_screen = FakeScreen()
     app.now_playing_screen = FakeScreen()
+    app.playlist_screen = FakeScreen()
     app.call_screen = FakeScreen()
+    app.contact_list_screen = FakeScreen()
     app.incoming_call_screen = FakeIncomingCallScreen()
     app.outgoing_call_screen = FakeScreen()
     app.in_call_screen = FakeScreen()
@@ -121,6 +138,8 @@ def _build_app(playback_state: str = "stopped", auto_resume: bool = True) -> tup
     screen_manager = FakeScreenManager(
         {
             "menu": app.menu_screen,
+            "playlists": app.playlist_screen,
+            "contacts": app.contact_list_screen,
             "incoming_call": app.incoming_call_screen,
             "outgoing_call": app.outgoing_call_screen,
             "in_call": app.in_call_screen,
@@ -259,3 +278,34 @@ def test_track_event_refreshes_now_playing_screen_when_visible() -> None:
     assert app.event_bus.drain() == 1
     assert app.now_playing_screen.render_calls == 1
     assert app.music_fsm.state == MusicState.IDLE
+
+
+def test_navigation_updates_runtime_base_state() -> None:
+    """Idle navigation should keep the derived runtime state aligned with the active screen."""
+    app, _, screen_manager = _build_app(playback_state="stopped")
+
+    screen_manager.push_screen("contacts")
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.CALL_IDLE
+
+    screen_manager.pop_screen()
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.MENU
+
+    screen_manager.push_screen("playlists")
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.PLAYLIST_BROWSER
+
+
+def test_call_end_restores_previous_screen_base_state() -> None:
+    """Ending a call should restore the derived state for the screen the user returns to."""
+    app, _, screen_manager = _build_app(playback_state="stopped")
+    screen_manager.push_screen("playlists")
+
+    app.call_fsm.sync(CallSessionState.ACTIVE)
+    app.coordinator_runtime.sync_app_state("call_connected")
+    screen_manager.push_screen("incoming_call")
+    screen_manager.push_screen("in_call")
+
+    _publish_from_worker(app, CallEndedEvent())
+
+    assert app.event_bus.drain() == 1
+    assert screen_manager.current_screen is app.playlist_screen
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.PLAYLIST_BROWSER

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -392,8 +392,6 @@ class YoyoPodApp:
         self.playback_coordinator.bind(self.event_bus)
         logger.info("  ✓ Event subscriptions registered")
 
-        logger.info("  ✓ State callbacks registered")
-
     def _run_on_main_thread(self, description: str, callback: Callable[[], None]) -> None:
         """Queue work onto the coordinator thread."""
         self.event_bus.publish(_MainThreadCallbackEvent(description=description, callback=callback))
@@ -439,6 +437,11 @@ class YoyoPodApp:
             runtime=self.coordinator_runtime,
             screen_coordinator=self.screen_coordinator,
         )
+        if self.screen_manager is not None:
+            self.screen_manager.on_screen_changed = self._handle_screen_changed
+            current_screen = self.screen_manager.get_current_screen()
+            current_route_name = current_screen.route_name if current_screen is not None else None
+            self._handle_screen_changed(current_route_name)
 
     def _pop_call_screens(self) -> None:
         """Compatibility wrapper for clearing call-related screens."""
@@ -459,6 +462,11 @@ class YoyoPodApp:
         """Compatibility wrapper for stopping the call ring tone."""
         self._ensure_coordinators()
         self.call_coordinator.stop_ringing()
+
+    def _handle_screen_changed(self, screen_name: str | None) -> None:
+        """Keep the derived base UI state aligned with the active screen."""
+        self._ensure_coordinators()
+        self.coordinator_runtime.sync_ui_state_for_screen(screen_name)
 
     def run(self) -> None:
         """Run the main application loop until interrupted."""

--- a/yoyopy/coordinators/runtime.py
+++ b/yoyopy/coordinators/runtime.py
@@ -167,6 +167,20 @@ class CoordinatorRuntime:
         actual_trigger = trigger if ready else "voip_unavailable"
         return self.sync_app_state(actual_trigger)
 
+    def sync_ui_state_for_screen(self, screen_name: str | None) -> AppStateChange | None:
+        """Update the base UI state for non-call overlay screens."""
+        state_by_screen = {
+            "home": AppRuntimeState.IDLE,
+            "menu": AppRuntimeState.MENU,
+            "playlists": AppRuntimeState.PLAYLIST_BROWSER,
+            "call": AppRuntimeState.CALL_IDLE,
+            "contacts": AppRuntimeState.CALL_IDLE,
+        }
+        if screen_name is None or screen_name not in state_by_screen:
+            return None
+
+        return self.set_ui_state(state_by_screen[screen_name], trigger=f"screen:{screen_name}")
+
     def get_state_name(self) -> str:
         """Return the current derived app-state name."""
         return self.current_app_state.value

--- a/yoyopy/ui/screens/manager.py
+++ b/yoyopy/ui/screens/manager.py
@@ -4,7 +4,7 @@ Screen management and navigation for YoyoPod.
 Handles screen transitions, route resolution, and the navigation stack.
 """
 
-from typing import Optional, Dict, TYPE_CHECKING
+from typing import Callable, Optional, Dict, TYPE_CHECKING
 from loguru import logger
 
 from yoyopy.ui.display import Display
@@ -36,6 +36,7 @@ class ScreenManager:
         display: Display,
         input_manager: Optional['InputManager'] = None,
         router: Optional[ScreenRouter] = None,
+        on_screen_changed: Optional[Callable[[Optional[str]], None]] = None,
     ) -> None:
         """
         Initialize the screen manager.
@@ -50,6 +51,7 @@ class ScreenManager:
         self.screen_stack: list[Screen] = []
         self.screens: Dict[str, Screen] = {}
         self.router = router or ScreenRouter()
+        self.on_screen_changed = on_screen_changed
 
         logger.info("ScreenManager initialized")
 
@@ -88,6 +90,7 @@ class ScreenManager:
         self.current_screen.enter()
         self._connect_buttons()
         self.current_screen.render()
+        self._notify_screen_changed()
 
         logger.info(f"Pushed screen: {screen_name} (stack depth: {len(self.screen_stack)})")
 
@@ -112,6 +115,7 @@ class ScreenManager:
         self.current_screen.enter()
         self._connect_buttons()
         self.current_screen.render()
+        self._notify_screen_changed()
 
         logger.info(f"Popped screen (stack depth: {len(self.screen_stack)})")
         return True
@@ -137,6 +141,7 @@ class ScreenManager:
         self.current_screen.enter()
         self._connect_buttons()
         self.current_screen.render()
+        self._notify_screen_changed()
 
         logger.info(f"Replaced screen with: {screen_name}")
 
@@ -153,6 +158,13 @@ class ScreenManager:
         """Re-render the current screen."""
         if self.current_screen:
             self.current_screen.render()
+
+    def _notify_screen_changed(self) -> None:
+        """Notify listeners when the active screen changes."""
+        if self.on_screen_changed is None:
+            return
+        route_name = self.current_screen.route_name if self.current_screen else None
+        self.on_screen_changed(route_name)
 
     def apply_navigation_request(
         self,


### PR DESCRIPTION
## Summary
- keep the derived app runtime state aligned with actual screen navigation
- update the screen manager to notify when the active screen changes
- add regressions for idle navigation and returning from calls to the previous screen

## Testing
- python -m compileall yoyopy tests
- uv run pytest -q