### PR TITLE
Implement Whisplay-native one-button UX

### DIFF
--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -28,6 +28,7 @@ from yoyopy.fsm import (
     MusicFSM,
     MusicState,
 )
+from yoyopy.ui.input import InputManager, InteractionProfile
 
 
 class FakeScreen:
@@ -495,3 +496,23 @@ def test_app_stop_uses_silent_voip_teardown() -> None:
     app.stop()
 
     assert app.voip_manager.stop_notify_events == [False]
+
+
+def test_standard_profile_starts_on_menu() -> None:
+    """Standard multi-button devices should keep the existing menu root."""
+    app = YoyoPodApp(simulate=True)
+    app.context = AppContext()
+    app.input_manager = InputManager(interaction_profile=InteractionProfile.STANDARD)
+
+    assert app._get_initial_screen_name() == "menu"
+    assert app._get_initial_ui_state() == AppRuntimeState.MENU
+
+
+def test_one_button_profile_starts_on_hub() -> None:
+    """Whisplay one-button devices should use the new hub root."""
+    app = YoyoPodApp(simulate=True)
+    app.context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+    app.input_manager = InputManager(interaction_profile=InteractionProfile.ONE_BUTTON)
+
+    assert app._get_initial_screen_name() == "hub"
+    assert app._get_initial_ui_state() == AppRuntimeState.HUB

--- a/tests/test_ptt_input_adapter.py
+++ b/tests/test_ptt_input_adapter.py
@@ -1,0 +1,66 @@
+"""Gesture-recognition tests for the Whisplay single-button adapter."""
+
+from __future__ import annotations
+
+from yoyopy.ui.input import InputAction
+from yoyopy.ui.input.adapters.ptt_button import PTTInputAdapter
+
+
+def _record_actions(adapter: PTTInputAdapter) -> list[InputAction]:
+    actions: list[InputAction] = []
+    for action in (InputAction.ADVANCE, InputAction.SELECT, InputAction.BACK):
+        adapter.on_action(action, lambda data=None, action=action: actions.append(action))
+    return actions
+
+
+def test_single_tap_emits_advance_after_double_tap_window() -> None:
+    """Single taps should resolve to ADVANCE only after the timeout expires."""
+    adapter = PTTInputAdapter(simulate=True, enable_navigation=True)
+    actions = _record_actions(adapter)
+
+    adapter._handle_button_press(0.0)
+    adapter._handle_button_release(0.1)
+    adapter._emit_pending_navigation(0.39)
+    assert actions == []
+
+    adapter._emit_pending_navigation(0.41)
+    assert actions == [InputAction.ADVANCE]
+
+
+def test_double_tap_emits_select_and_cancels_pending_advance() -> None:
+    """A second tap inside the window should emit SELECT instead of ADVANCE."""
+    adapter = PTTInputAdapter(simulate=True, enable_navigation=True)
+    actions = _record_actions(adapter)
+
+    adapter._handle_button_press(0.0)
+    adapter._handle_button_release(0.1)
+    adapter._handle_button_press(0.25)
+    adapter._handle_button_release(0.35)
+    adapter._emit_pending_navigation(0.7)
+
+    assert actions == [InputAction.SELECT]
+
+
+def test_long_hold_emits_back() -> None:
+    """Long holds should map to BACK in one-button navigation mode."""
+    adapter = PTTInputAdapter(simulate=True, enable_navigation=True)
+    actions = _record_actions(adapter)
+
+    adapter._handle_button_press(0.0)
+    adapter._handle_button_release(0.85)
+
+    assert actions == [InputAction.BACK]
+
+
+def test_long_hold_suppresses_pending_single_tap() -> None:
+    """A pending single tap should be cleared if the next gesture becomes a long hold."""
+    adapter = PTTInputAdapter(simulate=True, enable_navigation=True)
+    actions = _record_actions(adapter)
+
+    adapter._handle_button_press(0.0)
+    adapter._handle_button_release(0.1)
+    adapter._handle_button_press(0.25)
+    adapter._handle_button_release(1.1)
+    adapter._emit_pending_navigation(1.5)
+
+    assert actions == [InputAction.BACK]

--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -8,7 +8,15 @@ import pytest
 from yoyopy.app_context import AppContext
 from yoyopy.ui.display import Display
 from yoyopy.ui.input import InputAction, InputManager
-from yoyopy.ui.screens import HomeScreen, MenuScreen, NavigationRequest, Screen, ScreenManager, ScreenRouter
+from yoyopy.ui.screens import (
+    HubScreen,
+    HomeScreen,
+    MenuScreen,
+    NavigationRequest,
+    Screen,
+    ScreenManager,
+    ScreenRouter,
+)
 
 
 class RoutableStubScreen(Screen):
@@ -62,6 +70,15 @@ def test_screen_router_covers_call_hub_routes() -> None:
     assert router.resolve("call", "call_started") == NavigationRequest.push("outgoing_call")
 
 
+def test_screen_router_covers_whisplay_hub_routes() -> None:
+    """The Whisplay action hub should route each root card to the correct screen."""
+    router = ScreenRouter()
+
+    assert router.resolve("hub", "select", payload="Now Playing") == NavigationRequest.push("now_playing")
+    assert router.resolve("hub", "select", payload="Playlists") == NavigationRequest.push("playlists")
+    assert router.resolve("hub", "select", payload="Calls") == NavigationRequest.push("call")
+
+
 def test_screen_manager_routes_menu_labels_through_stack(display: Display) -> None:
     """Menu labels should resolve through the router and preserve stack navigation."""
     context = AppContext()
@@ -91,3 +108,36 @@ def test_screen_manager_routes_menu_labels_through_stack(display: Display) -> No
     menu.selected_index = 1
     input_manager.simulate_action(InputAction.SELECT)
     assert screen_manager.current_screen is home
+
+
+def test_screen_manager_routes_whisplay_hub_cards_through_stack(display: Display) -> None:
+    """The one-button hub should route its cards through the same declarative router."""
+    context = AppContext()
+    input_manager = InputManager()
+    screen_manager = ScreenManager(display, input_manager)
+
+    hub = HubScreen(display, context)
+    now_playing = RoutableStubScreen(display, context)
+    playlists = RoutableStubScreen(display, context)
+    call = RoutableStubScreen(display, context)
+
+    screen_manager.register_screen("hub", hub)
+    screen_manager.register_screen("now_playing", now_playing)
+    screen_manager.register_screen("playlists", playlists)
+    screen_manager.register_screen("call", call)
+
+    screen_manager.replace_screen("hub")
+    assert screen_manager.current_screen is hub
+
+    input_manager.simulate_action(InputAction.SELECT)
+    assert screen_manager.current_screen is now_playing
+
+    screen_manager.replace_screen("hub")
+    hub.selected_index = 1
+    input_manager.simulate_action(InputAction.SELECT)
+    assert screen_manager.current_screen is playlists
+
+    screen_manager.replace_screen("hub")
+    hub.selected_index = 2
+    input_manager.simulate_action(InputAction.SELECT)
+    assert screen_manager.current_screen is call

