### PR TITLE
Centralize app logger setup

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,25 @@
+import sys
+
+import yoyopy.main as main_module
+
+
+def test_configure_logger_uses_shared_utility(monkeypatch) -> None:
+    """Keep the app entrypoint aligned with the shared logging helper."""
+    calls = []
+
+    def fake_init_logger(**kwargs) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(main_module, "init_logger", fake_init_logger)
+
+    main_module.configure_logger()
+
+    assert calls == [
+        {
+            "level": "INFO",
+            "console": True,
+            "file_logging": False,
+            "console_stream": sys.stderr,
+            "announce": False,
+        }
+    ]

--- a/yoyopy/main.py
+++ b/yoyopy/main.py
@@ -10,15 +10,17 @@ import sys
 from loguru import logger
 
 from yoyopy.app import YoyoPodApp
+from yoyopy.utils.logger import init_logger
 
 
 def configure_logger() -> None:
     """Configure the default console logger for the app."""
-    logger.remove()
-    logger.add(
-        sys.stderr,
-        format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <level>{message}</level>",
+    init_logger(
         level="INFO",
+        console=True,
+        file_logging=False,
+        console_stream=sys.stderr,
+        announce=False,
     )
 
 

--- a/yoyopy/utils/logger.py
+++ b/yoyopy/utils/logger.py
@@ -7,7 +7,7 @@ colorized messages, and automatic rotation.
 
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TextIO
 from loguru import logger
 
 
@@ -16,8 +16,10 @@ def init_logger(
     log_dir: Optional[Path] = None,
     console: bool = True,
     file_logging: bool = True,
+    console_stream: Optional[TextIO] = None,
     rotation: str = "100 MB",
     retention: str = "10 days",
+    announce: bool = True,
 ) -> None:
     """
     Initialize the loguru logger with custom settings.
@@ -27,8 +29,10 @@ def init_logger(
         log_dir: Directory for log files (defaults to ./logs)
         console: Enable console output
         file_logging: Enable file output
+        console_stream: Stream for console output (defaults to sys.stdout)
         rotation: When to rotate log files (size or time-based)
         retention: How long to keep old log files
+        announce: Log a one-line initialization message after setup
     """
     # Remove default handler
     logger.remove()
@@ -42,8 +46,10 @@ def init_logger(
 
     # Console handler with colors
     if console:
+        if console_stream is None:
+            console_stream = sys.stdout
         logger.add(
-            sys.stdout,
+            console_stream,
             format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <level>{message}</level>",
             level=level,
             colorize=True,
@@ -62,7 +68,8 @@ def init_logger(
             enqueue=True,  # Thread-safe logging
         )
 
-    logger.info(f"Logger initialized with level: {level}")
+    if announce:
+        logger.info(f"Logger initialized with level: {level}")
 
 
 def get_logger():


### PR DESCRIPTION
## Summary
- route the package entrypoint logger configuration through the shared logging utility
- preserve the current app behavior by keeping console-only logging on stderr and suppressing the extra initialization line
- add a regression test so the entrypoint stays aligned with the shared logger helper

## Testing
- python -m compileall yoyopy tests
- uv run pytest tests/test_main.py -q
- uv run pytest -q