### PR TITLE
Add low-battery safety and graceful shutdown flow

### DIFF
--- a/config/yoyopod_config.yaml
+++ b/config/yoyopod_config.yaml
@@ -46,6 +46,13 @@ power:
   tcp_port: 8423
   timeout_seconds: 2.0
   poll_interval_seconds: 30.0
+  low_battery_warning_percent: 20.0
+  low_battery_warning_cooldown_seconds: 300.0
+  auto_shutdown_enabled: true
+  critical_shutdown_percent: 10.0
+  shutdown_delay_seconds: 15.0    # Grace period before poweroff to save state
+  shutdown_command: "sudo -n shutdown -h now"
+  shutdown_state_file: "data/last_shutdown_state.json"
 
 # Display Settings
 display:

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import threading
 from datetime import datetime
 from types import SimpleNamespace
@@ -163,10 +164,34 @@ class FakeStoppingVoIPManager:
 class FakePowerManager:
     """Minimal power manager double for app-level polling tests."""
 
-    def __init__(self, snapshots: list[PowerSnapshot], poll_interval_seconds: float = 30.0) -> None:
+    def __init__(
+        self,
+        snapshots: list[PowerSnapshot],
+        poll_interval_seconds: float = 30.0,
+        *,
+        low_battery_warning_percent: float = 20.0,
+        low_battery_warning_cooldown_seconds: float = 300.0,
+        auto_shutdown_enabled: bool = True,
+        critical_shutdown_percent: float = 10.0,
+        shutdown_delay_seconds: float = 15.0,
+        shutdown_state_file: str = "data/test_shutdown_state.json",
+    ) -> None:
         self._snapshots = snapshots
         self.refresh_calls = 0
-        self.config = SimpleNamespace(enabled=True, poll_interval_seconds=poll_interval_seconds)
+        self.config = SimpleNamespace(
+            enabled=True,
+            poll_interval_seconds=poll_interval_seconds,
+            low_battery_warning_percent=low_battery_warning_percent,
+            low_battery_warning_cooldown_seconds=low_battery_warning_cooldown_seconds,
+            auto_shutdown_enabled=auto_shutdown_enabled,
+            critical_shutdown_percent=critical_shutdown_percent,
+            shutdown_delay_seconds=shutdown_delay_seconds,
+            shutdown_command="sudo -n shutdown -h now",
+            shutdown_state_file=shutdown_state_file,
+        )
+        self.registered_shutdown_hooks: list[tuple[str, object]] = []
+        self.run_shutdown_hooks_calls = 0
+        self.shutdown_requested = False
 
     def refresh(self) -> PowerSnapshot:
         index = min(self.refresh_calls, len(self._snapshots) - 1)
@@ -176,6 +201,23 @@ class FakePowerManager:
     def get_snapshot(self) -> PowerSnapshot:
         index = max(0, min(self.refresh_calls - 1, len(self._snapshots) - 1))
         return self._snapshots[index]
+
+    def register_shutdown_hook(self, name: str, hook) -> None:
+        self.registered_shutdown_hooks.append((name, hook))
+
+    def run_shutdown_hooks(self) -> list[str]:
+        self.run_shutdown_hooks_calls += 1
+        failed_hooks: list[str] = []
+        for name, hook in self.registered_shutdown_hooks:
+            try:
+                hook()
+            except Exception:
+                failed_hooks.append(name)
+        return failed_hooks
+
+    def request_system_shutdown(self) -> bool:
+        self.shutdown_requested = True
+        return True
 
 
 def _publish_from_worker(app: YoyoPodApp, event: object) -> None:
@@ -222,6 +264,54 @@ def _build_app(playback_state: str = "stopped", auto_resume: bool = True) -> tup
     app.call_interruption_policy = CallInterruptionPolicy()
     app.auto_resume_after_call = auto_resume
     app.voip_registered = False
+    app.power_manager = None
+
+    mopidy = FakeMopidyClient(playback_state=playback_state)
+    app.mopidy_client = mopidy
+
+    app.menu_screen = FakeScreen()
+    app.now_playing_screen = FakeScreen()
+    app.playlist_screen = FakeScreen()
+    app.call_screen = FakeScreen()
+    app.contact_list_screen = FakeScreen()
+    app.incoming_call_screen = FakeIncomingCallScreen()
+    app.outgoing_call_screen = FakeScreen()
+    app.in_call_screen = FakeScreen()
+
+    screen_manager = FakeScreenManager(
+        {
+            "menu": app.menu_screen,
+            "playlists": app.playlist_screen,
+            "contacts": app.contact_list_screen,
+            "incoming_call": app.incoming_call_screen,
+            "outgoing_call": app.outgoing_call_screen,
+            "in_call": app.in_call_screen,
+        }
+    )
+    app.screen_manager = screen_manager
+    app.screen_manager.push_screen("menu")
+    app._ui_state = AppRuntimeState.MENU
+
+    app._setup_event_subscriptions()
+    app.call_coordinator.start_ringing = lambda: None
+    app.call_coordinator.stop_ringing = lambda: None
+    return app, mopidy, screen_manager
+
+
+def _build_app_with_power(
+    power_manager: FakePowerManager,
+    *,
+    playback_state: str = "stopped",
+    auto_resume: bool = True,
+) -> tuple[YoyoPodApp, FakeMopidyClient, FakeScreenManager]:
+    app = YoyoPodApp(simulate=True)
+    app.context = AppContext()
+    app.music_fsm = MusicFSM()
+    app.call_fsm = CallFSM()
+    app.call_interruption_policy = CallInterruptionPolicy()
+    app.auto_resume_after_call = auto_resume
+    app.voip_registered = False
+    app.power_manager = power_manager
 
     mopidy = FakeMopidyClient(playback_state=playback_state)
     app.mopidy_client = mopidy
