### PR TITLE
Complete VoIP hub screen actions

### DIFF
--- a/tests/test_call_screen.py
+++ b/tests/test_call_screen.py
@@ -1,0 +1,200 @@
+"""Focused tests for the VoIP call hub screen."""
+
+from __future__ import annotations
+
+import pytest
+
+from yoyopy.app_context import AppContext
+from yoyopy.config import Contact
+from yoyopy.ui.display import Display
+from yoyopy.ui.screens import CallScreen, NavigationRequest
+
+
+class FakeConfigManager:
+    """Minimal contact source for call-screen tests."""
+
+    def __init__(self, contacts: list[Contact]) -> None:
+        self._contacts = contacts
+
+    def get_contacts(self) -> list[Contact]:
+        return list(self._contacts)
+
+
+class FakeVoIPManager:
+    """Minimal VoIP manager double for call-screen actions."""
+
+    def __init__(
+        self,
+        *,
+        running: bool = True,
+        registered: bool = True,
+        registration_state: str = "ok",
+        call_state: str = "idle",
+        make_call_result: bool = True,
+        caller_name: str = "Unknown",
+        caller_address: str = "",
+    ) -> None:
+        self.status = {
+            "running": running,
+            "registered": registered,
+            "registration_state": registration_state,
+            "call_state": call_state,
+            "sip_identity": "sip:test@example.com",
+        }
+        self.make_call_result = make_call_result
+        self.make_calls: list[tuple[str, str | None]] = []
+        self.caller_name = caller_name
+        self.caller_address = caller_address
+
+    def get_status(self) -> dict:
+        return dict(self.status)
+
+    def get_caller_info(self) -> dict:
+        return {
+            "display_name": self.caller_name,
+            "address": self.caller_address,
+        }
+
+    def make_call(self, sip_address: str, contact_name: str | None = None) -> bool:
+        self.make_calls.append((sip_address, contact_name))
+        return self.make_call_result
+
+
+@pytest.fixture
+def display() -> Display:
+    """Create a simulation display and clean it up after the test."""
+    test_display = Display(simulate=True)
+    try:
+        yield test_display
+    finally:
+        test_display.cleanup()
+
+
+def test_call_screen_prefers_favorites_and_adds_contacts_shortcut(display: Display) -> None:
+    """The VoIP hub should highlight favorite quick calls before the full list."""
+    contacts = [
+        Contact(name="Bob", sip_address="sip:bob@example.com", favorite=False),
+        Contact(name="Alice", sip_address="sip:alice@example.com", favorite=True),
+        Contact(name="Carol", sip_address="sip:carol@example.com", favorite=True),
+    ]
+    screen = CallScreen(
+        display,
+        AppContext(),
+        voip_manager=FakeVoIPManager(),
+        config_manager=FakeConfigManager(contacts),
+    )
+
+    screen.enter()
+
+    assert [target.title for target in screen.quick_targets] == [
+        "Alice",
+        "Carol",
+        "All Contacts",
+    ]
+
+
+def test_call_screen_falls_back_to_all_contacts_when_no_favorites(display: Display) -> None:
+    """The VoIP hub should still offer quick calls when favorites are not configured."""
+    contacts = [
+        Contact(name="Alice", sip_address="sip:alice@example.com", favorite=False),
+        Contact(name="Bob", sip_address="sip:bob@example.com", favorite=False),
+    ]
+    screen = CallScreen(
+        display,
+        AppContext(),
+        voip_manager=FakeVoIPManager(),
+        config_manager=FakeConfigManager(contacts),
+    )
+
+    screen.enter()
+
+    assert [target.title for target in screen.quick_targets] == ["Alice", "Bob"]
+
+
+def test_call_screen_select_calls_selected_quick_contact(display: Display) -> None:
+    """Selecting a ready quick contact should place the call and route to outgoing."""
+    contacts = [
+        Contact(name="Alice", sip_address="sip:alice@example.com", favorite=True),
+    ]
+    voip_manager = FakeVoIPManager(running=True, registered=True)
+    screen = CallScreen(
+        display,
+        AppContext(),
+        voip_manager=voip_manager,
+        config_manager=FakeConfigManager(contacts),
+    )
+
+    screen.enter()
+    screen.render()
+    screen.on_select()
+
+    assert voip_manager.make_calls == [("sip:alice@example.com", "Alice")]
+    assert screen.consume_navigation_request() == NavigationRequest.route("call_started")
+
+
+def test_call_screen_select_opens_contacts_when_voip_is_not_ready(display: Display) -> None:
+    """Selecting from the VoIP hub while SIP is down should still open the contact list."""
+    contacts = [
+        Contact(name="Alice", sip_address="sip:alice@example.com", favorite=True),
+    ]
+    screen = CallScreen(
+        display,
+        AppContext(),
+        voip_manager=FakeVoIPManager(running=False, registered=False, registration_state="failed"),
+        config_manager=FakeConfigManager(contacts),
+    )
+
+    screen.enter()
+    screen.on_select()
+
+    assert screen.consume_navigation_request() == NavigationRequest.route("browse_contacts")
+
+
+def test_call_screen_browse_target_routes_to_full_contacts(display: Display) -> None:
+    """The explicit All Contacts shortcut should route to the full contact list."""
+    contacts = [
+        Contact(name="Alice", sip_address="sip:alice@example.com", favorite=True),
+        Contact(name="Bob", sip_address="sip:bob@example.com", favorite=False),
+    ]
+    screen = CallScreen(
+        display,
+        AppContext(),
+        voip_manager=FakeVoIPManager(),
+        config_manager=FakeConfigManager(contacts),
+    )
+
+    screen.enter()
+    screen.selected_index = len(screen.quick_targets) - 1
+    screen.render()
+    screen.on_select()
+
+    assert screen.quick_targets[-1].title == "All Contacts"
+    assert screen.consume_navigation_request() == NavigationRequest.route("browse_contacts")
+
+
+def test_call_screen_render_smoke_includes_active_call_context(display: Display) -> None:
+    """Rendering should stay stable when the VoIP hub reflects an active call state."""
+    contacts = [
+        Contact(name="Alice", sip_address="sip:alice@example.com", favorite=True),
+    ]
+    voip_manager = FakeVoIPManager(
+        running=True,
+        registered=True,
+        call_state="connected",
+        caller_name="Alice",
+        caller_address="sip:alice@example.com",
+    )
+    screen = CallScreen(
+        display,
+        AppContext(),
+        voip_manager=voip_manager,
+        config_manager=FakeConfigManager(contacts),
+    )
+
+    screen.enter()
+    screen.render()
+
+    assert screen._call_context_lines(voip_manager.get_status()) == (
+        "Call connected",
+        "Alice",
+    )

