### PR TITLE
Add PiSugar RTC support and validation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The current codebase supports three display/input modes:
 - `yoyopy/app.py`: `YoyoPodApp` coordinator
 - `scripts/pi_smoke.py`: Raspberry Pi smoke validator for hardware and optional service checks
 - `scripts/pi_remote.py`: SSH helper for Raspberry Pi sync, smoke, status, and run loops
+- `scripts/pisugar_rtc.py`: PiSugar RTC status, sync, and alarm helper
 - `yoyopy/fsm.py`: split `MusicFSM`, `CallFSM`, and call interruption policy
 - `yoyopy/coordinators/runtime.py`: derived `AppRuntimeState` over music, call, and UI state
 - `yoyopy/audio/mopidy_client.py`: Mopidy JSON-RPC client
@@ -92,7 +93,8 @@ Raspberry Pi smoke:
 
 ```bash
 uv run python scripts/pi_smoke.py
-uv run python scripts/pi_smoke.py --with-mopidy --with-voip
+uv run python scripts/pi_smoke.py --with-power --with-rtc
+uv run python scripts/pi_smoke.py --with-mopidy --with-voip --with-rtc
 ```
 
 Remote Pi workflow:
@@ -102,6 +104,8 @@ uv run python scripts/pi_remote.py status
 uv run python scripts/pi_remote.py preflight --branch main --with-mopidy --with-voip
 uv run python scripts/pi_remote.py sync --branch main
 uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip
+uv run python scripts/pi_remote.py rtc status
+uv run python scripts/pi_remote.py rtc sync-to-rtc
 uv run python scripts/pi_remote.py whisplay --duration-seconds 45
 ```
 

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -79,7 +79,8 @@ uv run python scripts/pi_remote.py sync --branch main --skip-uv-sync
 
 ```bash
 uv run python scripts/pi_remote.py smoke
-uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip
+uv run python scripts/pi_remote.py smoke --with-power --with-rtc
+uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip --with-rtc
 ```
 
 Useful variations:
@@ -94,6 +95,13 @@ uv run python scripts/pi_remote.py smoke --with-voip --voip-timeout 15 --verbose
 ```bash
 uv run python scripts/pi_remote.py whisplay
 uv run python scripts/pi_remote.py whisplay --duration-seconds 45 --double-tap-ms 240 --long-hold-ms 900
+```
+
+### PiSugar RTC helpers
+
+```bash
+uv run python scripts/pi_remote.py rtc status
+uv run python scripts/pi_remote.py rtc sync-to-rtc
 ```
 
 Use this during on-device tuning when the Whisplay button feels too eager or too sluggish. The helper runs interactively over SSH, prints every semantic gesture event, and accepts temporary timing overrides without modifying the tracked config file.

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -21,6 +21,7 @@ Run this on the target Raspberry Pi after pulling the latest branch:
 
 ```bash
 uv run python scripts/pi_smoke.py
+uv run python scripts/pi_smoke.py --with-power --with-rtc
 ```
 
 What it checks:
@@ -40,10 +41,12 @@ Add Mopidy and SIP checks when the services are expected to be available:
 
 ```bash
 uv run python scripts/pi_smoke.py --with-mopidy --with-voip
