### PR TITLE
Add backend recovery and offline states

### DIFF
--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -14,9 +14,11 @@ from yoyopy.events import (
     CallEndedEvent,
     CallStateChangedEvent,
     IncomingCallEvent,
+    MusicAvailabilityChangedEvent,
     PlaybackStateChangedEvent,
     RegistrationChangedEvent,
     TrackChangedEvent,
+    VoIPAvailabilityChangedEvent,
 )
 from yoyopy.fsm import (
     CallFSM,
@@ -102,6 +104,42 @@ class FakeMopidyClient:
         self.play_calls += 1
         self.playback_state = "playing"
         return True
+
+
+class FakeRecoveringVoIPManager:
+    """Minimal VoIP manager double for app-level recovery tests."""
+
+    def __init__(self, start_results: list[bool]) -> None:
+        self._start_results = start_results
+        self.start_calls = 0
+        self.running = False
+
+    def start(self) -> bool:
+        self.start_calls += 1
+        result_index = min(self.start_calls - 1, len(self._start_results) - 1)
+        self.running = self._start_results[result_index]
+        return self.running
+
+
+class FakeRecoveringMopidyClient:
+    """Minimal Mopidy double for recovery backoff tests."""
+
+    def __init__(self, connect_results: list[bool]) -> None:
+        self._connect_results = connect_results
+        self.connect_calls = 0
+        self.start_polling_calls = 0
+        self.is_connected = False
+        self.polling = False
+
+    def connect(self) -> bool:
+        self.connect_calls += 1
+        result_index = min(self.connect_calls - 1, len(self._connect_results) - 1)
+        self.is_connected = self._connect_results[result_index]
+        return self.is_connected
+
+    def start_polling(self) -> None:
+        self.polling = True
+        self.start_polling_calls += 1
 
 
 def _publish_from_worker(app: YoyoPodApp, event: object) -> None:
@@ -302,6 +340,44 @@ def test_periodic_in_call_refresh_only_renders_visible_call_screen() -> None:
     assert app.in_call_screen.render_calls == 1
 
 
+def test_voip_unavailable_event_ends_call_and_restores_music() -> None:
+    """VoIP backend loss should tear down the call flow and restore interrupted playback."""
+    app, mopidy, screen_manager = _build_app(playback_state="paused", auto_resume=True)
+    app.music_fsm.sync(MusicState.PAUSED)
+    app.call_fsm.sync(CallSessionState.ACTIVE)
+    app.call_interruption_policy.music_interrupted_by_call = True
+    app.coordinator_runtime.sync_app_state("test_setup")
+    screen_manager.push_screen("in_call")
+
+    _publish_from_worker(
+        app,
+        VoIPAvailabilityChangedEvent(available=False, reason="backend_stopped"),
+    )
+
+    assert app.event_bus.drain() == 1
+    assert app.call_fsm.state == CallSessionState.IDLE
+    assert app.music_fsm.state == MusicState.PLAYING
+    assert mopidy.play_calls == 1
+    assert screen_manager.current_screen is app.menu_screen
+
+
+def test_music_unavailable_event_stops_music_and_refreshes_now_playing() -> None:
+    """Mopidy loss should stop music state and refresh the visible now-playing screen."""
+    app, _, screen_manager = _build_app(playback_state="playing")
+    screen_manager.current_screen = app.now_playing_screen
+    app.music_fsm.transition("play")
+    app.coordinator_runtime.sync_app_state("playback_playing")
+
+    _publish_from_worker(
+        app,
+        MusicAvailabilityChangedEvent(available=False, reason="connection_lost"),
+    )
+
+    assert app.event_bus.drain() == 1
+    assert app.music_fsm.state == MusicState.IDLE
+    assert app.now_playing_screen.render_calls == 1
+
+
 def test_navigation_updates_runtime_base_state() -> None:
     """Idle navigation should keep the derived runtime state aligned with the active screen."""
     app, _, screen_manager = _build_app(playback_state="stopped")
@@ -343,3 +419,33 @@ def test_call_end_restores_previous_screen_base_state() -> None:
     assert app.event_bus.drain() == 1
     assert screen_manager.current_screen is app.playlist_screen
     assert app.coordinator_runtime.current_app_state == AppRuntimeState.PLAYLIST_BROWSER
+
+
+def test_manager_recovery_uses_backoff_and_starts_polling_after_reconnect() -> None:
+    """Recovery attempts should back off after failure and restart healthy managers."""
+    app = YoyoPodApp(simulate=True)
+    app.voip_manager = FakeRecoveringVoIPManager([False, True])
+    app.mopidy_client = FakeRecoveringMopidyClient([False, True])
+
+    app._attempt_manager_recovery(now=0.0)
+
+    assert app.voip_manager.start_calls == 1
+    assert app.mopidy_client.connect_calls == 1
+    assert app.mopidy_client.start_polling_calls == 0
+    assert app._voip_recovery.next_attempt_at == 1.0
+    assert app._mopidy_recovery.next_attempt_at == 1.0
+
+    app._attempt_manager_recovery(now=0.5)
+
+    assert app.voip_manager.start_calls == 1
+    assert app.mopidy_client.connect_calls == 1
+
+    app._attempt_manager_recovery(now=1.0)
+
+    assert app.voip_manager.start_calls == 2
+    assert app.voip_manager.running
+    assert app.mopidy_client.connect_calls == 2
+    assert app.mopidy_client.is_connected
+    assert app.mopidy_client.start_polling_calls == 1
+    assert app._voip_recovery.next_attempt_at == 0.0
+    assert app._mopidy_recovery.next_attempt_at == 0.0

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -50,6 +50,19 @@ class _MainThreadCallbackEvent:
     callback: Callable[[], None]
 
 
+@dataclass(slots=True)
+class _RecoveryState:
+    """Track reconnect backoff for a recoverable subsystem."""
+
+    next_attempt_at: float = 0.0
+    delay_seconds: float = 1.0
+
+    def reset(self) -> None:
+        """Reset backoff after a successful recovery."""
+        self.next_attempt_at = 0.0
+        self.delay_seconds = 1.0
+
+
 class YoyoPodApp:
     """
     Main YoyoPod application coordinator.
@@ -57,6 +70,8 @@ class YoyoPodApp:
     Owns startup, lifecycle, and the main loop while delegating call and
     playback orchestration to focused coordinator modules.
     """
+
+    _RECOVERY_MAX_DELAY_SECONDS = 30.0
 
     def __init__(self, config_dir: str = "config", simulate: bool = False) -> None:
         self.config_dir = config_dir
@@ -108,6 +123,10 @@ class YoyoPodApp:
         self.screen_coordinator: Optional[ScreenCoordinator] = None
         self.call_coordinator: Optional[CallCoordinator] = None
         self.playback_coordinator: Optional[PlaybackCoordinator] = None
+
+        # Recovery backoff state
+        self._voip_recovery = _RecoveryState()
+        self._mopidy_recovery = _RecoveryState()
 
         logger.info("=" * 60)
         logger.info("YoyoPod Application Initializing")
@@ -367,6 +386,7 @@ class YoyoPodApp:
         self.voip_manager.on_incoming_call(self.call_coordinator.publish_incoming_call)
         self.voip_manager.on_call_state_change(self.call_coordinator.publish_call_state_events)
         self.voip_manager.on_registration_change(self.call_coordinator.publish_registration_change)
+        self.voip_manager.on_availability_change(self.call_coordinator.publish_availability_change)
         logger.info("  ✓ VoIP callbacks registered")
 
     def _setup_music_callbacks(self) -> None:
@@ -381,6 +401,9 @@ class YoyoPodApp:
         self.mopidy_client.on_track_change(self.playback_coordinator.publish_track_change)
         self.mopidy_client.on_playback_state_change(
             self.playback_coordinator.publish_playback_state_change
+        )
+        self.mopidy_client.on_connection_change(
+            self.playback_coordinator.publish_availability_change
         )
         logger.info("  ✓ Music callbacks registered")
 
@@ -480,6 +503,77 @@ class YoyoPodApp:
         self._ensure_coordinators()
         self.coordinator_runtime.sync_ui_state_for_screen(screen_name)
 
+    def _attempt_manager_recovery(self, now: float | None = None) -> None:
+        """Try to recover VoIP and Mopidy when they become unavailable."""
+        recovery_now = time.monotonic() if now is None else now
+        self._attempt_voip_recovery(recovery_now)
+        self._attempt_mopidy_recovery(recovery_now)
+
+    def _attempt_voip_recovery(self, recovery_now: float) -> None:
+        """Restart the VoIP backend when it is not running."""
+        if self.voip_manager is None:
+            return
+
+        if self.voip_manager.running:
+            self._voip_recovery.reset()
+            return
+
+        if recovery_now < self._voip_recovery.next_attempt_at:
+            return
+
+        logger.info("Attempting VoIP recovery")
+        self._finalize_recovery_attempt(
+            "VoIP",
+            self._voip_recovery,
+            self.voip_manager.start(),
+            recovery_now,
+        )
+
+    def _attempt_mopidy_recovery(self, recovery_now: float) -> None:
+        """Reconnect Mopidy when the HTTP client becomes unavailable."""
+        if self.mopidy_client is None:
+            return
+
+        if self.mopidy_client.is_connected:
+            self._mopidy_recovery.reset()
+            return
+
+        if recovery_now < self._mopidy_recovery.next_attempt_at:
+            return
+
+        logger.info("Attempting Mopidy recovery")
+        recovered = self.mopidy_client.connect()
+        if recovered and not self.mopidy_client.polling:
+            self.mopidy_client.start_polling()
+
+        self._finalize_recovery_attempt(
+            "Mopidy",
+            self._mopidy_recovery,
+            recovered,
+            recovery_now,
+        )
+
+    def _finalize_recovery_attempt(
+        self,
+        label: str,
+        state: _RecoveryState,
+        recovered: bool,
+        recovery_now: float,
+    ) -> None:
+        """Update reconnect backoff after a recovery attempt."""
+        if recovered:
+            logger.info(f"{label} recovery succeeded")
+            state.reset()
+            return
+
+        retry_in = state.delay_seconds
+        logger.warning(f"{label} recovery failed, retrying in {retry_in:.0f}s")
+        state.next_attempt_at = recovery_now + retry_in
+        state.delay_seconds = min(
+            state.delay_seconds * 2.0,
+            self._RECOVERY_MAX_DELAY_SECONDS,
+        )
+
     def run(self) -> None:
         """Run the main application loop until interrupted."""
         logger.info("=" * 60)
@@ -532,6 +626,7 @@ class YoyoPodApp:
             while True:
                 time.sleep(0.1)
                 self._process_pending_main_thread_actions()
+                self._attempt_manager_recovery()
 
                 current_time = time.time()
                 if current_time - last_screen_update >= screen_update_interval:
@@ -584,6 +679,6 @@ class YoyoPodApp:
             "voip_registered": self.voip_registered,
             "music_was_playing": self.call_interruption_policy.music_interrupted_by_call,
             "auto_resume": self.auto_resume_after_call,
-            "voip_available": self.voip_manager is not None,
+            "voip_available": self.voip_manager is not None and self.voip_manager.running,
             "music_available": self.mopidy_client is not None and self.mopidy_client.is_connected,
         }

