### PR TITLE
Integrate PiSugar power telemetry into the app

### DIFF
--- a/demos/demo_runtime_state.py
+++ b/demos/demo_runtime_state.py
@@ -66,6 +66,7 @@ def main() -> int:
         call_interruption_policy=CallInterruptionPolicy(),
         screen_manager=screen_manager,
         mopidy_client=None,
+        power_manager=None,
         now_playing_screen=now_playing_screen,
         call_screen=None,
         incoming_call_screen=None,

--- a/scripts/pi_remote.py
+++ b/scripts/pi_remote.py
@@ -68,6 +68,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run the Raspberry Pi smoke validator remotely",
     )
     smoke_parser.add_argument(
+        "--with-power",
+        action="store_true",
+        help="Include PiSugar power checks",
+    )
+    smoke_parser.add_argument(
         "--with-mopidy",
         action="store_true",
         help="Include Mopidy connectivity checks",
@@ -149,6 +154,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--skip-uv-sync",
         action="store_true",
         help="Skip `uv sync --extra dev` during the remote sync step",
+    )
+    preflight_parser.add_argument(
+        "--with-power",
+        action="store_true",
+        help="Include PiSugar power checks in the remote smoke pass",
     )
     preflight_parser.add_argument(
         "--with-mopidy",
@@ -281,6 +291,8 @@ def build_sync_command(config: RemoteConfig, skip_uv_sync: bool) -> str:
 def build_smoke_command(args: argparse.Namespace) -> str:
     """Create the remote smoke-validation command."""
     parts = ["uv run python scripts/pi_smoke.py"]
+    if args.with_power:
+        parts.append("--with-power")
     if args.with_mopidy:
         parts.append("--with-mopidy")
     if args.with_voip:

--- a/scripts/pi_smoke.py
+++ b/scripts/pi_smoke.py
@@ -19,6 +19,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from yoyopy.audio.mopidy_client import MopidyClient
 from yoyopy.config import ConfigManager, YoyoPodConfig, config_to_dict, load_config_model_from_yaml
+from yoyopy.power import PowerManager
 from yoyopy.voip import VoIPConfig, VoIPManager
 from yoyopy.ui.display import Display, detect_hardware
 from yoyopy.ui.input import get_input_manager
@@ -179,6 +180,34 @@ def input_check(display: Display, app_config: dict[str, Any]) -> CheckResult:
                 pass
 
 
+def power_check(config_dir: Path) -> CheckResult:
+    """Validate PiSugar reachability and report a live battery snapshot."""
+    config_manager = ConfigManager(config_dir=str(config_dir))
+    manager = PowerManager.from_config_manager(config_manager)
+
+    if not manager.config.enabled:
+        return CheckResult(
+            name="power",
+            status="warn",
+            details="power backend disabled in yoyopod_config.yaml",
+        )
+
+    snapshot = manager.refresh()
+    if not snapshot.available:
+        details = snapshot.error or "power backend unavailable"
+        return CheckResult(name="power", status="fail", details=details)
+
+    details = ", ".join(
+        [
+            f"model={snapshot.device.model or 'unknown'}",
+            f"battery={snapshot.battery.level_percent:.1f}%" if snapshot.battery.level_percent is not None else "battery=unknown",
+            f"charging={snapshot.battery.charging}",
+            f"plugged={snapshot.battery.power_plugged}",
+        ]
+    )
+    return CheckResult(name="power", status="pass", details=details)
+
+
 def mopidy_check(app_config: dict[str, Any], timeout_seconds: int) -> CheckResult:
     """Validate Mopidy reachability and basic state queries."""
     audio_config = app_config.get("audio", {})
@@ -293,6 +322,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Also validate Mopidy connectivity from yoyopod_config.yaml",
     )
     parser.add_argument(
+        "--with-power",
+        action="store_true",
+        help="Also validate PiSugar power telemetry from yoyopod_config.yaml",
+    )
+    parser.add_argument(
         "--with-voip",
         action="store_true",
         help="Also validate linphone startup and SIP registration",
@@ -355,6 +389,9 @@ def main() -> int:
 
         if display_result.status == "pass" and display is not None:
             results.append(input_check(display, app_config))
+
+        if args.with_power:
+            results.append(power_check(config_dir))
 
         if args.with_mopidy:
             results.append(mopidy_check(app_config, args.mopidy_timeout))

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import threading
+from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 
@@ -28,6 +30,7 @@ from yoyopy.fsm import (
     MusicFSM,
     MusicState,
 )
+from yoyopy.power import BatteryState, PowerSnapshot
 from yoyopy.ui.input import InputManager, InteractionProfile
 
 
@@ -157,6 +160,24 @@ class FakeStoppingVoIPManager:
         self.stop_notify_events.append(notify_events)
 
 
+class FakePowerManager:
+    """Minimal power manager double for app-level polling tests."""
+
+    def __init__(self, snapshots: list[PowerSnapshot], poll_interval_seconds: float = 30.0) -> None:
+        self._snapshots = snapshots
+        self.refresh_calls = 0
+        self.config = SimpleNamespace(enabled=True, poll_interval_seconds=poll_interval_seconds)
+
+    def refresh(self) -> PowerSnapshot:
+        index = min(self.refresh_calls, len(self._snapshots) - 1)
+        self.refresh_calls += 1
+        return self._snapshots[index]
+
+    def get_snapshot(self) -> PowerSnapshot:
+        index = max(0, min(self.refresh_calls - 1, len(self._snapshots) - 1))
+        return self._snapshots[index]
+
+
 def _publish_from_worker(app: YoyoPodApp, event: object) -> None:
     worker = threading.Thread(target=lambda: app.event_bus.publish(event))
     worker.start()
@@ -167,6 +188,26 @@ def _navigate_from_worker(screen_manager: FakeScreenManager, screen_name: str) -
     worker = threading.Thread(target=lambda: screen_manager.push_screen(screen_name))
     worker.start()
     worker.join()
+
+
+def _power_snapshot(
+    *,
+    available: bool,
+    battery_percent: float | None = None,
+    charging: bool | None = None,
+    power_plugged: bool | None = None,
+    error: str = "",
+) -> PowerSnapshot:
+    return PowerSnapshot(
+        available=available,
+        checked_at=datetime(2026, 4, 4, 12, 0, 0),
+        battery=BatteryState(
+            level_percent=battery_percent,
+            charging=charging,
+            power_plugged=power_plugged,
+        ),
+        error=error,
+    )
 
 
 def _build_app(playback_state: str = "stopped", auto_resume: bool = True) -> tuple[
@@ -516,3 +557,53 @@ def test_one_button_profile_starts_on_hub() -> None:
 
     assert app._get_initial_screen_name() == "hub"
     assert app._get_initial_ui_state() == AppRuntimeState.HUB
+
+
+def test_power_poll_updates_context_runtime_and_visible_screen() -> None:
+    """A fresh power snapshot should update runtime/context and refresh the active screen."""
+    app, _, _ = _build_app(playback_state="stopped")
+    app.power_manager = FakePowerManager(
+        [
+            _power_snapshot(
+                available=True,
+                battery_percent=55.4,
+                charging=True,
+                power_plugged=True,
+            )
+        ]
+    )
+
+    app._poll_power_status(now=0.0, force=True)
+
+    assert app.power_manager.refresh_calls == 1
+    assert app.context.battery_percent == 55
+    assert app.context.battery_charging is True
+    assert app.context.external_power is True
+    assert app.context.power_available is True
+    assert app.coordinator_runtime.power_available is True
+    assert app.coordinator_runtime.power_snapshot is not None
+    assert app.coordinator_runtime.power_snapshot.battery.level_percent == 55.4
+    assert app.menu_screen.render_calls == 1
+
+
+def test_power_poll_honors_interval_and_tracks_unavailable_backend() -> None:
+    """Power polling should respect the configured interval and retain availability state."""
+    app, _, _ = _build_app(playback_state="stopped")
+    app.power_manager = FakePowerManager(
+        [
+            _power_snapshot(available=True, battery_percent=61.0, charging=False, power_plugged=False),
+            _power_snapshot(available=False, error="I2C not connected"),
+        ],
+        poll_interval_seconds=30.0,
+    )
+
+    app._poll_power_status(now=0.0, force=True)
+    app._poll_power_status(now=10.0)
+    app._poll_power_status(now=30.0)
+
+    assert app.power_manager.refresh_calls == 2
+    assert app.context.battery_percent == 61
+    assert app.context.power_available is False
+    assert app.context.power_error == "I2C not connected"
+    assert app.coordinator_runtime.power_available is False
+    assert app.menu_screen.render_calls == 2

--- a/tests/test_fsm_runtime.py
+++ b/tests/test_fsm_runtime.py
@@ -18,6 +18,7 @@ def _build_runtime() -> CoordinatorRuntime:
         call_interruption_policy=CallInterruptionPolicy(),
         screen_manager=None,
         mopidy_client=None,
+        power_manager=None,
         now_playing_screen=None,
         call_screen=None,
         incoming_call_screen=None,

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -37,6 +37,7 @@ def test_build_sync_command_includes_uv_sync_by_default() -> None:
 def test_build_smoke_command_adds_optional_checks() -> None:
     """Smoke command should include optional service-check flags when requested."""
     args = Namespace(
+        with_power=True,
         with_mopidy=True,
         with_voip=True,
         verbose=True,
@@ -47,6 +48,7 @@ def test_build_smoke_command_adds_optional_checks() -> None:
     command = build_smoke_command(args)
 
     assert command.startswith("uv run python scripts/pi_smoke.py")
+    assert "--with-power" in command
     assert "--with-mopidy" in command
     assert "--with-voip" in command
     assert "--verbose" in command

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -16,17 +16,18 @@ from loguru import logger
 from yoyopy.app_context import AppContext
 from yoyopy.audio.mopidy_client import MopidyClient
 from yoyopy.config import ConfigManager, YoyoPodConfig
-from yoyopy.voip import VoIPConfig, VoIPManager
 from yoyopy.coordinators import (
     AppRuntimeState,
     CallCoordinator,
     CoordinatorRuntime,
     PlaybackCoordinator,
+    PowerCoordinator,
     ScreenCoordinator,
 )
 from yoyopy.event_bus import EventBus
 from yoyopy.events import RecoveryAttemptCompletedEvent, ScreenChangedEvent
 from yoyopy.fsm import CallFSM, CallInterruptionPolicy, MusicFSM
+from yoyopy.power import PowerManager
 from yoyopy.ui.display import Display
 from yoyopy.ui.input import InputManager, InteractionProfile, get_input_manager
 from yoyopy.ui.screens import (
@@ -42,6 +43,7 @@ from yoyopy.ui.screens import (
     PlaylistScreen,
     ScreenManager,
 )
+from yoyopy.voip import VoIPConfig, VoIPManager
 
 
 @dataclass(slots=True)
@@ -84,6 +86,7 @@ class YoyoPodApp:
         # Manager components
         self.voip_manager: Optional[VoIPManager] = None
         self.mopidy_client: Optional[MopidyClient] = None
+        self.power_manager: Optional[PowerManager] = None
 
         # Screen instances
         self.hub_screen: Optional[HubScreen] = None
@@ -124,10 +127,13 @@ class YoyoPodApp:
         self.screen_coordinator: Optional[ScreenCoordinator] = None
         self.call_coordinator: Optional[CallCoordinator] = None
         self.playback_coordinator: Optional[PlaybackCoordinator] = None
+        self.power_coordinator: Optional[PowerCoordinator] = None
 
         # Recovery backoff state
         self._voip_recovery = _RecoveryState()
         self._mopidy_recovery = _RecoveryState()
+        self._next_power_poll_at = 0.0
+        self._power_available: bool | None = None
         self._stopping = False
 
         logger.info("=" * 60)
@@ -177,14 +183,16 @@ class YoyoPodApp:
             self._setup_event_subscriptions()
             self._setup_voip_callbacks()
             self._setup_music_callbacks()
+            self._poll_power_status(force=True, now=time.monotonic())
 
-            logger.info("✓ YoyoPod setup complete")
+            logger.info("YoyoPod setup complete")
             return True
         except Exception as exc:
             logger.error(f"Setup failed: {exc}")
             return False
 
     def _load_configuration(self) -> bool:
+
         """Load YoyoPod configuration."""
         logger.info("Loading configuration...")
 
@@ -292,6 +300,16 @@ class YoyoPodApp:
                 self.mopidy_client.start_polling()
             else:
                 logger.warning("    ⚠ Mopidy connection failed (VoIP-only mode)")
+
+            logger.info("  - PowerManager")
+            self.power_manager = PowerManager.from_config_manager(self.config_manager)
+            if self.power_manager.config.enabled:
+                logger.info(
+                    "    Poll interval: %.1fs",
+                    self.power_manager.config.poll_interval_seconds,
+                )
+            else:
+                logger.info("    Power backend disabled in config")
 
             return True
         except Exception as exc:
@@ -447,6 +465,7 @@ class YoyoPodApp:
         self._ensure_coordinators()
         self.call_coordinator.bind(self.event_bus)
         self.playback_coordinator.bind(self.event_bus)
+        self.power_coordinator.bind(self.event_bus)
         logger.info("  ✓ Event subscriptions registered")
 
     def _process_pending_main_thread_actions(self, limit: Optional[int] = None) -> int:
@@ -490,6 +509,7 @@ class YoyoPodApp:
             call_interruption_policy=self.call_interruption_policy,
             screen_manager=self.screen_manager,
             mopidy_client=self.mopidy_client,
+            power_manager=self.power_manager,
             now_playing_screen=self.now_playing_screen,
             call_screen=self.call_screen,
             incoming_call_screen=self.incoming_call_screen,
@@ -510,6 +530,11 @@ class YoyoPodApp:
         self.playback_coordinator = PlaybackCoordinator(
             runtime=self.coordinator_runtime,
             screen_coordinator=self.screen_coordinator,
+        )
+        self.power_coordinator = PowerCoordinator(
+            runtime=self.coordinator_runtime,
+            screen_coordinator=self.screen_coordinator,
+            context=self.context,
         )
         if self.screen_manager is not None:
             self.screen_manager.on_screen_changed = self._handle_screen_changed
@@ -559,6 +584,27 @@ class YoyoPodApp:
         recovery_now = time.monotonic() if now is None else now
         self._attempt_voip_recovery(recovery_now)
         self._attempt_mopidy_recovery(recovery_now)
+
+    def _poll_power_status(self, now: float | None = None, force: bool = False) -> None:
+        """Refresh PiSugar power telemetry on the coordinator thread."""
+        if self.power_manager is None:
+            return
+
+        poll_now = time.monotonic() if now is None else now
+        if not force and poll_now < self._next_power_poll_at:
+            return
+
+        self._ensure_coordinators()
+        snapshot = self.power_manager.refresh()
+        self.power_coordinator.publish_snapshot(snapshot)
+
+        if self._power_available is None or self._power_available != snapshot.available:
+            reason = snapshot.error or ("ready" if snapshot.available else "unavailable")
+            self._power_available = snapshot.available
+            self.power_coordinator.publish_availability_change(snapshot.available, reason)
+
+        interval = max(1.0, self.power_manager.config.poll_interval_seconds)
+        self._next_power_poll_at = poll_now + interval
 
     def _attempt_voip_recovery(self, recovery_now: float) -> None:
         """Restart the VoIP backend when it is not running."""
@@ -670,6 +716,21 @@ class YoyoPodApp:
         else:
             logger.info("  Mopidy not connected")
         logger.info("")
+        logger.info("Power Status:")
+        if self.power_manager:
+            power_snapshot = self.power_manager.get_snapshot()
+            logger.info(f"  Available: {power_snapshot.available}")
+            if power_snapshot.device.model:
+                logger.info(f"  Model: {power_snapshot.device.model}")
+            if power_snapshot.battery.level_percent is not None:
+                logger.info(f"  Battery: {power_snapshot.battery.level_percent:.1f}%")
+            if power_snapshot.battery.charging is not None:
+                logger.info(f"  Charging: {power_snapshot.battery.charging}")
+            if power_snapshot.battery.power_plugged is not None:
+                logger.info(f"  External power: {power_snapshot.battery.power_plugged}")
+        else:
+            logger.info("  Power backend not configured")
+        logger.info("")
         logger.info("Integration Settings:")
         logger.info(f"  Auto-resume after call: {self.auto_resume_after_call}")
         logger.info("")
@@ -697,6 +758,7 @@ class YoyoPodApp:
                 time.sleep(0.1)
                 self._process_pending_main_thread_actions()
                 self._attempt_manager_recovery()
+                self._poll_power_status()
 
                 current_time = time.time()
                 if current_time - last_screen_update >= screen_update_interval:
@@ -752,4 +814,8 @@ class YoyoPodApp:
             "auto_resume": self.auto_resume_after_call,
             "voip_available": self.voip_manager is not None and self.voip_manager.running,
             "music_available": self.mopidy_client is not None and self.mopidy_client.is_connected,
+            "power_available": self.power_manager is not None and self.power_manager.get_snapshot().available,
+            "battery_percent": self.context.battery_percent if self.context else None,
+            "battery_charging": self.context.battery_charging if self.context else None,
+            "external_power": self.context.external_power if self.context else None,
         }

--- a/yoyopy/app_context.py
+++ b/yoyopy/app_context.py
@@ -5,6 +5,8 @@ Maintains shared state across the application including
 current playlist, playback status, volume, and user settings.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, TYPE_CHECKING
 from pathlib import Path
@@ -14,6 +16,7 @@ from yoyopy.ui.input.hal import InteractionProfile
 
 if TYPE_CHECKING:
     from yoyopy.audio.audio_manager import AudioManager
+    from yoyopy.power import PowerSnapshot
 
 
 @dataclass
@@ -117,6 +120,10 @@ class AppContext:
 
         # System status
         self.battery_percent: int = 100
+        self.battery_charging: bool = False
+        self.external_power: bool = False
+        self.power_available: bool = False
+        self.power_error: str = ""
         self.signal_strength: int = 4  # 0-4 bars
         self.is_connected: bool = False
         self.connection_type: str = "none"  # wifi, 4g, none
@@ -328,3 +335,18 @@ class AppContext:
             self.signal_strength = max(0, min(4, signal))
         if connected is not None:
             self.is_connected = connected
+
+    def update_power_status(self, snapshot: "PowerSnapshot") -> None:
+        """Update cached power telemetry from the latest backend snapshot."""
+        self.power_available = snapshot.available
+        self.power_error = snapshot.error
+
+        if snapshot.battery.level_percent is not None:
+            level = round(snapshot.battery.level_percent)
+            self.battery_percent = max(0, min(100, level))
+
+        if snapshot.battery.charging is not None:
+            self.battery_charging = snapshot.battery.charging
+
+        if snapshot.battery.power_plugged is not None:
+            self.external_power = snapshot.battery.power_plugged

--- a/yoyopy/coordinators/__init__.py
+++ b/yoyopy/coordinators/__init__.py
@@ -3,6 +3,7 @@ Coordinator modules for YoyoPod orchestration.
 """
 
 from yoyopy.coordinators.call import CallCoordinator
+from yoyopy.coordinators.power import PowerCoordinator
 from yoyopy.coordinators.playback import PlaybackCoordinator
 from yoyopy.coordinators.runtime import AppRuntimeState, CoordinatorRuntime
 from yoyopy.coordinators.screen import ScreenCoordinator
@@ -10,6 +11,7 @@ from yoyopy.coordinators.screen import ScreenCoordinator
 __all__ = [
     "AppRuntimeState",
     "CallCoordinator",
+    "PowerCoordinator",
     "PlaybackCoordinator",
     "CoordinatorRuntime",
     "ScreenCoordinator",

--- a/yoyopy/coordinators/power.py
+++ b/yoyopy/coordinators/power.py
@@ -1,0 +1,96 @@
+"""
+Power telemetry coordination for YoyoPod.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+from yoyopy.app_context import AppContext
+from yoyopy.coordinators.runtime import CoordinatorRuntime
+from yoyopy.coordinators.screen import ScreenCoordinator
+from yoyopy.event_bus import EventBus
+from yoyopy.power import (
+    PowerAvailabilityChanged,
+    PowerSnapshot,
+    PowerSnapshotUpdated,
+)
+
+
+class PowerCoordinator:
+    """Own power event publishing and UI/runtime power sync."""
+
+    def __init__(
+        self,
+        runtime: CoordinatorRuntime,
+        screen_coordinator: ScreenCoordinator,
+        context: AppContext,
+    ) -> None:
+        self.runtime = runtime
+        self.screen_coordinator = screen_coordinator
+        self.context = context
+        self._event_bus: EventBus | None = None
+        self._bound = False
+
+    def bind(self, event_bus: EventBus) -> None:
+        """Bind typed power event subscriptions once."""
+        if self._bound:
+            return
+
+        self._event_bus = event_bus
+        event_bus.subscribe(PowerSnapshotUpdated, self._on_snapshot_updated)
+        event_bus.subscribe(PowerAvailabilityChanged, self._on_availability_changed)
+        self._bound = True
+
+    def publish_snapshot(self, snapshot: PowerSnapshot) -> None:
+        """Publish a refreshed power snapshot onto the event bus."""
+        if self._event_bus is None:
+            raise RuntimeError("PowerCoordinator is not bound to an EventBus")
+
+        self._event_bus.publish(PowerSnapshotUpdated(snapshot=snapshot))
+
+    def publish_availability_change(self, available: bool, reason: str = "") -> None:
+        """Publish power backend availability changes onto the event bus."""
+        if self._event_bus is None:
+            raise RuntimeError("PowerCoordinator is not bound to an EventBus")
+
+        self._event_bus.publish(PowerAvailabilityChanged(available=available, reason=reason))
+
+    def _on_snapshot_updated(self, event: PowerSnapshotUpdated) -> None:
+        self.handle_snapshot_updated(event.snapshot)
+
+    def _on_availability_changed(self, event: PowerAvailabilityChanged) -> None:
+        self.handle_availability_change(event.available, event.reason)
+
+    def handle_snapshot_updated(self, snapshot: PowerSnapshot) -> None:
+        """Apply the latest power telemetry to runtime and UI state."""
+        previous_signature = (
+            self.context.battery_percent,
+            self.context.battery_charging,
+            self.context.external_power,
+            self.context.power_available,
+            self.context.power_error,
+        )
+
+        self.runtime.set_power_snapshot(snapshot)
+        self.context.update_power_status(snapshot)
+
+        current_signature = (
+            self.context.battery_percent,
+            self.context.battery_charging,
+            self.context.external_power,
+            self.context.power_available,
+            self.context.power_error,
+        )
+
+        if current_signature != previous_signature:
+            self.screen_coordinator.refresh_current_screen()
+
+    def handle_availability_change(self, available: bool, reason: str) -> None:
+        """Track power backend reachability for the runtime."""
+        self.runtime.set_power_available(available)
+        if available:
+            logger.info(f"Power backend available ({reason or 'ready'})")
+            return
+
+        logger.warning(f"Power backend unavailable ({reason or 'unknown'})")

--- a/yoyopy/coordinators/runtime.py
+++ b/yoyopy/coordinators/runtime.py
@@ -21,6 +21,7 @@ from yoyopy.fsm import (
 if TYPE_CHECKING:
     from yoyopy.audio.mopidy_client import MopidyClient
     from yoyopy.config import ConfigManager
+    from yoyopy.power import PowerManager, PowerSnapshot
     from yoyopy.ui.screens import (
         CallScreen,
         InCallScreen,
@@ -80,6 +81,7 @@ class CoordinatorRuntime:
     call_interruption_policy: CallInterruptionPolicy
     screen_manager: ScreenManager | None
     mopidy_client: MopidyClient | None
+    power_manager: PowerManager | None
     now_playing_screen: NowPlayingScreen | None
     call_screen: CallScreen | None
     incoming_call_screen: IncomingCallScreen | None
@@ -89,6 +91,8 @@ class CoordinatorRuntime:
     config_manager: ConfigManager | None
     ui_state: AppRuntimeState = AppRuntimeState.IDLE
     voip_ready: bool = False
+    power_available: bool = False
+    power_snapshot: PowerSnapshot | None = None
     current_app_state: AppRuntimeState = field(init=False)
     previous_app_state: AppRuntimeState | None = field(init=False, default=None)
     state_history: list[AppRuntimeState] = field(init=False, default_factory=list)
@@ -180,6 +184,15 @@ class CoordinatorRuntime:
         self.voip_ready = ready
         actual_trigger = trigger if ready else "voip_unavailable"
         return self.sync_app_state(actual_trigger)
+
+    def set_power_snapshot(self, snapshot: PowerSnapshot) -> None:
+        """Retain the latest power snapshot for coordinator consumers."""
+        self.power_snapshot = snapshot
+        self.power_available = snapshot.available
+
+    def set_power_available(self, available: bool) -> None:
+        """Retain current power backend availability."""
+        self.power_available = available
 
     def sync_ui_state_for_screen(self, screen_name: str | None) -> AppStateChange | None:
         """Update the base UI state for non-call overlay screens."""

--- a/yoyopy/coordinators/screen.py
+++ b/yoyopy/coordinators/screen.py
@@ -45,6 +45,18 @@ class ScreenCoordinator:
         if self.runtime.screen_manager.current_screen == self.runtime.in_call_screen:
             self.runtime.in_call_screen.render()
 
+    def refresh_current_screen(self) -> None:
+        """Refresh whichever screen is currently visible."""
+        if self.runtime.screen_manager is None:
+            return
+
+        current_screen = self.runtime.screen_manager.get_current_screen()
+        if current_screen is None:
+            return
+
+        current_screen.render()
+        logger.debug("  -> Current screen refreshed")
+
     def refresh_now_playing_screen(self) -> None:
         """Refresh the now playing screen if it is currently visible."""
         if self.runtime.screen_manager.current_screen == self.runtime.now_playing_screen:

--- a/yoyopy/ui/display/adapters/pimoroni.py
+++ b/yoyopy/ui/display/adapters/pimoroni.py
@@ -188,7 +188,10 @@ class PimoroniDisplayAdapter(DisplayHAL):
         self,
         time_str: str = "--:--",
         battery_percent: int = 100,
-        signal_strength: int = 4
+        signal_strength: int = 4,
+        charging: bool = False,
+        external_power: bool = False,
+        power_available: bool = True,
     ) -> None:
         """Draw status bar at top of screen."""
         # Draw background
@@ -231,6 +234,23 @@ class PimoroniDisplayAdapter(DisplayHAL):
                 battery_x + 2, battery_y + 2,
                 battery_x + 2 + fill_width, battery_y + battery_height - 2,
                 fill=battery_color
+            )
+
+        indicator = ""
+        if not power_available:
+            indicator = "?"
+        elif charging:
+            indicator = "C"
+        elif external_power:
+            indicator = "P"
+
+        if indicator:
+            self.text(
+                indicator,
+                battery_x - 14,
+                battery_y - 1,
+                color=self.COLOR_YELLOW if indicator == "?" else self.COLOR_WHITE,
+                font_size=12,
             )
 
         # Draw signal strength (left side)

--- a/yoyopy/ui/display/adapters/simulation.py
+++ b/yoyopy/ui/display/adapters/simulation.py
@@ -370,7 +370,10 @@ class SimulationDisplayAdapter(DisplayHAL):
         self,
         time_str: str,
         battery_percent: int,
-        signal_strength: int
+        signal_strength: int,
+        charging: bool = False,
+        external_power: bool = False,
+        power_available: bool = True,
     ) -> None:
         """
         Draw the status bar at the top of the display.
@@ -416,6 +419,23 @@ class SimulationDisplayAdapter(DisplayHAL):
                 battery_x + 1, battery_y + 1,
                 battery_x + 1 + fill_width, battery_y + 11,
                 fill=fill_color
+            )
+
+        indicator = ""
+        if not power_available:
+            indicator = "?"
+        elif charging:
+            indicator = "C"
+        elif external_power:
+            indicator = "P"
+
+        if indicator:
+            self.text(
+                indicator,
+                battery_x - 14,
+                battery_y - 1,
+                color=self.COLOR_YELLOW if indicator == "?" else self.COLOR_WHITE,
+                font_size=12,
             )
 
         # Draw signal strength (signal bars)

--- a/yoyopy/ui/display/adapters/whisplay.py
+++ b/yoyopy/ui/display/adapters/whisplay.py
@@ -231,7 +231,10 @@ class WhisplayDisplayAdapter(DisplayHAL):
         self,
         time_str: str = "--:--",
         battery_percent: int = 100,
-        signal_strength: int = 4
+        signal_strength: int = 4,
+        charging: bool = False,
+        external_power: bool = False,
+        power_available: bool = True,
     ) -> None:
         """
         Draw status bar at top of screen.
@@ -279,6 +282,23 @@ class WhisplayDisplayAdapter(DisplayHAL):
                 battery_x + 2, battery_y + 2,
                 battery_x + 2 + fill_width, battery_y + battery_height - 2,
                 fill=battery_color
+            )
+
+        indicator = ""
+        if not power_available:
+            indicator = "?"
+        elif charging:
+            indicator = "C"
+        elif external_power:
+            indicator = "P"
+
+        if indicator:
+            self.text(
+                indicator,
+                battery_x - 14,
+                battery_y - 1,
+                color=self.COLOR_YELLOW if indicator == "?" else self.COLOR_WHITE,
+                font_size=12,
             )
 
         # Draw signal strength (left side)

--- a/yoyopy/ui/display/hal.py
+++ b/yoyopy/ui/display/hal.py
@@ -185,7 +185,10 @@ class DisplayHAL(ABC):
         self,
         time_str: str = "--:--",
         battery_percent: int = 100,
-        signal_strength: int = 4
+        signal_strength: int = 4,
+        charging: bool = False,
+        external_power: bool = False,
+        power_available: bool = True,
     ) -> None:
         """
         Draw a status bar at the top of the screen.
@@ -199,6 +202,9 @@ class DisplayHAL(ABC):
             time_str: Time string to display (e.g., "14:30")
             battery_percent: Battery level 0-100
             signal_strength: Signal bars 0-4 (0=no signal, 4=full)
+            charging: Whether the device is actively charging
+            external_power: Whether external power is currently attached
+            power_available: Whether live power telemetry is currently available
         """
         pass
 