@@ -607,3 +697,133 @@ def test_power_poll_honors_interval_and_tracks_unavailable_backend() -> None:
     assert app.context.power_error == "I2C not connected"
     assert app.coordinator_runtime.power_available is False
     assert app.menu_screen.render_calls == 2
+
+
+def test_low_battery_snapshot_sets_temporary_alert() -> None:
+    """A low battery snapshot should surface a temporary warning overlay."""
+
+    app, _, _ = _build_app_with_power(
+        FakePowerManager(
+            [
+                _power_snapshot(
+                    available=True,
+                    battery_percent=15.0,
+                    charging=False,
+                    power_plugged=False,
+                )
+            ],
+            low_battery_warning_percent=20.0,
+            critical_shutdown_percent=10.0,
+        )
+    )
+
+    app._poll_power_status(now=0.0, force=True)
+
+    assert app._pending_shutdown is None
+    assert app._power_alert is not None
+    assert app._power_alert.title == "Low Battery"
+    assert app._power_alert.subtitle == "15% remaining"
+
+
+def test_critical_battery_snapshot_creates_pending_shutdown() -> None:
+    """Crossing the critical threshold should schedule a delayed shutdown."""
+
+    app, _, _ = _build_app_with_power(
+        FakePowerManager(
+            [
+                _power_snapshot(
+                    available=True,
+                    battery_percent=8.0,
+                    charging=False,
+                    power_plugged=False,
+                )
+            ],
+            critical_shutdown_percent=10.0,
+            shutdown_delay_seconds=12.0,
+        )
+    )
+
+    app._poll_power_status(now=0.0, force=True)
+
+    assert app._pending_shutdown is not None
+    assert app._pending_shutdown.reason == "critical_battery"
+    assert app._pending_shutdown.battery_percent == 8.0
+    assert app.get_status()["shutdown_pending"] is True
+
+
+def test_power_restore_cancels_pending_shutdown() -> None:
+    """Restoring external power should cancel a pending graceful shutdown."""
+
+    app, _, _ = _build_app_with_power(
+        FakePowerManager(
+            [
+                _power_snapshot(
+                    available=True,
+                    battery_percent=8.0,
+                    charging=False,
+                    power_plugged=False,
+                ),
+                _power_snapshot(
+                    available=True,
+                    battery_percent=8.5,
+                    charging=True,
+                    power_plugged=True,
+                ),
+            ],
+            critical_shutdown_percent=10.0,
+        )
+    )
+
+    app._poll_power_status(now=0.0, force=True)
+    assert app._pending_shutdown is not None
+
+    app._poll_power_status(now=30.0, force=True)
+
+    assert app._pending_shutdown is None
+    assert app._power_alert is not None
+    assert app._power_alert.title == "Power Restored"
+
+
+def test_pending_shutdown_runs_hooks_and_requests_system_poweroff(tmp_path) -> None:
+    """The delayed shutdown path should save state, stop the app, and request poweroff."""
+
+    shutdown_state_file = tmp_path / "last_shutdown_state.json"
+    power_manager = FakePowerManager(
+        [
+            _power_snapshot(
+                available=True,
+                battery_percent=8.0,
+                charging=False,
+                power_plugged=False,
+            )
+        ],
+        critical_shutdown_percent=10.0,
+        shutdown_delay_seconds=0.0,
+        shutdown_state_file=str(shutdown_state_file),
+    )
+    app, _, _ = _build_app_with_power(power_manager)
+    stop_calls: list[str] = []
+
+    def fake_stop() -> None:
+        stop_calls.append("stop")
+        app._stopping = True
+
+    app.stop = fake_stop
+    app._register_power_shutdown_hooks()
+    app._poll_power_status(now=0.0, force=True)
+
+    assert [name for name, _ in power_manager.registered_shutdown_hooks] == ["save_shutdown_state"]
+    assert app._pending_shutdown is not None
+
+    app._process_pending_shutdown(app._pending_shutdown.execute_at)
+
+    assert stop_calls == ["stop"]
+    assert power_manager.run_shutdown_hooks_calls == 1
+    assert power_manager.shutdown_requested is True
+    assert app._shutdown_completed is True
+
+    payload = json.loads(shutdown_state_file.read_text(encoding="utf-8"))
+    assert payload["state"] == "menu"
+    assert payload["current_screen"] == "menu"
+    assert payload["battery_percent"] == 8
+    assert payload["external_power"] is False

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -34,6 +34,13 @@ def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> Non
     assert settings.power.transport == "auto"
     assert settings.power.socket_path == "/tmp/pisugar-server.sock"
     assert settings.power.tcp_port == 8423
+    assert settings.power.low_battery_warning_percent == 20.0
+    assert settings.power.low_battery_warning_cooldown_seconds == 300.0
+    assert settings.power.auto_shutdown_enabled is True
+    assert settings.power.critical_shutdown_percent == 10.0
+    assert settings.power.shutdown_delay_seconds == 15.0
+    assert settings.power.shutdown_command == "sudo -n shutdown -h now"
+    assert settings.power.shutdown_state_file == "data/last_shutdown_state.json"
     assert settings.display.hardware == "auto"
 
 
@@ -67,6 +74,10 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     monkeypatch.setenv("YOYOPOD_WHISPLAY_LONG_HOLD_MS", "900")
     monkeypatch.setenv("YOYOPOD_POWER_TRANSPORT", "tcp")
     monkeypatch.setenv("YOYOPOD_PISUGAR_PORT", "9001")
