### PR TITLE
Add Whisplay diagnostics and tuning helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Edit these in place for your environment:
 Important settings:
 
 - `config/yoyopod_config.yaml`: display hardware selection, Mopidy host/port, auto-resume behavior
+- `config/yoyopod_config.yaml`: Whisplay gesture tuning under `input.whisplay_*_ms`
 - `config/voip_config.yaml`: SIP account, transport, STUN, `linphonec` path
 - `config/contacts.yaml`: contact list and speed dial entries
 
@@ -100,6 +101,14 @@ uv run python scripts/pi_remote.py status
 uv run python scripts/pi_remote.py preflight --branch main --with-mopidy --with-voip
 uv run python scripts/pi_remote.py sync --branch main
 uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip
+uv run python scripts/pi_remote.py whisplay --duration-seconds 45
+```
+
+Whisplay tuning on-device:
+
+```bash
+uv run python scripts/whisplay_tune.py
+uv run python scripts/whisplay_tune.py --double-tap-ms 240 --long-hold-ms 900
 ```
 
 ## Running

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -89,6 +89,15 @@ uv run python scripts/pi_remote.py smoke --with-mopidy --mopidy-timeout 10
 uv run python scripts/pi_remote.py smoke --with-voip --voip-timeout 15 --verbose
 ```
 
+### Run Whisplay gesture tuning remotely
+
+```bash
+uv run python scripts/pi_remote.py whisplay
+uv run python scripts/pi_remote.py whisplay --duration-seconds 45 --double-tap-ms 240 --long-hold-ms 900
+```
+
+Use this during on-device tuning when the Whisplay button feels too eager or too sluggish. The helper runs interactively over SSH, prints every semantic gesture event, and accepts temporary timing overrides without modifying the tracked config file.
+
 ### Run the full preflight in one command
 
 ```bash

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -32,7 +32,7 @@ What it checks:
 Expected result:
 
 - `display` should report a real hardware adapter, not simulation
-- `input` should report semantic capabilities for the attached hardware
+- `input` should report the active interaction profile plus semantic capabilities for the attached hardware
 
 ### 3. Raspberry Pi service smoke
 
@@ -90,6 +90,23 @@ uv run python test_hal_whisplay.py
 ```
 
 Use this only on a Pi with the Whisplay hardware attached. It is a manual hardware smoke script, not part of CI.
+
+### Whisplay gesture tuning
+
+```bash
+uv run python scripts/whisplay_tune.py
+uv run python scripts/whisplay_tune.py --double-tap-ms 240 --long-hold-ms 900
+```
+
+Use this when button feel needs tuning on the real device. It listens for the semantic Whisplay gestures, prints every detected `advance` / `select` / `back` event with timing detail, and can apply temporary timing overrides without editing `config/yoyopod_config.yaml`.
+
+Useful flags:
+
+- `--duration-seconds 45`
+- `--debounce-ms 75`
+- `--double-tap-ms 240`
+- `--long-hold-ms 900`
+- `--verbose`
 
 ## Suggested Order On Hardware
 

--- a/scripts/pi_remote.py
+++ b/scripts/pi_remote.py
@@ -95,6 +95,42 @@ def build_parser() -> argparse.ArgumentParser:
         help="VoIP registration timeout in seconds (default: 10)",
     )
 