--- a/yoyopy/audio/mopidy_client.py
+++ b/yoyopy/audio/mopidy_client.py
@@ -92,6 +92,9 @@ class MopidyClient:
         # Playback state change callbacks
         self.playback_state_callbacks: List[Callable[[str], None]] = []
 
+        # Connectivity callbacks
+        self.connection_change_callbacks: List[Callable[[bool, str], None]] = []
+
         # State tracking
         self.current_track: Optional[MopidyTrack] = None
         self.current_playback_state: Optional[str] = None
@@ -148,7 +151,7 @@ class MopidyClient:
         except requests.exceptions.ConnectionError:
             if self.is_connected:
                 logger.error("Lost connection to Mopidy")
-                self.is_connected = False
+            self._set_connection_state(False, "connection_lost")
             raise
         except requests.exceptions.Timeout:
             logger.warning(f"Mopidy request timeout ({method})")
@@ -168,12 +171,12 @@ class MopidyClient:
             # Test connection with a simple call
             version = self._rpc_call("core.get_version")
             if version:
-                self.is_connected = True
+                self._set_connection_state(True, "connected")
                 logger.info(f"Connected to Mopidy {version}")
                 return True
         except Exception as e:
             logger.error(f"Failed to connect to Mopidy: {e}")
-            self.is_connected = False
+            self._set_connection_state(False, "connect_failed")
 
         return False
 