--- a/tests/test_whisplay_one_button.py
+++ b/tests/test_whisplay_one_button.py
@@ -1,0 +1,332 @@
+"""Focused tests for the Whisplay-native one-button UI flow."""
+
+from __future__ import annotations
+
+import pytest
+
+from yoyopy.app_context import AppContext
+from yoyopy.ui.display import Display
+from yoyopy.ui.input import InteractionProfile
+from yoyopy.ui.screens import (
+    CallScreen,
+    ContactListScreen,
+    HubScreen,
+    InCallScreen,
+    IncomingCallScreen,
+    NavigationRequest,
+    NowPlayingScreen,
+    OutgoingCallScreen,
+    PlaylistScreen,
+)
+
+
+class FakeTrack:
+    """Minimal Mopidy track double."""
+
+    def __init__(self, name: str = "Track", artist: str = "Artist") -> None:
+        self.name = name
+        self._artist = artist
+        self.length = 120000
+
+    def get_artist_string(self) -> str:
+        return self._artist
+
+
+class FakePlaylist:
+    """Minimal Mopidy playlist double."""
+
+    def __init__(self, name: str, uri: str) -> None:
+        self.name = name
+        self.uri = uri
+        self.track_count = 0
+
+
+class FakeMopidyClient:
+    """Minimal Mopidy double for one-button screen tests."""
+
+    def __init__(self) -> None:
+        self.is_connected = True
+        self.playback_state = "stopped"
+        self.track = FakeTrack()
+        self.next_track_calls = 0
+        self.play_calls = 0
+        self.pause_calls = 0
+        self.playlists = [
+            FakePlaylist("Alpha", "playlist:alpha"),
+            FakePlaylist("Beta", "playlist:beta"),
+        ]
+        self.loaded_playlists: list[str] = []
+
+    def get_current_track(self) -> FakeTrack | None:
+        return self.track
+
+    def get_playback_state(self) -> str:
+        return self.playback_state
+
+    def get_time_position(self) -> int:
+        return 0
+
+    def next_track(self) -> bool:
+        self.next_track_calls += 1
+        return True
+
+    def previous_track(self) -> bool:
+        return True
+
+    def play(self) -> bool:
+        self.play_calls += 1
+        self.playback_state = "playing"
+        return True
+
+    def pause(self) -> bool:
+        self.pause_calls += 1
+        self.playback_state = "paused"
+        return True
+
+    def get_playlists(self, fetch_track_counts: bool = False) -> list[FakePlaylist]:
+        return list(self.playlists)
+
+    def load_playlist(self, playlist_uri: str) -> bool:
+        self.loaded_playlists.append(playlist_uri)
+        return True
+
+
+class FakeContact:
+    """Minimal contact record for VoIP screen tests."""
+
+    def __init__(self, name: str, sip_address: str, favorite: bool = False) -> None:
+        self.name = name
+        self.sip_address = sip_address
+        self.favorite = favorite
+
+
+class FakeConfigManager:
+    """Minimal config manager returning test contacts."""
+
+    def __init__(self, contacts: list[FakeContact]) -> None:
+        self._contacts = contacts
+
+    def get_contacts(self) -> list[FakeContact]:
+        return list(self._contacts)
+
+
+class FakeVoIPManager:
+    """Minimal VoIP double for one-button screen tests."""
+
+    def __init__(self) -> None:
+        self.running = True
+        self.registered = True
+        self.call_state = "idle"
+        self.answer_calls = 0
+        self.reject_calls = 0
+        self.hangup_calls = 0
+        self.toggle_mute_calls = 0
+        self.is_muted = False
+        self.make_calls: list[tuple[str, str | None]] = []
+
+    def get_status(self) -> dict:
+        return {
+            "running": self.running,
+            "registered": self.registered,
+            "registration_state": "ok",
+            "call_state": self.call_state,
+            "sip_identity": "sip:test@example.com",
+        }
+
+    def get_caller_info(self) -> dict:
+        return {"display_name": "Alice", "address": "sip:alice@example.com"}
+
+    def make_call(self, sip_address: str, contact_name: str | None = None) -> bool:
+        self.make_calls.append((sip_address, contact_name))
+        return True
+
+    def answer_call(self) -> bool:
+        self.answer_calls += 1
+        return True
+
+    def reject_call(self) -> bool:
+        self.reject_calls += 1
+        return True
+
+    def hangup(self) -> bool:
+        self.hangup_calls += 1
+        return True
+
+    def toggle_mute(self) -> bool:
+        self.toggle_mute_calls += 1
+        self.is_muted = not self.is_muted
+        return self.is_muted
+
+    def get_call_duration(self) -> int:
+        return 42
+
+
+@pytest.fixture
+def display() -> Display:
+    """Create a simulation display and clean it up after each test."""
+    test_display = Display(simulate=True)
+    try:
+        yield test_display
+    finally:
+        test_display.cleanup()
+
+
+@pytest.fixture
+def one_button_context() -> AppContext:
+    """Create a Whisplay-mode app context."""
+    return AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+
+
+def test_hub_advance_wraps_from_last_card_to_first(
+    display: Display,
+    one_button_context: AppContext,
+) -> None:
+    """The Whisplay root hub should wrap its carousel on ADVANCE."""
+    hub = HubScreen(
+        display,
+        one_button_context,
+        mopidy_client=FakeMopidyClient(),
+        voip_manager=FakeVoIPManager(),
+    )
+
+    hub.selected_index = 2
+    hub.on_advance()
+
+    assert hub.selected_index == 0
+
+
+def test_now_playing_advance_and_select_follow_one_button_mapping(
+    display: Display,
+    one_button_context: AppContext,
+) -> None:
+    """Now Playing should map ADVANCE to next track and SELECT to play/pause."""
+    mopidy = FakeMopidyClient()
+    screen = NowPlayingScreen(display, one_button_context, mopidy_client=mopidy)
+
+    screen.on_advance()
+    screen.on_select()
+    screen.on_select()
+    screen.on_back()
+
+    assert mopidy.next_track_calls == 1
+    assert mopidy.play_calls == 1
+    assert mopidy.pause_calls == 1
+    assert screen.consume_navigation_request() == NavigationRequest.route("back")
+
+
+def test_playlist_advance_wraps_and_select_loads_playlist(
+    display: Display,
+    one_button_context: AppContext,
+) -> None:
+    """Playlists should wrap on ADVANCE and load the current selection on SELECT."""
+    mopidy = FakeMopidyClient()
+    screen = PlaylistScreen(display, one_button_context, mopidy_client=mopidy)
+
+    screen.enter()
+    screen.selected_index = len(screen.playlists) - 1
+    screen.on_advance()
+    screen.on_select()
+
+    assert screen.selected_index == 0
+    assert mopidy.loaded_playlists == ["playlist:alpha"]
+    assert screen.consume_navigation_request() == NavigationRequest.route("playlist_loaded")
+
+
+def test_call_screen_advance_wraps_through_quick_targets(
+    display: Display,
+    one_button_context: AppContext,
+) -> None:
+    """The call hub should wrap through quick-call targets on ADVANCE."""
+    contacts = [
+        FakeContact("Alice", "sip:alice@example.com", favorite=True),
+        FakeContact("Bob", "sip:bob@example.com", favorite=False),
+    ]
+    screen = CallScreen(
+        display,
+        one_button_context,
+        voip_manager=FakeVoIPManager(),
+        config_manager=FakeConfigManager(contacts),
+    )
+
+    screen.enter()
+    screen.selected_index = len(screen.quick_targets) - 1
+    screen.on_advance()
+
+    assert screen.selected_index == 0
+
+
+def test_contact_list_advance_wraps_and_select_calls_contact(
+    display: Display,
+    one_button_context: AppContext,
+) -> None:
+    """The contact list should wrap on ADVANCE and call on SELECT."""
+    voip_manager = FakeVoIPManager()
+    contacts = [
+        FakeContact("Alice", "sip:alice@example.com", favorite=True),
+        FakeContact("Bob", "sip:bob@example.com", favorite=False),
+    ]
+    screen = ContactListScreen(
+        display,
+        one_button_context,
+        voip_manager=voip_manager,
+        config_manager=FakeConfigManager(contacts),
+    )
+
+    screen.enter()
+    screen.selected_index = len(screen.contacts) - 1
+    screen.on_advance()
+    screen.on_select()
+
+    assert screen.selected_index == 0
+    assert voip_manager.make_calls == [("sip:alice@example.com", "Alice")]
+    assert screen.consume_navigation_request() == NavigationRequest.route("call_started")
+
+
+def test_incoming_call_select_answers_and_back_rejects(
+    display: Display,
+    one_button_context: AppContext,
+) -> None:
+    """Incoming calls should answer on SELECT and reject on BACK."""
+    voip_manager = FakeVoIPManager()
+    screen = IncomingCallScreen(display, one_button_context, voip_manager=voip_manager)
+
+    screen.on_advance()
+    screen.on_select()
+    assert voip_manager.answer_calls == 1
+    assert screen.consume_navigation_request() == NavigationRequest.route("call_answered")
+
+    screen.on_back()
+    assert voip_manager.reject_calls == 1
+    assert screen.consume_navigation_request() == NavigationRequest.route("call_rejected")
+
+
+def test_outgoing_call_back_cancels_call(
+    display: Display,
+    one_button_context: AppContext,
+) -> None:
+    """Outgoing calls should cancel on BACK in one-button mode."""
+    voip_manager = FakeVoIPManager()
+    screen = OutgoingCallScreen(display, one_button_context, voip_manager=voip_manager)
+
+    screen.on_advance()
+    screen.on_select()
+    screen.on_back()
+
+    assert voip_manager.hangup_calls == 1
+    assert screen.consume_navigation_request() == NavigationRequest.route("call_hangup")
+
+
+def test_in_call_advance_toggles_mute_and_back_hangs_up(
+    display: Display,
+    one_button_context: AppContext,
+) -> None:
+    """In-call view should use ADVANCE for mute and BACK for hangup."""
+    voip_manager = FakeVoIPManager()
+    screen = InCallScreen(display, one_button_context, voip_manager=voip_manager)
+
+    screen.on_advance()
+    screen.on_back()
+
+    assert voip_manager.toggle_mute_calls == 1
+    assert voip_manager.hangup_calls == 1
+    assert screen.consume_navigation_request() == NavigationRequest.route("call_hangup")

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -28,10 +28,11 @@ from yoyopy.event_bus import EventBus
 from yoyopy.events import RecoveryAttemptCompletedEvent, ScreenChangedEvent
 from yoyopy.fsm import CallFSM, CallInterruptionPolicy, MusicFSM
 from yoyopy.ui.display import Display