+    whisplay_parser = subparsers.add_parser(
+        "whisplay",
+        help="Run the Whisplay gesture-tuning helper remotely",
+    )
+    whisplay_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose tuner logging",
+    )
+    whisplay_parser.add_argument(
+        "--duration-seconds",
+        type=float,
+        default=30.0,
+        help="How long to monitor gestures before exiting (default: 30)",
+    )
+    whisplay_parser.add_argument(
+        "--debounce-ms",
+        type=int,
+        help="Temporary Whisplay debounce override in milliseconds",
+    )
+    whisplay_parser.add_argument(
+        "--double-tap-ms",
+        type=int,
+        help="Temporary Whisplay double-tap override in milliseconds",
+    )
+    whisplay_parser.add_argument(
+        "--long-hold-ms",
+        type=int,
+        help="Temporary Whisplay long-hold override in milliseconds",
+    )
+    whisplay_parser.add_argument(
+        "--no-display",
+        action="store_true",
+        help="Log events only without drawing tuner hints on the display",
+    )
+
     preflight_parser = subparsers.add_parser(
         "preflight",
         help="Run local checks, sync the Pi, and execute the Pi smoke pass",
@@ -258,6 +294,24 @@ def build_smoke_command(args: argparse.Namespace) -> str:
     return " ".join(parts)
 
 
+def build_whisplay_command(args: argparse.Namespace) -> str:
+    """Create the remote Whisplay tuning command."""
+    parts = ["uv run python scripts/whisplay_tune.py"]
+    if args.verbose:
+        parts.append("--verbose")
+    if args.no_display:
+        parts.append("--no-display")
+    if args.duration_seconds != 30.0:
+        parts.extend(["--duration-seconds", str(args.duration_seconds)])
+    if args.debounce_ms is not None:
+        parts.extend(["--debounce-ms", str(args.debounce_ms)])
+    if args.double_tap_ms is not None:
+        parts.extend(["--double-tap-ms", str(args.double_tap_ms)])
+    if args.long_hold_ms is not None:
+        parts.extend(["--long-hold-ms", str(args.long_hold_ms)])
+    return " ".join(parts)
+
+
 def build_run_command(args: argparse.Namespace) -> str:
     """Create the remote production-app command."""
     parts = ["uv run python yoyopod.py"]
@@ -281,6 +335,7 @@ def build_local_preflight_commands() -> list[tuple[str, list[str]]]:
                 "tests",
                 "scripts/pi_smoke.py",
                 "scripts/pi_remote.py",
+                "scripts/whisplay_tune.py",
             ],
         ),
         (
@@ -329,6 +384,9 @@ def main() -> int:
 
     if args.command == "smoke":
         return run_remote(config, build_smoke_command(args))
+
+    if args.command == "whisplay":
+        return run_remote(config, build_whisplay_command(args), tty=True)
 
     if args.command == "preflight":
         return run_preflight(config, args)

--- a/scripts/pi_smoke.py
+++ b/scripts/pi_smoke.py
@@ -156,6 +156,7 @@ def input_check(display: Display, app_config: dict[str, Any]) -> CheckResult:
             )
 
         capabilities = sorted(action.value for action in input_manager.get_capabilities())
+        interaction_profile = input_manager.interaction_profile.value
         input_manager.start()
         time.sleep(0.1)
         input_manager.stop()
@@ -163,7 +164,10 @@ def input_check(display: Display, app_config: dict[str, Any]) -> CheckResult:
         return CheckResult(
             name="input",
             status="pass",
-            details=f"capabilities={', '.join(capabilities)}",
+            details=(
+                f"profile={interaction_profile}, "
+                f"capabilities={', '.join(capabilities)}"
+            ),
         )
     except Exception as exc:
         return CheckResult(name="input", status="fail", details=str(exc))