@@ -434,11 +437,20 @@ class MopidyClient:
         self.playback_state_callbacks.append(callback)
         logger.debug("Registered playback state change callback")
 
+    def on_connection_change(self, callback: Callable[[bool, str], None]) -> None:
+        """Register callback for Mopidy connectivity changes."""
+        self.connection_change_callbacks.append(callback)
+        logger.debug("Registered Mopidy connection change callback")
+
     def _poll_track_changes(self) -> None:
         """Poll for track and playback state changes (runs in background thread)."""
         logger.debug("Track change polling started")
 
         while self.polling and not self.poll_event.is_set():
+            if not self.is_connected:
+                self.poll_event.wait(2.0)
+                continue
+
             try:
                 track = self.get_current_track()
                 playback_state = self.get_playback_state()
@@ -509,3 +521,21 @@ class MopidyClient:
         """Clean up resources."""
         self.stop_polling()
         logger.info("Mopidy client cleaned up")
+
+    def _set_connection_state(self, connected: bool, reason: str = "") -> None:
+        """Store connectivity and notify listeners when it changes."""
+        previous = self.is_connected
+        self.is_connected = connected
+
+        if not connected:
+            self.current_track = None
+            self.current_playback_state = None
+
+        if previous == connected:
+            return
+
+        for callback in self.connection_change_callbacks:
+            try:
+                callback(connected, reason)
+            except Exception as exc:
+                logger.error(f"Error in Mopidy connection callback: {exc}")

