### PR TITLE
Add PiSugar watchdog heartbeat and systemd unit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,13 @@
   - declarative screen routing
   - typed config models with YAML plus env overlay
   - dedicated `yoyopy/voip/` package
+- PiSugar-backed power management is now implemented:
+  - telemetry polling
+  - low-battery warning and graceful shutdown
+  - screen timeout and usage tracking
+  - RTC helpers
+  - PiSugar software watchdog support
+- Production Raspberry Pi deployment now has a committed systemd unit template under `deploy/systemd/`.
 - CI validates the Python test suite with `uv sync --extra dev` and `uv run pytest -q`.
 - Raspberry Pi validation has a defined path through `scripts/pi_smoke.py` and `scripts/pi_remote.py`.
 
@@ -34,6 +41,7 @@ When in doubt, trust these files first:
 - `yoyopy/events.py`
 - `yoyopy/coordinators/runtime.py`
 - `yoyopy/voip/`
+- `yoyopy/power/`
 - `yoyopy/ui/display/`
 - `yoyopy/ui/input/`
 - `yoyopy/ui/screens/`
@@ -66,6 +74,9 @@ yoyopod.py / yoyopy.main
      -> MopidyClient
      -> VoIPManager
         -> LinphonecBackend
+     -> PowerManager
+        -> PiSugarBackend
+        -> PiSugarWatchdog
 ```
 
 Key design points:
@@ -102,6 +113,15 @@ Key design points:
 - `yoyopy/voip/manager.py` - app-facing VoIP facade
 - `yoyopy/voip/backend.py` - `VoIPBackend`, `LinphonecBackend`, `MockVoIPBackend`
 - `yoyopy/voip/types.py` - SIP config and typed backend events
+
+### Power
+
+- `yoyopy/power/backend.py` - PiSugar socket/TCP backend for telemetry and RTC control
+- `yoyopy/power/watchdog.py` - PiSugar software watchdog controller over `i2cget`/`i2cset`
+- `yoyopy/power/manager.py` - app-facing power facade
+- `yoyopy/power/policies.py` - low-battery safety policy
+- `scripts/pisugar_rtc.py` - RTC status/sync/alarm helper
+- `deploy/systemd/yoyopod@.service` - production boot-time service unit
 
 ### UI
 
@@ -186,6 +206,7 @@ uv run python scripts/pi_remote.py status --host rpi-zero
 uv run python scripts/pi_remote.py preflight --host rpi-zero --with-mopidy --with-voip
 uv run python scripts/pi_remote.py sync --host rpi-zero --branch main
 uv run python scripts/pi_remote.py smoke --host rpi-zero --with-mopidy --with-voip
+uv run python scripts/pi_remote.py service install --host rpi-zero
 ```
 
 Direct smoke helper on the Pi:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The current codebase supports three display/input modes:
 - `scripts/pi_smoke.py`: Raspberry Pi smoke validator for hardware and optional service checks
 - `scripts/pi_remote.py`: SSH helper for Raspberry Pi sync, smoke, status, and run loops
 - `scripts/pisugar_rtc.py`: PiSugar RTC status, sync, and alarm helper
+- `deploy/systemd/yoyopod@.service`: production systemd unit for boot-time app supervision
 - `yoyopy/fsm.py`: split `MusicFSM`, `CallFSM`, and call interruption policy
 - `yoyopy/coordinators/runtime.py`: derived `AppRuntimeState` over music, call, and UI state
 - `yoyopy/audio/mopidy_client.py`: Mopidy JSON-RPC client
@@ -57,11 +58,13 @@ YoyoPod expects these external tools on Raspberry Pi OS:
 - `mopidy`
 - `linphone-cli`
 - `alsa-utils` for `speaker-test`
+- `i2c-tools` for PiSugar watchdog control
+- `pisugar-server` for PiSugar power/RTC telemetry via PiSugar's official installer
 
 Example:
 
 ```bash
-sudo apt install mopidy linphone-cli alsa-utils
+sudo apt install mopidy linphone-cli alsa-utils i2c-tools
 ```
 
 ### Configuration
@@ -78,6 +81,7 @@ Important settings:
 - `config/yoyopod_config.yaml`: display hardware selection, Mopidy host/port, auto-resume behavior
 - `config/yoyopod_config.yaml`: Whisplay gesture tuning under `input.whisplay_*_ms`
 - `config/yoyopod_config.yaml`: `input.ptt_navigation=false` is reserved for future voice/PTT work and is currently experimental
+- `config/yoyopod_config.yaml`: `power.watchdog_*` controls the PiSugar app heartbeat watchdog
 - `config/voip_config.yaml`: SIP account, transport, STUN, `linphonec` path
 - `config/contacts.yaml`: contact list and speed dial entries
 
@@ -106,7 +110,17 @@ uv run python scripts/pi_remote.py sync --branch main
 uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip
 uv run python scripts/pi_remote.py rtc status
 uv run python scripts/pi_remote.py rtc sync-to-rtc
+uv run python scripts/pi_remote.py service status
+uv run python scripts/pi_remote.py service install
 uv run python scripts/pi_remote.py whisplay --duration-seconds 45