--- a/scripts/whisplay_tune.py
+++ b/scripts/whisplay_tune.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Interactive Whisplay gesture-tuning helper for Raspberry Pi hardware."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from yoyopy.config import YoyoPodConfig, config_to_dict, load_config_model_from_yaml
+from yoyopy.ui.display import Display
+from yoyopy.ui.input import InputAction, InteractionProfile, get_input_manager
+
+
+@dataclass
+class GestureEvent:
+    """One recorded one-button semantic gesture."""
+
+    action: str
+    method: str
+    at_seconds: float
+    duration_ms: int | None = None
+
+
+def configure_logging(verbose: bool) -> None:
+    """Configure readable CLI logging."""
+    logger.remove()
+    logger.add(
+        sys.stderr,
+        format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <level>{message}</level>",
+        level="DEBUG" if verbose else "INFO",
+    )
+
+
+def load_app_config(config_dir: Path) -> dict[str, Any]:
+    """Load the current app config as a plain dict."""
+    config_file = config_dir / "yoyopod_config.yaml"
+    return config_to_dict(load_config_model_from_yaml(YoyoPodConfig, config_file))
+
+
+def apply_timing_overrides(
+    app_config: dict[str, Any],
+    *,
+    debounce_ms: int | None,
+    double_tap_ms: int | None,
+    long_hold_ms: int | None,
+) -> dict[str, Any]:
+    """Return a config dict with temporary Whisplay timing overrides applied."""
+    merged = dict(app_config)
+    input_config = dict(merged.get("input", {}))
+
+    if debounce_ms is not None:
+        input_config["whisplay_debounce_ms"] = debounce_ms
+    if double_tap_ms is not None:
+        input_config["whisplay_double_tap_ms"] = double_tap_ms
+    if long_hold_ms is not None:
+        input_config["whisplay_long_hold_ms"] = long_hold_ms
+
+    merged["input"] = input_config
+    return merged
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run an interactive Whisplay gesture monitor with optional timing "
+            "overrides, so button tuning can be validated on-device."
+        )
+    )
+    parser.add_argument(
+        "--config-dir",
+        default="config",
+        help="Configuration directory to use (default: config)",
+    )
+    parser.add_argument(
+        "--debounce-ms",
+        type=int,
+        help="Override Whisplay debounce timing in milliseconds for this run",
+    )
+    parser.add_argument(
+        "--double-tap-ms",
+        type=int,
+        help="Override double-tap timing in milliseconds for this run",
+    )
+    parser.add_argument(
+        "--long-hold-ms",
+        type=int,
+        help="Override long-hold timing in milliseconds for this run",
+    )
+    parser.add_argument(
+        "--duration-seconds",
+        type=float,
+        default=30.0,
+        help="How long to monitor gestures before exiting (default: 30)",
+    )
+    parser.add_argument(
+        "--hardware",
+        default="whisplay",
+        help="Display hardware to open (default: whisplay)",
+    )
+    parser.add_argument(
+        "--no-display",
+        action="store_true",
+        help="Skip drawing tuning hints on the display and log to the terminal only",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG logging",
+    )
+    return parser
+
+
+def summarize_timings(app_config: dict[str, Any]) -> str:
+    """Return one short timing summary for logs and display."""
+    input_config = app_config.get("input", {})
+    debounce_ms = int(input_config.get("whisplay_debounce_ms", 50))
+    double_tap_ms = int(input_config.get("whisplay_double_tap_ms", 300))
+    long_hold_ms = int(input_config.get("whisplay_long_hold_ms", 800))
+    return (
+        f"debounce={debounce_ms}ms, "
+        f"double={double_tap_ms}ms, "
+        f"hold={long_hold_ms}ms"
+    )
+
+
+def record_event(events: list[GestureEvent], start_time: float, action: InputAction, data: Any) -> None:
+    """Store one semantic gesture and log it for the operator."""
+    payload = data if isinstance(data, dict) else {}
+    duration_ms = None
+    duration = payload.get("duration")
+    if duration is not None:
+        duration_ms = int(float(duration) * 1000)
+
+    event = GestureEvent(
+        action=action.value,
+        method=str(payload.get("method", "unknown")),
+        at_seconds=time.monotonic() - start_time,
+        duration_ms=duration_ms,
+    )
+    events.append(event)
+
+    if duration_ms is None:
+        logger.info(
+            "Gesture {} via {} at {:.2f}s",
+            event.action,
+            event.method,
+            event.at_seconds,
+        )
+    else:
+        logger.info(
+            "Gesture {} via {} at {:.2f}s ({}ms)",
+            event.action,
+            event.method,
+            event.at_seconds,
+            event.duration_ms,
+        )
+
+
+def render_status_screen(
+    display: Display,
+    timing_summary: str,
+    events: list[GestureEvent],
+    ends_at: float,
+) -> None:
+    """Render the current tuning status on the Whisplay display."""
+    now = time.time()
+    countdown = max(0, int(ends_at - now))
+    last_event = events[-1] if events else None
+
+    display.clear(display.COLOR_BLACK)
+    display.text("Whisplay Tune", 18, 20, color=display.COLOR_WHITE, font_size=18)
+    display.text(timing_summary, 18, 48, color=display.COLOR_GRAY, font_size=11)
+    display.text("Tap next", 18, 86, color=display.COLOR_CYAN, font_size=16)
+    display.text("Double select", 18, 112, color=display.COLOR_WHITE, font_size=16)
+    display.text("Hold back", 18, 138, color=display.COLOR_YELLOW, font_size=16)
+    display.text(f"Left: {countdown}s", 18, 176, color=display.COLOR_GRAY, font_size=12)
+
+    if last_event is None:
+        display.text("Waiting for input", 18, 206, color=display.COLOR_GRAY, font_size=13)
+    else:
+        display.text(
+            f"Last: {last_event.action.upper()}",
+            18,
+            206,
+            color=display.COLOR_GREEN,
+            font_size=13,
+        )
+        detail = last_event.method
+        if last_event.duration_ms is not None:
+            detail = f"{detail} {last_event.duration_ms}ms"
+        display.text(detail, 18, 228, color=display.COLOR_GRAY, font_size=11)
+
+    display.update()
+
+
+def main() -> int:
+    """Run the interactive tuning helper."""
+    parser = build_parser()
+    args = parser.parse_args()
+    configure_logging(args.verbose)
+
+    config_dir = Path(args.config_dir)
+    if not config_dir.is_absolute():
+        config_dir = REPO_ROOT / config_dir
+
+    app_config = load_app_config(config_dir)
+    app_config = apply_timing_overrides(
+        app_config,
+        debounce_ms=args.debounce_ms,
+        double_tap_ms=args.double_tap_ms,
+        long_hold_ms=args.long_hold_ms,
+    )
+    timing_summary = summarize_timings(app_config)
+    logger.info("Whisplay tuning session using {}", timing_summary)
+
+    display = None
+    input_manager = None
+    events: list[GestureEvent] = []
+    start_time = time.monotonic()
+    ends_at = time.time() + args.duration_seconds
+
+    try:
+        display = Display(hardware=args.hardware, simulate=False)
+
+        input_manager = get_input_manager(
+            display.get_adapter(),
+            config=app_config,
+            simulate=False,
+        )
+        if input_manager is None:
+            logger.error("No input adapter available for the detected hardware")
+            return 1
+
+        if input_manager.interaction_profile != InteractionProfile.ONE_BUTTON:
+            logger.error(
+                "Detected interaction profile {} instead of one_button",
+                input_manager.interaction_profile.value,
+            )
+            return 1
+
+        for action in (InputAction.ADVANCE, InputAction.SELECT, InputAction.BACK):
+            input_manager.on_action(
+                action,
+                lambda data=None, action=action: record_event(events, start_time, action, data),
+            )
+
+        input_manager.start()
+        logger.info("Monitoring Whisplay gestures for %.1fs", args.duration_seconds)
+
+        while time.time() < ends_at:
+            if display is not None and not args.no_display:
+                render_status_screen(display, timing_summary, events, ends_at)
+            time.sleep(0.1)
+
+        logger.info("Whisplay tuning session complete")
+        logger.info(
+            "Summary: advance={}, select={}, back={}",
+            sum(1 for event in events if event.action == InputAction.ADVANCE.value),
+            sum(1 for event in events if event.action == InputAction.SELECT.value),
+            sum(1 for event in events if event.action == InputAction.BACK.value),
+        )
+        return 0
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user")
+        return 130
+    finally:
+        if input_manager is not None:
+            try:
+                input_manager.stop()
+            except Exception as exc:
+                logger.warning("Input cleanup failed: {}", exc)
+        if display is not None:
+            try:
+                display.cleanup()
+            except Exception as exc:
+                logger.warning("Display cleanup failed: {}", exc)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -5,6 +5,7 @@ from scripts.pi_remote import (
     build_local_preflight_commands,
     build_smoke_command,
     build_sync_command,
+    build_whisplay_command,
     quote_remote_project_dir,
 )
 from argparse import Namespace