--- a/yoyopy/ui/display/manager.py
+++ b/yoyopy/ui/display/manager.py
@@ -165,10 +165,20 @@ class Display:
         self,
         time_str: str = "--:--",
         battery_percent: int = 100,
-        signal_strength: int = 4
+        signal_strength: int = 4,
+        charging: bool = False,
+        external_power: bool = False,
+        power_available: bool = True,
     ) -> None:
         """Draw status bar at top of screen."""
-        self._adapter.status_bar(time_str, battery_percent, signal_strength)
+        self._adapter.status_bar(
+            time_str,
+            battery_percent,
+            signal_strength,
+            charging,
+            external_power,
+            power_available,
+        )
 
     def update(self) -> None:
         """Flush buffer to physical display."""

--- a/yoyopy/ui/screens/music/now_playing.py
+++ b/yoyopy/ui/screens/music/now_playing.py
@@ -81,12 +81,18 @@ class NowPlayingScreen(Screen):
         # Draw status bar
         current_time = datetime.now().strftime("%H:%M")
         battery = self.context.battery_percent if self.context else 100
+        charging = self.context.battery_charging if self.context else False
+        external_power = self.context.external_power if self.context else False
+        power_available = self.context.power_available if self.context else True
         signal = self.context.signal_strength if self.context else 4
 
         self.display.status_bar(
             time_str=current_time,
             battery_percent=battery,
-            signal_strength=signal
+            signal_strength=signal,
+            charging=charging,
+            external_power=external_power,
+            power_available=power_available,
         )
 
         # Draw "Now Playing" label