+    monkeypatch.setenv("YOYOPOD_LOW_BATTERY_WARNING_PERCENT", "17.5")
+    monkeypatch.setenv("YOYOPOD_CRITICAL_BATTERY_SHUTDOWN_PERCENT", "8.5")
+    monkeypatch.setenv("YOYOPOD_POWER_SHUTDOWN_DELAY_SECONDS", "22.0")
+    monkeypatch.setenv("YOYOPOD_POWER_SHUTDOWN_COMMAND", "sudo -n poweroff")
     monkeypatch.setenv("YOYOPOD_DISPLAY", "whisplay")
 
     config_manager = ConfigManager(config_dir=str(tmp_path))
@@ -81,6 +92,10 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     assert settings.input.whisplay_long_hold_ms == 900
     assert settings.power.transport == "tcp"
     assert settings.power.tcp_port == 9001
+    assert settings.power.low_battery_warning_percent == 17.5
+    assert settings.power.critical_shutdown_percent == 8.5
+    assert settings.power.shutdown_delay_seconds == 22.0
+    assert settings.power.shutdown_command == "sudo -n poweroff"
     assert settings.display.hardware == "whisplay"
     assert settings.logging.level == "DEBUG"
     assert config_dict["audio"]["mopidy_port"] == 7788

--- a/tests/test_power_manager.py
+++ b/tests/test_power_manager.py
@@ -77,6 +77,10 @@ power:
   tcp_host: "192.168.1.10"
   tcp_port: 9000
   timeout_seconds: 5.0
+  low_battery_warning_percent: 18.0
+  critical_shutdown_percent: 7.5
+  shutdown_delay_seconds: 20.0
+  shutdown_command: "sudo -n poweroff"
 """.strip(),
         encoding="utf-8",
     )
@@ -89,4 +93,51 @@ power:
     assert manager.config.tcp_host == "192.168.1.10"
     assert manager.config.tcp_port == 9000
     assert manager.config.timeout_seconds == 5.0
+    assert manager.config.low_battery_warning_percent == 18.0
+    assert manager.config.critical_shutdown_percent == 7.5
+    assert manager.config.shutdown_delay_seconds == 20.0
+    assert manager.config.shutdown_command == "sudo -n poweroff"
+
+
+def test_power_manager_runs_shutdown_hooks_and_reports_failures() -> None:
+    """Shutdown hooks should all run while reporting the ones that fail."""
+
+    snapshot = PowerSnapshot(
+        available=True,
+        checked_at=datetime(2026, 4, 4, 12, 0, 0),
+    )
+    manager = PowerManager(PowerConfig(), backend=FakeBackend(snapshot))
+    calls: list[str] = []
+
+    manager.register_shutdown_hook("save", lambda: calls.append("save"))
+
+    def failing_hook() -> None:
+        calls.append("failing")
+        raise RuntimeError("hook boom")
+
+    manager.register_shutdown_hook("failing", failing_hook)
+
+    failed_hooks = manager.run_shutdown_hooks()
+
+    assert calls == ["save", "failing"]
+    assert failed_hooks == ["failing"]
+
+
+def test_power_manager_request_system_shutdown_uses_configured_command() -> None:
+    """The configured shutdown command should be split and passed to the runner."""
+
+    snapshot = PowerSnapshot(
+        available=True,
+        checked_at=datetime(2026, 4, 4, 12, 0, 0),
+    )
+    commands: list[list[str]] = []
+
+    manager = PowerManager(
+        PowerConfig(shutdown_command="sudo -n shutdown -h now"),
+        backend=FakeBackend(snapshot),
+        shutdown_runner=lambda command: commands.append(command) or 0,
+    )
+
+    assert manager.request_system_shutdown() is True
+    assert commands == [["sudo", "-n", "shutdown", "-h", "now"]]
 

--- a/tests/test_power_policies.py
+++ b/tests/test_power_policies.py
@@ -1,0 +1,96 @@
+"""Tests for low-battery warning and graceful shutdown policy logic."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from yoyopy.power import (
+    BatteryState,
+    GracefulShutdownCancelled,
+    GracefulShutdownRequested,
+    LowBatteryWarningRaised,
+    PowerConfig,
+    PowerSafetyPolicy,
+    PowerSnapshot,
+)
+
+
+def _snapshot(
+    *,
+    available: bool = True,
+    battery_percent: float | None = None,
+    charging: bool | None = None,
+    power_plugged: bool | None = None,
+) -> PowerSnapshot:
+    return PowerSnapshot(
+        available=available,
+        checked_at=datetime(2026, 4, 4, 12, 0, 0),
+        battery=BatteryState(
+            level_percent=battery_percent,
+            charging=charging,
+            power_plugged=power_plugged,
+        ),
+    )
+
+
+def test_power_policy_raises_low_battery_warning_with_cooldown() -> None:
+    """Warnings should be rate-limited while battery stays below the warning threshold."""
+
+    policy = PowerSafetyPolicy(
+        PowerConfig(
+            low_battery_warning_percent=20.0,
+            low_battery_warning_cooldown_seconds=300.0,
+            critical_shutdown_percent=10.0,
+        )
+    )
+    snapshot = _snapshot(battery_percent=15.0, charging=False, power_plugged=False)
+
+    first_events = policy.evaluate(snapshot, now=100.0)
+    second_events = policy.evaluate(snapshot, now=200.0)
+    third_events = policy.evaluate(snapshot, now=401.0)
+
+    assert len(first_events) == 1
+    assert isinstance(first_events[0], LowBatteryWarningRaised)
+    assert first_events[0].battery_percent == 15.0
+    assert second_events == []
+    assert len(third_events) == 1
+    assert isinstance(third_events[0], LowBatteryWarningRaised)
+
+
+def test_power_policy_requests_shutdown_once_at_critical_threshold() -> None:
+    """Crossing the critical threshold should emit one shutdown request until reset."""
+
+    policy = PowerSafetyPolicy(
+        PowerConfig(
+            low_battery_warning_percent=20.0,
+            critical_shutdown_percent=10.0,
+            shutdown_delay_seconds=15.0,
+        )
+    )
+    snapshot = _snapshot(battery_percent=9.0, charging=False, power_plugged=False)
+
+    first_events = policy.evaluate(snapshot, now=10.0)
+    second_events = policy.evaluate(snapshot, now=20.0)
+
+    assert len(first_events) == 1
+    assert isinstance(first_events[0], GracefulShutdownRequested)
+    assert first_events[0].delay_seconds == 15.0
+    assert second_events == []
+
+
+def test_power_policy_cancels_pending_shutdown_when_external_power_returns() -> None:
+    """Restoring external power should cancel a pending critical-battery shutdown."""
+
+    policy = PowerSafetyPolicy(PowerConfig(critical_shutdown_percent=10.0))
+
+    critical_snapshot = _snapshot(battery_percent=8.5, charging=False, power_plugged=False)
+    restored_snapshot = _snapshot(battery_percent=8.5, charging=True, power_plugged=True)
+
+    request_events = policy.evaluate(critical_snapshot, now=50.0)
+    cancel_events = policy.evaluate(restored_snapshot, now=55.0)
+
+    assert len(request_events) == 1
+    assert isinstance(request_events[0], GracefulShutdownRequested)
+    assert len(cancel_events) == 1
+    assert isinstance(cancel_events[0], GracefulShutdownCancelled)
+    assert cancel_events[0].reason == "external_power_restored"

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -6,8 +6,10 @@ Main application bootstrap and lifecycle coordinator.
 
 from __future__ import annotations
 
