### PR TITLE
Add PiSugar power foundation

### DIFF
--- a/config/yoyopod_config.yaml
+++ b/config/yoyopod_config.yaml
@@ -36,6 +36,17 @@ input:
   whisplay_double_tap_ms: 300     # Max gap between taps for confirm
   whisplay_long_hold_ms: 800      # Hold time for back/cancel
 
+# Power Settings
+power:
+  enabled: true
+  backend: "pisugar"              # Current power backend implementation
+  transport: "auto"               # auto, socket, tcp
+  socket_path: "/tmp/pisugar-server.sock"
+  tcp_host: "127.0.0.1"
+  tcp_port: 8423
+  timeout_seconds: 2.0
+  poll_interval_seconds: 30.0
+
 # Display Settings
 display:
   hardware: "auto"                # auto, whisplay, pimoroni, simulation

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -15,11 +15,11 @@ def test_audio_device_defaults(tmp_path, monkeypatch) -> None:
 
     config_manager = ConfigManager(config_dir=str(tmp_path))
 
-    assert config_manager.get_playback_device_id() == "ALSA: plughw:1"
-    assert config_manager.get_ringer_device_id() == "ALSA: plughw:1"
-    assert config_manager.get_capture_device_id() == "ALSA: plughw:1"
-    assert config_manager.get_media_device_id() == "ALSA: plughw:1"
-    assert config_manager.get_ring_output_device() == "plughw:1"
+    assert config_manager.get_playback_device_id() == "ALSA: wm8960-soundcard"
+    assert config_manager.get_ringer_device_id() == "ALSA: wm8960-soundcard"
+    assert config_manager.get_capture_device_id() == "ALSA: wm8960-soundcard"
+    assert config_manager.get_media_device_id() == "ALSA: wm8960-soundcard"
+    assert config_manager.get_ring_output_device() == "wm8960-soundcard"
 
 
 def test_audio_env_overrides(tmp_path, monkeypatch) -> None:

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -29,6 +29,11 @@ def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> Non
     assert settings.input.ptt_navigation is True
     assert settings.input.whisplay_double_tap_ms == 300
     assert settings.input.whisplay_long_hold_ms == 800
+    assert settings.power.enabled is True
+    assert settings.power.backend == "pisugar"
+    assert settings.power.transport == "auto"
+    assert settings.power.socket_path == "/tmp/pisugar-server.sock"
+    assert settings.power.tcp_port == 8423
     assert settings.display.hardware == "auto"
 
 
@@ -60,6 +65,8 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     monkeypatch.setenv("YOYOPOD_AUTO_RESUME_AFTER_CALL", "false")
     monkeypatch.setenv("YOYOPOD_WHISPLAY_DOUBLE_TAP_MS", "260")
     monkeypatch.setenv("YOYOPOD_WHISPLAY_LONG_HOLD_MS", "900")
+    monkeypatch.setenv("YOYOPOD_POWER_TRANSPORT", "tcp")
+    monkeypatch.setenv("YOYOPOD_PISUGAR_PORT", "9001")
     monkeypatch.setenv("YOYOPOD_DISPLAY", "whisplay")
 
     config_manager = ConfigManager(config_dir=str(tmp_path))
@@ -72,6 +79,8 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     assert settings.audio.auto_resume_after_call is False
     assert settings.input.whisplay_double_tap_ms == 260
     assert settings.input.whisplay_long_hold_ms == 900
+    assert settings.power.transport == "tcp"
+    assert settings.power.tcp_port == 9001
     assert settings.display.hardware == "whisplay"
     assert settings.logging.level == "DEBUG"
     assert config_dict["audio"]["mopidy_port"] == 7788