+```
+
+Production service install on the Pi:
+
+```bash
+uv run python scripts/pi_remote.py sync --branch main
+uv run python scripts/pi_remote.py service install
+uv run python scripts/pi_remote.py service status
 ```
 
 Whisplay tuning on-device:

--- a/config/yoyopod_config.yaml
+++ b/config/yoyopod_config.yaml
@@ -53,6 +53,12 @@ power:
   shutdown_delay_seconds: 15.0    # Grace period before poweroff to save state
   shutdown_command: "sudo -n shutdown -h now"
   shutdown_state_file: "data/last_shutdown_state.json"
+  watchdog_enabled: false         # Enable PiSugar software watchdog for app-loop heartbeat
+  watchdog_timeout_seconds: 60    # PiSugar timeout register uses 2-second units
+  watchdog_feed_interval_seconds: 15.0
+  watchdog_i2c_bus: 1
+  watchdog_i2c_address: 0x57
+  watchdog_command_timeout_seconds: 5.0
 
 # Display Settings
 display:

--- a/deploy/systemd/yoyopod@.service
+++ b/deploy/systemd/yoyopod@.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=YoyoPod portable VoIP/music appliance (%i)
+After=network-online.target sound.target pisugar-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=%i
+Group=%i
+WorkingDirectory=/home/%i/yoyo-py
+Environment=PYTHONUNBUFFERED=1
+Environment=PATH=/home/%i/.local/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-/etc/default/yoyopod
+ExecStart=/usr/bin/env bash -lc 'exec uv run python yoyopod.py'
+Restart=always
+RestartSec=5
+KillSignal=SIGTERM
+TimeoutStopSec=30
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -11,6 +11,7 @@ The repo now has a clear hardware smoke path, but developers still need a quick 
 - run one combined preflight before manual app startup
 - run the Pi smoke checks
 - launch the production app
+- install and inspect the production systemd unit
 
 Use `scripts/pi_remote.py` for that loop.
 
@@ -104,6 +105,19 @@ uv run python scripts/pi_remote.py rtc status
 uv run python scripts/pi_remote.py rtc sync-to-rtc
 ```
 
+### Production systemd service
+
+```bash
+uv run python scripts/pi_remote.py service status
+uv run python scripts/pi_remote.py service install
+uv run python scripts/pi_remote.py service restart
+uv run python scripts/pi_remote.py service logs --lines 150
+```
+
+This installs `deploy/systemd/yoyopod@.service` onto the Pi as
+`yoyopod@<remote-user>.service`, enables it at boot, and keeps the app paired
+with the PiSugar watchdog recovery loop.
+
 Use this during on-device tuning when the Whisplay button feels too eager or too sluggish. The helper runs interactively over SSH, prints every semantic gesture event, and accepts temporary timing overrides without modifying the tracked config file.
 
 ### Run the full preflight in one command
@@ -149,6 +163,12 @@ uv run python scripts/pi_remote.py run --app-arg=--your-extra-flag
 4. Launch the app:
    `uv run python scripts/pi_remote.py run`
 
+If you are validating the production boot path rather than an interactive SSH
+run, use:
+
+5. `uv run python scripts/pi_remote.py service restart`
+6. `uv run python scripts/pi_remote.py service status`
+
 ## Release / Pre-Merge Checklist
 
 - Local branch is green with `uv run pytest -q`
@@ -166,5 +186,6 @@ uv run python scripts/pi_remote.py run --app-arg=--your-extra-flag
 
 - `pi_remote.py run` uses an interactive SSH session so you can stop the remote app with `Ctrl+C`.
 - `pi_remote.py preflight` is intentionally non-interactive. It validates but does not launch the app.
+- `pi_remote.py service install` expects passwordless `sudo` or an interactive sudo policy on the Pi.
 - The helper does not kill existing remote processes for you. If the Pi already has a stale YoyoPod or `linphonec` process, stop it first.
 - For deeper hardware debugging, use `docs/RPI_SMOKE_VALIDATION.md`.

--- a/scripts/pi_remote.py
+++ b/scripts/pi_remote.py
@@ -168,6 +168,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Enable verbose RTC helper logging",
     )
 
+    service_parser = subparsers.add_parser(
+        "service",
+        help="Install or inspect the production YoyoPod systemd service",
+    )
+    service_parser.add_argument(
+        "service_action",
+        nargs="?",
+        default="status",
+        choices=["status", "install", "start", "stop", "restart", "logs"],
+        help="Service action to run remotely (default: status)",
+    )
+    service_parser.add_argument(
+        "--lines",
+        type=int,
+        default=100,
+        help="How many journal lines to show for `service logs` (default: 100)",
+    )
+
     preflight_parser = subparsers.add_parser(
         "preflight",
         help="Run local checks, sync the Pi, and execute the Pi smoke pass",
@@ -307,6 +325,12 @@ def build_status_command() -> str:
             "echo '== Mopidy ==' ",
             "systemctl --user is-active mopidy || true",
             "echo",
+            "echo '== YoyoPod Service ==' ",
+            "systemctl is-active \"yoyopod@$(id -un).service\" || true",
+            "echo",
+            "echo '== PiSugar Server ==' ",
+            "systemctl is-active pisugar-server || true",
+            "echo",
             "echo '== Top Processes ==' ",
             "ps -eo pid,comm,%mem,%cpu --sort=-%mem | head -15",
         ]
@@ -376,6 +400,39 @@ def build_rtc_command(args: argparse.Namespace) -> str:
         if args.repeat_mask != 127:
             parts.extend(["--repeat-mask", str(args.repeat_mask)])
     return " ".join(parts)
+
+
+def build_service_command(args: argparse.Namespace) -> str:
+    """Create the remote systemd service command."""
+    service_name = 'yoyopod@"$(id -un)".service'
+
+    if args.service_action == "status":
+        return f"sudo systemctl status {service_name} --no-pager || true"
+
+    if args.service_action == "install":
+        return " && ".join(
+            [
+                "test -f deploy/systemd/yoyopod@.service",
+                "sudo cp deploy/systemd/yoyopod@.service /etc/systemd/system/yoyopod@.service",
+                "sudo systemctl daemon-reload",
+                f"sudo systemctl enable --now {service_name}",
+                f"sudo systemctl status {service_name} --no-pager",
+            ]
+        )
+
+    if args.service_action == "start":
+        return f"sudo systemctl start {service_name} && sudo systemctl status {service_name} --no-pager"
+
+    if args.service_action == "stop":
+        return f"sudo systemctl stop {service_name} && sudo systemctl status {service_name} --no-pager || true"
+
+    if args.service_action == "restart":
+        return f"sudo systemctl restart {service_name} && sudo systemctl status {service_name} --no-pager"
+
+    if args.service_action == "logs":
+        return f"sudo journalctl -u {service_name} -n {args.lines} --no-pager"
+
+    raise SystemExit(f"Unsupported service action: {args.service_action}")
 
 
 def build_run_command(args: argparse.Namespace) -> str:
@@ -457,6 +514,9 @@ def main() -> int:
 
     if args.command == "rtc":
         return run_remote(config, build_rtc_command(args))
+
+    if args.command == "service":
+        return run_remote(config, build_service_command(args))
 
     if args.command == "preflight":
         return run_preflight(config, args)

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -129,6 +129,12 @@ class FakeMopidyClient:
         self.playback_state = "playing"
         return True
 
+    def stop_polling(self) -> None:
+        pass
+
+    def cleanup(self) -> None:
+        pass
+
 
 class FakeRecoveringVoIPManager:
     """Minimal VoIP manager double for app-level recovery tests."""
@@ -193,9 +199,15 @@ class FakePowerManager:
         critical_shutdown_percent: float = 10.0,
         shutdown_delay_seconds: float = 15.0,
         shutdown_state_file: str = "data/test_shutdown_state.json",
+        watchdog_enabled: bool = False,
+        watchdog_timeout_seconds: int = 60,
+        watchdog_feed_interval_seconds: float = 15.0,
     ) -> None:
         self._snapshots = snapshots
         self.refresh_calls = 0
+        self.enable_watchdog_calls = 0
+        self.feed_watchdog_calls = 0
+        self.disable_watchdog_calls = 0
         self.config = SimpleNamespace(
             enabled=True,
             poll_interval_seconds=poll_interval_seconds,
@@ -206,6 +218,9 @@ class FakePowerManager:
             shutdown_delay_seconds=shutdown_delay_seconds,
             shutdown_command="sudo -n shutdown -h now",
             shutdown_state_file=shutdown_state_file,
+            watchdog_enabled=watchdog_enabled,
+            watchdog_timeout_seconds=watchdog_timeout_seconds,
+            watchdog_feed_interval_seconds=watchdog_feed_interval_seconds,
         )
         self.registered_shutdown_hooks: list[tuple[str, object]] = []
         self.run_shutdown_hooks_calls = 0
@@ -235,6 +250,18 @@ class FakePowerManager:
 
     def request_system_shutdown(self) -> bool:
         self.shutdown_requested = True
+        return True
+
+    def enable_watchdog(self) -> bool:
+        self.enable_watchdog_calls += 1
+        return True
+
+    def feed_watchdog(self) -> bool:
+        self.feed_watchdog_calls += 1
+        return True
+
+    def disable_watchdog(self) -> bool:
+        self.disable_watchdog_calls += 1
         return True
 
 
@@ -891,7 +918,7 @@ def test_pending_shutdown_runs_hooks_and_requests_system_poweroff(tmp_path) -> N
     app, _, _ = _build_app_with_power(power_manager)
     stop_calls: list[str] = []
 
-    def fake_stop() -> None:
+    def fake_stop(disable_watchdog: bool = True) -> None:
         stop_calls.append("stop")
         app._stopping = True
 
@@ -914,3 +941,70 @@ def test_pending_shutdown_runs_hooks_and_requests_system_poweroff(tmp_path) -> N
     assert payload["current_screen"] == "menu"
     assert payload["battery_percent"] == 8
     assert payload["external_power"] is False
+
+
+def test_watchdog_starts_and_feeds_from_app_loop() -> None:
+    """The app loop should enable and periodically feed the PiSugar watchdog."""
+
+    power_manager = FakePowerManager(
+        [_power_snapshot(available=True, battery_percent=60.0)],
+        watchdog_enabled=True,
+        watchdog_timeout_seconds=60,
+        watchdog_feed_interval_seconds=10.0,
+    )
+    app, _, _ = _build_app_with_power(power_manager)
+    app.simulate = False
+
+    app._start_watchdog(now=0.0)
+    app._feed_watchdog_if_due(9.0)
+    app._feed_watchdog_if_due(10.0)
+
+    assert power_manager.enable_watchdog_calls == 1
+    assert power_manager.feed_watchdog_calls == 1
+    assert app.get_status()["watchdog_active"] is True
+
+
+def test_intentional_stop_disables_watchdog() -> None:
+    """Ordinary app stops should disable the watchdog to avoid reboot loops."""
+
+    power_manager = FakePowerManager(
+        [_power_snapshot(available=True, battery_percent=60.0)],
+        watchdog_enabled=True,
+    )
+    app, _, _ = _build_app_with_power(power_manager)
+    app.simulate = False
+
+    app._start_watchdog(now=0.0)
+    app.stop()
+
+    assert power_manager.enable_watchdog_calls == 1
+    assert power_manager.disable_watchdog_calls == 1
+
+
+def test_poweroff_path_suppresses_watchdog_feed_without_disabling_it() -> None:
+    """Battery-driven poweroff should preserve the watchdog as a recovery backstop."""
+
+    power_manager = FakePowerManager(
+        [_power_snapshot(available=True, battery_percent=8.0)],
+        watchdog_enabled=True,
+        critical_shutdown_percent=10.0,
+        shutdown_delay_seconds=0.0,
+    )
+    app, _, _ = _build_app_with_power(power_manager)
+    app.simulate = False
+    stop_disable_watchdog: list[bool] = []
+
+    def fake_stop(disable_watchdog: bool = True) -> None:
+        stop_disable_watchdog.append(disable_watchdog)
+        app._stopping = True
+        app._stopped = True
+
+    app.stop = fake_stop
+    app._start_watchdog(now=0.0)
+    app._register_power_shutdown_hooks()
+    app._poll_power_status(now=0.0, force=True)
+    app._process_pending_shutdown(app._pending_shutdown.execute_at)
+
+    assert stop_disable_watchdog == [False]
+    assert power_manager.disable_watchdog_calls == 0
+    assert app.get_status()["watchdog_feed_suppressed"] is True

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -41,6 +41,11 @@ def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> Non
     assert settings.power.shutdown_delay_seconds == 15.0
     assert settings.power.shutdown_command == "sudo -n shutdown -h now"
     assert settings.power.shutdown_state_file == "data/last_shutdown_state.json"