+import json
 import threading
 import time
+from pathlib import Path
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -27,7 +29,12 @@ from yoyopy.coordinators import (
 from yoyopy.event_bus import EventBus
 from yoyopy.events import RecoveryAttemptCompletedEvent, ScreenChangedEvent
 from yoyopy.fsm import CallFSM, CallInterruptionPolicy, MusicFSM
-from yoyopy.power import PowerManager
+from yoyopy.power import (
+    GracefulShutdownCancelled,
+    GracefulShutdownRequested,
+    LowBatteryWarningRaised,
+    PowerManager,
+)
 from yoyopy.ui.display import Display
 from yoyopy.ui.input import InputManager, InteractionProfile, get_input_manager
 from yoyopy.ui.screens import (
@@ -59,6 +66,26 @@ class _RecoveryState:
         self.next_attempt_at = 0.0
         self.delay_seconds = 1.0
         self.in_flight = False
+
+
+@dataclass(slots=True)
+class _PowerAlert:
+    """Short-lived full-screen power alert overlay."""
+
+    title: str
+    subtitle: str
+    color: tuple[int, int, int]
+    expires_at: float
+
+
+@dataclass(slots=True)
+class _PendingShutdown:
+    """Track a delayed low-battery shutdown countdown."""
+
+    reason: str
+    requested_at: float
+    execute_at: float
+    battery_percent: float | None
 
 
 class YoyoPodApp:
@@ -121,6 +148,18 @@ class YoyoPodApp:
             RecoveryAttemptCompletedEvent,
             self._handle_recovery_attempt_completed_event,
         )
+        self.event_bus.subscribe(
+            LowBatteryWarningRaised,
+            self._handle_low_battery_warning_event,
+        )
+        self.event_bus.subscribe(
+            GracefulShutdownRequested,
+            self._handle_graceful_shutdown_requested_event,
+        )
+        self.event_bus.subscribe(
+            GracefulShutdownCancelled,
+            self._handle_graceful_shutdown_cancelled_event,
+        )
 
         # Extracted coordinators
         self.coordinator_runtime: Optional[CoordinatorRuntime] = None
@@ -134,6 +173,10 @@ class YoyoPodApp:
         self._mopidy_recovery = _RecoveryState()
         self._next_power_poll_at = 0.0
         self._power_available: bool | None = None
+        self._power_alert: _PowerAlert | None = None
+        self._pending_shutdown: _PendingShutdown | None = None
+        self._power_hooks_registered = False
+        self._shutdown_completed = False
         self._stopping = False
 
         logger.info("=" * 60)
@@ -183,6 +226,7 @@ class YoyoPodApp:
             self._setup_event_subscriptions()
             self._setup_voip_callbacks()
             self._setup_music_callbacks()
+            self._register_power_shutdown_hooks()
             self._poll_power_status(force=True, now=time.monotonic())
 
             logger.info("YoyoPod setup complete")
@@ -192,7 +236,6 @@ class YoyoPodApp:
             return False
 
     def _load_configuration(self) -> bool:
-
         """Load YoyoPod configuration."""
         logger.info("Loading configuration...")
 
@@ -305,7 +348,7 @@ class YoyoPodApp:
             self.power_manager = PowerManager.from_config_manager(self.config_manager)
             if self.power_manager.config.enabled:
                 logger.info(
-                    "    Poll interval: %.1fs",
+                    "    Poll interval: {:.1f}s",
                     self.power_manager.config.poll_interval_seconds,
                 )
             else:
@@ -498,6 +541,113 @@ class YoyoPodApp:
             event.recovery_now,
         )
 
