### PR TITLE
Add screen timeout and usage tracking

### DIFF
--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -22,6 +22,7 @@ from yoyopy.events import (
     RecoveryAttemptCompletedEvent,
     RegistrationChangedEvent,
     TrackChangedEvent,
+    UserActivityEvent,
     VoIPAvailabilityChangedEvent,
 )
 from yoyopy.fsm import (
@@ -54,6 +55,23 @@ class FakeIncomingCallScreen(FakeScreen):
         self.caller_address = ""
         self.caller_name = "Unknown"
         self.ring_animation_frame = 0
+
+
+class FakeDisplay:
+    """Minimal display double for screen-power tests."""
+
+    COLOR_RED = (255, 0, 0)
+    COLOR_YELLOW = (255, 255, 0)
+    COLOR_GREEN = (0, 255, 0)
+    COLOR_WHITE = (255, 255, 255)
+    COLOR_BLACK = (0, 0, 0)
+    COLOR_CYAN = (0, 255, 255)
+
+    def __init__(self) -> None:
+        self.set_backlight_calls: list[float] = []
+
+    def set_backlight(self, brightness: float) -> None:
+        self.set_backlight_calls.append(brightness)
 
 
 class FakeScreenManager:
@@ -697,6 +715,75 @@ def test_power_poll_honors_interval_and_tracks_unavailable_backend() -> None:
     assert app.context.power_error == "I2C not connected"
     assert app.coordinator_runtime.power_available is False
     assert app.menu_screen.render_calls == 2
+
+
+def test_screen_timeout_turns_backlight_off_after_inactivity() -> None:
+    """Inactivity beyond the configured timeout should sleep the screen."""
+
+    app, _, _ = _build_app(playback_state="stopped")
+    app.display = FakeDisplay()
+    app.app_settings = SimpleNamespace(
+        ui=SimpleNamespace(screen_timeout_seconds=300),
+        display=SimpleNamespace(brightness=80, backlight_timeout_seconds=30),
+    )
+
+    app._screen_timeout_seconds = app._resolve_screen_timeout_seconds()
+    app._active_brightness = app._resolve_active_brightness()
+    app._configure_screen_power(initial_now=0.0)
+    app._update_screen_power(31.0)
+
+    assert app.display.set_backlight_calls == [0.8, 0.0]
+    assert app.context.screen_awake is False
+    assert app.context.screen_on_seconds == 31
+    assert app.context.screen_idle_seconds == 31
+
+
+def test_user_activity_event_wakes_screen_and_refreshes_current_screen() -> None:
+    """Queued user activity should wake a sleeping screen and re-render the visible route."""
+
+    app, _, _ = _build_app(playback_state="stopped")
+    app.display = FakeDisplay()
+    app.app_settings = SimpleNamespace(
+        ui=SimpleNamespace(screen_timeout_seconds=300),
+        display=SimpleNamespace(brightness=75, backlight_timeout_seconds=30),
+    )
+
+    app._screen_timeout_seconds = app._resolve_screen_timeout_seconds()
+    app._active_brightness = app._resolve_active_brightness()
+    app._configure_screen_power(initial_now=0.0)
+    app._sleep_screen(31.0)
+
+    assert app.context.screen_awake is False
+    render_calls_before = app.menu_screen.render_calls
+
+    _publish_from_worker(app, UserActivityEvent(action_name="select"))
+
+    assert app.event_bus.drain() == 1
+    assert app.display.set_backlight_calls[-1] == 0.75
+    assert app.context.screen_awake is True
+    assert app.menu_screen.render_calls == render_calls_before + 1
+
+
+def test_screen_on_time_accumulates_across_sleep_and_wake_cycles() -> None:
+    """Screen-on metrics should accumulate only while the backlight is awake."""
+
+    app, _, _ = _build_app(playback_state="stopped")
+    app.display = FakeDisplay()
+    app.app_settings = SimpleNamespace(
+        ui=SimpleNamespace(screen_timeout_seconds=300),
+        display=SimpleNamespace(brightness=80, backlight_timeout_seconds=30),
+    )
+
+    app._screen_timeout_seconds = app._resolve_screen_timeout_seconds()
+    app._active_brightness = app._resolve_active_brightness()
+    app._configure_screen_power(initial_now=0.0)
+    app._sleep_screen(10.0)
+    app._wake_screen(20.0, render_current=False)
+    app._sleep_screen(25.0)
+
+    assert app.display.set_backlight_calls == [0.8, 0.0, 0.8, 0.0]
+    assert app.context.screen_on_seconds == 15
+    assert app.get_status()["screen_on_seconds"] == 15
 
 
 def test_low_battery_snapshot_sets_temporary_alert() -> None:

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -1,0 +1,22 @@
+"""Tests for input-manager activity callbacks."""
+
+from __future__ import annotations
+
+from yoyopy.ui.input import InputAction, InputManager
+
+
+def test_input_manager_notifies_activity_callbacks_for_each_action() -> None:
+    """Every semantic action should also trigger registered activity listeners."""
+
+    manager = InputManager()
+    events: list[tuple[str, object | None]] = []
+
+    manager.on_activity(lambda action, data: events.append((action.value, data)))
+
+    manager.simulate_action(InputAction.SELECT, {"source": "test"})
+    manager.simulate_action(InputAction.BACK)
+
+    assert events == [
+        ("select", {"source": "test"}),
+        ("back", None),
+    ]

--- a/yoyopy/__init__.py
+++ b/yoyopy/__init__.py
@@ -14,6 +14,7 @@ from yoyopy.events import (
     RegistrationChangedEvent,
     ScreenChangedEvent,
     TrackChangedEvent,
+    UserActivityEvent,
     VoIPAvailabilityChangedEvent,
 )
 from yoyopy.fsm import CallFSM, CallInterruptionPolicy, CallSessionState, MusicFSM, MusicState
@@ -28,6 +29,7 @@ __all__ = [
     "CallEndedEvent",
     "RegistrationChangedEvent",
     "ScreenChangedEvent",
+    "UserActivityEvent",
     "VoIPAvailabilityChangedEvent",
     "TrackChangedEvent",
     "PlaybackStateChangedEvent",

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -27,7 +27,11 @@ from yoyopy.coordinators import (
     ScreenCoordinator,
 )
 from yoyopy.event_bus import EventBus
-from yoyopy.events import RecoveryAttemptCompletedEvent, ScreenChangedEvent
+from yoyopy.events import (
+    RecoveryAttemptCompletedEvent,
+    ScreenChangedEvent,
+    UserActivityEvent,
+)
 from yoyopy.fsm import CallFSM, CallInterruptionPolicy, MusicFSM
 from yoyopy.power import (
     GracefulShutdownCancelled,
@@ -144,6 +148,7 @@ class YoyoPodApp:
         self._main_thread_id = threading.get_ident()
         self.event_bus = EventBus(main_thread_id=self._main_thread_id)
         self.event_bus.subscribe(ScreenChangedEvent, self._handle_screen_changed_event)
+        self.event_bus.subscribe(UserActivityEvent, self._handle_user_activity_event)
         self.event_bus.subscribe(
             RecoveryAttemptCompletedEvent,
             self._handle_recovery_attempt_completed_event,
@@ -178,6 +183,13 @@ class YoyoPodApp:
         self._power_hooks_registered = False
         self._shutdown_completed = False
         self._stopping = False
+        self._app_started_at = time.monotonic()
+        self._last_user_activity_at = self._app_started_at
+        self._screen_on_started_at = self._app_started_at
+        self._screen_on_accumulated_seconds = 0.0
+        self._screen_timeout_seconds = 0.0
+        self._active_brightness = 1.0
+        self._screen_awake = True
 
         logger.info("=" * 60)
         logger.info("YoyoPod Application Initializing")
@@ -250,11 +262,48 @@ class YoyoPodApp:
                 logger.info("Using default application configuration")
 
             self.auto_resume_after_call = self.app_settings.audio.auto_resume_after_call
+            self._screen_timeout_seconds = self._resolve_screen_timeout_seconds()
+            self._active_brightness = self._resolve_active_brightness()
             logger.info(f"  Auto-resume after call: {self.auto_resume_after_call}")
+            logger.info(f"  Screen timeout: {self._screen_timeout_seconds:.1f}s")
+            logger.info(f"  Active brightness: {self._active_brightness:.2f}")
             return True
         except Exception as exc:
             logger.error(f"Failed to load configuration: {exc}")
             return False
+
+    def _resolve_screen_timeout_seconds(self) -> float:
+        """Resolve the effective inactivity timeout used to sleep the screen."""
+        if self.app_settings is None:
+            return 0.0
+
+        display_timeout = max(0.0, float(self.app_settings.display.backlight_timeout_seconds))
+        if display_timeout > 0.0:
+            return display_timeout
+
+        return max(0.0, float(self.app_settings.ui.screen_timeout_seconds))
+
+    def _resolve_active_brightness(self) -> float:
+        """Resolve the active display brightness as a normalized 0.0-1.0 value."""
+        if self.app_settings is None:
+            return 1.0
+
+        brightness = max(0, min(100, int(self.app_settings.display.brightness)))
+        return brightness / 100.0
+
+    def _configure_screen_power(self, initial_now: float | None = None) -> None:
+        """Initialize screen timeout and usage tracking state."""
+        now = time.monotonic() if initial_now is None else initial_now
+        self._app_started_at = now
+        self._last_user_activity_at = now
+        self._screen_on_started_at = now
+        self._screen_on_accumulated_seconds = 0.0
+        self._screen_awake = True
+
+        if self.display is not None:
+            self.display.set_backlight(self._active_brightness)
+
+        self._update_screen_runtime_metrics(now)
 
     def _init_core_components(self) -> bool:
         """Initialize display, context, orchestration models, input, and screen manager."""
@@ -279,9 +328,11 @@ class YoyoPodApp:
                 font_size=16,
             )
             self.display.update()
+            self._configure_screen_power(initial_now=time.monotonic())
 
             logger.info("  - AppContext")
             self.context = AppContext()
+            self._update_screen_runtime_metrics(time.monotonic())
 
             logger.info("  - Orchestration Models")
             self.music_fsm = MusicFSM()
@@ -296,6 +347,7 @@ class YoyoPodApp:
             )
             if self.input_manager:
                 self.context.interaction_profile = self.input_manager.interaction_profile
+                self.input_manager.on_activity(self._queue_user_activity_event)
                 self.input_manager.start()
                 logger.info("    ✓ Input system initialized")
             else:
@@ -518,6 +570,17 @@ class YoyoPodApp:
     def _handle_screen_changed_event(self, event: ScreenChangedEvent) -> None:
         """Apply queued screen-change state sync on the coordinator thread."""
         self._sync_screen_changed(event.screen_name)
+        self._mark_user_activity(now=time.monotonic(), render_on_wake=False)
+
+    def _queue_user_activity_event(self, action, data: Any | None = None) -> None:
+        """Publish semantic user activity onto the main-thread event bus."""
+        action_name = getattr(action, "value", None)
+        self.event_bus.publish(UserActivityEvent(action_name=action_name))
+
+    def _handle_user_activity_event(self, event: UserActivityEvent) -> None:
+        """Wake the display and reset the inactivity timer on user activity."""
+        logger.debug(f"User activity received: {event.action_name or 'unknown'}")
+        self._mark_user_activity(now=time.monotonic(), render_on_wake=True)
 
     def _handle_recovery_attempt_completed_event(
         self,
@@ -570,6 +633,7 @@ class YoyoPodApp:
             execute_at=requested_at + max(0.0, event.delay_seconds),
             battery_percent=event.snapshot.battery.level_percent,
         )
+        self._wake_screen(requested_at, render_current=False)
         logger.warning(
             "Critical battery detected; shutdown in {:.1f}s",
             event.delay_seconds,
@@ -634,6 +698,10 @@ class YoyoPodApp:
             "external_power": self.context.external_power if self.context else None,
             "voip_registered": self.voip_registered,
             "music_available": self.mopidy_client.is_connected if self.mopidy_client else False,
+            "app_uptime_seconds": self.context.app_uptime_seconds if self.context else 0,
+            "screen_on_seconds": self.context.screen_on_seconds if self.context else 0,
+            "screen_awake": self.context.screen_awake if self.context else True,
+            "screen_idle_seconds": self.context.screen_idle_seconds if self.context else 0,
             "playback": {
                 "is_playing": self.context.playback.is_playing if self.context else False,
                 "is_paused": self.context.playback.is_paused if self.context else False,
@@ -726,6 +794,87 @@ class YoyoPodApp:
         self._ensure_coordinators()
         self.coordinator_runtime.sync_ui_state_for_screen(screen_name)
 
+    def _mark_user_activity(
+        self,
+        *,
+        now: float | None = None,
+        render_on_wake: bool,
+    ) -> None:
+        """Reset inactivity tracking and wake the screen when needed."""
+        activity_now = time.monotonic() if now is None else now
+        self._last_user_activity_at = activity_now
+        if self._screen_awake:
+            self._update_screen_runtime_metrics(activity_now)
+            return
+
+        self._wake_screen(activity_now, render_current=render_on_wake)
+
+    def _wake_screen(self, now: float, *, render_current: bool) -> None:
+        """Restore active brightness and optionally re-render the current screen."""
+        if self._screen_awake:
+            self._update_screen_runtime_metrics(now)
+            return
+
+        self._screen_awake = True
+        self._screen_on_started_at = now
+        if self.display is not None:
+            self.display.set_backlight(self._active_brightness)
+
+        if render_current and self.screen_manager is not None:
+            current_screen = self.screen_manager.get_current_screen()
+            if current_screen is not None:
+                current_screen.render()
+
+        self._update_screen_runtime_metrics(now)
+        logger.debug("Screen woke from inactivity")
+
+    def _sleep_screen(self, now: float) -> None:
+        """Turn off the display backlight and retain cumulative screen-on time."""
+        if not self._screen_awake:
+            self._update_screen_runtime_metrics(now)
+            return
+
+        if self._screen_on_started_at is not None:
+            self._screen_on_accumulated_seconds += max(0.0, now - self._screen_on_started_at)
+        self._screen_on_started_at = None
+        self._screen_awake = False
+        if self.display is not None:
+            self.display.set_backlight(0.0)
+        self._update_screen_runtime_metrics(now)
+        logger.info("Screen slept after inactivity timeout")
+
+    def _update_screen_runtime_metrics(self, now: float) -> None:
+        """Refresh app uptime and screen usage metrics in the shared context."""
+        screen_on_seconds = self._screen_on_accumulated_seconds
+        if self._screen_awake and self._screen_on_started_at is not None:
+            screen_on_seconds += max(0.0, now - self._screen_on_started_at)
+
+        idle_seconds = max(0.0, now - self._last_user_activity_at)
+        app_uptime_seconds = max(0.0, now - self._app_started_at)
+
+        if self.context is not None:
+            self.context.update_screen_runtime(
+                screen_awake=self._screen_awake,
+                app_uptime_seconds=app_uptime_seconds,
+                screen_on_seconds=screen_on_seconds,
+                idle_seconds=idle_seconds,
+            )
+
+    def _update_screen_power(self, now: float) -> None:
+        """Apply inactivity-based screen timeout policy and refresh runtime metrics."""
+        if self._pending_shutdown is not None or self._power_alert is not None:
+            self._wake_screen(now, render_current=False)
+            return
+
+        self._update_screen_runtime_metrics(now)
+        if self._screen_timeout_seconds <= 0 or not self._screen_awake:
+            return
+
+        if now - self._last_user_activity_at < self._screen_timeout_seconds:
+            return
+
+        self._sleep_screen(now)
+
     def _attempt_manager_recovery(self, now: float | None = None) -> None:
         """Try to recover VoIP and Mopidy when they become unavailable."""
         if self._stopping:
@@ -765,6 +914,7 @@ class YoyoPodApp:
         duration_seconds: float,
     ) -> None:
         """Queue a short-lived fullscreen power alert overlay."""
+        self._wake_screen(time.monotonic(), render_current=False)
         self._power_alert = _PowerAlert(
             title=title,
             subtitle=subtitle,
@@ -1014,10 +1164,15 @@ class YoyoPodApp:
                 self._process_pending_shutdown(monotonic_now)
                 if self._shutdown_completed:
                     break
+                self._update_screen_power(monotonic_now)
 
                 current_time = time.time()
                 overlay_active = self._update_power_overlays(monotonic_now)
                 if overlay_active:
+                    last_screen_update = current_time
+                    continue
+
+                if not self._screen_awake:
                     last_screen_update = current_time
                     continue
 
@@ -1060,6 +1215,7 @@ class YoyoPodApp:
 
         if self.display:
             logger.info("  - Clearing display")
+            self.display.set_backlight(self._active_brightness)
             self.display.clear(self.display.COLOR_BLACK)
             self.display.text("Goodbye!", 70, 120, color=self.display.COLOR_CYAN, font_size=20)
             self.display.update()
@@ -1088,6 +1244,10 @@ class YoyoPodApp:
             "battery_percent": self.context.battery_percent if self.context else None,
             "battery_charging": self.context.battery_charging if self.context else None,
             "external_power": self.context.external_power if self.context else None,
+            "screen_awake": self.context.screen_awake if self.context else self._screen_awake,
+            "screen_idle_seconds": self.context.screen_idle_seconds if self.context else None,
+            "screen_on_seconds": self.context.screen_on_seconds if self.context else None,
+            "app_uptime_seconds": self.context.app_uptime_seconds if self.context else None,
             "shutdown_pending": self._pending_shutdown is not None,
             "shutdown_reason": self._pending_shutdown.reason if self._pending_shutdown else None,
             "shutdown_in_seconds": pending_shutdown_in_seconds,

--- a/yoyopy/app_context.py
+++ b/yoyopy/app_context.py
@@ -124,6 +124,10 @@ class AppContext:
         self.external_power: bool = False
         self.power_available: bool = False
         self.power_error: str = ""
+        self.screen_awake: bool = True
+        self.screen_idle_seconds: int = 0
+        self.screen_on_seconds: int = 0
+        self.app_uptime_seconds: int = 0
         self.signal_strength: int = 4  # 0-4 bars
         self.is_connected: bool = False
         self.connection_type: str = "none"  # wifi, 4g, none
@@ -350,3 +354,17 @@ class AppContext:
 
         if snapshot.battery.power_plugged is not None:
             self.external_power = snapshot.battery.power_plugged
+
+    def update_screen_runtime(
+        self,
+        *,
+        screen_awake: bool,
+        app_uptime_seconds: float,
+        screen_on_seconds: float,
+        idle_seconds: float,
+    ) -> None:
+        """Update runtime metrics for app uptime and display activity."""
+        self.screen_awake = screen_awake
+        self.app_uptime_seconds = max(0, int(app_uptime_seconds))
+        self.screen_on_seconds = max(0, int(screen_on_seconds))
+        self.screen_idle_seconds = max(0, int(idle_seconds))

--- a/yoyopy/events.py
+++ b/yoyopy/events.py
@@ -48,6 +48,13 @@ class ScreenChangedEvent:
 
 
 @dataclass(frozen=True, slots=True)
+class UserActivityEvent:
+    """Published when user input activity should wake or keep the screen alive."""
+
+    action_name: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class RecoveryAttemptCompletedEvent:
     """Published when a background backend recovery attempt finishes."""
 

--- a/yoyopy/ui/input/manager.py
+++ b/yoyopy/ui/input/manager.py
@@ -40,6 +40,7 @@ class InputManager:
         """Initialize the input manager."""
         self.adapters: List[InputHAL] = []
         self.callbacks: Dict[InputAction, List[Callable]] = defaultdict(list)
+        self.activity_callbacks: List[Callable[[InputAction, Optional[Any]], None]] = []
         self.interaction_profile = interaction_profile
         self.running = False
         logger.debug("InputManager initialized")
@@ -100,6 +101,14 @@ class InputManager:
         """
         self.callbacks[action].append(callback)
         logger.debug(f"Registered callback for action: {action.value}")
+
+    def on_activity(
+        self,
+        callback: Callable[[InputAction, Optional[Any]], None],
+    ) -> None:
+        """Register a callback fired whenever any semantic action occurs."""
+        self.activity_callbacks.append(callback)
+        logger.debug("Registered input activity callback")
 
     def clear_callbacks(self) -> None:
         """
@@ -188,6 +197,12 @@ class InputManager:
             action: Action that occurred
             data: Optional data dict with action-specific information
         """
+        for callback in self.activity_callbacks:
+            try:
+                callback(action, data)
+            except Exception as e:
+                logger.error(f"Error in activity callback for {action.value}: {e}")
+
         callbacks = self.callbacks.get(action, [])
         if callbacks:
             logger.debug(f"Action fired: {action.value} (data: {data})")


### PR DESCRIPTION
## Summary
- add input-activity events and app-level screen wake/sleep handling for inactivity timeouts
- track app uptime, screen-on time, idle time, and awake state in the shared app context and status output
- add focused tests for input activity callbacks and screen timeout/wake behavior

## Testing
- python -m compileall yoyopy tests
- uv run pytest tests/test_input_manager.py tests/test_app_orchestration.py -q
- uv run pytest -q