+    assert settings.power.watchdog_enabled is False
+    assert settings.power.watchdog_timeout_seconds == 60
+    assert settings.power.watchdog_feed_interval_seconds == 15.0
+    assert settings.power.watchdog_i2c_bus == 1
+    assert settings.power.watchdog_i2c_address == 0x57
     assert settings.display.hardware == "auto"
 
 
@@ -78,6 +83,10 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     monkeypatch.setenv("YOYOPOD_CRITICAL_BATTERY_SHUTDOWN_PERCENT", "8.5")
     monkeypatch.setenv("YOYOPOD_POWER_SHUTDOWN_DELAY_SECONDS", "22.0")
     monkeypatch.setenv("YOYOPOD_POWER_SHUTDOWN_COMMAND", "sudo -n poweroff")
+    monkeypatch.setenv("YOYOPOD_POWER_WATCHDOG_ENABLED", "true")
+    monkeypatch.setenv("YOYOPOD_POWER_WATCHDOG_TIMEOUT_SECONDS", "90")
+    monkeypatch.setenv("YOYOPOD_POWER_WATCHDOG_FEED_INTERVAL_SECONDS", "30")
+    monkeypatch.setenv("YOYOPOD_POWER_WATCHDOG_I2C_ADDRESS", "0x58")
     monkeypatch.setenv("YOYOPOD_DISPLAY", "whisplay")
 
     config_manager = ConfigManager(config_dir=str(tmp_path))
@@ -96,6 +105,10 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     assert settings.power.critical_shutdown_percent == 8.5
     assert settings.power.shutdown_delay_seconds == 22.0
     assert settings.power.shutdown_command == "sudo -n poweroff"