+    def _handle_low_battery_warning_event(self, event: LowBatteryWarningRaised) -> None:
+        """Show a temporary low-battery alert when the warning threshold is crossed."""
+        logger.warning(
+            "Low battery warning: {:.1f}% remaining (threshold {:.1f}%)",
+            event.battery_percent,
+            event.threshold_percent,
+        )
+        self._set_power_alert(
+            title="Low Battery",
+            subtitle=f"{event.battery_percent:.0f}% remaining",
+            color=self.display.COLOR_YELLOW if self.display is not None else (255, 255, 0),
+            duration_seconds=4.0,
+        )
+
+    def _handle_graceful_shutdown_requested_event(
+        self,
+        event: GracefulShutdownRequested,
+    ) -> None:
+        """Start a delayed graceful shutdown countdown for critical battery."""
+        if self._pending_shutdown is not None:
+            return
+
+        requested_at = time.monotonic()
+        self._pending_shutdown = _PendingShutdown(
+            reason=event.reason,
+            requested_at=requested_at,
+            execute_at=requested_at + max(0.0, event.delay_seconds),
+            battery_percent=event.snapshot.battery.level_percent,
+        )
+        logger.warning(
+            "Critical battery detected; shutdown in {:.1f}s",
+            event.delay_seconds,
+        )
+
+    def _handle_graceful_shutdown_cancelled_event(
+        self,
+        event: GracefulShutdownCancelled,
+    ) -> None:
+        """Cancel a pending battery-triggered shutdown when power returns."""
+        if self._pending_shutdown is None:
+            return
+
+        logger.info(f"Graceful shutdown cancelled ({event.reason})")
+        self._pending_shutdown = None
+        self._set_power_alert(
+            title="Power Restored",
+            subtitle="Shutdown cancelled",
+            color=self.display.COLOR_GREEN if self.display is not None else (0, 255, 0),
+            duration_seconds=3.0,
+        )
+
+    def _register_power_shutdown_hooks(self) -> None:
+        """Register built-in shutdown hooks once the power manager is available."""
+        if self.power_manager is None or self._power_hooks_registered:
+            return
+
+        self.power_manager.register_shutdown_hook(
+            "save_shutdown_state",
+            self._save_shutdown_state,
+        )
+        self._power_hooks_registered = True
+
+    def _save_shutdown_state(self) -> None:
+        """Persist a small runtime snapshot before graceful poweroff."""
+        if self.power_manager is None:
+            return
+
+        snapshot_path = Path(self.power_manager.config.shutdown_state_file)
+        if not snapshot_path.is_absolute():
+            snapshot_path = Path.cwd() / snapshot_path
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+
+        current_screen = None
+        if self.screen_manager is not None and self.screen_manager.get_current_screen() is not None:
+            current_screen = self.screen_manager.get_current_screen().route_name
+
+        current_track = None
+        if self.context is not None and self.context.get_current_track() is not None:
+            track = self.context.get_current_track()
+            current_track = {
+                "title": track.title,
+                "artist": track.artist,
+            }
+
+        payload = {
+            "saved_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "state": self.coordinator_runtime.get_state_name() if self.coordinator_runtime else None,
+            "current_screen": current_screen,
+            "battery_percent": self.context.battery_percent if self.context else None,
+            "battery_charging": self.context.battery_charging if self.context else None,
+            "external_power": self.context.external_power if self.context else None,
+            "voip_registered": self.voip_registered,
+            "music_available": self.mopidy_client.is_connected if self.mopidy_client else False,
+            "playback": {
+                "is_playing": self.context.playback.is_playing if self.context else False,
+                "is_paused": self.context.playback.is_paused if self.context else False,
+                "volume": self.context.playback.volume if self.context else None,
+            },
+            "track": current_track,
+        }
+
+        snapshot_path.write_text(
+            json.dumps(payload, indent=2),
+            encoding="utf-8",
+        )
+        logger.info(f"Saved shutdown state to {snapshot_path}")
+
     def _ensure_coordinators(self) -> None:
         """Build coordinator helpers around the initialized runtime."""
         if self.coordinator_runtime is not None:
@@ -605,6 +755,107 @@ class YoyoPodApp:
 
         interval = max(1.0, self.power_manager.config.poll_interval_seconds)
         self._next_power_poll_at = poll_now + interval