-from yoyopy.ui.input import InputManager, get_input_manager
+from yoyopy.ui.input import InputManager, InteractionProfile, get_input_manager
 from yoyopy.ui.screens import (
     CallScreen,
     ContactListScreen,
+    HubScreen,
     HomeScreen,
     InCallScreen,
     IncomingCallScreen,
@@ -85,6 +86,7 @@ class YoyoPodApp:
         self.mopidy_client: Optional[MopidyClient] = None
 
         # Screen instances
+        self.hub_screen: Optional[HubScreen] = None
         self.home_screen: Optional[HomeScreen] = None
         self.menu_screen: Optional[MenuScreen] = None
         self.now_playing_screen: Optional[NowPlayingScreen] = None
@@ -171,7 +173,7 @@ class YoyoPodApp:
                 return False
 
             self._ensure_coordinators()
-            self.coordinator_runtime.set_ui_state(AppRuntimeState.MENU, trigger="initial_screen")
+            self.coordinator_runtime.set_ui_state(self._ui_state, trigger="initial_screen")
             self._setup_event_subscriptions()
             self._setup_voip_callbacks()
             self._setup_music_callbacks()
@@ -242,6 +244,7 @@ class YoyoPodApp:
                 simulate=self.simulate,
             )
             if self.input_manager:
+                self.context.interaction_profile = self.input_manager.interaction_profile
                 self.input_manager.start()
                 logger.info("    ✓ Input system initialized")
             else:
@@ -307,6 +310,12 @@ class YoyoPodApp:
                 "Call Contact",
                 "Back",
             ]
+            self.hub_screen = HubScreen(
+                self.display,
+                self.context,
+                mopidy_client=self.mopidy_client,
+                voip_manager=self.voip_manager,
+            )
             self.menu_screen = MenuScreen(self.display, self.context, items=menu_items)
             self.home_screen = HomeScreen(self.display, self.context)
             self.now_playing_screen = NowPlayingScreen(
@@ -351,6 +360,7 @@ class YoyoPodApp:
                 voip_manager=self.voip_manager,
             )
 
+            self.screen_manager.register_screen("hub", self.hub_screen)
             self.screen_manager.register_screen("home", self.home_screen)
             self.screen_manager.register_screen("menu", self.menu_screen)
             self.screen_manager.register_screen("now_playing", self.now_playing_screen)
@@ -360,19 +370,42 @@ class YoyoPodApp:
             self.screen_manager.register_screen("incoming_call", self.incoming_call_screen)
             self.screen_manager.register_screen("outgoing_call", self.outgoing_call_screen)
             self.screen_manager.register_screen("in_call", self.in_call_screen)
+            logger.info("    - Whisplay root: hub")
 
             logger.info("  ✓ All screens registered")
             logger.info("    - Music screens: now_playing, playlists")
             logger.info("    - VoIP screens: call, contacts, incoming_call, outgoing_call, in_call")
             logger.info("    - Navigation: home, menu")
 
-            self.screen_manager.push_screen("menu")
-            self._ui_state = AppRuntimeState.MENU
+            initial_screen = self._get_initial_screen_name()
+            self.screen_manager.push_screen(initial_screen)
+            self._ui_state = self._get_initial_ui_state()
+            logger.info(f"  Initial route resolved to {initial_screen}")
             logger.info("  ✓ Initial screen set to menu")
             return True
         except Exception as exc:
             logger.error(f"Failed to setup screens: {exc}")
             return False
+
+    def _get_interaction_profile(self) -> InteractionProfile:
+        """Return the active hardware interaction profile."""
+        if self.input_manager is not None:
+            return self.input_manager.interaction_profile
+        if self.context is not None:
+            return self.context.interaction_profile
+        return InteractionProfile.STANDARD
+
+    def _get_initial_screen_name(self) -> str:
+        """Return the root screen for the active interaction profile."""
+        if self._get_interaction_profile() == InteractionProfile.ONE_BUTTON:
+            return "hub"
+        return "menu"
+
+    def _get_initial_ui_state(self) -> AppRuntimeState:
+        """Return the base runtime state for the active interaction profile."""
+        if self._get_interaction_profile() == InteractionProfile.ONE_BUTTON:
+            return AppRuntimeState.HUB
+        return AppRuntimeState.MENU
 
     def _setup_voip_callbacks(self) -> None:
         """Register VoIP event callbacks."""

--- a/yoyopy/app_context.py
+++ b/yoyopy/app_context.py
@@ -10,6 +10,8 @@ from typing import Optional, List, Dict, Any, TYPE_CHECKING
 from pathlib import Path
 from loguru import logger
 
+from yoyopy.ui.input.hal import InteractionProfile
+
 if TYPE_CHECKING:
     from yoyopy.audio.audio_manager import AudioManager
 
@@ -81,7 +83,11 @@ class AppContext:
     user settings, and system status.
     """
 
-    def __init__(self, audio_manager: Optional['AudioManager'] = None) -> None:
+    def __init__(
+        self,
+        audio_manager: Optional['AudioManager'] = None,
+        interaction_profile: InteractionProfile = InteractionProfile.STANDARD,
+    ) -> None:
         """
         Initialize application context.
 
@@ -93,6 +99,7 @@ class AppContext:
 
         # Audio manager (optional, for actual audio playback)
         self.audio_manager = audio_manager
+        self.interaction_profile = interaction_profile
 
         # Current playlist
         self.current_playlist: Optional[Playlist] = None

--- a/yoyopy/coordinators/runtime.py
+++ b/yoyopy/coordinators/runtime.py
@@ -35,6 +35,7 @@ class AppRuntimeState(Enum):
     """Derived application state used by the production coordinator path."""
 
     IDLE = "idle"
+    HUB = "hub"
     MENU = "menu"
     PLAYING = "playing"
     PAUSED = "paused"