+    assert settings.power.watchdog_enabled is True
+    assert settings.power.watchdog_timeout_seconds == 90
+    assert settings.power.watchdog_feed_interval_seconds == 30.0
+    assert settings.power.watchdog_i2c_address == 0x58
     assert settings.display.hardware == "whisplay"
     assert settings.logging.level == "DEBUG"
     assert config_dict["audio"]["mopidy_port"] == 7788

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -4,7 +4,9 @@ from scripts.pi_remote import (
     RemoteConfig,
     build_local_preflight_commands,
     build_rtc_command,
+    build_service_command,
     build_smoke_command,
+    build_status_command,
     build_sync_command,
     build_whisplay_command,
     quote_remote_project_dir,
@@ -115,3 +117,26 @@ def test_build_rtc_command_supports_status_and_set_alarm() -> None:
     assert set_alarm_command.startswith("uv run python scripts/pisugar_rtc.py --verbose set-alarm")
     assert "--time 2026-04-06T07:30:00+02:00" in set_alarm_command
     assert "--repeat-mask 31" in set_alarm_command
+
+
+def test_build_status_command_reports_yoyopod_service_and_pisugar_server() -> None:
+    """Status output should include the production YoyoPod service and PiSugar daemon."""
+
+    command = build_status_command()
+
+    assert 'systemctl is-active "yoyopod@$(id -un).service" || true' in command
+    assert "systemctl is-active pisugar-server || true" in command
+
+
+def test_build_service_command_supports_install_and_logs() -> None:
+    """Service helper should build install and log commands for the systemd unit."""
+
+    install_args = Namespace(service_action="install", lines=100)
+    logs_args = Namespace(service_action="logs", lines=25)
+
+    install_command = build_service_command(install_args)
+    logs_command = build_service_command(logs_args)
+
+    assert "deploy/systemd/yoyopod@.service" in install_command
+    assert 'sudo systemctl enable --now yoyopod@"$(id -un)".service' in install_command
+    assert logs_command == 'sudo journalctl -u yoyopod@"$(id -un)".service -n 25 --no-pager'

--- a/tests/test_power_manager.py
+++ b/tests/test_power_manager.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-
 from yoyopy.config import ConfigManager
 from yoyopy.power.manager import PowerManager
 from yoyopy.power.models import BatteryState, PowerConfig, PowerSnapshot, RTCState
@@ -49,6 +48,24 @@ class ExplodingBackend:
 
     def get_snapshot(self) -> PowerSnapshot:
         raise RuntimeError("backend boom")
+
+
+class FakeWatchdog:
+    """Minimal watchdog double for power-manager tests."""
+
+    def __init__(self) -> None:
+        self.enable_calls = 0
+        self.feed_calls = 0
+        self.disable_calls = 0
+
+    def enable(self, timeout_seconds: int | None = None) -> None:
+        self.enable_calls += 1
+
+    def feed(self) -> None:
+        self.feed_calls += 1
+
+    def disable(self) -> None:
+        self.disable_calls += 1
 
 
 def test_power_manager_refresh_caches_latest_snapshot() -> None:
@@ -97,6 +114,10 @@ power:
   critical_shutdown_percent: 7.5
   shutdown_delay_seconds: 20.0
   shutdown_command: "sudo -n poweroff"
+  watchdog_enabled: true
+  watchdog_timeout_seconds: 90
+  watchdog_feed_interval_seconds: 30.0
+  watchdog_i2c_address: 0x58
 """.strip(),
         encoding="utf-8",
     )
@@ -113,6 +134,10 @@ power:
     assert manager.config.critical_shutdown_percent == 7.5
     assert manager.config.shutdown_delay_seconds == 20.0
     assert manager.config.shutdown_command == "sudo -n poweroff"
+    assert manager.config.watchdog_enabled is True
+    assert manager.config.watchdog_timeout_seconds == 90
+    assert manager.config.watchdog_feed_interval_seconds == 30.0
+    assert manager.config.watchdog_i2c_address == 0x58
 
 
 def test_power_manager_runs_shutdown_hooks_and_reports_failures() -> None:
@@ -181,4 +206,26 @@ def test_power_manager_exposes_rtc_sync_and_alarm_helpers() -> None:
     assert backend.disable_alarm_calls == 1
     assert backend.refresh_calls == 4
     assert rtc_state.time == datetime(2026, 4, 4, 12, 0, tzinfo=timezone.utc)
+
+
+def test_power_manager_wraps_watchdog_lifecycle() -> None:
+    """Watchdog enable/feed/disable should delegate to the configured controller."""
+
+    snapshot = PowerSnapshot(
+        available=True,
+        checked_at=datetime(2026, 4, 4, 12, 0, 0),
+    )
+    watchdog = FakeWatchdog()
+    manager = PowerManager(
+        PowerConfig(watchdog_enabled=True),
+        backend=FakeBackend(snapshot),
+        watchdog=watchdog,
+    )
+
+    assert manager.enable_watchdog() is True
+    assert manager.feed_watchdog() is True
+    assert manager.disable_watchdog() is True
+    assert watchdog.enable_calls == 1
+    assert watchdog.feed_calls == 1
+    assert watchdog.disable_calls == 1
 

--- a/tests/test_power_watchdog.py
+++ b/tests/test_power_watchdog.py
@@ -1,0 +1,92 @@
+"""Tests for the PiSugar watchdog controller."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from yoyopy.power.models import PowerConfig
+from yoyopy.power.watchdog import PiSugarWatchdog, WatchdogCommandError
+
+
+def test_enable_sets_timeout_and_starts_with_fresh_feed() -> None:
+    """Enabling the watchdog should write the timeout register and feed immediately."""
+
+    commands: list[list[str]] = []
+
+    def runner(command: list[str]):
+        commands.append(command)
+        if command[0] == "i2cget":
+            return SimpleNamespace(returncode=0, stdout="0x10\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    watchdog = PiSugarWatchdog(
+        PowerConfig(
+            watchdog_enabled=True,
+            watchdog_timeout_seconds=19,
+        ),
+        runner=runner,
+    )
+
+    watchdog.enable()
+
+    assert commands == [
+        ["i2cget", "-y", "1", "0x57", "0x6"],
+        ["i2cset", "-y", "1", "0x57", "0x7", "0xa"],
+        ["i2cset", "-y", "1", "0x57", "0x6", "0xb0"],
+    ]
+
+
+def test_feed_preserves_enable_bit_and_sets_reset_bit() -> None:
+    """Feeding the watchdog should read the current control register and kick the timer."""
+
+    commands: list[list[str]] = []
+
+    def runner(command: list[str]):
+        commands.append(command)
+        if command[0] == "i2cget":
+            return SimpleNamespace(returncode=0, stdout="0x80\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    watchdog = PiSugarWatchdog(PowerConfig(watchdog_enabled=True), runner=runner)
+
+    watchdog.feed()
+
+    assert commands == [
+        ["i2cget", "-y", "1", "0x57", "0x6"],
+        ["i2cset", "-y", "1", "0x57", "0x6", "0xa0"],
+    ]
+
+
+def test_disable_clears_watchdog_enable_bit() -> None:
+    """Disabling should write the control register without the watchdog bits set."""
+
+    commands: list[list[str]] = []
+
+    def runner(command: list[str]):
+        commands.append(command)
+        if command[0] == "i2cget":
+            return SimpleNamespace(returncode=0, stdout="0xa0\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    watchdog = PiSugarWatchdog(PowerConfig(watchdog_enabled=True), runner=runner)
+
+    watchdog.disable()
+
+    assert commands == [
+        ["i2cget", "-y", "1", "0x57", "0x6"],
+        ["i2cset", "-y", "1", "0x57", "0x6", "0x0"],
+    ]
+
+
+def test_watchdog_raises_on_failed_command() -> None:
+    """Non-zero i2c command exits should be surfaced as watchdog failures."""
+
+    def runner(_command: list[str]):
+        return SimpleNamespace(returncode=1, stdout="", stderr="i2c failure")
+
+    watchdog = PiSugarWatchdog(PowerConfig(watchdog_enabled=True), runner=runner)
+
+    with pytest.raises(WatchdogCommandError):
+        watchdog.feed()

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -190,6 +190,10 @@ class YoyoPodApp:
         self._screen_timeout_seconds = 0.0
         self._active_brightness = 1.0
         self._screen_awake = True
+        self._watchdog_active = False
+        self._watchdog_feed_suppressed = False
+        self._next_watchdog_feed_at = 0.0
+        self._stopped = False
 
         logger.info("=" * 60)
         logger.info("YoyoPod Application Initializing")
@@ -989,6 +993,7 @@ class YoyoPodApp:
         if self._shutdown_completed:
             return
 
+        self._suppress_watchdog_feeding("pending system poweroff")
         self._render_power_overlay(
             "Powering Off",
             "Saving state...",
@@ -1000,12 +1005,80 @@ class YoyoPodApp:
             if failed_hooks:
                 logger.warning(f"Shutdown hooks failed: {', '.join(failed_hooks)}")
 
-        self.stop()
+        self.stop(disable_watchdog=False)
 
         if self.power_manager is not None:
             self.power_manager.request_system_shutdown()
 
         self._shutdown_completed = True
+
+    def _start_watchdog(self, now: float | None = None) -> None:
+        """Enable the PiSugar software watchdog once the app loop is ready."""
+        if self.simulate or self.power_manager is None:
+            return
+
+        if not self.power_manager.config.watchdog_enabled or self._watchdog_active:
+            return
+
+        feed_interval = max(1.0, float(self.power_manager.config.watchdog_feed_interval_seconds))
+        timeout_seconds = max(1, int(self.power_manager.config.watchdog_timeout_seconds))
+        if feed_interval >= timeout_seconds:
+            logger.warning(
+                "Power watchdog feed interval ({}) should be less than timeout ({})",
+                feed_interval,
+                timeout_seconds,
+            )
+
+        if not self.power_manager.enable_watchdog():
+            logger.warning("Power watchdog could not be enabled")
+            return
+
+        watchdog_now = time.monotonic() if now is None else now
+        self._watchdog_active = True
+        self._watchdog_feed_suppressed = False
+        self._next_watchdog_feed_at = watchdog_now + feed_interval
+        logger.info(
+            "Power watchdog enabled (timeout={}s, feed={}s)",
+            timeout_seconds,
+            feed_interval,
+        )
+
+    def _feed_watchdog_if_due(self, now: float) -> None:
+        """Feed the PiSugar software watchdog on the coordinator thread."""
+        if not self._watchdog_active or self._watchdog_feed_suppressed:
+            return
+
+        if self.power_manager is None or now < self._next_watchdog_feed_at:
+            return
+
+        feed_interval = max(1.0, float(self.power_manager.config.watchdog_feed_interval_seconds))
+        if self.power_manager.feed_watchdog():
+            self._next_watchdog_feed_at = now + feed_interval
+            return
+
+        self._next_watchdog_feed_at = now + min(feed_interval, 5.0)
+
+    def _disable_watchdog(self) -> None:
+        """Disable the PiSugar watchdog during intentional app shutdowns."""
+        if not self._watchdog_active:
+            return
+
+        if self.power_manager is not None and self.power_manager.disable_watchdog():
+            logger.info("Power watchdog disabled for intentional stop")
+        else:
+            logger.warning("Failed to disable power watchdog cleanly")
+
+        self._watchdog_active = False
+        self._watchdog_feed_suppressed = False
+        self._next_watchdog_feed_at = 0.0
+
+    def _suppress_watchdog_feeding(self, reason: str) -> None:
+        """Stop feeding the watchdog without disabling it."""
+        if not self._watchdog_active or self._watchdog_feed_suppressed:
+            return
+
+        self._watchdog_feed_suppressed = True
+        logger.info(f"Power watchdog feeding suppressed: {reason}")
 
     def _attempt_voip_recovery(self, recovery_now: float) -> None:
         """Restart the VoIP backend when it is not running."""
@@ -1129,6 +1202,7 @@ class YoyoPodApp:
                 logger.info(f"  Charging: {power_snapshot.battery.charging}")
             if power_snapshot.battery.power_plugged is not None:
                 logger.info(f"  External power: {power_snapshot.battery.power_plugged}")
+            logger.info(f"  Watchdog enabled: {self.power_manager.config.watchdog_enabled}")
         else:
             logger.info("  Power backend not configured")
         logger.info("")
@@ -1148,6 +1222,7 @@ class YoyoPodApp:
         try:
             last_screen_update = time.time()
             screen_update_interval = 1.0
+            self._start_watchdog(now=time.monotonic())
 
             if self.simulate:
                 logger.info("")
@@ -1161,6 +1236,7 @@ class YoyoPodApp:
                 self._attempt_manager_recovery()
                 self._poll_power_status()
                 monotonic_now = time.monotonic()
+                self._feed_watchdog_if_due(monotonic_now)
                 self._process_pending_shutdown(monotonic_now)
                 if self._shutdown_completed:
                     break
@@ -1188,10 +1264,16 @@ class YoyoPodApp:
             if not self._shutdown_completed and not self._stopping:
                 self.stop()
 
-    def stop(self) -> None:
+    def stop(self, disable_watchdog: bool = True) -> None:
         """Clean up and stop the application."""
+        if self._stopped:
+            return
+
         logger.info("Stopping YoyoPod...")
         self._stopping = True
+
+        if disable_watchdog:
+            self._disable_watchdog()
 
         self._ensure_coordinators()
         self.call_coordinator.cleanup()
@@ -1224,6 +1306,8 @@ class YoyoPodApp:
 
         logger.info("✓ YoyoPod stopped")
 
+        self._stopped = True
+
     def get_status(self) -> Dict[str, Any]:
         """Return the current application status."""
         pending_shutdown_in_seconds = None
@@ -1252,4 +1336,11 @@ class YoyoPodApp:
             "shutdown_reason": self._pending_shutdown.reason if self._pending_shutdown else None,
             "shutdown_in_seconds": pending_shutdown_in_seconds,
             "shutdown_completed": self._shutdown_completed,
+            "watchdog_enabled": (
+                self.power_manager.config.watchdog_enabled
+                if self.power_manager is not None
+                else False
+            ),
+            "watchdog_active": self._watchdog_active,
+            "watchdog_feed_suppressed": self._watchdog_feed_suppressed,
         }

--- a/yoyopy/config/models.py
+++ b/yoyopy/config/models.py
@@ -120,6 +120,8 @@ def _coerce_value(value: Any, field_type: Any) -> Any:
             return False
         raise ValueError(f"Cannot coerce {value!r} to bool")
     if target_type is int:
+        if isinstance(value, str):
+            return int(value, 0)
         return int(value)
     if target_type is float:
         return float(value)
@@ -242,6 +244,30 @@ class AppPowerConfig:
     shutdown_state_file: str = config_value(
         default="data/last_shutdown_state.json",
         env="YOYOPOD_POWER_SHUTDOWN_STATE_FILE",
+    )
+    watchdog_enabled: bool = config_value(
+        default=False,
+        env="YOYOPOD_POWER_WATCHDOG_ENABLED",
+    )
+    watchdog_timeout_seconds: int = config_value(
+        default=60,
+        env="YOYOPOD_POWER_WATCHDOG_TIMEOUT_SECONDS",
+    )
+    watchdog_feed_interval_seconds: float = config_value(
+        default=15.0,
+        env="YOYOPOD_POWER_WATCHDOG_FEED_INTERVAL_SECONDS",
+    )
+    watchdog_i2c_bus: int = config_value(
+        default=1,
+        env="YOYOPOD_POWER_WATCHDOG_I2C_BUS",
+    )
+    watchdog_i2c_address: int = config_value(
+        default=0x57,
+        env="YOYOPOD_POWER_WATCHDOG_I2C_ADDRESS",
+    )
+    watchdog_command_timeout_seconds: float = config_value(
+        default=5.0,
+        env="YOYOPOD_POWER_WATCHDOG_COMMAND_TIMEOUT_SECONDS",
     )
 
 

--- a/yoyopy/main.py
+++ b/yoyopy/main.py
@@ -6,6 +6,7 @@ and keeps the installed entry point aligned with the top-level launcher.
 """
 
 import sys
+import signal
 
 from loguru import logger
 
@@ -73,6 +74,14 @@ def main() -> int:
     logger.info("=" * 60)
     logger.info("")
 
+    def handle_shutdown_signal(signum, _frame) -> None:
+        signal_name = signal.Signals(signum).name
+        logger.info(f"Received {signal_name}, shutting down...")
+        raise KeyboardInterrupt
+
+    previous_sigterm = signal.getsignal(signal.SIGTERM)
+    signal.signal(signal.SIGTERM, handle_shutdown_signal)
+
     try:
         app.run()
     except KeyboardInterrupt:
@@ -80,6 +89,7 @@ def main() -> int:
         logger.info("=" * 60)
         logger.info("Shutting down...")
     finally:
+        signal.signal(signal.SIGTERM, previous_sigterm)
         app.stop()
 
     logger.info("")

--- a/yoyopy/power/__init__.py
+++ b/yoyopy/power/__init__.py
@@ -26,6 +26,7 @@ from yoyopy.power.models import (
     ShutdownState,
 )
 from yoyopy.power.policies import PowerSafetyPolicy
+from yoyopy.power.watchdog import PiSugarWatchdog, WatchdogCommandError
 
 __all__ = [
     "PowerBackend",
@@ -36,6 +37,8 @@ __all__ = [
     "PiSugarAutoTransport",
     "build_pisugar_transport",
     "PowerManager",
+    "PiSugarWatchdog",
+    "WatchdogCommandError",
     "PowerConfig",
     "PowerDeviceInfo",
     "BatteryState",

--- a/yoyopy/power/manager.py
+++ b/yoyopy/power/manager.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from yoyopy.power.backend import PiSugarBackend, PowerBackend
 from yoyopy.power.models import PowerConfig, PowerSnapshot, RTCState
+from yoyopy.power.watchdog import PiSugarWatchdog, WatchdogCommandError
 
 if TYPE_CHECKING:
     from yoyopy.config import ConfigManager
@@ -28,10 +29,14 @@ class PowerManager:
         config: PowerConfig,
         backend: PowerBackend | None = None,
         shutdown_runner: ShutdownRunner | None = None,
+        watchdog: PiSugarWatchdog | None = None,
     ) -> None:
         self.config = config
         self.backend = backend or PiSugarBackend(config)
         self._shutdown_runner = shutdown_runner or self._default_shutdown_runner
+        self.watchdog = watchdog or (
+            PiSugarWatchdog(config) if config.watchdog_enabled else None
+        )
         self._shutdown_hooks: list[tuple[str, ShutdownHook]] = []
         self.last_snapshot = PowerSnapshot(
             available=False,
@@ -99,6 +104,43 @@ class PowerManager:
         """Disable the PiSugar RTC wake alarm and return fresh RTC state."""
         self.backend.disable_rtc_alarm()
         return self.get_rtc_state(refresh=True)
+
+    def enable_watchdog(self) -> bool:
+        """Enable and immediately feed the PiSugar software watchdog."""
+        if self.watchdog is None:
+            logger.info("Power watchdog not configured")
+            return False
+
+        try:
+            self.watchdog.enable()
+        except WatchdogCommandError as exc:
+            logger.error(f"Failed to enable power watchdog: {exc}")
+            return False
+        return True
+
+    def feed_watchdog(self) -> bool:
+        """Feed the PiSugar software watchdog once."""
+        if self.watchdog is None:
+            return False
+
+        try:
+            self.watchdog.feed()
+        except WatchdogCommandError as exc:
+            logger.error(f"Failed to feed power watchdog: {exc}")
+            return False
+        return True
+
+    def disable_watchdog(self) -> bool:
+        """Disable the PiSugar software watchdog."""
+        if self.watchdog is None:
+            return False
+
+        try:
+            self.watchdog.disable()
+        except WatchdogCommandError as exc:
+            logger.error(f"Failed to disable power watchdog: {exc}")
+            return False
+        return True
 
     def register_shutdown_hook(self, name: str, hook: ShutdownHook) -> None:
         """Register one callable to run before a graceful poweroff."""

--- a/yoyopy/power/models.py
+++ b/yoyopy/power/models.py
@@ -29,6 +29,12 @@ class PowerConfig:
     shutdown_delay_seconds: float = 15.0
     shutdown_command: str = "sudo -n shutdown -h now"
     shutdown_state_file: str = "data/last_shutdown_state.json"
+    watchdog_enabled: bool = False
+    watchdog_timeout_seconds: int = 60
+    watchdog_feed_interval_seconds: float = 15.0
+    watchdog_i2c_bus: int = 1
+    watchdog_i2c_address: int = 0x57
+    watchdog_command_timeout_seconds: float = 5.0
 
     @staticmethod
     def from_config_manager(config_manager: "ConfigManager") -> "PowerConfig":
@@ -51,6 +57,12 @@ class PowerConfig:
             shutdown_delay_seconds=settings.shutdown_delay_seconds,
             shutdown_command=settings.shutdown_command,
             shutdown_state_file=settings.shutdown_state_file,
+            watchdog_enabled=settings.watchdog_enabled,
+            watchdog_timeout_seconds=settings.watchdog_timeout_seconds,
+            watchdog_feed_interval_seconds=settings.watchdog_feed_interval_seconds,
+            watchdog_i2c_bus=settings.watchdog_i2c_bus,
+            watchdog_i2c_address=settings.watchdog_i2c_address,
+            watchdog_command_timeout_seconds=settings.watchdog_command_timeout_seconds,
         )
 
 

--- a/yoyopy/power/watchdog.py
+++ b/yoyopy/power/watchdog.py
@@ -1,0 +1,124 @@
+"""PiSugar software watchdog helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from math import ceil
+from typing import Callable, Protocol
+
+from yoyopy.power.models import PowerConfig
+
+
+class WatchdogRunnerResult(Protocol):
+    """Minimal subprocess-like result contract used by the watchdog controller."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+WatchdogRunner = Callable[[list[str]], WatchdogRunnerResult]
+
+
+class WatchdogCommandError(RuntimeError):
+    """Raised when one PiSugar watchdog command cannot be completed."""
+
+
+class PiSugarWatchdog:
+    """Control the PiSugar 3 software watchdog over I2C tools."""
+
+    CONTROL_REGISTER = 0x06
+    TIMEOUT_REGISTER = 0x07
+    ENABLE_MASK = 0x80
+    FEED_MASK = 0x20
+
+    def __init__(
+        self,
+        config: PowerConfig,
+        runner: WatchdogRunner | None = None,
+    ) -> None:
+        self.config = config
+        self._runner = runner or self._default_runner
+
+    def enable(self, timeout_seconds: int | None = None) -> None:
+        """Enable the PiSugar watchdog and start a fresh timeout window."""
+        timeout_value = self._coerce_timeout_value(timeout_seconds)
+        control_value = self._read_register(self.CONTROL_REGISTER)
+        self._write_register(self.TIMEOUT_REGISTER, timeout_value)
+        self._write_register(
+            self.CONTROL_REGISTER,
+            control_value | self.ENABLE_MASK | self.FEED_MASK,
+        )
+
+    def feed(self) -> None:
+        """Reset the PiSugar watchdog timer while keeping it enabled."""
+        control_value = self._read_register(self.CONTROL_REGISTER)
+        self._write_register(
+            self.CONTROL_REGISTER,
+            control_value | self.ENABLE_MASK | self.FEED_MASK,
+        )
+
+    def disable(self) -> None:
+        """Turn off the PiSugar watchdog."""
+        control_value = self._read_register(self.CONTROL_REGISTER)
+        disabled_value = control_value & ~self.ENABLE_MASK & ~self.FEED_MASK
+        self._write_register(self.CONTROL_REGISTER, disabled_value)
+
+    def _coerce_timeout_value(self, timeout_seconds: int | None) -> int:
+        effective_timeout = (
+            self.config.watchdog_timeout_seconds
+            if timeout_seconds is None
+            else timeout_seconds
+        )
+        if effective_timeout <= 0:
+            raise WatchdogCommandError("Watchdog timeout must be positive")
+
+        # PiSugar stores the watchdog timeout in 2-second units.
+        return max(1, min(255, ceil(effective_timeout / 2.0)))
+
+    def _read_register(self, register: int) -> int:
+        result = self._run_command(
+            [
+                "i2cget",
+                "-y",
+                str(self.config.watchdog_i2c_bus),
+                hex(self.config.watchdog_i2c_address),
+                hex(register),
+            ]
+        )
+        try:
+            return int(result.stdout.strip(), 0)
+        except ValueError as exc:
+            raise WatchdogCommandError(
+                f"Unexpected i2cget output for register {hex(register)}: {result.stdout!r}"
+            ) from exc
+
+    def _write_register(self, register: int, value: int) -> None:
+        self._run_command(
+            [
+                "i2cset",
+                "-y",
+                str(self.config.watchdog_i2c_bus),
+                hex(self.config.watchdog_i2c_address),
+                hex(register),
+                hex(value),
+            ]
+        )
+
+    def _run_command(self, command: list[str]) -> WatchdogRunnerResult:
+        result = self._runner(command)
+        if result.returncode != 0:
+            raise WatchdogCommandError(
+                f"Watchdog command failed ({result.returncode}): {' '.join(command)}; "
+                f"stderr={result.stderr.strip()!r}"
+            )
+        return result
+
+    def _default_runner(self, command: list[str]) -> WatchdogRunnerResult:
+        return subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=self.config.watchdog_command_timeout_seconds,
+        )


### PR DESCRIPTION
## Summary
- add PiSugar watchdog control and app-loop heartbeat support
- suppress watchdog feeding during poweroff while disabling it for intentional service stops
- add a production systemd unit plus remote helper and docs for service install and status

## Testing
- python -m compileall yoyopy tests demos scripts
- uv run pytest -q
- uv run python scripts/pi_remote.py --host rpi-zero service status
- ssh rpi-zero "bash -lc 'command -v i2cget; command -v i2cset; systemctl is-active pisugar-server || true'"