+
+    def _set_power_alert(
+        self,
+        *,
+        title: str,
+        subtitle: str,
+        color: tuple[int, int, int],
+        duration_seconds: float,
+    ) -> None:
+        """Queue a short-lived fullscreen power alert overlay."""
+        self._power_alert = _PowerAlert(
+            title=title,
+            subtitle=subtitle,
+            color=color,
+            expires_at=time.monotonic() + max(0.0, duration_seconds),
+        )
+
+    def _render_power_overlay(self, title: str, subtitle: str, color: tuple[int, int, int]) -> None:
+        """Render a simple fullscreen power-status overlay."""
+        if self.display is None:
+            return
+
+        self.display.clear(self.display.COLOR_BLACK)
+        title_size = 24
+        subtitle_size = 14
+        title_width, title_height = self.display.get_text_size(title, title_size)
+        subtitle_width, _ = self.display.get_text_size(subtitle, subtitle_size)
+        title_x = (self.display.WIDTH - title_width) // 2
+        subtitle_x = (self.display.WIDTH - subtitle_width) // 2
+        title_y = max(self.display.STATUS_BAR_HEIGHT + 30, (self.display.HEIGHT // 2) - 30)
+        subtitle_y = title_y + title_height + 18
+
+        self.display.text(title, title_x, title_y, color=color, font_size=title_size)
+        self.display.text(
+            subtitle,
+            subtitle_x,
+            subtitle_y,
+            color=self.display.COLOR_WHITE,
+            font_size=subtitle_size,
+        )
+        self.display.update()
+
+    def _update_power_overlays(self, now: float) -> bool:
+        """Render pending power overlays and return True when one is active."""
+        if self._pending_shutdown is not None:
+            seconds_remaining = max(0, int(self._pending_shutdown.execute_at - now + 0.999))
+            subtitle = "Saving state and powering off"
+            if seconds_remaining > 0:
+                subtitle = f"Shutdown in {seconds_remaining}s"
+            self._render_power_overlay(
+                "Critical Battery",
+                subtitle,
+                self.display.COLOR_RED if self.display is not None else (255, 0, 0),
+            )
+            return True
+
+        if self._power_alert is None:
+            return False
+
+        if now >= self._power_alert.expires_at:
+            self._power_alert = None
+            if self.screen_manager is not None and self.screen_manager.get_current_screen() is not None:
+                self.screen_manager.get_current_screen().render()
+            return False
+
+        self._render_power_overlay(
+            self._power_alert.title,
+            self._power_alert.subtitle,
+            self._power_alert.color,
+        )
+        return True
+
+    def _process_pending_shutdown(self, now: float) -> None:
+        """Execute a delayed shutdown when its grace period expires."""
+        if self._pending_shutdown is None or now < self._pending_shutdown.execute_at:
+            return
+
+        self._execute_pending_shutdown()
+
+    def _execute_pending_shutdown(self) -> None:
+        """Run graceful-shutdown hooks, stop the app, and request system poweroff."""
+        if self._shutdown_completed:
+            return
+
+        self._render_power_overlay(
+            "Powering Off",
+            "Saving state...",
+            self.display.COLOR_RED if self.display is not None else (255, 0, 0),
+        )
+
+        if self.power_manager is not None:
+            failed_hooks = self.power_manager.run_shutdown_hooks()
+            if failed_hooks:
+                logger.warning(f"Shutdown hooks failed: {', '.join(failed_hooks)}")
+
+        self.stop()
+
+        if self.power_manager is not None:
+            self.power_manager.request_system_shutdown()
+
+        self._shutdown_completed = True
 
     def _attempt_voip_recovery(self, recovery_now: float) -> None:
         """Restart the VoIP backend when it is not running."""
@@ -754,13 +1005,22 @@ class YoyoPodApp:
                 logger.info("  (Incoming calls and track changes will trigger callbacks)")
                 logger.info("")
 
-            while True:
+            while not self._stopping:
                 time.sleep(0.1)
                 self._process_pending_main_thread_actions()
                 self._attempt_manager_recovery()
                 self._poll_power_status()
+                monotonic_now = time.monotonic()
+                self._process_pending_shutdown(monotonic_now)
+                if self._shutdown_completed:
+                    break
 
                 current_time = time.time()
+                overlay_active = self._update_power_overlays(monotonic_now)
+                if overlay_active:
+                    last_screen_update = current_time
+                    continue
+
                 if current_time - last_screen_update >= screen_update_interval:
                     self._update_now_playing_if_needed()
                     self._update_in_call_if_needed()
@@ -769,6 +1029,9 @@ class YoyoPodApp:
             logger.info("\n" + "=" * 60)
             logger.info("Shutting down...")
             logger.info("=" * 60)
+        finally:
+            if not self._shutdown_completed and not self._stopping:
+                self.stop()
 
     def stop(self) -> None:
         """Clean up and stop the application."""
@@ -807,6 +1070,13 @@ class YoyoPodApp:
 
     def get_status(self) -> Dict[str, Any]:
         """Return the current application status."""
+        pending_shutdown_in_seconds = None
+        if self._pending_shutdown is not None:
+            pending_shutdown_in_seconds = max(
+                0.0,
+                self._pending_shutdown.execute_at - time.monotonic(),
+            )
+
         return {
             "state": self.coordinator_runtime.get_state_name(),
             "voip_registered": self.voip_registered,
@@ -818,4 +1088,8 @@ class YoyoPodApp:
             "battery_percent": self.context.battery_percent if self.context else None,
             "battery_charging": self.context.battery_charging if self.context else None,
             "external_power": self.context.external_power if self.context else None,
+            "shutdown_pending": self._pending_shutdown is not None,
+            "shutdown_reason": self._pending_shutdown.reason if self._pending_shutdown else None,
+            "shutdown_in_seconds": pending_shutdown_in_seconds,
+            "shutdown_completed": self._shutdown_completed,
         }

--- a/yoyopy/config/models.py
+++ b/yoyopy/config/models.py
@@ -215,6 +215,34 @@ class AppPowerConfig:
         default=30.0,
         env="YOYOPOD_POWER_POLL_INTERVAL_SECONDS",
     )
+    low_battery_warning_percent: float = config_value(
+        default=20.0,
+        env="YOYOPOD_LOW_BATTERY_WARNING_PERCENT",
+    )
+    low_battery_warning_cooldown_seconds: float = config_value(
+        default=300.0,
+        env="YOYOPOD_LOW_BATTERY_WARNING_COOLDOWN_SECONDS",
+    )
+    auto_shutdown_enabled: bool = config_value(
+        default=True,
+        env="YOYOPOD_AUTO_SHUTDOWN_ENABLED",
+    )
+    critical_shutdown_percent: float = config_value(
+        default=10.0,
+        env="YOYOPOD_CRITICAL_BATTERY_SHUTDOWN_PERCENT",
+    )
+    shutdown_delay_seconds: float = config_value(
+        default=15.0,
+        env="YOYOPOD_POWER_SHUTDOWN_DELAY_SECONDS",
+    )
+    shutdown_command: str = config_value(
+        default="sudo -n shutdown -h now",
+        env="YOYOPOD_POWER_SHUTDOWN_COMMAND",
+    )
+    shutdown_state_file: str = config_value(
+        default="data/last_shutdown_state.json",
+        env="YOYOPOD_POWER_SHUTDOWN_STATE_FILE",
+    )
 
 
 @dataclass(slots=True)

--- a/yoyopy/coordinators/power.py
+++ b/yoyopy/coordinators/power.py
@@ -4,6 +4,9 @@ Power telemetry coordination for YoyoPod.
 
 from __future__ import annotations
 
+import time
+from typing import Callable
+
 from loguru import logger
 
 from yoyopy.app_context import AppContext
@@ -11,7 +14,11 @@ from yoyopy.coordinators.runtime import CoordinatorRuntime
 from yoyopy.coordinators.screen import ScreenCoordinator
 from yoyopy.event_bus import EventBus
 from yoyopy.power import (
+    GracefulShutdownCancelled,
+    GracefulShutdownRequested,
+    LowBatteryWarningRaised,
     PowerAvailabilityChanged,
+    PowerSafetyPolicy,
     PowerSnapshot,
     PowerSnapshotUpdated,
 )
@@ -25,10 +32,14 @@ class PowerCoordinator:
         runtime: CoordinatorRuntime,
         screen_coordinator: ScreenCoordinator,
         context: AppContext,
+        now_provider: Callable[[], float] | None = None,
     ) -> None:
         self.runtime = runtime
         self.screen_coordinator = screen_coordinator
         self.context = context