--- a/yoyopy/ui/screens/music/playlist.py
+++ b/yoyopy/ui/screens/music/playlist.py
@@ -89,12 +89,18 @@ class PlaylistScreen(Screen):
         # Draw status bar
         current_time = datetime.now().strftime("%H:%M")
         battery = self.context.battery_percent if self.context else 100
+        charging = self.context.battery_charging if self.context else False
+        external_power = self.context.external_power if self.context else False
+        power_available = self.context.power_available if self.context else True
         signal = self.context.signal_strength if self.context else 4
 
         self.display.status_bar(
             time_str=current_time,
             battery_percent=battery,
-            signal_strength=signal
+            signal_strength=signal,
+            charging=charging,
+            external_power=external_power,
+            power_available=power_available,
         )
 
         # Draw title

--- a/yoyopy/ui/screens/navigation/home.py
+++ b/yoyopy/ui/screens/navigation/home.py
@@ -31,12 +31,18 @@ class HomeScreen(Screen):
         # Draw status bar
         current_time = datetime.now().strftime("%H:%M")
         battery = self.context.battery_percent if self.context else 100
+        charging = self.context.battery_charging if self.context else False
+        external_power = self.context.external_power if self.context else False
+        power_available = self.context.power_available if self.context else True
         signal = self.context.signal_strength if self.context else 4
 
         self.display.status_bar(
             time_str=current_time,
             battery_percent=battery,
-            signal_strength=signal
+            signal_strength=signal,
+            charging=charging,
+            external_power=external_power,
+            power_available=power_available,
         )
 
         # Draw YoyoPod logo text