--- a/tests/test_power_backend.py
+++ b/tests/test_power_backend.py
@@ -1,0 +1,131 @@
+"""Tests for the PiSugar power backend foundation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from yoyopy.power.backend import PiSugarBackend, PowerTransportError
+from yoyopy.power.models import PowerConfig
+
+
+class FakeTransport:
+    """Simple command/response transport double for PiSugar tests."""
+
+    def __init__(self, responses: dict[str, str], failures: set[str] | None = None) -> None:
+        self.responses = responses
+        self.failures = failures or set()
+
+    def send_command(self, command: str) -> str:
+        if command in self.failures:
+            raise PowerTransportError(f"simulated failure for {command}")
+        if command not in self.responses:
+            raise PowerTransportError(f"unexpected command: {command}")
+        return self.responses[command]
+
+
+def test_pisugar_backend_parses_snapshot_from_documented_commands() -> None:
+    """The backend should coerce PiSugar string responses into typed snapshot fields."""
+
+    checked_at = datetime(2026, 4, 4, 12, 0, tzinfo=timezone.utc)
+    backend = PiSugarBackend(
+        PowerConfig(),
+        transport=FakeTransport(
+            {
+                "get model": "model: PiSugar 3",
+                "get firmware_version": "firmware_version: 1.0.23",
+                "get battery": "battery: 87.5",
+                "get battery_v": "battery_v: 4.07",
+                "get battery_charging": "battery_charging: true",
+                "get battery_power_plugged": "battery_power_plugged: false",
+                "get battery_allow_charging": "battery_allow_charging: true",
+                "get battery_output_enabled": "battery_output_enabled: true",
+                "get temperature": "temperature: 31.4",
+                "get rtc_time": "rtc_time: 2026-04-04T11:59:00+00:00",
+                "get rtc_alarm_enabled": "rtc_alarm_enabled: false",
+                "get rtc_alarm_time": "rtc_alarm_time: 2026-04-05T07:30:00+00:00",
+                "get alarm_repeat": "alarm_repeat: 127",
+                "get rtc_adjust_ppm": "rtc_adjust_ppm: 0.0",
+                "get safe_shutdown_level": "safe_shutdown_level: 12.0",
+                "get safe_shutdown_delay": "safe_shutdown_delay: 30",
+            }
+        ),
+        now_provider=lambda: checked_at,
+    )
+
+    snapshot = backend.get_snapshot()
+
+    assert snapshot.available is True
+    assert snapshot.checked_at == checked_at
+    assert snapshot.device.model == "PiSugar 3"
+    assert snapshot.device.firmware_version == "1.0.23"
+    assert snapshot.battery.level_percent == 87.5
+    assert snapshot.battery.voltage_volts == 4.07
+    assert snapshot.battery.charging is True
+    assert snapshot.battery.power_plugged is False
+    assert snapshot.rtc.time == datetime(2026, 4, 4, 11, 59, tzinfo=timezone.utc)
+    assert snapshot.rtc.alarm_time == datetime(2026, 4, 5, 7, 30, tzinfo=timezone.utc)
+    assert snapshot.shutdown.safe_shutdown_level_percent == 12.0
+    assert snapshot.shutdown.safe_shutdown_delay_seconds == 30
+    assert snapshot.error == ""
+
+
+def test_pisugar_backend_reports_partial_failures_without_losing_availability() -> None:
+    """Optional command failures should be surfaced in the snapshot error string."""
+
+    backend = PiSugarBackend(
+        PowerConfig(),
+        transport=FakeTransport(
+            {
+                "get model": "PiSugar 3",
+                "get firmware_version": "1.0.23",
+                "get battery": "91",
+                "get battery_v": "4.11",
+                "get battery_charging": "false",
+                "get battery_power_plugged": "true",
+                "get battery_allow_charging": "true",
+                "get battery_output_enabled": "true",
+                "get rtc_time": "2026-04-04T12:00:00+00:00",
+                "get rtc_alarm_enabled": "false",
+                "get rtc_alarm_time": "2026-04-05T07:30:00+00:00",
+                "get alarm_repeat": "127",
+                "get rtc_adjust_ppm": "0.0",
+                "get safe_shutdown_level": "15.0",
+                "get safe_shutdown_delay": "45",
+            },
+            failures={"get temperature"},
+        ),
+    )
+
+    snapshot = backend.get_snapshot()
+
+    assert snapshot.available is True
+    assert snapshot.battery.temperature_celsius is None
+    assert "get temperature" in snapshot.error
+
+
+def test_pisugar_backend_marks_snapshot_unavailable_when_transport_is_down() -> None:
+    """If every command fails, the snapshot should report the backend as unavailable."""
+
+    backend = PiSugarBackend(
+        PowerConfig(),
+        transport=FakeTransport({}, failures={"get model"}),
+    )
+
+    snapshot = backend.get_snapshot()
+
+    assert snapshot.available is False
+    assert "get model" in snapshot.error
+
+
+def test_pisugar_probe_returns_false_when_backend_is_disabled() -> None:
+    """Disabled power config should short-circuit probe attempts."""
+
+    backend = PiSugarBackend(
+        PowerConfig(enabled=False),
+        transport=FakeTransport({"get model": "PiSugar 3"}),
+    )
+
+    assert backend.probe() is False
+

--- a/tests/test_power_manager.py
+++ b/tests/test_power_manager.py
@@ -1,0 +1,92 @@
+"""Tests for the app-facing power manager facade."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from yoyopy.config import ConfigManager
+from yoyopy.power.manager import PowerManager
+from yoyopy.power.models import BatteryState, PowerConfig, PowerSnapshot
+
+
+class FakeBackend:
+    """Minimal power backend double for manager tests."""
+
+    def __init__(self, snapshot: PowerSnapshot, probe_result: bool = True) -> None:
+        self.snapshot = snapshot
+        self.probe_result = probe_result
+        self.refresh_calls = 0
+
+    def probe(self) -> bool:
+        return self.probe_result
+
+    def get_snapshot(self) -> PowerSnapshot:
+        self.refresh_calls += 1
+        return self.snapshot
+
+
+class ExplodingBackend:
+    """Backend double that raises on refresh."""
+
+    def probe(self) -> bool:
+        return False
+
+    def get_snapshot(self) -> PowerSnapshot:
+        raise RuntimeError("backend boom")
+
+
+def test_power_manager_refresh_caches_latest_snapshot() -> None:
+    """Refreshing through the manager should retain the latest backend snapshot."""
+
+    snapshot = PowerSnapshot(
+        available=True,
+        checked_at=datetime(2026, 4, 4, 12, 0, 0),
+        battery=BatteryState(level_percent=83.0),
+    )
+    backend = FakeBackend(snapshot)
+    manager = PowerManager(PowerConfig(), backend=backend)
+
+    result = manager.refresh()
+
+    assert result is snapshot
+    assert manager.get_snapshot() is snapshot
+    assert manager.get_battery_percentage() == 83.0
+    assert backend.refresh_calls == 1
+
+
+def test_power_manager_returns_unavailable_snapshot_when_backend_refresh_fails() -> None:
+    """Refresh failures should be captured as an unavailable snapshot instead of bubbling up."""
+
+    manager = PowerManager(PowerConfig(), backend=ExplodingBackend())
+
+    snapshot = manager.refresh()
+
+    assert snapshot.available is False
+    assert snapshot.error == "backend boom"
+
+
+def test_power_manager_reads_power_config_from_config_manager(tmp_path) -> None:
+    """Typed application settings should feed the power manager configuration."""
+
+    config_dir = tmp_path
+    (config_dir / "yoyopod_config.yaml").write_text(
+        """
+power:
+  enabled: true
+  transport: tcp
+  tcp_host: "192.168.1.10"
+  tcp_port: 9000
+  timeout_seconds: 5.0
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config_manager = ConfigManager(config_dir=str(config_dir))
+    manager = PowerManager.from_config_manager(config_manager)
+
+    assert manager.config.enabled is True
+    assert manager.config.transport == "tcp"
+    assert manager.config.tcp_host == "192.168.1.10"
+    assert manager.config.tcp_port == 9000
+    assert manager.config.timeout_seconds == 5.0
+

--- a/yoyopy/config/__init__.py
+++ b/yoyopy/config/__init__.py
@@ -5,6 +5,7 @@ Handles VoIP settings and contacts.
 
 from yoyopy.config.config_manager import ConfigManager, Contact
 from yoyopy.config.models import (
+    AppPowerConfig,
     VoIPFileConfig,
     YoyoPodConfig,
     config_to_dict,
@@ -14,6 +15,7 @@ from yoyopy.config.models import (
 __all__ = [
     "ConfigManager",
     "Contact",
+    "AppPowerConfig",
     "YoyoPodConfig",
     "VoIPFileConfig",
     "load_config_model_from_yaml",

--- a/yoyopy/config/models.py
+++ b/yoyopy/config/models.py
@@ -198,6 +198,26 @@ class AppInputConfig:
 
 
 @dataclass(slots=True)
+class AppPowerConfig:
+    """Power-management backend settings."""
+
+    enabled: bool = config_value(default=True, env="YOYOPOD_POWER_ENABLED")
+    backend: str = config_value(default="pisugar", env="YOYOPOD_POWER_BACKEND")
+    transport: str = config_value(default="auto", env="YOYOPOD_POWER_TRANSPORT")
+    socket_path: str = config_value(
+        default="/tmp/pisugar-server.sock",
+        env="YOYOPOD_PISUGAR_SOCKET_PATH",
+    )
+    tcp_host: str = config_value(default="127.0.0.1", env="YOYOPOD_PISUGAR_HOST")
+    tcp_port: int = config_value(default=8423, env="YOYOPOD_PISUGAR_PORT")
+    timeout_seconds: float = config_value(default=2.0, env="YOYOPOD_POWER_TIMEOUT_SECONDS")
+    poll_interval_seconds: float = config_value(
+        default=30.0,
+        env="YOYOPOD_POWER_POLL_INTERVAL_SECONDS",
+    )
+
+
+@dataclass(slots=True)
 class AppDisplayConfig:
     """Display hardware configuration."""
 
@@ -226,6 +246,7 @@ class YoyoPodConfig:
     voip: AppVoIPConfig = config_value(default_factory=AppVoIPConfig)
     ui: AppUiConfig = config_value(default_factory=AppUiConfig)
     input: AppInputConfig = config_value(default_factory=AppInputConfig)
+    power: AppPowerConfig = config_value(default_factory=AppPowerConfig)
     display: AppDisplayConfig = config_value(default_factory=AppDisplayConfig)
     logging: AppLoggingConfig = config_value(default_factory=AppLoggingConfig)
 

--- a/yoyopy/power/__init__.py
+++ b/yoyopy/power/__init__.py
@@ -1,4 +1,41 @@
-"""
-Power management module for YoyoPod.
-Handles battery monitoring, charging status, and power optimization.
-"""
+"""Power management foundation for YoyoPod."""
+
+from yoyopy.power.backend import (
+    PiSugarAutoTransport,
+    PiSugarBackend,
+    PiSugarTCPTransport,
+    PiSugarUnixTransport,
+    PowerBackend,
+    PowerTransportError,
+    build_pisugar_transport,
+)
+from yoyopy.power.events import PowerAvailabilityChanged, PowerSnapshotUpdated
+from yoyopy.power.manager import PowerManager
+from yoyopy.power.models import (
+    BatteryState,
+    PowerConfig,
+    PowerDeviceInfo,
+    PowerSnapshot,
+    RTCState,
+    ShutdownState,
+)
+
+__all__ = [
+    "PowerBackend",
+    "PowerTransportError",
+    "PiSugarBackend",
+    "PiSugarTCPTransport",
+    "PiSugarUnixTransport",
+    "PiSugarAutoTransport",
+    "build_pisugar_transport",
+    "PowerManager",
+    "PowerConfig",
+    "PowerDeviceInfo",
+    "BatteryState",
+    "RTCState",
+    "ShutdownState",
+    "PowerSnapshot",
+    "PowerSnapshotUpdated",
+    "PowerAvailabilityChanged",
+]
+

--- a/yoyopy/power/backend.py
+++ b/yoyopy/power/backend.py
@@ -1,0 +1,271 @@
+"""PiSugar power backend protocol and transport implementation."""
+
+from __future__ import annotations
+
+import socket
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Protocol
+
+from loguru import logger
+
+from yoyopy.power.models import (
+    BatteryState,
+    PowerConfig,
+    PowerDeviceInfo,
+    PowerSnapshot,
+    RTCState,
+    ShutdownState,
+)
+
+
+class PowerBackend(Protocol):
+    """Read-only backend contract for power-management integrations."""
+
+    def probe(self) -> bool:
+        """Return True when the backend is reachable."""
+
+    def get_snapshot(self) -> PowerSnapshot:
+        """Return a best-effort point-in-time power snapshot."""
+
+
+class PowerTransportError(RuntimeError):
+    """Raised when the PiSugar transport cannot complete a command."""
+
+
+class PiSugarTransport(Protocol):
+    """Simple command transport for the PiSugar server."""
+
+    def send_command(self, command: str) -> str:
+        """Send one command and return the raw response."""
+
+
+class PiSugarTCPTransport:
+    """Talk to PiSugar over the documented local TCP API."""
+
+    def __init__(self, host: str, port: int, timeout_seconds: float) -> None:
+        self.host = host
+        self.port = port
+        self.timeout_seconds = timeout_seconds
+
+    def send_command(self, command: str) -> str:
+        try:
+            with socket.create_connection(
+                (self.host, self.port),
+                timeout=self.timeout_seconds,
+            ) as conn:
+                conn.settimeout(self.timeout_seconds)
+                conn.sendall((command.strip() + "\n").encode("utf-8"))
+                conn.shutdown(socket.SHUT_WR)
+                return _read_socket_response(conn)
+        except OSError as exc:
+            raise PowerTransportError(
+                f"TCP transport failed for {self.host}:{self.port}: {exc}"
+            ) from exc
+
+
+class PiSugarUnixTransport:
+    """Talk to PiSugar over the documented Unix-domain socket API."""
+
+    def __init__(self, socket_path: str, timeout_seconds: float) -> None:
+        self.socket_path = socket_path
+        self.timeout_seconds = timeout_seconds
+
+    def send_command(self, command: str) -> str:
+        path = Path(self.socket_path)
+        if not path.exists():
+            raise PowerTransportError(f"Unix socket not found: {path}")
+
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as conn:
+                conn.settimeout(self.timeout_seconds)
+                conn.connect(self.socket_path)
+                conn.sendall((command.strip() + "\n").encode("utf-8"))
+                conn.shutdown(socket.SHUT_WR)
+                return _read_socket_response(conn)
+        except OSError as exc:
+            raise PowerTransportError(
+                f"Unix transport failed for {self.socket_path}: {exc}"
+            ) from exc
+
+
+class PiSugarAutoTransport:
+    """Try Unix socket first, then local TCP, until one responds."""
+
+    def __init__(self, transports: list[PiSugarTransport]) -> None:
+        self.transports = transports
+
+    def send_command(self, command: str) -> str:
+        errors: list[str] = []
+        for transport in self.transports:
+            try:
+                return transport.send_command(command)
+            except PowerTransportError as exc:
+                errors.append(str(exc))
+
+        raise PowerTransportError("; ".join(errors) or "No PiSugar transports configured")
+
+
+class PiSugarBackend:
+    """Read-only PiSugar backend backed by the local socket/TCP server."""
+
+    def __init__(
+        self,
+        config: PowerConfig,
+        transport: PiSugarTransport | None = None,
+        now_provider: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.config = config
+        self.transport = transport or build_pisugar_transport(config)
+        self.now_provider = now_provider or datetime.now
+
+    def probe(self) -> bool:
+        """Return True if the backend responds to a lightweight command."""
+        if not self.config.enabled:
+            return False
+
+        try:
+            self._query("get model")
+            return True
+        except (PowerTransportError, ValueError) as exc:
+            logger.debug(f"PiSugar probe failed: {exc}")
+            return False
+
+    def get_snapshot(self) -> PowerSnapshot:
+        """Collect a best-effort snapshot of the current PiSugar state."""
+        checked_at = self.now_provider()
+
+        if not self.config.enabled:
+            return PowerSnapshot(
+                available=False,
+                checked_at=checked_at,
+                error="power backend disabled",
+            )
+
+        success_count = 0
+        errors: list[str] = []
+
+        def read_optional(reader: Callable[[str], object], command: str):
+            nonlocal success_count
+            try:
+                value = reader(command)
+            except (PowerTransportError, ValueError) as exc:
+                errors.append(f"{command}: {exc}")
+                return None
+            success_count += 1
+            return value
+
+        device = PowerDeviceInfo(
+            model=read_optional(self._read_str, "get model"),
+            firmware_version=read_optional(self._read_str, "get firmware_version"),
+        )
+        battery = BatteryState(
+            level_percent=read_optional(self._read_float, "get battery"),
+            voltage_volts=read_optional(self._read_float, "get battery_v"),
+            charging=read_optional(self._read_bool, "get battery_charging"),
+            power_plugged=read_optional(self._read_bool, "get battery_power_plugged"),
+            allow_charging=read_optional(self._read_bool, "get battery_allow_charging"),
+            output_enabled=read_optional(self._read_bool, "get battery_output_enabled"),
+            temperature_celsius=read_optional(self._read_float, "get temperature"),
+        )
+        rtc = RTCState(
+            time=read_optional(self._read_datetime, "get rtc_time"),
+            alarm_enabled=read_optional(self._read_bool, "get rtc_alarm_enabled"),
+            alarm_time=read_optional(self._read_datetime, "get rtc_alarm_time"),
+            alarm_repeat_mask=read_optional(self._read_int, "get alarm_repeat"),
+            adjust_ppm=read_optional(self._read_float, "get rtc_adjust_ppm"),
+        )
+        shutdown = ShutdownState(
+            safe_shutdown_level_percent=read_optional(
+                self._read_float,
+                "get safe_shutdown_level",
+            ),
+            safe_shutdown_delay_seconds=read_optional(
+                self._read_int,
+                "get safe_shutdown_delay",
+            ),
+        )
+
+        return PowerSnapshot(
+            available=success_count > 0,
+            checked_at=checked_at,
+            device=device,
+            battery=battery,
+            rtc=rtc,
+            shutdown=shutdown,
+            error="; ".join(errors),
+        )
+
+    def _query(self, command: str) -> str:
+        """Execute one PiSugar command and normalize its payload."""
+        response = self.transport.send_command(command)
+        return _extract_response_value(command, response)
+
+    def _read_str(self, command: str) -> str:
+        return self._query(command)
+
+    def _read_bool(self, command: str) -> bool:
+        value = self._query(command).strip().lower()
+        if value in {"true", "1", "yes", "on"}:
+            return True
+        if value in {"false", "0", "no", "off"}:
+            return False
+        raise ValueError(f"Cannot coerce {value!r} to bool")
+
+    def _read_int(self, command: str) -> int:
+        return int(float(self._query(command)))
+
+    def _read_float(self, command: str) -> float:
+        return float(self._query(command))
+
+    def _read_datetime(self, command: str) -> datetime:
+        value = self._query(command)
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value)
+
+
+def build_pisugar_transport(config: PowerConfig) -> PiSugarTransport:
+    """Build a transport based on the configured PiSugar access mode."""
+    unix_transport = PiSugarUnixTransport(config.socket_path, config.timeout_seconds)
+    tcp_transport = PiSugarTCPTransport(
+        config.tcp_host,
+        config.tcp_port,
+        config.timeout_seconds,
+    )
+
+    if config.transport == "socket":
+        return unix_transport
+    if config.transport == "tcp":
+        return tcp_transport
+    return PiSugarAutoTransport([unix_transport, tcp_transport])
+
+
+def _read_socket_response(conn: socket.socket) -> str:
+    """Read all response bytes from a socket connection."""
+    chunks: list[bytes] = []
+    while True:
+        data = conn.recv(4096)
+        if not data:
+            break
+        chunks.append(data)
+    response = b"".join(chunks).decode("utf-8", errors="replace").strip()
+    if not response:
+        raise PowerTransportError("No response from PiSugar server")
+    return response
+
+
+def _extract_response_value(command: str, response: str) -> str:
+    """Normalize raw PiSugar command responses into their payload value."""
+    lines = [line.strip() for line in response.splitlines() if line.strip()]
+    if not lines:
+        raise PowerTransportError(f"Empty response for {command!r}")
+
+    line = lines[-1]
+    if ":" in line:
+        _, line = line.split(":", 1)
+    value = line.strip()
+    if not value:
+        raise PowerTransportError(f"Malformed response for {command!r}: {response!r}")
+    return value
+

--- a/yoyopy/power/events.py
+++ b/yoyopy/power/events.py
@@ -1,0 +1,23 @@
+"""Typed power-domain events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from yoyopy.power.models import PowerSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class PowerSnapshotUpdated:
+    """Published when a new power snapshot is collected."""
+
+    snapshot: PowerSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class PowerAvailabilityChanged:
+    """Published when the power backend becomes available or unavailable."""
+
+    available: bool
+    reason: str = ""
+

--- a/yoyopy/power/manager.py
+++ b/yoyopy/power/manager.py
@@ -1,0 +1,64 @@
+"""App-facing power manager facade."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from yoyopy.power.backend import PiSugarBackend, PowerBackend
+from yoyopy.power.models import PowerConfig, PowerSnapshot
+
+if TYPE_CHECKING:
+    from yoyopy.config import ConfigManager
+
+
+class PowerManager:
+    """Coordinate power backend access and retain the latest snapshot."""
+
+    def __init__(self, config: PowerConfig, backend: PowerBackend | None = None) -> None:
+        self.config = config
+        self.backend = backend or PiSugarBackend(config)
+        self.last_snapshot = PowerSnapshot(
+            available=False,
+            checked_at=datetime.now(),
+            error="power snapshot not collected yet",
+        )
+
+    @classmethod
+    def from_config_manager(cls, config_manager: "ConfigManager") -> "PowerManager":
+        """Build a power manager from the typed app configuration."""
+
+        return cls(PowerConfig.from_config_manager(config_manager))
+
+    def probe(self) -> bool:
+        """Return True when the configured backend is reachable."""
+        if not self.config.enabled:
+            return False
+        return self.backend.probe()
+
+    def refresh(self) -> PowerSnapshot:
+        """Collect and store a new snapshot from the backend."""
+        try:
+            self.last_snapshot = self.backend.get_snapshot()
+        except Exception as exc:
+            logger.error(f"Power snapshot refresh failed: {exc}")
+            self.last_snapshot = PowerSnapshot(
+                available=False,
+                checked_at=datetime.now(),
+                error=str(exc),
+            )
+        return self.last_snapshot
+
+    def get_snapshot(self, refresh: bool = False) -> PowerSnapshot:
+        """Return the cached snapshot, optionally refreshing first."""
+        if refresh:
+            return self.refresh()
+        return self.last_snapshot
+
+    def get_battery_percentage(self, refresh: bool = False) -> float | None:
+        """Return the current battery percentage when available."""
+        snapshot = self.get_snapshot(refresh=refresh)
+        return snapshot.battery.level_percent
+

--- a/yoyopy/power/models.py
+++ b/yoyopy/power/models.py
@@ -1,0 +1,94 @@
+"""Typed models for PiSugar-backed power management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from yoyopy.config import ConfigManager
+
+
+@dataclass(slots=True)
+class PowerConfig:
+    """Runtime power-backend configuration."""
+
+    enabled: bool = True
+    backend: str = "pisugar"
+    transport: str = "auto"
+    socket_path: str = "/tmp/pisugar-server.sock"
+    tcp_host: str = "127.0.0.1"
+    tcp_port: int = 8423
+    timeout_seconds: float = 2.0
+    poll_interval_seconds: float = 30.0
+
+    @staticmethod
+    def from_config_manager(config_manager: "ConfigManager") -> "PowerConfig":
+        """Create a power config from the current application settings."""
+
+        settings = config_manager.get_app_settings().power
+        return PowerConfig(
+            enabled=settings.enabled,
+            backend=settings.backend,
+            transport=settings.transport,
+            socket_path=settings.socket_path,
+            tcp_host=settings.tcp_host,
+            tcp_port=settings.tcp_port,
+            timeout_seconds=settings.timeout_seconds,
+            poll_interval_seconds=settings.poll_interval_seconds,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PowerDeviceInfo:
+    """Static-ish information about the attached PiSugar device."""
+
+    model: str | None = None
+    firmware_version: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BatteryState:
+    """Current battery and charger state."""
+
+    level_percent: float | None = None
+    voltage_volts: float | None = None
+    charging: bool | None = None
+    power_plugged: bool | None = None
+    allow_charging: bool | None = None
+    output_enabled: bool | None = None
+    temperature_celsius: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RTCState:
+    """Current RTC status exposed by PiSugar."""
+
+    time: datetime | None = None
+    alarm_enabled: bool | None = None
+    alarm_time: datetime | None = None
+    alarm_repeat_mask: int | None = None
+    adjust_ppm: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ShutdownState:
+    """Safe-shutdown configuration currently active on the PiSugar."""
+
+    safe_shutdown_level_percent: float | None = None
+    safe_shutdown_delay_seconds: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PowerSnapshot:
+    """Best-effort point-in-time power snapshot."""
+
+    available: bool
+    checked_at: datetime
+    source: str = "pisugar"
+    device: PowerDeviceInfo = field(default_factory=PowerDeviceInfo)
+    battery: BatteryState = field(default_factory=BatteryState)
+    rtc: RTCState = field(default_factory=RTCState)
+    shutdown: ShutdownState = field(default_factory=ShutdownState)
+    error: str = ""


### PR DESCRIPTION
## Summary
- add a typed power package with PiSugar config, models, events, backend transport, and manager facade
- support documented PiSugar socket and local TCP transports with read-only snapshot collection
- add focused tests for config loading, backend parsing, and manager behavior
- align one stale audio-default test with the already-merged wm8960 device defaults

## Testing
- python -m compileall yoyopy tests
- uv run pytest tests/test_config_models.py tests/test_power_backend.py tests/test_power_manager.py -q
- uv run pytest -q