### PR TITLE
Marshal screen sync onto coordinator thread

### DIFF
--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -110,6 +110,12 @@ def _publish_from_worker(app: YoyoPodApp, event: object) -> None:
     worker.join()
 
 
+def _navigate_from_worker(screen_manager: FakeScreenManager, screen_name: str) -> None:
+    worker = threading.Thread(target=lambda: screen_manager.push_screen(screen_name))
+    worker.start()
+    worker.join()
+
+
 def _build_app(playback_state: str = "stopped", auto_resume: bool = True) -> tuple[
     YoyoPodApp,
     FakeMopidyClient,
@@ -308,6 +314,18 @@ def test_navigation_updates_runtime_base_state() -> None:
 
     screen_manager.push_screen("playlists")
     assert app.coordinator_runtime.current_app_state == AppRuntimeState.PLAYLIST_BROWSER
+
+
+def test_worker_navigation_waits_for_coordinator_drain_before_syncing_state() -> None:
+    """Screen-change callbacks from worker threads should queue runtime sync onto the event bus."""
+    app, _, screen_manager = _build_app(playback_state="stopped")
+
+    _navigate_from_worker(screen_manager, "contacts")
+
+    assert screen_manager.current_screen is app.contact_list_screen
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.MENU
+    assert app.event_bus.drain() == 1
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.CALL_IDLE
 
 
 def test_call_end_restores_previous_screen_base_state() -> None:

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -469,6 +469,13 @@ class YoyoPodApp:
         self.call_coordinator.stop_ringing()
 
     def _handle_screen_changed(self, screen_name: str | None) -> None:
+        """Marshal screen-state sync work onto the coordinator thread."""
+        self._run_on_main_thread(
+            f"sync screen state: {screen_name or 'none'}",
+            lambda: self._sync_screen_changed(screen_name),
+        )
+
+    def _sync_screen_changed(self, screen_name: str | None) -> None:
         """Keep the derived base UI state aligned with the active screen."""
         self._ensure_coordinators()
         self.coordinator_runtime.sync_ui_state_for_screen(screen_name)


### PR DESCRIPTION
## Summary
- route screen-change runtime sync through the app's main-thread event bus
- keep immediate sync behavior when navigation already happens on the coordinator thread
- add a regression test proving worker-thread navigation does not mutate runtime state until drain

## Verification
- python -m compileall yoyopy tests
- uv run pytest tests/test_app_orchestration.py -q
- uv run pytest -q