--- a/yoyopy/ui/screens/navigation/hub.py
+++ b/yoyopy/ui/screens/navigation/hub.py
@@ -126,11 +126,17 @@ class HubScreen(Screen):
 
         current_time = datetime.now().strftime("%H:%M")
         battery = self.context.battery_percent if self.context else 100
+        charging = self.context.battery_charging if self.context else False
+        external_power = self.context.external_power if self.context else False
+        power_available = self.context.power_available if self.context else True
         signal = self.context.signal_strength if self.context else 4
         self.display.status_bar(
             time_str=current_time,
             battery_percent=battery,
             signal_strength=signal,
+            charging=charging,
+            external_power=external_power,
+            power_available=power_available,
         )
 
         title = "YoyoPod"

--- a/yoyopy/ui/screens/navigation/menu.py
+++ b/yoyopy/ui/screens/navigation/menu.py
@@ -54,10 +54,18 @@ class MenuScreen(Screen):
 
         # Draw status bar
         current_time = datetime.now().strftime("%H:%M")
+        battery = self.context.battery_percent if self.context else 85
+        charging = self.context.battery_charging if self.context else False
+        external_power = self.context.external_power if self.context else False
+        power_available = self.context.power_available if self.context else True
+        signal = self.context.signal_strength if self.context else 3
         self.display.status_bar(
             time_str=current_time,
-            battery_percent=85,
-            signal_strength=3
+            battery_percent=battery,
+            signal_strength=signal,
+            charging=charging,
+            external_power=external_power,
+            power_available=power_available,
         )
 
         # Draw menu title