--- a/yoyopy/connectivity/voip_manager.py
+++ b/yoyopy/connectivity/voip_manager.py
@@ -47,6 +47,7 @@ class VoIPManager:
         self.registration_callbacks: list[Callable[[RegistrationState], None]] = []
         self.call_state_callbacks: list[Callable[[CallState], None]] = []
         self.incoming_call_callbacks: list[Callable[[str, str], None]] = []
+        self.availability_callbacks: list[Callable[[bool, str], None]] = []
 
         self.duration_thread: Optional[threading.Thread] = None
         self.duration_stop_event = threading.Event()
@@ -62,6 +63,9 @@ class VoIPManager:
             return True
 
         self.running = self.backend.start()
+        if not self.running:
+            self._update_registration_state(RegistrationState.FAILED)
+        self._notify_availability_change(self.running, "started" if self.running else "start_failed")
         return self.running
 
     def stop(self) -> None:
@@ -70,7 +74,10 @@ class VoIPManager:
         logger.info("Stopping VoIP manager...")
         self._stop_call_timer()
         self.backend.stop()
+        if self.call_state not in (CallState.IDLE, CallState.RELEASED):
+            self._update_call_state(CallState.RELEASED)
         self.running = False
+        self._notify_availability_change(False, "stopped")
         logger.info("VoIP manager stopped")
 
     def make_call(self, sip_address: str, contact_name: str | None = None) -> bool:
@@ -161,6 +168,11 @@ class VoIPManager:
 
         self.incoming_call_callbacks.append(callback)
 
+    def on_availability_change(self, callback: Callable[[bool, str], None]) -> None:
+        """Register a callback for backend availability changes."""
+
+        self.availability_callbacks.append(callback)
+
     def get_call_duration(self) -> int:
         """Return the current call duration in seconds."""
 
@@ -204,7 +216,11 @@ class VoIPManager:
             return
         if isinstance(event, BackendStopped):
             logger.warning(f"VoIP backend stopped unexpectedly: {event.reason or 'unknown'}")
+            if self.call_state not in (CallState.IDLE, CallState.RELEASED):
+                self._update_call_state(CallState.RELEASED)
+            self._update_registration_state(RegistrationState.FAILED)
             self.running = False
+            self._notify_availability_change(False, event.reason or "backend_stopped")
 
     def _handle_incoming_call_event(self, caller_address: str) -> None:
         """Resolve caller metadata and notify incoming-call callbacks."""
@@ -318,3 +334,11 @@ class VoIPManager:
             if self.call_start_time is not None:
                 self.call_duration = int(time.time() - self.call_start_time)
             time.sleep(1)