@@ -59,4 +60,27 @@ def test_build_local_preflight_commands_cover_compile_and_pytest() -> None:
 
     assert commands[0][0] == "compileall"
     assert commands[0][1][1:3] == ["-m", "compileall"]
+    assert "scripts/whisplay_tune.py" in commands[0][1]
     assert commands[1] == ("pytest", ["uv", "run", "pytest", "-q"])
+
+
+def test_build_whisplay_command_adds_timing_overrides() -> None:
+    """Whisplay tuning command should forward optional timing overrides."""
+    args = Namespace(
+        verbose=True,
+        no_display=True,
+        duration_seconds=45.0,
+        debounce_ms=75,
+        double_tap_ms=240,
+        long_hold_ms=900,
+    )
+
+    command = build_whisplay_command(args)
+
+    assert command.startswith("uv run python scripts/whisplay_tune.py")
+    assert "--verbose" in command
+    assert "--no-display" in command
+    assert "--duration-seconds 45.0" in command
+    assert "--debounce-ms 75" in command
+    assert "--double-tap-ms 240" in command
+    assert "--long-hold-ms 900" in command

--- a/tests/test_whisplay_tune.py
+++ b/tests/test_whisplay_tune.py
@@ -1,0 +1,44 @@
+"""Tests for pure Whisplay tuning-script helpers."""
+
+from __future__ import annotations
+
+from scripts.whisplay_tune import apply_timing_overrides, summarize_timings
+
+
+def test_apply_timing_overrides_updates_input_section() -> None:
+    """Temporary CLI overrides should land in the input config only."""
+    app_config = {
+        "audio": {"mopidy_host": "localhost"},
+        "input": {
+            "whisplay_debounce_ms": 50,
+            "whisplay_double_tap_ms": 300,
+            "whisplay_long_hold_ms": 800,
+        },
+    }
+
+    merged = apply_timing_overrides(
+        app_config,
+        debounce_ms=70,
+        double_tap_ms=260,
+        long_hold_ms=920,
+    )
+
+    assert merged["audio"]["mopidy_host"] == "localhost"
+    assert merged["input"]["whisplay_debounce_ms"] == 70
+    assert merged["input"]["whisplay_double_tap_ms"] == 260
+    assert merged["input"]["whisplay_long_hold_ms"] == 920
+
+
+def test_summarize_timings_formats_current_values() -> None:
+    """Timing summary should expose the current debounce/double/hold values."""
+    summary = summarize_timings(
+        {
+            "input": {
+                "whisplay_debounce_ms": 60,
+                "whisplay_double_tap_ms": 250,
+                "whisplay_long_hold_ms": 900,
+            }
+        }
+    )
+
+    assert summary == "debounce=60ms, double=250ms, hold=900ms"

--- a/yoyopy/ui/input/factory.py
+++ b/yoyopy/ui/input/factory.py
@@ -82,7 +82,7 @@ def get_input_manager(
             if enable_navigation:
                 logger.info("  -> Added one-button Whisplay navigation")
                 logger.info(
-                    "  -> Gesture timings: %dms debounce, %dms double tap, %dms hold",
+                    "  -> Gesture timings: {}ms debounce, {}ms double tap, {}ms hold",
                     int(debounce_time * 1000),
                     int(double_click_time * 1000),
                     int(long_press_time * 1000),


### PR DESCRIPTION
## Summary
- add an interactive Whisplay tuning helper for on-device gesture validation with temporary timing overrides
- expose the tuner through the Raspberry Pi remote workflow and surface interaction profile details in the smoke script
- document the Whisplay tuning loop and cover the new CLI helpers with tests

## Verification
- python -m compileall yoyopy tests scripts/whisplay_tune.py scripts/pi_remote.py scripts/pi_smoke.py
- uv run pytest -q
- uv run python scripts/whisplay_tune.py --help
- uv run python scripts/pi_remote.py whisplay --help