### PR TITLE
Fix lingering Whisplay review findings

### DIFF
--- a/tests/test_input_factory.py
+++ b/tests/test_input_factory.py
@@ -38,3 +38,20 @@ def test_whisplay_factory_applies_one_button_profile_and_custom_timings() -> Non
     assert adapter.debounce_time == 0.08
     assert adapter.double_click_time == 0.24
     assert adapter.long_press_time == 0.95
+
+
+def test_whisplay_factory_keeps_standard_profile_when_navigation_disabled() -> None:
+    """Raw PTT mode should not advertise the Whisplay one-button navigation profile."""
+    manager = get_input_manager(
+        WhisplayDisplayAdapter(),
+        config={"input": {"ptt_navigation": False}},
+        simulate=True,
+    )
+
+    assert manager is not None
+    assert manager.interaction_profile == InteractionProfile.STANDARD
+    assert len(manager.adapters) == 1
+
+    adapter = manager.adapters[0]
+    assert isinstance(adapter, PTTInputAdapter)
+    assert adapter.enable_navigation is False

--- a/tests/test_ptt_input_adapter.py
+++ b/tests/test_ptt_input_adapter.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from yoyopy.ui.input import InputAction
+from yoyopy.ui.input.adapters import ptt_button
 from yoyopy.ui.input.adapters.ptt_button import PTTInputAdapter
 
 
@@ -41,6 +44,20 @@ def test_double_tap_emits_select_and_cancels_pending_advance() -> None:
     assert actions == [InputAction.SELECT]
 
 
+def test_double_tap_uses_second_press_time_not_second_release_time() -> None:
+    """A confirm tap that begins in time should still select even if released later."""
+    adapter = PTTInputAdapter(simulate=True, enable_navigation=True)
+    actions = _record_actions(adapter)
+
+    adapter._handle_button_press(0.0)
+    adapter._handle_button_release(0.1)
+    adapter._handle_button_press(0.39)
+    adapter._handle_button_release(0.5)
+    adapter._emit_pending_navigation(0.9)
+
+    assert actions == [InputAction.SELECT]
+
+
 def test_long_hold_emits_back() -> None:
     """Long holds should map to BACK in one-button navigation mode."""
     adapter = PTTInputAdapter(simulate=True, enable_navigation=True)
@@ -64,3 +81,36 @@ def test_long_hold_suppresses_pending_single_tap() -> None:
     adapter._emit_pending_navigation(1.5)
 
     assert actions == [InputAction.BACK]
+
+
+def test_poll_loop_preserves_double_tap_window_across_debounce(monkeypatch) -> None:
+    """A second tap near the timeout should still resolve to SELECT, not ADVANCE."""
+    adapter = PTTInputAdapter(
+        simulate=False,
+        enable_navigation=True,
+        debounce_time=0.05,
+        double_click_time=0.3,
+    )
+    actions = _record_actions(adapter)
+
+    clock = SimpleNamespace(current=0.0)
+
+    def fake_time() -> float:
+        return clock.current
+
+    def fake_sleep(duration: float) -> None:
+        clock.current = round(clock.current + duration, 4)
+
+    def fake_button_state() -> bool:
+        current = clock.current
+        return (0.0 <= current < 0.10) or (0.39 <= current < 0.49)
+
+    monkeypatch.setattr(ptt_button.time, "time", fake_time)
+    monkeypatch.setattr(ptt_button.time, "sleep", fake_sleep)
+    adapter._get_button_state = fake_button_state
+    adapter.poll_rate = 0.01
+    adapter.stop_event = SimpleNamespace(is_set=lambda: clock.current >= 0.8)
+
+    adapter._poll_button()
+
+    assert actions == [InputAction.SELECT]

--- a/yoyopy/ui/input/adapters/ptt_button.py
+++ b/yoyopy/ui/input/adapters/ptt_button.py
@@ -61,6 +61,7 @@ class PTTInputAdapter(InputHAL):
         self.button_pressed = False
         self.press_start_time: Optional[float] = None
         self.pending_single_tap_time: Optional[float] = None
+        self.double_tap_candidate = False
 
         logger.debug(f"PTTInputAdapter initialized (navigation: {enable_navigation})")
 
@@ -151,7 +152,13 @@ class PTTInputAdapter(InputHAL):
 
     def _handle_button_press(self, current_time: float) -> None:
         """Record a physical button press."""
-        self._emit_pending_navigation(current_time)
+        self.double_tap_candidate = (
+            self.enable_navigation
+            and self.pending_single_tap_time is not None
+            and (current_time - self.pending_single_tap_time) < self.double_click_time
+        )
+        if not self.double_tap_candidate:
+            self._emit_pending_navigation(current_time)
         self.button_pressed = True
         self.press_start_time = current_time
 
@@ -175,10 +182,12 @@ class PTTInputAdapter(InputHAL):
                 },
             )
             self.press_start_time = None
+            self.double_tap_candidate = False
             return
 
         if press_duration >= self.long_press_time:
             self.pending_single_tap_time = None
+            self.double_tap_candidate = False
             self._fire_action(
                 InputAction.BACK,
                 {
@@ -189,11 +198,9 @@ class PTTInputAdapter(InputHAL):
             self.press_start_time = None
             return
 
-        if (
-            self.pending_single_tap_time is not None
-            and (current_time - self.pending_single_tap_time) < self.double_click_time
-        ):
+        if self.double_tap_candidate:
             self.pending_single_tap_time = None
+            self.double_tap_candidate = False
             self._fire_action(
                 InputAction.SELECT,
                 {
@@ -204,6 +211,7 @@ class PTTInputAdapter(InputHAL):
             self.press_start_time = None
             return
 
+        self.double_tap_candidate = False
         self.pending_single_tap_time = current_time
         self.press_start_time = None
 
@@ -239,10 +247,11 @@ class PTTInputAdapter(InputHAL):
             previous_state = self.button_pressed
 
             if current_state and not previous_state:
+                press_detected_at = current_time
                 time.sleep(self.debounce_time)
                 current_state = self._get_button_state()
                 if current_state:
-                    self._handle_button_press(time.time())
+                    self._handle_button_press(press_detected_at)
 
             elif not current_state and previous_state:
                 self._handle_button_release(time.time())

--- a/yoyopy/ui/input/factory.py
+++ b/yoyopy/ui/input/factory.py
@@ -59,9 +59,14 @@ def get_input_manager(
 
     elif adapter_name == "WhisplayDisplayAdapter":
         logger.info("  Detected Whisplay HAT")
-        manager.set_interaction_profile(InteractionProfile.ONE_BUTTON)
         whisplay_device = getattr(display_adapter, "device", None)
         enable_navigation = input_config.get("ptt_navigation", True)
+        if enable_navigation:
+            manager.set_interaction_profile(InteractionProfile.ONE_BUTTON)
+        else:
+            logger.warning(
+                "  -> Whisplay PTT navigation disabled; keeping standard interaction profile",
+            )
         debounce_time = float(input_config.get("whisplay_debounce_ms", 50)) / 1000.0
         double_click_time = float(input_config.get("whisplay_double_tap_ms", 300)) / 1000.0
         long_press_time = float(input_config.get("whisplay_long_hold_ms", 800)) / 1000.0


### PR DESCRIPTION
## Summary
- preserve the double-tap window across Whisplay debounce timing
- keep the standard interaction profile when Whisplay PTT navigation is disabled
- add regression tests for both review findings

## Testing
- uv run pytest tests/test_ptt_input_adapter.py tests/test_input_factory.py -q
- uv run pytest -q