+uv run python scripts/pi_smoke.py --with-power --with-rtc --with-mopidy --with-voip
 ```
 
 What it checks:
 
+- PiSugar battery telemetry and RTC state when requested
 - Mopidy JSON-RPC connectivity using `config/yoyopod_config.yaml`
 - `linphonec` startup and SIP registration using `config/voip_config.yaml`
 
@@ -107,6 +110,15 @@ Useful flags:
 - `--double-tap-ms 240`
 - `--long-hold-ms 900`
 - `--verbose`
+
+### PiSugar RTC drill
+
+```bash
+uv run python scripts/pisugar_rtc.py status
+uv run python scripts/pisugar_rtc.py sync-to-rtc
+```
+
+Use this when you want a focused RTC read/sync pass without running the full app.
 
 ## Suggested Order On Hardware
 

--- a/scripts/pi_remote.py
+++ b/scripts/pi_remote.py
@@ -73,6 +73,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Include PiSugar power checks",
     )
     smoke_parser.add_argument(
+        "--with-rtc",
+        action="store_true",
+        help="Include PiSugar RTC checks",
+    )
+    smoke_parser.add_argument(
         "--with-mopidy",
         action="store_true",
         help="Include Mopidy connectivity checks",
@@ -136,6 +141,33 @@ def build_parser() -> argparse.ArgumentParser:
         help="Log events only without drawing tuner hints on the display",
     )
 
+    rtc_parser = subparsers.add_parser(
+        "rtc",
+        help="Inspect or control PiSugar RTC state remotely",
+    )
+    rtc_parser.add_argument(
+        "rtc_action",
+        nargs="?",
+        default="status",
+        choices=["status", "sync-to-rtc", "sync-from-rtc", "set-alarm", "disable-alarm"],
+        help="RTC action to run remotely (default: status)",
+    )
+    rtc_parser.add_argument(
+        "--time",
+        help="ISO8601 timestamp for set-alarm, e.g. 2026-04-06T07:30:00+02:00",
+    )
+    rtc_parser.add_argument(
+        "--repeat-mask",
+        type=int,
+        default=127,
+        help="Weekday repeat bitmask for set-alarm (default: 127)",
+    )
+    rtc_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose RTC helper logging",
+    )
+
     preflight_parser = subparsers.add_parser(
         "preflight",
         help="Run local checks, sync the Pi, and execute the Pi smoke pass",
@@ -159,6 +191,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--with-power",
         action="store_true",
         help="Include PiSugar power checks in the remote smoke pass",
+    )
+    preflight_parser.add_argument(
+        "--with-rtc",
+        action="store_true",
+        help="Include PiSugar RTC checks in the remote smoke pass",
     )
     preflight_parser.add_argument(
         "--with-mopidy",
@@ -293,6 +330,8 @@ def build_smoke_command(args: argparse.Namespace) -> str:
     parts = ["uv run python scripts/pi_smoke.py"]
     if args.with_power:
         parts.append("--with-power")
+    if args.with_rtc:
+        parts.append("--with-rtc")
     if args.with_mopidy:
         parts.append("--with-mopidy")
     if args.with_voip:
@@ -324,6 +363,21 @@ def build_whisplay_command(args: argparse.Namespace) -> str:
     return " ".join(parts)
 
 
+def build_rtc_command(args: argparse.Namespace) -> str:
+    """Create the remote PiSugar RTC command."""
+    parts = ["uv run python scripts/pisugar_rtc.py"]
+    if args.verbose:
+        parts.append("--verbose")
+    parts.append(args.rtc_action)
+    if args.rtc_action == "set-alarm":
+        if not args.time:
+            raise SystemExit("--time is required for `pi_remote.py rtc set-alarm`")
+        parts.extend(["--time", shlex.quote(args.time)])
+        if args.repeat_mask != 127:
+            parts.extend(["--repeat-mask", str(args.repeat_mask)])
+    return " ".join(parts)
+
+
 def build_run_command(args: argparse.Namespace) -> str:
     """Create the remote production-app command."""
     parts = ["uv run python yoyopod.py"]
@@ -347,6 +401,7 @@ def build_local_preflight_commands() -> list[tuple[str, list[str]]]:
                 "tests",
                 "scripts/pi_smoke.py",
                 "scripts/pi_remote.py",
+                "scripts/pisugar_rtc.py",
                 "scripts/whisplay_tune.py",
             ],
         ),
@@ -399,6 +454,9 @@ def main() -> int:
 
     if args.command == "whisplay":
         return run_remote(config, build_whisplay_command(args), tty=True)
+
+    if args.command == "rtc":
+        return run_remote(config, build_rtc_command(args))
 
     if args.command == "preflight":
         return run_preflight(config, args)

--- a/scripts/pi_smoke.py
+++ b/scripts/pi_smoke.py
@@ -208,6 +208,41 @@ def power_check(config_dir: Path) -> CheckResult:
     return CheckResult(name="power", status="pass", details=details)
 
 
+def rtc_check(config_dir: Path) -> CheckResult:
+    """Validate PiSugar RTC reachability and report the current RTC state."""
+    config_manager = ConfigManager(config_dir=str(config_dir))
+    manager = PowerManager.from_config_manager(config_manager)
+
+    if not manager.config.enabled:
+        return CheckResult(
+            name="rtc",
+            status="warn",
+            details="power backend disabled in yoyopod_config.yaml",
+        )
+
+    snapshot = manager.refresh()
+    if not snapshot.available:
+        details = snapshot.error or "power backend unavailable"
+        return CheckResult(name="rtc", status="fail", details=details)
+
+    if snapshot.rtc.time is None:
+        return CheckResult(
+            name="rtc",
+            status="fail",
+            details="PiSugar backend responded but rtc_time is unavailable",
+        )
+
+    details = ", ".join(
+        [
+            f"time={snapshot.rtc.time.isoformat()}",
+            f"alarm_enabled={snapshot.rtc.alarm_enabled}",
+            f"alarm_time={snapshot.rtc.alarm_time.isoformat() if snapshot.rtc.alarm_time is not None else 'none'}",
+            f"repeat_mask={snapshot.rtc.alarm_repeat_mask if snapshot.rtc.alarm_repeat_mask is not None else 'unknown'}",
+        ]
+    )
+    return CheckResult(name="rtc", status="pass", details=details)
+
+
 def mopidy_check(app_config: dict[str, Any], timeout_seconds: int) -> CheckResult:
     """Validate Mopidy reachability and basic state queries."""
     audio_config = app_config.get("audio", {})
@@ -327,6 +362,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Also validate PiSugar power telemetry from yoyopod_config.yaml",
     )
     parser.add_argument(
+        "--with-rtc",
+        action="store_true",
+        help="Also validate PiSugar RTC state and alarm visibility",
+    )
+    parser.add_argument(
         "--with-voip",
         action="store_true",
         help="Also validate linphone startup and SIP registration",
@@ -392,6 +432,9 @@ def main() -> int:
 
         if args.with_power:
             results.append(power_check(config_dir))
+
+        if args.with_rtc:
+            results.append(rtc_check(config_dir))
 
         if args.with_mopidy:
             results.append(mopidy_check(app_config, args.mopidy_timeout))

--- a/scripts/pisugar_rtc.py
+++ b/scripts/pisugar_rtc.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""PiSugar RTC helper for status, sync, and alarm operations."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from loguru import logger
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from yoyopy.config import ConfigManager
+from yoyopy.power import PowerManager, RTCState
+
+
+def configure_logging(verbose: bool) -> None:
+    """Configure human-readable logging."""
+    logger.remove()
+    logger.add(
+        sys.stderr,
+        format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <level>{message}</level>",
+        level="DEBUG" if verbose else "INFO",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Inspect and control PiSugar RTC state through YoyoPod's power module.",
+    )
+    parser.add_argument(
+        "--config-dir",
+        default="config",
+        help="Configuration directory to use (default: config)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG logging",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("status", help="Show current RTC and alarm state")
+    subparsers.add_parser("sync-to-rtc", help="Sync Raspberry Pi system time to the PiSugar RTC")
+    subparsers.add_parser("sync-from-rtc", help="Sync PiSugar RTC time to the Raspberry Pi system clock")
+
+    set_alarm = subparsers.add_parser("set-alarm", help="Set the PiSugar RTC wake alarm")
+    set_alarm.add_argument(
+        "--time",
+        required=True,
+        help="Alarm time as an ISO8601 timestamp, e.g. 2026-04-06T07:30:00+02:00",
+    )
+    set_alarm.add_argument(
+        "--repeat-mask",
+        type=int,
+        default=127,
+        help="Weekday repeat bitmask (default: 127 for every day)",
+    )
+
+    subparsers.add_parser("disable-alarm", help="Disable the PiSugar RTC wake alarm")
+    return parser
+
+
+def format_rtc_state(state: RTCState) -> list[str]:
+    """Return a human-readable summary of RTC state."""
+    lines = [
+        f"rtc_time={state.time.isoformat() if state.time is not None else 'unknown'}",
+        f"alarm_enabled={state.alarm_enabled}",
+        f"alarm_time={state.alarm_time.isoformat() if state.alarm_time is not None else 'none'}",
+        f"alarm_repeat_mask={state.alarm_repeat_mask if state.alarm_repeat_mask is not None else 'unknown'}",
+        f"adjust_ppm={state.adjust_ppm if state.adjust_ppm is not None else 'unknown'}",
+    ]
+    return lines
+
+
+def build_manager(config_dir: Path) -> PowerManager:
+    """Create a power manager for the configured PiSugar backend."""
+    config_manager = ConfigManager(config_dir=str(config_dir))
+    manager = PowerManager.from_config_manager(config_manager)
+    if not manager.config.enabled:
+        raise RuntimeError("power backend disabled in yoyopod_config.yaml")
+    return manager
+
+
+def parse_alarm_time(value: str) -> datetime:
+    """Parse an ISO8601 alarm timestamp."""
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    return datetime.fromisoformat(normalized)
+
+
+def print_rtc_status(manager: PowerManager, heading: str) -> int:
+    """Refresh and print the current RTC status."""
+    snapshot = manager.refresh()
+    if not snapshot.available:
+        logger.error(snapshot.error or "power backend unavailable")
+        return 1
+
+    print("")
+    print(heading)
+    print("=" * len(heading))
+    print(f"model={snapshot.device.model or 'unknown'}")
+    for line in format_rtc_state(snapshot.rtc):
+        print(line)
+    return 0
+
+
+def main() -> int:
+    """Program entry point."""
+    parser = build_parser()
+    args = parser.parse_args()
+    configure_logging(args.verbose)
+
+    config_dir = Path(args.config_dir)
+    if not config_dir.is_absolute():
+        config_dir = REPO_ROOT / config_dir
+
+    manager = build_manager(config_dir)
+
+    if args.command == "status":
+        return print_rtc_status(manager, "PiSugar RTC status")
+
+    if args.command == "sync-to-rtc":
+        state = manager.sync_time_to_rtc()
+        print("")
+        print("PiSugar RTC synced from Raspberry Pi system time")
+        print("==============================================")
+        for line in format_rtc_state(state):
+            print(line)
+        return 0
+
+    if args.command == "sync-from-rtc":
+        state = manager.sync_time_from_rtc()
+        print("")
+        print("Raspberry Pi system time synced from PiSugar RTC")
+        print("===============================================")
+        for line in format_rtc_state(state):
+            print(line)
+        return 0
+
+    if args.command == "set-alarm":
+        state = manager.set_rtc_alarm(
+            parse_alarm_time(args.time),
+            repeat_mask=args.repeat_mask,
+        )
+        print("")
+        print("PiSugar RTC alarm updated")
+        print("=========================")
+        for line in format_rtc_state(state):
+            print(line)
+        return 0
+
+    if args.command == "disable-alarm":
+        state = manager.disable_rtc_alarm()
+        print("")
+        print("PiSugar RTC alarm disabled")
+        print("==========================")
+        for line in format_rtc_state(state):
+            print(line)
+        return 0
+
+    parser.error(f"Unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -3,6 +3,7 @@
 from scripts.pi_remote import (
     RemoteConfig,
     build_local_preflight_commands,
+    build_rtc_command,
     build_smoke_command,
     build_sync_command,
     build_whisplay_command,
@@ -38,6 +39,7 @@ def test_build_smoke_command_adds_optional_checks() -> None:
     """Smoke command should include optional service-check flags when requested."""
     args = Namespace(
         with_power=True,
+        with_rtc=True,
         with_mopidy=True,
         with_voip=True,
         verbose=True,
@@ -49,6 +51,7 @@ def test_build_smoke_command_adds_optional_checks() -> None:
 
     assert command.startswith("uv run python scripts/pi_smoke.py")
     assert "--with-power" in command
+    assert "--with-rtc" in command
     assert "--with-mopidy" in command
     assert "--with-voip" in command
     assert "--verbose" in command
@@ -62,6 +65,7 @@ def test_build_local_preflight_commands_cover_compile_and_pytest() -> None:
 
     assert commands[0][0] == "compileall"
     assert commands[0][1][1:3] == ["-m", "compileall"]
+    assert "scripts/pisugar_rtc.py" in commands[0][1]
     assert "scripts/whisplay_tune.py" in commands[0][1]
     assert commands[1] == ("pytest", ["uv", "run", "pytest", "-q"])
 
@@ -86,3 +90,28 @@ def test_build_whisplay_command_adds_timing_overrides() -> None:
     assert "--debounce-ms 75" in command
     assert "--double-tap-ms 240" in command
     assert "--long-hold-ms 900" in command
+
+
+def test_build_rtc_command_supports_status_and_set_alarm() -> None:
+    """RTC helper command should support both read-only status and alarm updates."""
+
+    status_args = Namespace(
+        verbose=False,
+        rtc_action="status",
+        time=None,
+        repeat_mask=127,
+    )
+    set_alarm_args = Namespace(
+        verbose=True,
+        rtc_action="set-alarm",
+        time="2026-04-06T07:30:00+02:00",
+        repeat_mask=31,
+    )
+
+    status_command = build_rtc_command(status_args)
+    set_alarm_command = build_rtc_command(set_alarm_args)
+
+    assert status_command == "uv run python scripts/pisugar_rtc.py status"
+    assert set_alarm_command.startswith("uv run python scripts/pisugar_rtc.py --verbose set-alarm")
+    assert "--time 2026-04-06T07:30:00+02:00" in set_alarm_command
+    assert "--repeat-mask 31" in set_alarm_command

--- a/tests/test_power_backend.py
+++ b/tests/test_power_backend.py
@@ -16,8 +16,10 @@ class FakeTransport:
     def __init__(self, responses: dict[str, str], failures: set[str] | None = None) -> None:
         self.responses = responses
         self.failures = failures or set()
+        self.commands: list[str] = []
 
     def send_command(self, command: str) -> str:
+        self.commands.append(command)
         if command in self.failures:
             raise PowerTransportError(f"simulated failure for {command}")
         if command not in self.responses:
@@ -128,4 +130,30 @@ def test_pisugar_probe_returns_false_when_backend_is_disabled() -> None:
     )
 
     assert backend.probe() is False
+
+
+def test_pisugar_backend_issues_documented_rtc_control_commands() -> None:
+    """RTC sync and alarm helpers should use the official PiSugar command names."""
+
+    transport = FakeTransport(
+        {
+            "rtc_pi2rtc": "done: rtc_pi2rtc",
+            "rtc_rtc2pi": "done: rtc_rtc2pi",
+            "rtc_alarm_set 2026-04-06T07:30:00+00:00 31": "done: rtc_alarm_set",
+            "rtc_alarm_disable": "done: rtc_alarm_disable",
+        }
+    )
+    backend = PiSugarBackend(PowerConfig(), transport=transport)
+
+    backend.sync_time_to_rtc()
+    backend.sync_time_from_rtc()
+    backend.set_rtc_alarm(datetime(2026, 4, 6, 7, 30, tzinfo=timezone.utc), repeat_mask=31)
+    backend.disable_rtc_alarm()
+
+    assert transport.commands == [
+        "rtc_pi2rtc",
+        "rtc_rtc2pi",
+        "rtc_alarm_set 2026-04-06T07:30:00+00:00 31",
+        "rtc_alarm_disable",
+    ]
 

--- a/tests/test_power_manager.py
+++ b/tests/test_power_manager.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from yoyopy.config import ConfigManager
 from yoyopy.power.manager import PowerManager
-from yoyopy.power.models import BatteryState, PowerConfig, PowerSnapshot
+from yoyopy.power.models import BatteryState, PowerConfig, PowerSnapshot, RTCState
 
 
 class FakeBackend:
@@ -16,6 +16,10 @@ class FakeBackend:
         self.snapshot = snapshot
         self.probe_result = probe_result
         self.refresh_calls = 0
+        self.sync_to_rtc_calls = 0
+        self.sync_from_rtc_calls = 0
+        self.set_alarm_calls: list[tuple[datetime, int]] = []
+        self.disable_alarm_calls = 0
 
     def probe(self) -> bool:
         return self.probe_result
@@ -23,6 +27,18 @@ class FakeBackend:
     def get_snapshot(self) -> PowerSnapshot:
         self.refresh_calls += 1
         return self.snapshot
+
+    def sync_time_to_rtc(self) -> None:
+        self.sync_to_rtc_calls += 1
+
+    def sync_time_from_rtc(self) -> None:
+        self.sync_from_rtc_calls += 1
+
+    def set_rtc_alarm(self, when: datetime, repeat_mask: int = 127) -> None:
+        self.set_alarm_calls.append((when, repeat_mask))
+
+    def disable_rtc_alarm(self) -> None:
+        self.disable_alarm_calls += 1
 
 
 class ExplodingBackend:
@@ -140,4 +156,29 @@ def test_power_manager_request_system_shutdown_uses_configured_command() -> None
 
     assert manager.request_system_shutdown() is True
     assert commands == [["sudo", "-n", "shutdown", "-h", "now"]]
+
+
+def test_power_manager_exposes_rtc_sync_and_alarm_helpers() -> None:
+    """RTC sync and alarm operations should delegate to the backend and return fresh state."""
+
+    snapshot = PowerSnapshot(
+        available=True,
+        checked_at=datetime(2026, 4, 4, 12, 0, 0),
+        rtc=RTCState(time=datetime(2026, 4, 4, 12, 0, tzinfo=timezone.utc)),
+    )
+    backend = FakeBackend(snapshot)
+    manager = PowerManager(PowerConfig(), backend=backend)
+    alarm_time = datetime(2026, 4, 6, 7, 30, tzinfo=timezone.utc)
+
+    rtc_state = manager.sync_time_to_rtc()
+    rtc_state = manager.sync_time_from_rtc()
+    rtc_state = manager.set_rtc_alarm(alarm_time, repeat_mask=31)
+    rtc_state = manager.disable_rtc_alarm()
+
+    assert backend.sync_to_rtc_calls == 1
+    assert backend.sync_from_rtc_calls == 1
+    assert backend.set_alarm_calls == [(alarm_time, 31)]
+    assert backend.disable_alarm_calls == 1
+    assert backend.refresh_calls == 4
+    assert rtc_state.time == datetime(2026, 4, 4, 12, 0, tzinfo=timezone.utc)
 

--- a/yoyopy/power/backend.py
+++ b/yoyopy/power/backend.py
@@ -28,6 +28,18 @@ class PowerBackend(Protocol):
     def get_snapshot(self) -> PowerSnapshot:
         """Return a best-effort point-in-time power snapshot."""
 
+    def sync_time_to_rtc(self) -> None:
+        """Sync Raspberry Pi system time to the PiSugar RTC."""
+
+    def sync_time_from_rtc(self) -> None:
+        """Sync PiSugar RTC time back to the Raspberry Pi system clock."""
+
+    def set_rtc_alarm(self, when: datetime, repeat_mask: int = 127) -> None:
+        """Configure the PiSugar RTC wake alarm."""
+
+    def disable_rtc_alarm(self) -> None:
+        """Disable the configured PiSugar RTC wake alarm."""
+
 
 class PowerTransportError(RuntimeError):
     """Raised when the PiSugar transport cannot complete a command."""
@@ -196,10 +208,36 @@ class PiSugarBackend:
             error="; ".join(errors),
         )
 
+    def sync_time_to_rtc(self) -> None:
+        """Sync Raspberry Pi system time to the PiSugar RTC."""
+        self._execute_control("rtc_pi2rtc")
+
+    def sync_time_from_rtc(self) -> None:
+        """Sync PiSugar RTC time back to the Raspberry Pi system clock."""
+        self._execute_control("rtc_rtc2pi")
+
+    def set_rtc_alarm(self, when: datetime, repeat_mask: int = 127) -> None:
+        """Configure the PiSugar RTC wake alarm."""
+        iso_time = when.isoformat()
+        self._execute_control(f"rtc_alarm_set {iso_time} {int(repeat_mask)}")
+
+    def disable_rtc_alarm(self) -> None:
+        """Disable the PiSugar RTC wake alarm."""
+        self._execute_control("rtc_alarm_disable")
+
     def _query(self, command: str) -> str:
         """Execute one PiSugar command and normalize its payload."""
         response = self.transport.send_command(command)
         return _extract_response_value(command, response)
+
+    def _execute_control(self, command: str) -> str:
+        """Execute one PiSugar control command and validate that it responded."""
+        response = self.transport.send_command(command).strip()
+        if not response:
+            raise PowerTransportError(f"Empty response for {command!r}")
+        if response.lower().startswith("error"):
+            raise PowerTransportError(f"PiSugar command failed for {command!r}: {response}")
+        return response
 
     def _read_str(self, command: str) -> str:
         return self._query(command)

--- a/yoyopy/power/manager.py
+++ b/yoyopy/power/manager.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Callable
 from loguru import logger
 
 from yoyopy.power.backend import PiSugarBackend, PowerBackend
-from yoyopy.power.models import PowerConfig, PowerSnapshot
+from yoyopy.power.models import PowerConfig, PowerSnapshot, RTCState
 
 if TYPE_CHECKING:
     from yoyopy.config import ConfigManager
@@ -74,6 +74,31 @@ class PowerManager:
         """Return the current battery percentage when available."""
         snapshot = self.get_snapshot(refresh=refresh)
         return snapshot.battery.level_percent
+
+    def get_rtc_state(self, refresh: bool = False) -> RTCState:
+        """Return the latest RTC state, optionally refreshing first."""
+        snapshot = self.get_snapshot(refresh=refresh)
+        return snapshot.rtc
+
+    def sync_time_to_rtc(self) -> RTCState:
+        """Sync Raspberry Pi system time to the PiSugar RTC and return fresh RTC state."""
+        self.backend.sync_time_to_rtc()
+        return self.get_rtc_state(refresh=True)
+
+    def sync_time_from_rtc(self) -> RTCState:
+        """Sync PiSugar RTC time to the Raspberry Pi system clock and return fresh RTC state."""
+        self.backend.sync_time_from_rtc()
+        return self.get_rtc_state(refresh=True)
+
+    def set_rtc_alarm(self, when: datetime, repeat_mask: int = 127) -> RTCState:
+        """Set the PiSugar RTC wake alarm and return fresh RTC state."""
+        self.backend.set_rtc_alarm(when, repeat_mask)
+        return self.get_rtc_state(refresh=True)
+
+    def disable_rtc_alarm(self) -> RTCState:
+        """Disable the PiSugar RTC wake alarm and return fresh RTC state."""
+        self.backend.disable_rtc_alarm()
+        return self.get_rtc_state(refresh=True)
 
     def register_shutdown_hook(self, name: str, hook: ShutdownHook) -> None:
         """Register one callable to run before a graceful poweroff."""


### PR DESCRIPTION
## Summary
- add PiSugar RTC sync and alarm operations to the power backend and manager
- add a dedicated scripts/pisugar_rtc.py helper plus pi_remote.py rtc and pi_smoke.py --with-rtc
- extend tests and docs for RTC status, sync, and remote validation flows

## Testing
- python -m compileall yoyopy tests scripts
- uv run pytest tests/test_power_backend.py tests/test_power_manager.py tests/test_pi_remote.py -q
- uv run python scripts/pisugar_rtc.py --help
- uv run python scripts/pi_remote.py rtc --help
- uv run pytest -q

## Hardware validation
- attempted remote Pi validation, but SSH to pi-zero (192.168.178.85) timed out during banner exchange in this environment, so on-device RTC verification is still pending