--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -54,6 +54,14 @@ def test_screen_router_covers_live_menu_labels() -> None:
         assert router.resolve("menu", "select", payload=label) == expected_request
 
 
+def test_screen_router_covers_call_hub_routes() -> None:
+    """The VoIP hub should resolve its quick-call routes through the router."""
+    router = ScreenRouter()
+
+    assert router.resolve("call", "browse_contacts") == NavigationRequest.push("contacts")
+    assert router.resolve("call", "call_started") == NavigationRequest.push("outgoing_call")
+
+
 def test_screen_manager_routes_menu_labels_through_stack(display: Display) -> None:
     """Menu labels should resolve through the router and preserve stack navigation."""
     context = AppContext()

--- a/yoyopy/ui/screens/router.py
+++ b/yoyopy/ui/screens/router.py
@@ -92,6 +92,8 @@ class ScreenRouter:
             },
             "call": {
                 "back": NavigationRequest.pop(),
+                "browse_contacts": NavigationRequest.push("contacts"),
+                "call_started": NavigationRequest.push("outgoing_call"),
             },
             "contacts": {
                 "back": NavigationRequest.pop(),

--- a/yoyopy/ui/screens/voip/call.py
+++ b/yoyopy/ui/screens/voip/call.py
@@ -1,53 +1,116 @@
 """Call screen for YoyoPod VoIP functionality."""
 
-from yoyopy.ui.screens.base import Screen
-from yoyopy.ui.display import Display
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from dataclasses import dataclass
 from datetime import datetime
+from typing import TYPE_CHECKING, Literal, Optional
+
+from loguru import logger
+
+from yoyopy.ui.display import Display
+from yoyopy.ui.screens.base import Screen
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
+    from yoyopy.config import ConfigManager, Contact
+    from yoyopy.connectivity import VoIPManager
+
+
+@dataclass(slots=True)
+class QuickCallTarget:
+    """Represents one selectable quick action on the VoIP hub screen."""
+
+    kind: Literal["contact", "browse_contacts"]
+    title: str
+    subtitle: str
+    sip_address: str = ""
+    favorite: bool = False
 
 
 class CallScreen(Screen):
     """
-    VoIP call screen showing registration and call status.
-
-    Displays VoIP registration status and allows making/receiving calls.
+    VoIP hub screen showing registration status and quick-call actions.
 
     Button mapping:
-    - Button A: (Reserved for answer/hangup)
+    - Button A: Call selected quick contact or open contacts
     - Button B: Back to menu
-    - Button X: (Reserved for dial pad)
-    - Button Y: (Reserved for dial pad)
+    - Button X: Move selection up
+    - Button Y: Move selection down
     """
+
+    _MAX_QUICK_CONTACTS = 6
 
     def __init__(
         self,
         display: Display,
-        context: Optional['AppContext'] = None,
-        voip_manager=None,
-        config_manager=None
+        context: Optional["AppContext"] = None,
+        voip_manager: Optional["VoIPManager"] = None,
+        config_manager: Optional["ConfigManager"] = None,
     ) -> None:
-        """
-        Initialize call screen.
-
-        Args:
-            display: Display controller
-            context: Application context
-            voip_manager: VoIPManager instance
-            config_manager: ConfigManager instance for contacts
-        """
+        """Initialize the VoIP hub screen."""
         super().__init__(display, context, "Call")
         self.voip_manager = voip_manager
         self.config_manager = config_manager
+        self.quick_targets: list[QuickCallTarget] = []
+        self.selected_index = 0
+        self.scroll_offset = 0
+        self.max_visible_items = 4 if display.is_portrait() else 3
+
+    def enter(self) -> None:
+        """Refresh quick-call shortcuts whenever the screen becomes active."""
+        super().enter()
+        self._load_quick_targets()
+
+    def _load_quick_targets(self) -> None:
+        """Load favorite or recent contacts for quick calling."""
+        contacts: list["Contact"] = []
+        if self.config_manager is not None:
+            contacts = sorted(
+                self.config_manager.get_contacts(),
+                key=lambda contact: (not contact.favorite, contact.name.lower()),
+            )
+
+        favorites = [contact for contact in contacts if contact.favorite]
+        quick_contacts = favorites or contacts
+        visible_contacts = quick_contacts[: self._MAX_QUICK_CONTACTS]
+
+        self.quick_targets = [
+            QuickCallTarget(
+                kind="contact",
+                title=contact.name,
+                subtitle=contact.sip_address,
+                sip_address=contact.sip_address,
+                favorite=contact.favorite,
+            )
+            for contact in visible_contacts
+        ]
+
+        has_more_contacts = bool(contacts) and (
+            len(contacts) > len(visible_contacts)
+            or (bool(favorites) and len(favorites) < len(contacts))
+        )
+        if has_more_contacts:
+            self.quick_targets.append(
+                QuickCallTarget(
+                    kind="browse_contacts",
+                    title="All Contacts",
+                    subtitle="Open the full contact list",
+                )
+            )
+
+        if not self.quick_targets:
+            self.selected_index = 0
+            self.scroll_offset = 0
+            return
+
+        self.selected_index = min(self.selected_index, len(self.quick_targets) - 1)
+        self._ensure_selection_visible()
 
     def render(self) -> None:
-        """Render the call screen."""
-        # Clear display
+        """Render the VoIP hub with status details and quick-call shortcuts."""
         self.display.clear(self.display.COLOR_BLACK)
 
-        # Draw status bar
         current_time = datetime.now().strftime("%H:%M")
         battery = self.context.battery_percent if self.context else 100
         signal = self.context.signal_strength if self.context else 4
@@ -55,161 +118,326 @@ class CallScreen(Screen):
         self.display.status_bar(
             time_str=current_time,
             battery_percent=battery,
-            signal_strength=signal
+            signal_strength=signal,
         )
 
-        # Draw title
-        title = "VoIP Call"
+        title = "VoIP"
         title_size = 20
         title_width, title_height = self.display.get_text_size(title, title_size)
         title_x = (self.display.WIDTH - title_width) // 2
-        title_y = self.display.STATUS_BAR_HEIGHT + 15
-
+        title_y = self.display.STATUS_BAR_HEIGHT + 10
         self.display.text(
             title,
             title_x,
             title_y,
             color=self.display.COLOR_WHITE,
-            font_size=title_size
+            font_size=title_size,
         )
 
-        # Draw separator line
-        separator_y = title_y + title_height + 10
+        separator_y = title_y + title_height + 8
         self.display.line(
-            20, separator_y,
-            self.display.WIDTH - 20, separator_y,
+            20,
+            separator_y,
+            self.display.WIDTH - 20,
+            separator_y,
             color=self.display.COLOR_GRAY,
-            width=2
+            width=2,
         )
 
-        content_y = separator_y + 20
+        status = self._get_status_snapshot()
+        status_text, status_color, detail_text = self._status_lines(status)
+        detail_y = separator_y + 14
 
-        # Get VoIP status
-        if self.voip_manager:
-            status = self.voip_manager.get_status()
-            running = status.get("running", False)
-            registered = status.get("registered", False)
-            reg_state = status.get("registration_state", "none")
-            call_state = status.get("call_state", "idle")
-            sip_identity = status.get("sip_identity", "")
+        status_size = 18
+        status_width, status_height = self.display.get_text_size(status_text, status_size)
+        status_x = (self.display.WIDTH - status_width) // 2
+        self.display.text(
+            status_text,
+            status_x,
+            detail_y,
+            color=status_color,
+            font_size=status_size,
+        )
 
-            # Draw registration status
-            if not running:
-                status_text = "VoIP Recovering..."
-                status_color = self.display.COLOR_YELLOW
-            elif registered:
-                status_text = "VoIP Ready"
-                status_color = self.display.COLOR_GREEN
-            elif reg_state == "progress":
-                status_text = "Connecting..."
-                status_color = self.display.COLOR_YELLOW
-            elif reg_state == "failed":
-                status_text = "Registration Failed"
-                status_color = self.display.COLOR_RED
-            else:
-                status_text = "VoIP Disconnected"
-                status_color = self.display.COLOR_GRAY
-
-            # Draw status with icon
-            status_size = 18
-            status_width, _ = self.display.get_text_size(status_text, status_size)
-            status_x = (self.display.WIDTH - status_width) // 2
-            status_y = content_y + 30
-
+        secondary_y = detail_y + status_height + 8
+        if detail_text:
+            detail_size = 12
+            detail_width, detail_height = self.display.get_text_size(detail_text, detail_size)
+            detail_x = (self.display.WIDTH - detail_width) // 2
             self.display.text(
-                status_text,
-                status_x,
-                status_y,
-                color=status_color,
-                font_size=status_size
+                detail_text,
+                detail_x,
+                secondary_y,
+                color=self.display.COLOR_GRAY,
+                font_size=detail_size,
             )
+            secondary_y += detail_height + 6
 
-            # Draw SIP identity
-            if sip_identity:
-                identity_size = 12
-                # Truncate long identity
-                max_len = 30
-                display_identity = sip_identity[:max_len]
-                if len(sip_identity) > max_len:
-                    display_identity = display_identity[:-3] + "..."
+        call_state_text, caller_text = self._call_context_lines(status)
+        if call_state_text:
+            context_size = 13
+            context_width, context_height = self.display.get_text_size(call_state_text, context_size)
+            context_x = (self.display.WIDTH - context_width) // 2
+            self.display.text(
+                call_state_text,
+                context_x,
+                secondary_y,
+                color=self.display.COLOR_CYAN,
+                font_size=context_size,
+            )
+            secondary_y += context_height + 4
 
-                identity_width, _ = self.display.get_text_size(display_identity, identity_size)
-                identity_x = (self.display.WIDTH - identity_width) // 2
-                identity_y = status_y + 30
+        if caller_text:
+            caller_size = 11
+            display_caller = self._truncate(caller_text, 34)
+            caller_width, caller_height = self.display.get_text_size(display_caller, caller_size)
+            caller_x = (self.display.WIDTH - caller_width) // 2
+            self.display.text(
+                display_caller,
+                caller_x,
+                secondary_y,
+                color=self.display.COLOR_GRAY,
+                font_size=caller_size,
+            )
+            secondary_y += caller_height + 8
 
-                self.display.text(
-                    display_identity,
-                    identity_x,
-                    identity_y,
-                    color=self.display.COLOR_GRAY,
-                    font_size=identity_size
-                )
+        hub_title = "Quick Calls"
+        hub_size = 14
+        _, hub_height = self.display.get_text_size(hub_title, hub_size)
+        hub_x = 20
+        hub_y = secondary_y + 6
+        self.display.text(
+            hub_title,
+            hub_x,
+            hub_y,
+            color=self.display.COLOR_WHITE,
+            font_size=hub_size,
+        )
 
-            # Draw call state if not idle
-            if call_state != "idle":
-                call_text = f"Call: {call_state}"
-                call_size = 14
-                call_width, _ = self.display.get_text_size(call_text, call_size)
-                call_x = (self.display.WIDTH - call_width) // 2
-                call_y = self.display.HEIGHT // 2 + 20
+        footer_y = self.display.HEIGHT - 15
+        list_top = hub_y + hub_height + 10
+        list_bottom = footer_y - 16
 
-                self.display.text(
-                    call_text,
-                    call_x,
-                    call_y,
-                    color=self.display.COLOR_CYAN,
-                    font_size=call_size
-                )
-
+        if not self.quick_targets:
+            empty_text = "No contacts configured"
+            empty_size = 14
+            empty_width, _ = self.display.get_text_size(empty_text, empty_size)
+            empty_x = (self.display.WIDTH - empty_width) // 2
+            empty_y = list_top + ((list_bottom - list_top) // 2)
+            self.display.text(
+                empty_text,
+                empty_x,
+                empty_y,
+                color=self.display.COLOR_GRAY,
+                font_size=empty_size,
+            )
         else:
-            # No VoIP manager
-            error_text = "VoIP Not Available"
-            error_size = 16
-            error_width, _ = self.display.get_text_size(error_text, error_size)
-            error_x = (self.display.WIDTH - error_width) // 2
-            error_y = self.display.HEIGHT // 2
+            item_height = 34
+            visible_items = max(1, min(self.max_visible_items, (list_bottom - list_top) // item_height))
+            self._ensure_selection_visible(visible_items)
 
-            self.display.text(
-                error_text,
-                error_x,
-                error_y,
-                color=self.display.COLOR_RED,
-                font_size=error_size
-            )
+            for row in range(visible_items):
+                target_index = self.scroll_offset + row
+                if target_index >= len(self.quick_targets):
+                    break
 
-        # Draw instructions at bottom
-        instructions_y = self.display.HEIGHT - 15
+                target = self.quick_targets[target_index]
+                y_pos = list_top + (row * item_height)
+                selected = target_index == self.selected_index
+
+                if selected:
+                    self.display.rectangle(
+                        10,
+                        y_pos - 2,
+                        self.display.WIDTH - 10,
+                        y_pos + item_height - 4,
+                        fill=self.display.COLOR_DARK_GRAY,
+                        outline=self.display.COLOR_CYAN,
+                        width=2,
+                    )
+
+                title_text = target.title
+                if target.favorite:
+                    title_text = f"{target.title} [Fav]"
+
+                title_color = self.display.COLOR_WHITE
+                if target.favorite and not selected:
+                    title_color = self.display.COLOR_YELLOW
+                if target.kind == "browse_contacts":
+                    title_color = self.display.COLOR_CYAN if selected else self.display.COLOR_WHITE
+
+                self.display.text(
+                    self._truncate(title_text, 24),
+                    18,
+                    y_pos,
+                    color=title_color,
+                    font_size=14,
+                )
+                self.display.text(
+                    self._truncate(target.subtitle, 38),
+                    18,
+                    y_pos + 16,
+                    color=self.display.COLOR_GRAY,
+                    font_size=10,
+                )
+
+        instructions = self._instruction_text()
         instructions_size = 10
-        instructions = "B: Back"
-        instr_width, _ = self.display.get_text_size(instructions, instructions_size)
-        instr_x = (self.display.WIDTH - instr_width) // 2
-
+        instructions_width, _ = self.display.get_text_size(instructions, instructions_size)
+        instructions_x = (self.display.WIDTH - instructions_width) // 2
         self.display.text(
             instructions,
-            instr_x,
-            instructions_y,
+            instructions_x,
+            footer_y,
             color=self.display.COLOR_GRAY,
-            font_size=instructions_size
+            font_size=instructions_size,
         )
 
-        # Update display
         self.display.update()
 
+    def _get_status_snapshot(self) -> dict:
+        """Return a stable VoIP status dict for rendering and actions."""
+        if self.voip_manager is None:
+            return {}
+        return self.voip_manager.get_status()
+
+    def _status_lines(self, status: dict) -> tuple[str, tuple[int, int, int], str]:
+        """Return the primary VoIP availability text for the screen header."""
+        if not self.voip_manager:
+            return ("VoIP Unavailable", self.display.COLOR_RED, "Manager not initialized")
+
+        running = status.get("running", False)
+        registered = status.get("registered", False)
+        registration_state = status.get("registration_state", "none")
+        identity = status.get("sip_identity", "")
+
+        if not running:
+            return ("VoIP Recovering...", self.display.COLOR_YELLOW, "Retrying in background")
+        if registered:
+            return ("VoIP Ready", self.display.COLOR_GREEN, self._truncate(identity, 32))
+        if registration_state == "progress":
+            return ("Connecting...", self.display.COLOR_YELLOW, self._truncate(identity, 32))
+        if registration_state == "failed":
+            return ("Registration Failed", self.display.COLOR_RED, "Check SIP settings or network")
+        return ("VoIP Disconnected", self.display.COLOR_GRAY, self._truncate(identity, 32))
+
+    def _call_context_lines(self, status: dict) -> tuple[str, str]:
+        """Return the current call state summary if the backend is mid-call."""
+        if not self.voip_manager:
+            return ("", "")
+
+        call_state = status.get("call_state", "idle")
+        if call_state == "idle":
+            return ("", "")
+
+        state_labels = {
+            "incoming": "Incoming call",
+            "outgoing": "Dialing",
+            "outgoing_progress": "Dialing",
+            "outgoing_ringing": "Ringing",
+            "outgoing_early_media": "Connecting media",
+            "connected": "Call connected",
+            "streams_running": "Call connected",
+            "released": "Call ended",
+        }
+        caller_info = self.voip_manager.get_caller_info()
+        caller_text = caller_info.get("display_name") or caller_info.get("address") or ""
+        return (state_labels.get(call_state, call_state.replace("_", " ").title()), caller_text)
+
+    def _selected_target(self) -> Optional[QuickCallTarget]:
+        """Return the currently selected quick target, if any."""
+        if not self.quick_targets:
+            return None
+        return self.quick_targets[self.selected_index]
+
+    def _is_ready_to_call(self) -> bool:
+        """Return whether the VoIP backend is ready to place a call."""
+        status = self._get_status_snapshot()
+        return bool(status.get("running")) and bool(status.get("registered"))
+
+    def _instruction_text(self) -> str:
+        """Return the footer instructions for the current selection and state."""
+        if not self.quick_targets:
+            return "B: Back"
+
+        selected_target = self._selected_target()
+        if selected_target is None:
+            return "B: Back"
+
+        if selected_target.kind == "browse_contacts" or not self._is_ready_to_call():
+            primary_text = "A: Open"
+        else:
+            primary_text = "A: Call"
+
+        if len(self.quick_targets) > 1:
+            return f"{primary_text} | B: Back | X/Y: Move"
+        return f"{primary_text} | B: Back"
+
+    def _ensure_selection_visible(self, visible_items: Optional[int] = None) -> None:
+        """Adjust scroll offset to keep the selected quick target on screen."""
+        if not self.quick_targets:
+            self.scroll_offset = 0
+            return
+
+        visible = visible_items or self.max_visible_items
+        if self.selected_index < self.scroll_offset:
+            self.scroll_offset = self.selected_index
+        elif self.selected_index >= self.scroll_offset + visible:
+            self.scroll_offset = self.selected_index - visible + 1
+
+    @staticmethod
+    def _truncate(text: str, max_length: int) -> str:
+        """Truncate a string for compact display."""
+        if len(text) <= max_length:
+            return text
+        return text[: max_length - 3] + "..."
+
+    def _browse_contacts(self) -> None:
+        """Open the full contact list."""
+        logger.info("Opening full contact list from VoIP hub")
+        self.request_route("browse_contacts")
+
+    def _call_selected_target(self) -> None:
+        """Place a call to the currently selected quick contact."""
+        selected_target = self._selected_target()
+        if selected_target is None:
+            logger.debug("No quick-call target selected")
+            return
+
+        if selected_target.kind == "browse_contacts" or not self._is_ready_to_call():
+            self._browse_contacts()
+            return
+
+        if self.voip_manager is None:
+            logger.error("Cannot place call: VoIP manager unavailable")
+            return
+
+        logger.info(f"Calling quick contact: {selected_target.title} ({selected_target.sip_address})")
+        if self.voip_manager.make_call(
+            selected_target.sip_address,
+            contact_name=selected_target.title,
+        ):
+            self.request_route("call_started")
+            return
+
+        logger.error(f"Failed to initiate quick call to {selected_target.title}")
+
     def on_select(self, data=None) -> None:
-        """Reserved for answer/hangup."""
-        # TODO: Implement call answer/hangup
-        pass
+        """Call the selected quick contact or open contacts when unavailable."""
+        self._call_selected_target()
 
     def on_back(self, data=None) -> None:
-        """Go back to the previous screen."""
+        """Return to the previous screen."""
         self.request_route("back")
 
     def on_up(self, data=None) -> None:
-        """Reserved for dial pad."""
-        # TODO: Implement dial pad
-        pass
+        """Move the quick-call selection upward."""
+        if self.selected_index > 0:
+            self.selected_index -= 1
+            self._ensure_selection_visible()
 
     def on_down(self, data=None) -> None:
-        """Reserved for dial pad."""
-        # TODO: Implement dial pad
-        pass
+        """Move the quick-call selection downward."""
+        if self.selected_index < len(self.quick_targets) - 1:
+            self.selected_index += 1
+            self._ensure_selection_visible()


### PR DESCRIPTION
## Summary
- turn the VoIP status screen into a quick-call hub with favorite contacts and context-aware actions
- route call hub actions through the declarative router to contacts and outgoing call screens
- add focused call-screen coverage and router assertions

## Testing
- python -m compileall yoyopy tests
- uv run pytest tests/test_call_screen.py tests/test_screen_routing.py -q
- uv run pytest -q