+        power_config = runtime.power_manager.config if runtime.power_manager is not None else None
+        self.policy = PowerSafetyPolicy(power_config) if power_config is not None else None
+        self.now_provider = now_provider or time.monotonic
         self._event_bus: EventBus | None = None
         self._bound = False
 
@@ -86,6 +97,12 @@ class PowerCoordinator:
         if current_signature != previous_signature:
             self.screen_coordinator.refresh_current_screen()
 
+        if self.policy is None or self._event_bus is None:
+            return
+
+        for event in self.policy.evaluate(snapshot, now=self.now_provider()):
+            self._event_bus.publish(event)
+
     def handle_availability_change(self, available: bool, reason: str) -> None:
         """Track power backend reachability for the runtime."""
         self.runtime.set_power_available(available)
@@ -94,3 +111,6 @@ class PowerCoordinator:
             return
 
         logger.warning(f"Power backend unavailable ({reason or 'unknown'})")
+        if self.policy is not None:
+            self.policy.shutdown_requested = False
+            self.policy.next_warning_at = 0.0

--- a/yoyopy/power/__init__.py
+++ b/yoyopy/power/__init__.py
@@ -9,7 +9,13 @@ from yoyopy.power.backend import (
     PowerTransportError,
     build_pisugar_transport,
 )