@@ -94,6 +95,7 @@ class CoordinatorRuntime:
 
     _UI_STATES = {
         AppRuntimeState.IDLE,
+        AppRuntimeState.HUB,
         AppRuntimeState.MENU,
         AppRuntimeState.SETTINGS,
         AppRuntimeState.PLAYLIST,
@@ -183,6 +185,7 @@ class CoordinatorRuntime:
         """Update the base UI state for non-call overlay screens."""
         state_by_screen = {
             "home": AppRuntimeState.IDLE,
+            "hub": AppRuntimeState.HUB,
             "menu": AppRuntimeState.MENU,
             "playlists": AppRuntimeState.PLAYLIST_BROWSER,
             "call": AppRuntimeState.CALL_IDLE,

--- a/yoyopy/ui/__init__.py
+++ b/yoyopy/ui/__init__.py
@@ -8,7 +8,7 @@ Provides display management, input handling, and screen navigation.
 from yoyopy.ui.display import Display, DisplayHAL
 
 # Input module
-from yoyopy.ui.input import InputManager, InputAction
+from yoyopy.ui.input import InputManager, InputAction, InteractionProfile
 
 # Screens module
 from yoyopy.ui.screens import (
@@ -32,6 +32,7 @@ __all__ = [
     # Input
     'InputManager',
     'InputAction',
+    'InteractionProfile',
     # Screens
     'Screen',
     'ScreenManager',

--- a/yoyopy/ui/input/__init__.py
+++ b/yoyopy/ui/input/__init__.py
@@ -9,12 +9,13 @@ Provides hardware abstraction for various input methods:
 """
 
 from yoyopy.ui.input.factory import get_input_manager
-from yoyopy.ui.input.hal import InputAction, InputHAL
+from yoyopy.ui.input.hal import InputAction, InputHAL, InteractionProfile
 from yoyopy.ui.input.manager import InputManager
 
 __all__ = [
     'InputHAL',
     'InputAction',
+    'InteractionProfile',
     'InputManager',
     'get_input_manager',
 ]

--- a/yoyopy/ui/input/adapters/ptt_button.py
+++ b/yoyopy/ui/input/adapters/ptt_button.py
@@ -1,75 +1,58 @@
 """
-PTT (Push-to-Talk) button input adapter for Whisplay HAT.
+Single-button input adapter for the Whisplay HAT.
 
-Maps the single button to PTT press/release actions and optional
-navigation actions for menu control.
+In Whisplay navigation mode the adapter emits:
+- Single tap -> ADVANCE
+- Double tap -> SELECT
+- Long hold -> BACK
+
+If navigation is disabled, the adapter falls back to raw PTT press/release
+events for compatibility.
 """
+
+from __future__ import annotations
 
 import time
 from collections import defaultdict
-from typing import Callable, Optional, Any, List, Dict
-from threading import Thread, Event
+from threading import Event, Thread
+from typing import Any, Callable, Dict, List, Optional
+
 from loguru import logger
 
-from yoyopy.ui.input.hal import InputHAL, InputAction
+from yoyopy.ui.input.hal import InputAction, InputHAL
 
 
 class PTTInputAdapter(InputHAL):
-    """
-    Input adapter for single PTT button (Whisplay HAT).
+    """Input adapter for the Whisplay single button."""
 
-    The Whisplay HAT has a single button that can be used for:
-    - Push-to-talk (press/release events)
-    - Navigation via patterns:
-      - Single click → SELECT
-      - Double click → BACK
-      - Long press → Hold for PTT voice input
-
-    This adapter polls the button state via the WhisPlayBoard GPIO interface.
-    """
-
-    # Timing constants (in seconds)
-    DEBOUNCE_TIME = 0.05       # 50ms debounce
-    LONG_PRESS_TIME = 0.8      # 800ms for PTT long press
-    DOUBLE_CLICK_TIME = 0.3    # 300ms window for double click
-    POLL_RATE = 0.01           # 10ms polling rate
+    DEBOUNCE_TIME = 0.05
+    LONG_PRESS_TIME = 0.8
+    DOUBLE_CLICK_TIME = 0.3
+    POLL_RATE = 0.01
 
     def __init__(
         self,
         whisplay_device: Optional[object] = None,
         enable_navigation: bool = True,
-        simulate: bool = False
+        simulate: bool = False,
     ) -> None:
-        """
-        Initialize the PTT button input adapter.
-
-        Args:
-            whisplay_device: WhisPlayBoard device instance
-            enable_navigation: Enable navigation via button patterns (single/double click)
-            simulate: Run in simulation mode (no hardware)
-        """
         self.device = whisplay_device
         self.enable_navigation = enable_navigation
         self.simulate = simulate
 
-        # Callback storage
         self.callbacks: Dict[InputAction, List[Callable]] = defaultdict(list)
-
-        # Polling thread control
         self.running = False
         self.poll_thread: Optional[Thread] = None
         self.stop_event = Event()
 
-        # Button state tracking
         self.button_pressed = False
         self.press_start_time: Optional[float] = None
-        self.last_click_time: Optional[float] = None
-        self.long_press_fired = False
+        self.pending_single_tap_time: Optional[float] = None
 
         logger.debug(f"PTTInputAdapter initialized (navigation: {enable_navigation})")
 
     def start(self) -> None:
-        """Start PTT button monitoring."""
+        """Start button polling."""
         if self.running:
             logger.warning("PTTInputAdapter already running")
             return
@@ -81,7 +64,7 @@ class PTTInputAdapter(InputHAL):
         logger.info("PTTInputAdapter started")
 
     def stop(self) -> None:
-        """Stop PTT button monitoring."""
+        """Stop button polling."""
         if not self.running:
             return
 
@@ -96,7 +79,7 @@ class PTTInputAdapter(InputHAL):
     def on_action(
         self,
         action: InputAction,
-        callback: Callable[[Optional[Any]], None]
+        callback: Callable[[Optional[Any]], None],
     ) -> None:
         """Register callback for an action."""
         self.callbacks[action].append(callback)
@@ -108,144 +91,148 @@ class PTTInputAdapter(InputHAL):
         logger.debug("Cleared all PTT callbacks")
 
     def get_capabilities(self) -> List[InputAction]:
-        """Return list of supported actions."""
-        capabilities = [
+        """Return supported actions for the current mode."""
+        if self.enable_navigation:
+            return [
+                InputAction.ADVANCE,
+                InputAction.SELECT,
+                InputAction.BACK,
+            ]
+
+        return [
             InputAction.PTT_PRESS,
             InputAction.PTT_RELEASE,
         ]
 
-        if self.enable_navigation:
-            capabilities.extend([
-                InputAction.SELECT,   # Single click
-                InputAction.BACK,     # Double click
-            ])
-
-        return capabilities
-
     def _get_button_state(self) -> bool:
-        """
-        Get the current state of the PTT button.
-
-        Returns:
-            True if button is pressed, False otherwise
-        """
+        """Return True when the physical button is pressed."""
         if self.simulate or not self.device:
             return False
 
         try:
-            # WhisPlayBoard button state
-            # The button is connected to GPIO and can be read via device
-            # We check the button attribute if available
-            if hasattr(self.device, 'button_pressed'):
+            if hasattr(self.device, "button_pressed"):
                 return self.device.button_pressed
-            elif hasattr(self.device, 'get_button_state'):
+            if hasattr(self.device, "get_button_state"):
                 return self.device.get_button_state()
-            else:
-                # Fallback: Try to read GPIO directly if available
-                import RPi.GPIO as GPIO
-                BUTTON_PIN = 26  # Whisplay button GPIO pin
-                return GPIO.input(BUTTON_PIN) == GPIO.LOW  # Active low
-        except Exception as e:
-            logger.error(f"Error reading PTT button state: {e}")
+
+            import RPi.GPIO as GPIO
+
+            button_pin = 26
+            return GPIO.input(button_pin) == GPIO.LOW
+        except Exception as exc:
+            logger.error(f"Error reading PTT button state: {exc}")
             return False
 
     def _fire_action(self, action: InputAction, data: Optional[Any] = None) -> None:
-        """
-        Fire all registered callbacks for an action.
-
-        Args:
-            action: Action that occurred
-            data: Optional data dict
-        """
+        """Fire registered callbacks for one action."""
         callbacks = self.callbacks.get(action, [])
-        if callbacks:
-            logger.debug(f"PTT action: {action.value}")
-            for callback in callbacks:
-                try:
-                    callback(data)
-                except Exception as e:
-                    logger.error(f"Error in PTT callback: {e}")
+        if not callbacks:
+            return
+
+        logger.debug(f"PTT action: {action.value}")
+        for callback in callbacks:
+            try:
+                callback(data)
+            except Exception as exc:
+                logger.error(f"Error in PTT callback: {exc}")
+
+    def _handle_button_press(self, current_time: float) -> None:
+        """Record a physical button press."""
+        self._emit_pending_navigation(current_time)
+        self.button_pressed = True
+        self.press_start_time = current_time
+
+        if not self.enable_navigation:
+            self._fire_action(InputAction.PTT_PRESS, {"timestamp": current_time})
+
+    def _handle_button_release(self, current_time: float) -> None:
+        """Resolve a press/release sequence into the current interaction grammar."""
+        self.button_pressed = False
+
+        press_duration = 0.0
+        if self.press_start_time is not None:
+            press_duration = current_time - self.press_start_time
+
+        if not self.enable_navigation:
+            self._fire_action(
+                InputAction.PTT_RELEASE,
+                {
+                    "timestamp": current_time,
+                    "duration": press_duration,
+                },
+            )
+            self.press_start_time = None
+            return
+
+        if press_duration >= self.LONG_PRESS_TIME:
+            self.pending_single_tap_time = None
+            self._fire_action(
+                InputAction.BACK,
+                {
+                    "method": "long_hold",
+                    "duration": press_duration,
+                },
+            )
+            self.press_start_time = None
+            return
+
+        if (
+            self.pending_single_tap_time is not None
+            and (current_time - self.pending_single_tap_time) < self.DOUBLE_CLICK_TIME
+        ):
+            self.pending_single_tap_time = None
+            self._fire_action(
+                InputAction.SELECT,
+                {
+                    "method": "double_tap",
+                    "duration": press_duration,
+                },
+            )
+            self.press_start_time = None
+            return
+
+        self.pending_single_tap_time = current_time
+        self.press_start_time = None
+
+    def _emit_pending_navigation(self, current_time: float) -> None:
+        """Emit ADVANCE once the double-tap window has expired."""
+        if not self.enable_navigation or self.button_pressed:
+            return
+
+        if self.pending_single_tap_time is None:
+            return
+
+        if (current_time - self.pending_single_tap_time) < self.DOUBLE_CLICK_TIME:
+            return
+
+        self.pending_single_tap_time = None
+        self._fire_action(
+            InputAction.ADVANCE,
+            {
+                "method": "single_tap",
+                "timestamp": current_time,
+            },
+        )
 
     def _poll_button(self) -> None:
-        """
-        Poll PTT button state in a loop.
-
-        Detects:
-        - Button press (PTT_PRESS)
-        - Button release (PTT_RELEASE)
-        - Long press (extended PTT hold)
-        - Single click (SELECT) if navigation enabled
-        - Double click (BACK) if navigation enabled
-        """
+        """Poll the button and emit semantic actions."""
         logger.debug("PTT button polling started")
 
         while not self.stop_event.is_set():
             current_time = time.time()
+            self._emit_pending_navigation(current_time)
+
             current_state = self._get_button_state()
             previous_state = self.button_pressed
 
-            # Button just pressed (transition from False to True)
             if current_state and not previous_state:
-                # Debounce
                 time.sleep(self.DEBOUNCE_TIME)
                 current_state = self._get_button_state()
+                if current_state:
+                    self._handle_button_press(time.time())
 
-                if current_state:  # Still pressed after debounce
-                    self.button_pressed = True
-                    self.press_start_time = current_time
-                    self.long_press_fired = False
-
-                    # Fire PTT_PRESS immediately
-                    self._fire_action(InputAction.PTT_PRESS, {
-                        "timestamp": current_time
-                    })
-                    logger.trace("PTT button pressed")
-
-            # Button released (transition from True to False)
             elif not current_state and previous_state:
-                self.button_pressed = False
-                press_duration = 0.0
-
-                if self.press_start_time:
-                    press_duration = current_time - self.press_start_time
-
-                # Fire PTT_RELEASE
-                self._fire_action(InputAction.PTT_RELEASE, {
-                    "timestamp": current_time,
-                    "duration": press_duration
-                })
-
-                # Handle navigation patterns if enabled and not a long press
-                if self.enable_navigation and not self.long_press_fired:
-                    # Check for double click
-                    if self.last_click_time and \
-                       (current_time - self.last_click_time) < self.DOUBLE_CLICK_TIME:
-                        # Double click → BACK
-                        self._fire_action(InputAction.BACK, {
-                            "method": "double_click"
-                        })
-                        self.last_click_time = None  # Reset to avoid triple click
-                    else:
-                        # Single click → SELECT
-                        # We fire this with a slight delay to allow double-click detection
-                        # For now, fire immediately and let double-click override
-                        self._fire_action(InputAction.SELECT, {
-                            "method": "single_click"
-                        })
-                        self.last_click_time = current_time
-
-                self.press_start_time = None
-                logger.trace(f"PTT button released after {press_duration:.2f}s")
-
-            # Button held down - check for long press
-            elif current_state and previous_state:
-                if self.press_start_time and not self.long_press_fired:
-                    hold_duration = current_time - self.press_start_time
-                    if hold_duration >= self.LONG_PRESS_TIME:
-                        # Long press detected - useful for voice recording indication
-                        logger.debug("PTT long press detected")
-                        self.long_press_fired = True
-                        # Don't fire SELECT for long press (PTT mode)
+                self._handle_button_release(time.time())
 
             time.sleep(self.POLL_RATE)
 

--- a/yoyopy/ui/input/factory.py
+++ b/yoyopy/ui/input/factory.py
@@ -5,17 +5,18 @@ Automatically selects the appropriate input adapter based on
 hardware detection and configuration.
 """
 
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
+
 from loguru import logger
 
-from yoyopy.ui.input.hal import InputAction
+from yoyopy.ui.input.hal import InputAction, InteractionProfile
 from yoyopy.ui.input.manager import InputManager
 
 
 def get_input_manager(
     display_adapter: object,
     config: Optional[Dict[str, Any]] = None,
-    simulate: bool = False
+    simulate: bool = False,
 ) -> Optional[InputManager]:
     """
     Create input manager with appropriate adapters based on hardware.
@@ -30,140 +31,104 @@ def get_input_manager(
 
     Returns:
         Configured InputManager instance, or None if no input available
-
-    Example:
-        from yoyopy.ui.display import Display
-        from yoyopy.ui.input import get_input_manager
-
-        display = Display(hardware="auto")
-        input_manager = get_input_manager(
-            display.get_adapter(),
-            config={'input': {'enable_voice': False}}
-        )
-
-        if input_manager:
-            input_manager.start()
     """
     config = config or {}
-    input_config = config.get('input', {})
+    input_config = config.get("input", {})
 
-    # Create InputManager
-    manager = InputManager()
-
-    # Determine hardware type from display adapter
+    manager = InputManager(interaction_profile=InteractionProfile.STANDARD)
     adapter_name = display_adapter.__class__.__name__
 
     logger.info("Creating input manager...")
     logger.debug(f"  Display adapter: {adapter_name}")
 
-    # ===== Pimoroni Display HAT Mini (4 buttons) =====
     if adapter_name == "PimoroniDisplayAdapter":
         logger.info("  Detected Pimoroni Display HAT Mini")
-
-        # Get display device for button access
-        display_device = getattr(display_adapter, 'device', None)
+        display_device = getattr(display_adapter, "device", None)
 
         if display_device or simulate:
-            # Create 4-button adapter
             from yoyopy.ui.input.adapters.four_button import FourButtonInputAdapter
 
             button_adapter = FourButtonInputAdapter(
                 display_device=display_device,
-                simulate=simulate
+                simulate=simulate,
             )
             manager.add_adapter(button_adapter)
-            logger.info("  → Added 4-button input (A, B, X, Y)")
+            logger.info("  -> Added 4-button input (A, B, X, Y)")
         else:
-            logger.warning("  → No display device available for button input")
+            logger.warning("  -> No display device available for button input")
 
-    # ===== Whisplay HAT (PTT button) =====
     elif adapter_name == "WhisplayDisplayAdapter":
         logger.info("  Detected Whisplay HAT")
-
-        # Get Whisplay device for button access
-        whisplay_device = getattr(display_adapter, 'device', None)
-
-        # Check if navigation via PTT button is enabled
-        enable_navigation = input_config.get('ptt_navigation', True)
+        manager.set_interaction_profile(InteractionProfile.ONE_BUTTON)
+        whisplay_device = getattr(display_adapter, "device", None)
+        enable_navigation = input_config.get("ptt_navigation", True)
 
         if whisplay_device or simulate:
-            # Create PTT button adapter
             from yoyopy.ui.input.adapters.ptt_button import PTTInputAdapter
 
             ptt_adapter = PTTInputAdapter(
                 whisplay_device=whisplay_device,
                 enable_navigation=enable_navigation,
-                simulate=simulate
+                simulate=simulate,
             )
             manager.add_adapter(ptt_adapter)
 
             if enable_navigation:
-                logger.info("  → Added PTT button input (press/release + navigation)")
+                logger.info("  -> Added one-button Whisplay navigation")
             else:
-                logger.info("  → Added PTT button input (press/release only)")
+                logger.info("  -> Added PTT button input (press/release only)")
         else:
-            logger.warning("  → No Whisplay device available for PTT input")
+            logger.warning("  -> No Whisplay device available for PTT input")
 
-        # Optional: Add voice input for Whisplay (future)
-        if input_config.get('enable_voice', False):
-            logger.info("  → Voice input requested but not yet implemented")
-            # TODO: Add VoiceInputAdapter when implemented
+        if input_config.get("enable_voice", False):
+            logger.info("  -> Voice input requested but not yet implemented")
 
-    # ===== Simulation Display Adapter (keyboard + web input) =====
     elif adapter_name == "SimulationDisplayAdapter":
         logger.info("  Detected Simulation Display Adapter")
-
-        # Add keyboard input adapter
         from yoyopy.ui.input.adapters.keyboard import get_keyboard_adapter
 
         keyboard_adapter = get_keyboard_adapter()
         manager.add_adapter(keyboard_adapter)
-        logger.info("  → Added keyboard input (Enter, Esc, Arrow keys)")
+        logger.info("  -> Added keyboard input (Enter, Esc, Arrow keys)")
 
-        # Connect web server input to keyboard adapter (reuse same callbacks)
         try:
             from yoyopy.ui.web_server import get_server
+
             server = get_server()
 
-            def web_input_handler(action: str):
+            def web_input_handler(action: str) -> None:
                 """Handle input from web UI buttons."""
-
-                # Map action string to InputAction
                 action_map = {
-                    'SELECT': InputAction.SELECT,
-                    'BACK': InputAction.BACK,
-                    'UP': InputAction.UP,
-                    'DOWN': InputAction.DOWN
+                    "SELECT": InputAction.SELECT,
+                    "BACK": InputAction.BACK,
+                    "UP": InputAction.UP,
+                    "DOWN": InputAction.DOWN,
                 }
 
                 if action in action_map:
-                    # Simulate the action through the manager
                     manager.simulate_action(action_map[action])
 
             server.set_input_callback(web_input_handler)
-            logger.info("  → Added web button input (browser UI)")
+            logger.info("  -> Added web button input (browser UI)")
+        except Exception as exc:
+            logger.warning(f"  -> Failed to connect web input: {exc}")
 
-        except Exception as e:
-            logger.warning(f"  → Failed to connect web input: {e}")
-
-    # ===== Simulation mode or unknown hardware =====
     else:
         logger.info(f"  Unknown display adapter: {adapter_name}")
         if simulate:
-            logger.info("  → Running in simulation mode (no input hardware)")
+            logger.info("  -> Running in simulation mode (no input hardware)")
         else:
-            logger.warning("  → No input adapters available for this hardware")
+            logger.warning("  -> No input adapters available for this hardware")
             return None
 
-    # Check if any adapters were added
     if not manager.adapters:
         logger.warning("No input adapters configured")
         return None
 
-    # Log capabilities
     capabilities = manager.get_capabilities()
     logger.info(f"  Input capabilities: {len(capabilities)} action(s)")
-    logger.debug(f"    Actions: {[a.value for a in capabilities]}")
+    logger.debug(f"    Actions: {[action.value for action in capabilities]}")
+    logger.info(f"  Interaction profile: {manager.interaction_profile.value}")
 
     return manager
 
@@ -177,48 +142,41 @@ def get_input_info(display_adapter: object) -> Dict[str, Any]:
 
     Returns:
         Dict with input hardware information
-
-    Example:
-        info = get_input_info(display.get_adapter())
-        print(f"Input type: {info['type']}")
-        print(f"Capabilities: {info['capabilities']}")
     """
     adapter_name = display_adapter.__class__.__name__
 
     if adapter_name == "PimoroniDisplayAdapter":
         return {
-            'type': 'four_button',
-            'hardware': 'Pimoroni Display HAT Mini',
-            'buttons': 4,
-            'capabilities': [
-                'SELECT (Button A)',
-                'BACK (Button B)',
-                'UP (Button X)',
-                'DOWN (Button Y)',
-                'HOME (Long press B)',
+            "type": "four_button",
+            "hardware": "Pimoroni Display HAT Mini",
+            "buttons": 4,
+            "capabilities": [
+                "SELECT (Button A)",
+                "BACK (Button B)",
+                "UP (Button X)",
+                "DOWN (Button Y)",
+                "HOME (Long press B)",
             ],
-            'description': '4-button interface for menu navigation'
+            "description": "4-button interface for menu navigation",
         }
 
-    elif adapter_name == "WhisplayDisplayAdapter":
+    if adapter_name == "WhisplayDisplayAdapter":
         return {
-            'type': 'ptt_button',
-            'hardware': 'Whisplay HAT',
-            'buttons': 1,
-            'capabilities': [
-                'PTT_PRESS (Button press)',
-                'PTT_RELEASE (Button release)',
-                'SELECT (Single click)',
-                'BACK (Double click)',
+            "type": "ptt_button",
+            "hardware": "Whisplay HAT",
+            "buttons": 1,
+            "capabilities": [
+                "ADVANCE (Single tap)",
+                "SELECT (Double tap)",
+                "BACK (Long hold)",
             ],
-            'description': 'PTT button with voice input support'
+            "description": "Single-button carousel and list navigation",
         }
 
-    else:
-        return {
-            'type': 'unknown',
-            'hardware': adapter_name,
-            'buttons': 0,
-            'capabilities': [],
-            'description': 'No input hardware detected'
-        }
+    return {
+        "type": "unknown",
+        "hardware": adapter_name,
+        "buttons": 0,
+        "capabilities": [],
+        "description": "No input hardware detected",
+    }

--- a/yoyopy/ui/input/hal.py
+++ b/yoyopy/ui/input/hal.py
@@ -10,6 +10,18 @@ from typing import Callable, List, Optional, Any
 from loguru import logger
 
 
+class InteractionProfile(Enum):
+    """
+    High-level interaction profiles derived from available hardware.
+
+    STANDARD covers multi-button devices and simulation, while ONE_BUTTON is
+    the Whisplay-native single-button navigation model.
+    """
+
+    STANDARD = "standard"
+    ONE_BUTTON = "one_button"
+
+
 class InputAction(Enum):
     """
     Semantic input actions independent of hardware.
@@ -19,6 +31,7 @@ class InputAction(Enum):
     """
 
     # Navigation actions
+    ADVANCE = "advance"         # Move to the next item in a one-button flow
     SELECT = "select"           # Select/Confirm current item
     BACK = "back"               # Go back/Cancel
     UP = "up"                   # Navigate up in lists

--- a/yoyopy/ui/input/manager.py
+++ b/yoyopy/ui/input/manager.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from typing import List, Callable, Optional, Any, Dict
 from loguru import logger
 
-from yoyopy.ui.input.hal import InputAction, InputHAL
+from yoyopy.ui.input.hal import InputAction, InputHAL, InteractionProfile
 
 
 class InputManager:
@@ -33,12 +33,20 @@ class InputManager:
         manager.start()
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        interaction_profile: InteractionProfile = InteractionProfile.STANDARD,
+    ) -> None:
         """Initialize the input manager."""
         self.adapters: List[InputHAL] = []
         self.callbacks: Dict[InputAction, List[Callable]] = defaultdict(list)
+        self.interaction_profile = interaction_profile
         self.running = False
         logger.debug("InputManager initialized")
+
+    def set_interaction_profile(self, profile: InteractionProfile) -> None:
+        """Store the active interaction profile for the current hardware setup."""
+        self.interaction_profile = profile
 
     def add_adapter(self, adapter: InputHAL) -> None:
         """

--- a/yoyopy/ui/screens/__init__.py
+++ b/yoyopy/ui/screens/__init__.py
@@ -17,7 +17,7 @@ from yoyopy.ui.screens.manager import ScreenManager
 from yoyopy.ui.screens.router import NavigationRequest, ScreenRouter
 
 # Navigation screens
-from yoyopy.ui.screens.navigation import HomeScreen, MenuScreen
+from yoyopy.ui.screens.navigation import HubScreen, HomeScreen, MenuScreen
 
 # Music screens
 from yoyopy.ui.screens.music import NowPlayingScreen, PlaylistScreen
@@ -38,6 +38,7 @@ __all__ = [
     'NavigationRequest',
     'ScreenRouter',
     # Navigation
+    'HubScreen',
     'HomeScreen',
     'MenuScreen',
     # Music

--- a/yoyopy/ui/screens/base.py
+++ b/yoyopy/ui/screens/base.py
@@ -10,6 +10,7 @@ from typing import Optional, Any, TYPE_CHECKING
 from loguru import logger
 
 from yoyopy.ui.display import Display
+from yoyopy.ui.input.hal import InteractionProfile
 from yoyopy.ui.screens.router import NavigationRequest
 
 if TYPE_CHECKING:
@@ -82,6 +83,16 @@ class Screen(ABC):
         self._pending_navigation = None
         return request
 
+    def get_interaction_profile(self) -> InteractionProfile:
+        """Return the current interaction profile for the active device."""
+        if self.context is None:
+            return InteractionProfile.STANDARD
+        return getattr(self.context, "interaction_profile", InteractionProfile.STANDARD)
+
+    def is_one_button_mode(self) -> bool:
+        """Return True when the screen should render Whisplay-first hints."""
+        return self.get_interaction_profile() == InteractionProfile.ONE_BUTTON
+
     def handle_action(self, action: "InputAction", data: Optional[Any] = None) -> None:
         """Dispatch a semantic input action to the matching handler method."""
         handler = getattr(self, f"on_{action.value}", None)
@@ -119,6 +130,10 @@ class Screen(ABC):
     # ===== SEMANTIC ACTION HANDLERS =====
     # These are hardware-independent input actions that screens can respond to.
     # Screens override these methods based on their functionality.
+
+    def on_advance(self, data: Optional[Any] = None) -> None:
+        """Handle ADVANCE action for one-button navigation flows."""
+        pass
 
     def on_select(self, data: Optional[Any] = None) -> None:
         """Handle SELECT action (confirm/accept current item)."""

--- a/yoyopy/ui/screens/music/now_playing.py
+++ b/yoyopy/ui/screens/music/now_playing.py
@@ -217,6 +217,17 @@ class NowPlayingScreen(Screen):
                 fill=self.display.COLOR_YELLOW
             )
 
+        if self.is_one_button_mode():
+            help_text = "Tap: Next | Double: Play/Pause | Hold: Back"
+            help_width, _ = self.display.get_text_size(help_text, 9)
+            self.display.text(
+                help_text,
+                (self.display.WIDTH - help_width) // 2,
+                self.display.HEIGHT - 10,
+                color=self.display.COLOR_GRAY,
+                font_size=9
+            )
+
         # Update display
         self.display.update()
 
@@ -262,6 +273,10 @@ class NowPlayingScreen(Screen):
     def on_back(self, data=None) -> None:
         """Go back to the previous screen."""
         self.request_route("back")
+
+    def on_advance(self, data=None) -> None:
+        """Advance to the next track for one-button navigation."""
+        self._next_track()
 
     def on_up(self, data=None) -> None:
         """Go to the previous track."""

--- a/yoyopy/ui/screens/music/playlist.py
+++ b/yoyopy/ui/screens/music/playlist.py
@@ -279,7 +279,10 @@ class PlaylistScreen(Screen):
         # Draw instructions at bottom
         instructions_y = self.display.HEIGHT - 15
         instructions_size = 10
-        instructions = "A: Load | B: Back | X/Y: Navigate"
+        if self.is_one_button_mode():
+            instructions = "Tap: Next | Double: Load | Hold: Back"
+        else:
+            instructions = "A: Load | B: Back | X/Y: Navigate"
         instr_width, _ = self.display.get_text_size(instructions, instructions_size)
         instr_x = (self.display.WIDTH - instr_width) // 2
 
@@ -299,6 +302,13 @@ class PlaylistScreen(Screen):
         if self.playlists and self.selected_index < len(self.playlists) - 1:
             self.selected_index += 1
             logger.debug(f"Selected: {self.playlists[self.selected_index].name}")
+
+    def select_next_wrapped(self) -> None:
+        """Move selection to next playlist with wraparound."""
+        if not self.playlists:
+            return
+        self.selected_index = (self.selected_index + 1) % len(self.playlists)
+        logger.debug(f"Selected: {self.playlists[self.selected_index].name}")
 
     def select_previous(self) -> None:
         """Move selection to previous playlist."""
@@ -357,6 +367,10 @@ class PlaylistScreen(Screen):
     def on_back(self, data=None) -> None:
         """Go back to the previous screen."""
         self.request_route("back")
+
+    def on_advance(self, data=None) -> None:
+        """Move to the next playlist for one-button navigation."""
+        self.select_next_wrapped()
 
     def on_up(self, data=None) -> None:
         """Move selection up."""

--- a/yoyopy/ui/screens/navigation/__init__.py
+++ b/yoyopy/ui/screens/navigation/__init__.py
@@ -1,6 +1,7 @@
 """Navigation screens for YoyoPod."""
 
+from yoyopy.ui.screens.navigation.hub import HubScreen
 from yoyopy.ui.screens.navigation.home import HomeScreen
 from yoyopy.ui.screens.navigation.menu import MenuScreen
 
-__all__ = ['HomeScreen', 'MenuScreen']
+__all__ = ['HubScreen', 'HomeScreen', 'MenuScreen']

--- a/yoyopy/ui/screens/navigation/hub.py
+++ b/yoyopy/ui/screens/navigation/hub.py
@@ -1,0 +1,251 @@
+"""Whisplay-native action hub screen."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from yoyopy.ui.display import Display
+from yoyopy.ui.screens.base import Screen
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.audio.mopidy_client import MopidyClient
+    from yoyopy.voip import VoIPManager
+
+
+@dataclass(frozen=True, slots=True)
+class HubCard:
+    """One primary Whisplay root action."""
+
+    title: str
+    subtitle: str
+
+
+class HubScreen(Screen):
+    """Carousel root screen for one-button Whisplay navigation."""
+
+    def __init__(
+        self,
+        display: Display,
+        context: Optional["AppContext"] = None,
+        mopidy_client: Optional["MopidyClient"] = None,
+        voip_manager: Optional["VoIPManager"] = None,
+    ) -> None:
+        super().__init__(display, context, "ActionHub")
+        self.mopidy_client = mopidy_client
+        self.voip_manager = voip_manager
+        self.selected_index = 0
+        self._playlist_count: int | None = None
+
+    def enter(self) -> None:
+        """Refresh light-weight summaries when the hub becomes active."""
+        super().enter()
+        self._refresh_playlist_count()
+
+    def _refresh_playlist_count(self) -> None:
+        """Refresh the cached playlist count for the root hub card."""
+        if self.mopidy_client is None or not self.mopidy_client.is_connected:
+            self._playlist_count = None
+            return
+
+        try:
+            playlists = self.mopidy_client.get_playlists(fetch_track_counts=False)
+        except Exception:
+            self._playlist_count = None
+            return
+        self._playlist_count = len(playlists)
+
+    def _cards(self) -> list[HubCard]:
+        """Build the live card list for rendering and selection."""
+        return [
+            HubCard(title="Now Playing", subtitle=self._music_subtitle()),
+            HubCard(title="Playlists", subtitle=self._playlist_subtitle()),
+            HubCard(title="Calls", subtitle=self._calls_subtitle()),
+        ]
+
+    def _music_subtitle(self) -> str:
+        """Return the compact music status subtitle."""
+        if self.mopidy_client is None:
+            return "Music unavailable"
+        if not self.mopidy_client.is_connected:
+            return "Music offline"
+
+        track = self.mopidy_client.get_current_track()
+        if track is None:
+            return "No track loaded"
+        return self._truncate(f"{track.name} - {track.get_artist_string()}", 28)
+
+    def _playlist_subtitle(self) -> str:
+        """Return the compact playlist status subtitle."""
+        if self.mopidy_client is None:
+            return "Music unavailable"
+        if not self.mopidy_client.is_connected:
+            return "Mopidy offline"
+        if self._playlist_count is None:
+            return "Open playlist browser"
+        if self._playlist_count == 1:
+            return "1 playlist ready"
+        return f"{self._playlist_count} playlists ready"
+
+    def _calls_subtitle(self) -> str:
+        """Return the compact VoIP status subtitle."""
+        if self.voip_manager is None:
+            return "VoIP unavailable"
+
+        status = self.voip_manager.get_status()
+        if not status.get("running", False):
+            return "Recovering..."
+        if status.get("registered", False):
+            return "VoIP ready"
+
+        registration_state = status.get("registration_state", "none")
+        if registration_state == "progress":
+            return "Connecting..."
+        if registration_state == "failed":
+            return "Registration failed"
+        return "VoIP unavailable"
+
+    def render(self) -> None:
+        """Render the Whisplay-first root carousel."""
+        cards = self._cards()
+        self.selected_index %= len(cards)
+        selected_card = cards[self.selected_index]
+
+        self.display.clear(self.display.COLOR_BLACK)
+
+        current_time = datetime.now().strftime("%H:%M")
+        battery = self.context.battery_percent if self.context else 100
+        signal = self.context.signal_strength if self.context else 4
+        self.display.status_bar(
+            time_str=current_time,
+            battery_percent=battery,
+            signal_strength=signal,
+        )
+
+        title = "YoyoPod"
+        title_size = 18
+        title_width, title_height = self.display.get_text_size(title, title_size)
+        title_x = (self.display.WIDTH - title_width) // 2
+        title_y = self.display.STATUS_BAR_HEIGHT + 12
+        self.display.text(
+            title,
+            title_x,
+            title_y,
+            color=self.display.COLOR_GRAY,
+            font_size=title_size,
+        )
+
+        card_left = 18
+        card_top = title_y + title_height + 12
+        card_right = self.display.WIDTH - 18
+        card_bottom = self.display.HEIGHT - 44
+        self.display.rectangle(
+            card_left,
+            card_top,
+            card_right,
+            card_bottom,
+            fill=self.display.COLOR_DARK_GRAY,
+            outline=self.display.COLOR_CYAN,
+            width=2,
+        )
+
+        accent_top = card_top + 14
+        accent_bottom = accent_top + 52
+        accent_left = card_left + 16
+        accent_right = accent_left + 52
+        self.display.rectangle(
+            accent_left,
+            accent_top,
+            accent_right,
+            accent_bottom,
+            fill=self.display.COLOR_CYAN,
+        )
+
+        self.display.text(
+            self._card_icon(selected_card.title),
+            accent_left + 14,
+            accent_top + 12,
+            color=self.display.COLOR_BLACK,
+            font_size=24,
+        )
+
+        card_title = selected_card.title.upper()
+        card_title_size = 22
+        card_title_width, card_title_height = self.display.get_text_size(
+            card_title,
+            card_title_size,
+        )
+        card_title_x = (self.display.WIDTH - card_title_width) // 2
+        card_title_y = accent_bottom + 20
+        self.display.text(
+            card_title,
+            card_title_x,
+            card_title_y,
+            color=self.display.COLOR_WHITE,
+            font_size=card_title_size,
+        )
+
+        subtitle = self._truncate(selected_card.subtitle, 32)
+        subtitle_size = 14
+        subtitle_width, subtitle_height = self.display.get_text_size(subtitle, subtitle_size)
+        subtitle_x = (self.display.WIDTH - subtitle_width) // 2
+        subtitle_y = card_title_y + card_title_height + 14
+        self.display.text(
+            subtitle,
+            subtitle_x,
+            subtitle_y,
+            color=self.display.COLOR_GRAY,
+            font_size=subtitle_size,
+        )
+
+        dots_y = card_bottom - 22
+        dots_width = 14 * len(cards)
+        dots_x = (self.display.WIDTH - dots_width) // 2
+        for index in range(len(cards)):
+            color = self.display.COLOR_CYAN if index == self.selected_index else self.display.COLOR_GRAY
+            self.display.circle(dots_x + (index * 14), dots_y, 3, fill=color)
+
+        help_text = "Tap: Next  Double: Open  Hold: Stay"
+        help_size = 10
+        help_width, _ = self.display.get_text_size(help_text, help_size)
+        help_x = (self.display.WIDTH - help_width) // 2
+        self.display.text(
+            help_text,
+            help_x,
+            self.display.HEIGHT - 15,
+            color=self.display.COLOR_GRAY,
+            font_size=help_size,
+        )
+
+        self.display.update()
+
+    @staticmethod
+    def _card_icon(title: str) -> str:
+        """Return a minimal text icon for the selected hub card."""
+        return {
+            "Now Playing": "N",
+            "Playlists": "P",
+            "Calls": "C",
+        }.get(title, "?")
+
+    @staticmethod
+    def _truncate(text: str, max_length: int) -> str:
+        """Truncate a string for compact root-card rendering."""
+        if len(text) <= max_length:
+            return text
+        return text[: max_length - 3] + "..."
+
+    def on_advance(self, data=None) -> None:
+        """Cycle to the next root card."""
+        self.selected_index = (self.selected_index + 1) % len(self._cards())
+
+    def on_select(self, data=None) -> None:
+        """Open the selected root card."""
+        card = self._cards()[self.selected_index]
+        self.request_route("select", payload=card.title)
+
+    def on_back(self, data=None) -> None:
+        """Root hold gesture is a no-op."""
+        return

--- a/yoyopy/ui/screens/router.py
+++ b/yoyopy/ui/screens/router.py
@@ -64,6 +64,11 @@ class ScreenRouter:
     def _default_routes(self) -> Dict[str, Dict[str, NavigationRequest]]:
         """Return the default route map for current YoyoPod screens."""
         return {
+            "hub": {
+                "select:Now Playing": NavigationRequest.push("now_playing"),
+                "select:Playlists": NavigationRequest.push("playlists"),
+                "select:Calls": NavigationRequest.push("call"),
+            },
             "home": {
                 "select": NavigationRequest.push("menu"),
             },

--- a/yoyopy/ui/screens/voip/contact_list.py
+++ b/yoyopy/ui/screens/voip/contact_list.py
@@ -220,7 +220,10 @@ class ContactListScreen(Screen):
         # Draw instructions at bottom
         instructions_y = self.display.HEIGHT - 15
         instructions_size = 10
-        instructions = "A: Call | B: Back | X/Y: Navigate"
+        if self.is_one_button_mode():
+            instructions = "Tap: Next | Double: Call | Hold: Back"
+        else:
+            instructions = "A: Call | B: Back | X/Y: Navigate"
         instr_width, _ = self.display.get_text_size(instructions, instructions_size)
         instr_x = (self.display.WIDTH - instr_width) // 2
 
@@ -240,6 +243,13 @@ class ContactListScreen(Screen):
         if self.contacts and self.selected_index < len(self.contacts) - 1:
             self.selected_index += 1
             logger.debug(f"Selected: {self.contacts[self.selected_index].name}")
+
+    def select_next_wrapped(self) -> None:
+        """Move selection to next contact with wraparound."""
+        if not self.contacts:
+            return
+        self.selected_index = (self.selected_index + 1) % len(self.contacts)
+        logger.debug(f"Selected: {self.contacts[self.selected_index].name}")
 
     def select_previous(self) -> None:
         """Move selection to previous contact."""
@@ -274,6 +284,10 @@ class ContactListScreen(Screen):
     def on_back(self, data=None) -> None:
         """Go back to the previous screen."""
         self.request_route("back")
+
+    def on_advance(self, data=None) -> None:
+        """Move to the next contact for one-button navigation."""
+        self.select_next_wrapped()
 
     def on_up(self, data=None) -> None:
         """Move selection up."""

--- a/yoyopy/ui/screens/voip/hub.py
+++ b/yoyopy/ui/screens/voip/hub.py
@@ -357,6 +357,18 @@ class CallScreen(Screen):
 
     def _instruction_text(self) -> str:
         """Return the footer instructions for the current selection and state."""
+        if self.is_one_button_mode():
+            if not self.quick_targets:
+                return "Double: Open | Hold: Back"
+
+            selected_target = self._selected_target()
+            if selected_target is None:
+                return "Double: Open | Hold: Back"
+
+            if selected_target.kind == "browse_contacts" or not self._is_ready_to_call():
+                return "Tap: Next | Double: Open | Hold: Back"
+            return "Tap: Next | Double: Call | Hold: Back"
+
         if not self.quick_targets:
             return "B: Back"
 
@@ -441,3 +453,10 @@ class CallScreen(Screen):
         if self.selected_index < len(self.quick_targets) - 1:
             self.selected_index += 1
             self._ensure_selection_visible()
+
+    def on_advance(self, data=None) -> None:
+        """Move through quick-call targets with wraparound for one-button UX."""
+        if not self.quick_targets:
+            return
+        self.selected_index = (self.selected_index + 1) % len(self.quick_targets)
+        self._ensure_selection_visible()

--- a/yoyopy/ui/screens/voip/in_call.py
+++ b/yoyopy/ui/screens/voip/in_call.py
@@ -186,31 +186,41 @@ class InCallScreen(Screen):
         instructions_y = self.display.HEIGHT - 15
         instructions_size = 12
 
-        # Mute button (X)
-        mute_text = f"X: {'Unmute' if is_muted else 'Mute'}"
-        mute_width, _ = self.display.get_text_size(mute_text, instructions_size)
-        mute_x = 20
+        if self.is_one_button_mode():
+            instructions = f"Tap: {'Unmute' if is_muted else 'Mute'} | Hold: Hang up"
+            instr_width, _ = self.display.get_text_size(instructions, instructions_size)
+            self.display.text(
+                instructions,
+                (self.display.WIDTH - instr_width) // 2,
+                instructions_y,
+                color=self.display.COLOR_GRAY,
+                font_size=instructions_size
+            )
+        else:
+            # Mute button (X)
+            mute_text = f"X: {'Unmute' if is_muted else 'Mute'}"
+            mute_x = 20
 
-        self.display.text(
-            mute_text,
-            mute_x,
-            instructions_y,
-            color=self.display.COLOR_YELLOW,
-            font_size=instructions_size
-        )
+            self.display.text(
+                mute_text,
+                mute_x,
+                instructions_y,
+                color=self.display.COLOR_YELLOW,
+                font_size=instructions_size
+            )
 
-        # End call button (B)
-        end_text = "B: End Call"
-        end_width, _ = self.display.get_text_size(end_text, instructions_size)
-        end_x = self.display.WIDTH - end_width - 20
+            # End call button (B)
+            end_text = "B: End Call"
+            end_width, _ = self.display.get_text_size(end_text, instructions_size)
+            end_x = self.display.WIDTH - end_width - 20
 
-        self.display.text(
-            end_text,
-            end_x,
-            instructions_y,
-            color=self.display.COLOR_RED,
-            font_size=instructions_size
-        )
+            self.display.text(
+                end_text,
+                end_x,
+                instructions_y,
+                color=self.display.COLOR_RED,
+                font_size=instructions_size
+            )
 
         # Update display
         self.display.update()
@@ -242,4 +252,8 @@ class InCallScreen(Screen):
 
     def on_up(self, data=None) -> None:
         """Toggle microphone mute."""
+        self._toggle_mute()
+
+    def on_advance(self, data=None) -> None:
+        """Toggle microphone mute for one-button navigation."""
         self._toggle_mute()

--- a/yoyopy/ui/screens/voip/incoming_call.py
+++ b/yoyopy/ui/screens/voip/incoming_call.py
@@ -161,31 +161,41 @@ class IncomingCallScreen(Screen):
         instructions_y = self.display.HEIGHT - 15
         instructions_size = 12
 
-        # Answer button (A)
-        answer_text = "A: Answer"
-        answer_width, _ = self.display.get_text_size(answer_text, instructions_size)
-        answer_x = 20
+        if self.is_one_button_mode():
+            instructions = "Double: Answer | Hold: Reject"
+            instr_width, _ = self.display.get_text_size(instructions, instructions_size)
+            self.display.text(
+                instructions,
+                (self.display.WIDTH - instr_width) // 2,
+                instructions_y,
+                color=self.display.COLOR_GRAY,
+                font_size=instructions_size
+            )
+        else:
+            # Answer button (A)
+            answer_text = "A: Answer"
+            answer_x = 20
 
-        self.display.text(
-            answer_text,
-            answer_x,
-            instructions_y,
-            color=self.display.COLOR_GREEN,
-            font_size=instructions_size
-        )
+            self.display.text(
+                answer_text,
+                answer_x,
+                instructions_y,
+                color=self.display.COLOR_GREEN,
+                font_size=instructions_size
+            )
 
-        # Reject button (B)
-        reject_text = "B: Reject"
-        reject_width, _ = self.display.get_text_size(reject_text, instructions_size)
-        reject_x = self.display.WIDTH - reject_width - 20
+            # Reject button (B)
+            reject_text = "B: Reject"
+            reject_width, _ = self.display.get_text_size(reject_text, instructions_size)
+            reject_x = self.display.WIDTH - reject_width - 20
 
-        self.display.text(
-            reject_text,
-            reject_x,
-            instructions_y,
-            color=self.display.COLOR_RED,
-            font_size=instructions_size
-        )
+            self.display.text(
+                reject_text,
+                reject_x,
+                instructions_y,
+                color=self.display.COLOR_RED,
+                font_size=instructions_size
+            )
 
         # Update display
         self.display.update()
@@ -213,6 +223,10 @@ class IncomingCallScreen(Screen):
     def on_select(self, data=None) -> None:
         """Answer the incoming call."""
         self._answer_call()
+
+    def on_advance(self, data=None) -> None:
+        """Incoming-call single tap is intentionally a no-op."""
+        return
 
     def on_call_answer(self, data=None) -> None:
         """Answer the incoming call from a dedicated VoIP action."""

--- a/yoyopy/ui/screens/voip/outgoing_call.py
+++ b/yoyopy/ui/screens/voip/outgoing_call.py
@@ -196,8 +196,10 @@ class OutgoingCallScreen(Screen):
         instructions_y = self.display.HEIGHT - 15
         instructions_size = 12
 
-        # Cancel button (B)
-        cancel_text = "B: Cancel"
+        if self.is_one_button_mode():
+            cancel_text = "Hold: Cancel"
+        else:
+            cancel_text = "B: Cancel"
         cancel_width, _ = self.display.get_text_size(cancel_text, instructions_size)
         cancel_x = (self.display.WIDTH - cancel_width) // 2
 
@@ -225,6 +227,14 @@ class OutgoingCallScreen(Screen):
     def on_back(self, data=None) -> None:
         """Cancel the outgoing call."""
         self._cancel_call()
+
+    def on_advance(self, data=None) -> None:
+        """Outgoing-call single tap is intentionally a no-op."""
+        return
+
+    def on_select(self, data=None) -> None:
+        """Outgoing-call double tap is intentionally a no-op."""
+        return
 
     def on_call_hangup(self, data=None) -> None:
         """Cancel the outgoing call from a dedicated VoIP action."""


### PR DESCRIPTION
## Summary
- add a Whisplay-native one-button interaction profile with ADVANCE/SELECT/BACK semantics
- add the new 3-card action hub root and one-button behavior across music and VoIP screens
- cover the gesture grammar, hub routing, startup profile selection, and screen behavior with focused tests

## Verification
- python -m compileall yoyopy tests
- uv run pytest -q