--- a/yoyopy/ui/screens/voip/contact_list.py
+++ b/yoyopy/ui/screens/voip/contact_list.py
@@ -73,12 +73,18 @@ class ContactListScreen(Screen):
         # Draw status bar
         current_time = datetime.now().strftime("%H:%M")
         battery = self.context.battery_percent if self.context else 100
+        charging = self.context.battery_charging if self.context else False
+        external_power = self.context.external_power if self.context else False
+        power_available = self.context.power_available if self.context else True
         signal = self.context.signal_strength if self.context else 4
 
         self.display.status_bar(
             time_str=current_time,
             battery_percent=battery,
-            signal_strength=signal
+            signal_strength=signal,
+            charging=charging,
+            external_power=external_power,
+            power_available=power_available,
         )
 
         # Draw title

--- a/yoyopy/ui/screens/voip/hub.py
+++ b/yoyopy/ui/screens/voip/hub.py
@@ -113,12 +113,18 @@ class CallScreen(Screen):
 
         current_time = datetime.now().strftime("%H:%M")
         battery = self.context.battery_percent if self.context else 100
+        charging = self.context.battery_charging if self.context else False
+        external_power = self.context.external_power if self.context else False
+        power_available = self.context.power_available if self.context else True
         signal = self.context.signal_strength if self.context else 4
 
         self.display.status_bar(
             time_str=current_time,
             battery_percent=battery,
             signal_strength=signal,
+            charging=charging,
+            external_power=external_power,
+            power_available=power_available,
         )
 
         title = "VoIP"