-from yoyopy.power.events import PowerAvailabilityChanged, PowerSnapshotUpdated
+from yoyopy.power.events import (
+    GracefulShutdownCancelled,
+    GracefulShutdownRequested,
+    LowBatteryWarningRaised,
+    PowerAvailabilityChanged,
+    PowerSnapshotUpdated,
+)
 from yoyopy.power.manager import PowerManager
 from yoyopy.power.models import (
     BatteryState,
@@ -19,6 +25,7 @@ from yoyopy.power.models import (
     RTCState,
     ShutdownState,
 )
+from yoyopy.power.policies import PowerSafetyPolicy
 
 __all__ = [
     "PowerBackend",
@@ -37,5 +44,9 @@ __all__ = [
     "PowerSnapshot",
     "PowerSnapshotUpdated",
     "PowerAvailabilityChanged",
+    "LowBatteryWarningRaised",
+    "GracefulShutdownRequested",
+    "GracefulShutdownCancelled",
+    "PowerSafetyPolicy",
 ]
 

--- a/yoyopy/power/events.py
+++ b/yoyopy/power/events.py
@@ -21,3 +21,28 @@ class PowerAvailabilityChanged:
     available: bool
     reason: str = ""
 
+
+@dataclass(frozen=True, slots=True)
+class LowBatteryWarningRaised:
+    """Published when battery reaches the warning threshold."""
+
+    threshold_percent: float
+    battery_percent: float
+    snapshot: PowerSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class GracefulShutdownRequested:
+    """Published when battery reaches the critical shutdown threshold."""
+
+    reason: str
+    delay_seconds: float
+    snapshot: PowerSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class GracefulShutdownCancelled:
+    """Published when a pending battery shutdown is cancelled."""
+
+    reason: str
+

--- a/yoyopy/power/manager.py
+++ b/yoyopy/power/manager.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import shlex
+import subprocess
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from loguru import logger
 
@@ -14,12 +16,23 @@ if TYPE_CHECKING:
     from yoyopy.config import ConfigManager
 
 
+ShutdownHook = Callable[[], None]
+ShutdownRunner = Callable[[list[str]], int]
+
+
 class PowerManager:
     """Coordinate power backend access and retain the latest snapshot."""
 
-    def __init__(self, config: PowerConfig, backend: PowerBackend | None = None) -> None:
+    def __init__(
+        self,
+        config: PowerConfig,
+        backend: PowerBackend | None = None,
+        shutdown_runner: ShutdownRunner | None = None,
+    ) -> None:
         self.config = config
         self.backend = backend or PiSugarBackend(config)
+        self._shutdown_runner = shutdown_runner or self._default_shutdown_runner
+        self._shutdown_hooks: list[tuple[str, ShutdownHook]] = []
         self.last_snapshot = PowerSnapshot(
             available=False,
             checked_at=datetime.now(),
@@ -61,4 +74,42 @@ class PowerManager:
         """Return the current battery percentage when available."""
         snapshot = self.get_snapshot(refresh=refresh)
         return snapshot.battery.level_percent
+
+    def register_shutdown_hook(self, name: str, hook: ShutdownHook) -> None:
+        """Register one callable to run before a graceful poweroff."""
+        self._shutdown_hooks.append((name, hook))
+
+    def run_shutdown_hooks(self) -> list[str]:
+        """Run graceful-shutdown hooks and return any failing hook names."""
+        failed_hooks: list[str] = []
+        for name, hook in self._shutdown_hooks:
+            try:
+                hook()
+            except Exception as exc:
+                logger.error(f"Shutdown hook failed ({name}): {exc}")
+                failed_hooks.append(name)
+        return failed_hooks
+
+    def request_system_shutdown(self) -> bool:
+        """Execute the configured system shutdown command."""
+        command = shlex.split(self.config.shutdown_command)
+        if not command:
+            logger.warning("No power shutdown command configured")
+            return False
+
+        return_code = self._shutdown_runner(command)
+        if return_code != 0:
+            logger.error(
+                "System shutdown command failed (code {}): {}",
+                return_code,
+                self.config.shutdown_command,
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _default_shutdown_runner(command: list[str]) -> int:
+        """Execute the real shutdown command via subprocess."""
+        completed = subprocess.run(command, check=False)
+        return completed.returncode
 

--- a/yoyopy/power/models.py
+++ b/yoyopy/power/models.py
@@ -22,6 +22,13 @@ class PowerConfig:
     tcp_port: int = 8423
     timeout_seconds: float = 2.0
     poll_interval_seconds: float = 30.0
+    low_battery_warning_percent: float = 20.0
+    low_battery_warning_cooldown_seconds: float = 300.0
+    auto_shutdown_enabled: bool = True
+    critical_shutdown_percent: float = 10.0
+    shutdown_delay_seconds: float = 15.0
+    shutdown_command: str = "sudo -n shutdown -h now"
+    shutdown_state_file: str = "data/last_shutdown_state.json"
 
     @staticmethod
     def from_config_manager(config_manager: "ConfigManager") -> "PowerConfig":
@@ -37,6 +44,13 @@ class PowerConfig:
             tcp_port=settings.tcp_port,
             timeout_seconds=settings.timeout_seconds,
             poll_interval_seconds=settings.poll_interval_seconds,
+            low_battery_warning_percent=settings.low_battery_warning_percent,
+            low_battery_warning_cooldown_seconds=settings.low_battery_warning_cooldown_seconds,
+            auto_shutdown_enabled=settings.auto_shutdown_enabled,
+            critical_shutdown_percent=settings.critical_shutdown_percent,
+            shutdown_delay_seconds=settings.shutdown_delay_seconds,
+            shutdown_command=settings.shutdown_command,
+            shutdown_state_file=settings.shutdown_state_file,
         )
 
 

--- a/yoyopy/power/policies.py
+++ b/yoyopy/power/policies.py
@@ -1,0 +1,66 @@
+"""Safety policies for low-battery warning and graceful shutdown."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from yoyopy.power.events import (
+    GracefulShutdownCancelled,
+    GracefulShutdownRequested,
+    LowBatteryWarningRaised,
+)
+from yoyopy.power.models import PowerConfig, PowerSnapshot
+
+
+@dataclass(slots=True)
+class PowerSafetyPolicy:
+    """Track warning/shutdown state derived from power snapshots."""
+
+    config: PowerConfig
+    next_warning_at: float = 0.0
+    shutdown_requested: bool = False
+
+    def evaluate(self, snapshot: PowerSnapshot, now: float) -> list[object]:
+        """Return policy events triggered by the latest power snapshot."""
+        if not self.config.enabled or not snapshot.available:
+            return []
+
+        battery_percent = snapshot.battery.level_percent
+        if battery_percent is None:
+            return []
+
+        has_external_power = bool(snapshot.battery.power_plugged) or bool(snapshot.battery.charging)
+        if has_external_power:
+            self.next_warning_at = 0.0
+            if self.shutdown_requested:
+                self.shutdown_requested = False
+                return [GracefulShutdownCancelled(reason="external_power_restored")]
+            return []
+
+        if self.config.auto_shutdown_enabled and battery_percent <= self.config.critical_shutdown_percent:
+            if not self.shutdown_requested:
+                self.shutdown_requested = True
+                return [
+                    GracefulShutdownRequested(
+                        reason="critical_battery",
+                        delay_seconds=self.config.shutdown_delay_seconds,
+                        snapshot=snapshot,
+                    )
+                ]
+            return []
+
+        if battery_percent > self.config.low_battery_warning_percent:
+            self.next_warning_at = 0.0
+            return []
+
+        if now < self.next_warning_at:
+            return []
+
+        self.next_warning_at = now + self.config.low_battery_warning_cooldown_seconds
+        return [
+            LowBatteryWarningRaised(
+                threshold_percent=self.config.low_battery_warning_percent,
+                battery_percent=battery_percent,
+                snapshot=snapshot,
+            )
+        ]


### PR DESCRIPTION
## Summary
- add typed low-battery warning and graceful shutdown power events plus a safety policy
- wire delayed shutdown overlays, shutdown hooks, and poweroff requests into the app loop
- add coverage for power policy cooldowns, shutdown hooks, config defaults, and app-level shutdown flow

## Testing
- python -m compileall yoyopy tests demos scripts
- uv run pytest tests/test_power_policies.py tests/test_power_manager.py tests/test_app_orchestration.py tests/test_config_models.py -q
- uv run pytest -q