### PR TITLE
Document experimental Whisplay raw PTT mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Important settings:
 
 - `config/yoyopod_config.yaml`: display hardware selection, Mopidy host/port, auto-resume behavior
 - `config/yoyopod_config.yaml`: Whisplay gesture tuning under `input.whisplay_*_ms`
+- `config/yoyopod_config.yaml`: `input.ptt_navigation=false` is reserved for future voice/PTT work and is currently experimental
 - `config/voip_config.yaml`: SIP account, transport, STUN, `linphonec` path
 - `config/contacts.yaml`: contact list and speed dial entries
 

--- a/config/yoyopod_config.yaml
+++ b/config/yoyopod_config.yaml
@@ -31,7 +31,7 @@ ui:
 
 # Input Settings
 input:
-  ptt_navigation: true            # Single-button Whisplay navigation mode
+  ptt_navigation: true            # true = Whisplay navigation; false = experimental raw PTT mode for future voice features
   whisplay_debounce_ms: 50        # Debounce for the hardware button
   whisplay_double_tap_ms: 300     # Max gap between taps for confirm
   whisplay_long_hold_ms: 800      # Hold time for back/cancel

--- a/yoyopy/config/models.py
+++ b/yoyopy/config/models.py
@@ -178,7 +178,12 @@ class AppUiConfig:
 
 @dataclass(slots=True)
 class AppInputConfig:
-    """Input hardware and gesture timing settings."""
+    """Input hardware and gesture timing settings.
+
+    `ptt_navigation=False` keeps the Whisplay button in raw press/release mode
+    for future voice/PTT features. That path is experimental today and does not
+    provide a complete navigable app flow.
+    """
 
     ptt_navigation: bool = config_value(default=True, env="YOYOPOD_PTT_NAVIGATION")
     whisplay_debounce_ms: int = config_value(default=50, env="YOYOPOD_WHISPLAY_DEBOUNCE_MS")

--- a/yoyopy/ui/input/factory.py
+++ b/yoyopy/ui/input/factory.py
@@ -65,7 +65,7 @@ def get_input_manager(
             manager.set_interaction_profile(InteractionProfile.ONE_BUTTON)
         else:
             logger.warning(
-                "  -> Whisplay PTT navigation disabled; keeping standard interaction profile",
+                "  -> Whisplay raw PTT mode is experimental; keeping standard interaction profile",
             )
         debounce_time = float(input_config.get("whisplay_debounce_ms", 50)) / 1000.0
         double_click_time = float(input_config.get("whisplay_double_tap_ms", 300)) / 1000.0
@@ -93,7 +93,9 @@ def get_input_manager(
                     int(long_press_time * 1000),
                 )
             else:
-                logger.info("  -> Added PTT button input (press/release only)")
+                logger.info(
+                    "  -> Added experimental raw PTT input (press/release only)",
+                )
         else:
             logger.warning("  -> No Whisplay device available for PTT input")
 


### PR DESCRIPTION
## Summary
- mark Whisplay raw press/release mode as experimental in config and runtime messaging
- clarify that ptt_navigation=false is reserved for future voice/PTT features
- keep current one-button navigation as the supported Whisplay flow

## Testing
- python -m compileall yoyopy