+
+    def _notify_availability_change(self, available: bool, reason: str) -> None:
+        """Notify listeners that backend availability changed."""
+        for callback in self.availability_callbacks:
+            try:
+                callback(available, reason)
+            except Exception as exc:
+                logger.error(f"Error in availability callback: {exc}")

--- a/yoyopy/coordinators/call.py
+++ b/yoyopy/coordinators/call.py
@@ -17,6 +17,7 @@ from yoyopy.events import (
     CallStateChangedEvent,
     IncomingCallEvent,
     RegistrationChangedEvent,
+    VoIPAvailabilityChangedEvent,
 )
 from yoyopy.connectivity import CallState, RegistrationState
 
@@ -50,6 +51,7 @@ class CallCoordinator:
         event_bus.subscribe(CallStateChangedEvent, self._on_call_state_changed_event)
         event_bus.subscribe(CallEndedEvent, self._on_call_ended_event)
         event_bus.subscribe(RegistrationChangedEvent, self._on_registration_changed_event)
+        event_bus.subscribe(VoIPAvailabilityChangedEvent, self._on_availability_changed_event)
         self._bound = True
 
     def publish_incoming_call(self, caller_address: str, caller_name: str) -> None:
@@ -76,6 +78,13 @@ class CallCoordinator:
             raise RuntimeError("CallCoordinator is not bound to an EventBus")
 
         self._event_bus.publish(RegistrationChangedEvent(state=state))
+
+    def publish_availability_change(self, available: bool, reason: str = "") -> None:
+        """Publish backend availability changes from VoIP threads."""
+        if self._event_bus is None:
+            raise RuntimeError("CallCoordinator is not bound to an EventBus")
+
+        self._event_bus.publish(VoIPAvailabilityChangedEvent(available=available, reason=reason))
 
     def start_ringing(self) -> None:
         """Start playing the ring tone for an incoming call."""
@@ -137,6 +146,9 @@ class CallCoordinator:
     def _on_registration_changed_event(self, event: RegistrationChangedEvent) -> None:
         self.handle_registration_change(event.state)
 
+    def _on_availability_changed_event(self, event: VoIPAvailabilityChangedEvent) -> None:
+        self.handle_availability_change(event.available, event.reason)
+
     def handle_incoming_call(self, caller_address: str, caller_name: str) -> None:
         """Coordinate music pause and UI transitions for an incoming call."""
         if self.handling_incoming_call:
@@ -148,7 +160,7 @@ class CallCoordinator:
 
         playback_state = (
             self.runtime.mopidy_client.get_playback_state()
-            if self.runtime.mopidy_client
+            if self.runtime.mopidy_client and self.runtime.mopidy_client.is_connected
             else "stopped"
         )
 
@@ -232,3 +244,19 @@ class CallCoordinator:
             logger.warning("  ⚠ VoIP registration failed")
 
         self.screen_coordinator.refresh_call_screen_if_visible()
+
+    def handle_availability_change(self, available: bool, reason: str) -> None:
+        """Coordinate backend availability changes and forced call cleanup."""
+        if available:
+            logger.info(f"VoIP backend available ({reason or 'ready'})")
+            self.screen_coordinator.refresh_call_screen_if_visible()
+            return
+
+        logger.warning(f"VoIP backend unavailable ({reason or 'unknown'})")
+        self.voip_registered = False
+        self.runtime.set_voip_ready(False, trigger=f"voip_{reason or 'unavailable'}")
+        self.stop_ringing()
+        self.screen_coordinator.refresh_call_screen_if_visible()
+
+        if self.runtime.call_fsm.is_active:
+            self.handle_call_ended()

--- a/yoyopy/coordinators/playback.py
+++ b/yoyopy/coordinators/playback.py
@@ -10,7 +10,11 @@ from yoyopy.audio.mopidy_client import MopidyTrack
 from yoyopy.coordinators.runtime import AppRuntimeState, CoordinatorRuntime
 from yoyopy.coordinators.screen import ScreenCoordinator
 from yoyopy.event_bus import EventBus
-from yoyopy.events import PlaybackStateChangedEvent, TrackChangedEvent
+from yoyopy.events import (
+    MusicAvailabilityChangedEvent,
+    PlaybackStateChangedEvent,
+    TrackChangedEvent,
+)
 
 
 class PlaybackCoordinator:
@@ -30,6 +34,7 @@ class PlaybackCoordinator:
         self._event_bus = event_bus
         event_bus.subscribe(TrackChangedEvent, self._on_track_changed_event)
         event_bus.subscribe(PlaybackStateChangedEvent, self._on_playback_state_changed_event)
+        event_bus.subscribe(MusicAvailabilityChangedEvent, self._on_availability_changed_event)
         self._bound = True
 
     def publish_track_change(self, track: MopidyTrack | None) -> None:
@@ -46,6 +51,13 @@ class PlaybackCoordinator:
 
         self._event_bus.publish(PlaybackStateChangedEvent(state=playback_state))
 
+    def publish_availability_change(self, available: bool, reason: str = "") -> None:
+        """Publish Mopidy connectivity changes from worker threads."""
+        if self._event_bus is None:
+            raise RuntimeError("PlaybackCoordinator is not bound to an EventBus")
+
+        self._event_bus.publish(MusicAvailabilityChangedEvent(available=available, reason=reason))
+
     def update_now_playing_if_needed(self) -> None:
         """Refresh the now-playing screen for periodic progress updates."""
         self.screen_coordinator.update_now_playing_if_needed()
@@ -59,6 +71,9 @@ class PlaybackCoordinator:
 
     def _on_playback_state_changed_event(self, event: PlaybackStateChangedEvent) -> None:
         self.handle_playback_state_change(event.state)
+
+    def _on_availability_changed_event(self, event: MusicAvailabilityChangedEvent) -> None:
+        self.handle_availability_change(event.available, event.reason)
 
     def handle_track_change(self, track: MopidyTrack | None) -> None:
         """Handle track changes and refresh the active screen when needed."""
@@ -90,4 +105,17 @@ class PlaybackCoordinator:
         state_change = self.runtime.sync_app_state(f"playback_{playback_state}")
         if state_change.entered(AppRuntimeState.PLAYING_WITH_VOIP):
             logger.info("Music playing with VoIP ready")
+        self.screen_coordinator.refresh_now_playing_screen()
+
+    def handle_availability_change(self, available: bool, reason: str) -> None:
+        """Keep playback state aligned with Mopidy connectivity."""
+        if available:
+            logger.info(f"Music backend connected ({reason or 'ready'})")
+            self.screen_coordinator.refresh_now_playing_screen()
+            return
+
+        logger.warning(f"Music backend unavailable ({reason or 'unknown'})")
+        self.runtime.call_interruption_policy.clear()
+        self.runtime.music_fsm.transition("stop")
+        self.runtime.sync_app_state(f"music_{reason or 'unavailable'}")
         self.screen_coordinator.refresh_now_playing_screen()

--- a/yoyopy/coordinators/screen.py
+++ b/yoyopy/coordinators/screen.py
@@ -35,7 +35,7 @@ class ScreenCoordinator:
         if self.runtime.screen_manager.current_screen != self.runtime.now_playing_screen:
             return
 
-        if self.runtime.mopidy_client:
+        if self.runtime.mopidy_client and self.runtime.mopidy_client.is_connected:
             playback_state = self.runtime.mopidy_client.get_playback_state()
             if playback_state == "playing":
                 self.runtime.now_playing_screen.render()

--- a/yoyopy/events.py
+++ b/yoyopy/events.py
@@ -41,6 +41,14 @@ class RegistrationChangedEvent:
 
 
 @dataclass(frozen=True, slots=True)
+class VoIPAvailabilityChangedEvent:
+    """Published when VoIP backend availability changes."""
+
+    available: bool
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
 class TrackChangedEvent:
     """Published when the current Mopidy track changes."""
 
@@ -52,3 +60,11 @@ class PlaybackStateChangedEvent:
     """Published when Mopidy playback changes state."""
 
     state: str
+
+
+@dataclass(frozen=True, slots=True)
+class MusicAvailabilityChangedEvent:
+    """Published when Mopidy connectivity changes."""
+
+    available: bool
+    reason: str = ""

--- a/yoyopy/ui/screens/music/now_playing.py
+++ b/yoyopy/ui/screens/music/now_playing.py
@@ -44,23 +44,29 @@ class NowPlayingScreen(Screen):
         """Render the now playing screen."""
         # Get track info from Mopidy or context
         if self.mopidy_client:
-            # Get track from Mopidy
-            mopidy_track = self.mopidy_client.get_current_track()
-            if mopidy_track:
-                track_title = mopidy_track.name
-                artist = mopidy_track.get_artist_string()
-                # Calculate progress from position and track length
-                if mopidy_track.length > 0:
-                    position_ms = self.mopidy_client.get_time_position()
-                    progress = position_ms / mopidy_track.length
-                else:
-                    progress = 0.0
-                is_playing = self.mopidy_client.get_playback_state() == "playing"
-            else:
-                track_title = "No Track"
-                artist = "Unknown Artist"
+            if not self.mopidy_client.is_connected:
+                track_title = "Music Offline"
+                artist = "Reconnecting..."
                 progress = 0.0
                 is_playing = False
+            else:
+                # Get track from Mopidy
+                mopidy_track = self.mopidy_client.get_current_track()
+                if mopidy_track:
+                    track_title = mopidy_track.name
+                    artist = mopidy_track.get_artist_string()
+                    # Calculate progress from position and track length
+                    if mopidy_track.length > 0:
+                        position_ms = self.mopidy_client.get_time_position()
+                        progress = position_ms / mopidy_track.length
+                    else:
+                        progress = 0.0
+                    is_playing = self.mopidy_client.get_playback_state() == "playing"
+                else:
+                    track_title = "No Track"
+                    artist = "Unknown Artist"
+                    progress = 0.0
+                    is_playing = False
         else:
             # Fallback to context for local tracks
             track = self.context.get_current_track() if self.context else None
@@ -217,6 +223,8 @@ class NowPlayingScreen(Screen):
     def _toggle_playback(self) -> None:
         """Toggle playback via Mopidy or the local app context."""
         if self.mopidy_client:
+            if not self.mopidy_client.is_connected:
+                return
             state = self.mopidy_client.get_playback_state()
             if state == "playing":
                 self.mopidy_client.pause()
@@ -228,6 +236,8 @@ class NowPlayingScreen(Screen):
     def _previous_track(self) -> None:
         """Go to the previous track."""
         if self.mopidy_client:
+            if not self.mopidy_client.is_connected:
+                return
             self.mopidy_client.previous_track()
         elif self.context:
             self.context.previous_track()
@@ -235,6 +245,8 @@ class NowPlayingScreen(Screen):
     def _next_track(self) -> None:
         """Go to the next track."""
         if self.mopidy_client:
+            if not self.mopidy_client.is_connected:
+                return
             self.mopidy_client.next_track()
         elif self.context:
             self.context.next_track()

--- a/yoyopy/ui/screens/music/playlist.py
+++ b/yoyopy/ui/screens/music/playlist.py
@@ -61,6 +61,11 @@ class PlaylistScreen(Screen):
             logger.error("Cannot fetch playlists: No Mopidy client")
             return
 
+        if not self.mopidy_client.is_connected:
+            self.error_message = "Mopidy offline"
+            logger.error("Cannot fetch playlists: Mopidy is offline")
+            return
+
         self.loading = True
         self.render()  # Show loading indicator
 

--- a/yoyopy/ui/screens/voip/call.py
+++ b/yoyopy/ui/screens/voip/call.py
@@ -87,13 +87,17 @@ class CallScreen(Screen):
         # Get VoIP status
         if self.voip_manager:
             status = self.voip_manager.get_status()
+            running = status.get("running", False)
             registered = status.get("registered", False)
             reg_state = status.get("registration_state", "none")
             call_state = status.get("call_state", "idle")
             sip_identity = status.get("sip_identity", "")
 
             # Draw registration status
-            if registered:
+            if not running:
+                status_text = "VoIP Recovering..."
+                status_color = self.display.COLOR_YELLOW
+            elif registered:
                 status_text = "VoIP Ready"
                 status_color = self.display.COLOR_GREEN
             elif reg_state == "progress":


### PR DESCRIPTION
## Summary
- publish typed VoIP and Mopidy availability events into the coordinator path
- add reconnect backoff in the app loop for VoIP backend restarts and Mopidy reconnects
- surface offline and recovering states in the call, now playing, and playlist screens
- add regression coverage for backend loss and recovery behavior

## Verification
- python -m compileall yoyopy tests
- uv run pytest tests/test_app_orchestration.py -q
- uv run pytest -q