--- a/yoyopy/ui/screens/voip/in_call.py
+++ b/yoyopy/ui/screens/voip/in_call.py
@@ -60,12 +60,18 @@ class InCallScreen(Screen):
         # Draw status bar
         current_time = datetime.now().strftime("%H:%M")
         battery = self.context.battery_percent if self.context else 100
+        charging = self.context.battery_charging if self.context else False
+        external_power = self.context.external_power if self.context else False
+        power_available = self.context.power_available if self.context else True
         signal = self.context.signal_strength if self.context else 4
 
         self.display.status_bar(
             time_str=current_time,
             battery_percent=battery,
-            signal_strength=signal
+            signal_strength=signal,
+            charging=charging,
+            external_power=external_power,
+            power_available=power_available,
         )
 
         # Get call info

--- a/yoyopy/ui/screens/voip/incoming_call.py
+++ b/yoyopy/ui/screens/voip/incoming_call.py
@@ -53,12 +53,18 @@ class IncomingCallScreen(Screen):
         # Draw status bar
         current_time = datetime.now().strftime("%H:%M")
         battery = self.context.battery_percent if self.context else 100
+        charging = self.context.battery_charging if self.context else False
+        external_power = self.context.external_power if self.context else False
+        power_available = self.context.power_available if self.context else True
         signal = self.context.signal_strength if self.context else 4
 
         self.display.status_bar(
             time_str=current_time,
             battery_percent=battery,
-            signal_strength=signal
+            signal_strength=signal,
+            charging=charging,
+            external_power=external_power,
+            power_available=power_available,
         )
 
         # Draw "Incoming Call" title

--- a/yoyopy/ui/screens/voip/outgoing_call.py
+++ b/yoyopy/ui/screens/voip/outgoing_call.py
@@ -52,12 +52,18 @@ class OutgoingCallScreen(Screen):
         # Draw status bar
         current_time = datetime.now().strftime("%H:%M")
         battery = self.context.battery_percent if self.context else 100
+        charging = self.context.battery_charging if self.context else False
+        external_power = self.context.external_power if self.context else False
+        power_available = self.context.power_available if self.context else True
         signal = self.context.signal_strength if self.context else 4
 
         self.display.status_bar(
             time_str=current_time,
             battery_percent=battery,
-            signal_strength=signal
+            signal_strength=signal,
+            charging=charging,
+            external_power=external_power,
+            power_available=power_available,
         )
 
         # Draw "Calling..." title


### PR DESCRIPTION
## Summary
- add a dedicated power coordinator and periodic PiSugar polling in YoyoPodApp
- propagate battery, charging, and external-power state into AppContext, runtime, and visible status bars
- extend Pi smoke/remote helpers with optional PiSugar validation and add coverage for the new polling path

## Verification
- python -m compileall yoyopy tests demos scripts/pi_smoke.py scripts/pi_remote.py
- uv run pytest tests/test_app_orchestration.py tests/test_fsm_runtime.py tests/test_pi_remote.py -q
- uv run pytest -q
- uv run python scripts/pi_smoke.py --help
- uv run python scripts/pi_remote.py smoke --help