### PR TITLE
Finish power module UI and diagnostics polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # YoyoPod Current Status & Developer Guide
 
-**Last Updated:** 2026-04-02
+**Last Updated:** 2026-04-05
 **Target Hardware:** Raspberry Pi Zero 2W
 **Project:** iPod-inspired VoIP and Mopidy player with a small-screen, button-driven UI
 
@@ -120,6 +120,7 @@ Key design points:
 - `yoyopy/power/watchdog.py` - PiSugar software watchdog controller over `i2cget`/`i2cset`
 - `yoyopy/power/manager.py` - app-facing power facade
 - `yoyopy/power/policies.py` - low-battery safety policy
+- `scripts/pisugar_power.py` - battery, charging, shutdown, and watchdog helper
 - `scripts/pisugar_rtc.py` - RTC status/sync/alarm helper
 - `deploy/systemd/yoyopod@.service` - production boot-time service unit
 
@@ -129,6 +130,7 @@ Key design points:
 - `yoyopy/ui/input/` - input HAL, factory, manager, and adapters
 - `yoyopy/ui/screens/manager.py` - stack navigation and input binding
 - `yoyopy/ui/screens/router.py` - declarative route resolution
+- `yoyopy/ui/screens/navigation/power.py` - two-page power and runtime status screen
 - `yoyopy/ui/screens/voip/hub.py` - VoIP hub / quick-call screen
 
 ### Configuration
@@ -206,6 +208,7 @@ uv run python scripts/pi_remote.py status --host rpi-zero
 uv run python scripts/pi_remote.py preflight --host rpi-zero --with-mopidy --with-voip
 uv run python scripts/pi_remote.py sync --host rpi-zero --branch main
 uv run python scripts/pi_remote.py smoke --host rpi-zero --with-mopidy --with-voip
+uv run python scripts/pi_remote.py power --host rpi-zero
 uv run python scripts/pi_remote.py service install --host rpi-zero
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The current codebase supports three display/input modes:
 - `yoyopy/app.py`: `YoyoPodApp` coordinator
 - `scripts/pi_smoke.py`: Raspberry Pi smoke validator for hardware and optional service checks
 - `scripts/pi_remote.py`: SSH helper for Raspberry Pi sync, smoke, status, and run loops
+- `scripts/pisugar_power.py`: PiSugar battery, shutdown, and watchdog helper
 - `scripts/pisugar_rtc.py`: PiSugar RTC status, sync, and alarm helper
 - `deploy/systemd/yoyopod@.service`: production systemd unit for boot-time app supervision
 - `yoyopy/fsm.py`: split `MusicFSM`, `CallFSM`, and call interruption policy
@@ -82,6 +83,7 @@ Important settings:
 - `config/yoyopod_config.yaml`: Whisplay gesture tuning under `input.whisplay_*_ms`
 - `config/yoyopod_config.yaml`: `input.ptt_navigation=false` is reserved for future voice/PTT work and is currently experimental
 - `config/yoyopod_config.yaml`: `power.watchdog_*` controls the PiSugar app heartbeat watchdog
+- `config/yoyopod_config.yaml`: `power.*` also controls low-battery warning, graceful shutdown, and PiSugar polling
 - `config/voip_config.yaml`: SIP account, transport, STUN, `linphonec` path
 - `config/contacts.yaml`: contact list and speed dial entries
 
@@ -108,6 +110,7 @@ uv run python scripts/pi_remote.py status
 uv run python scripts/pi_remote.py preflight --branch main --with-mopidy --with-voip
 uv run python scripts/pi_remote.py sync --branch main
 uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip
+uv run python scripts/pi_remote.py power
 uv run python scripts/pi_remote.py rtc status
 uv run python scripts/pi_remote.py rtc sync-to-rtc
 uv run python scripts/pi_remote.py service status
@@ -128,6 +131,13 @@ Whisplay tuning on-device:
 ```bash
 uv run python scripts/whisplay_tune.py
 uv run python scripts/whisplay_tune.py --double-tap-ms 240 --long-hold-ms 900
+```
+
+PiSugar power diagnostics:
+
+```bash
+uv run python scripts/pisugar_power.py
+uv run python scripts/pi_remote.py power
 ```
 
 ## Running

--- a/demos/demo_runtime_state.py
+++ b/demos/demo_runtime_state.py
@@ -69,6 +69,7 @@ def main() -> int:
         power_manager=None,
         now_playing_screen=now_playing_screen,
         call_screen=None,
+        power_screen=None,
         incoming_call_screen=None,
         outgoing_call_screen=None,
         in_call_screen=None,

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -105,6 +105,14 @@ uv run python scripts/pi_remote.py rtc status
 uv run python scripts/pi_remote.py rtc sync-to-rtc
 ```
 
+### PiSugar power helper
+
+```bash
+uv run python scripts/pi_remote.py power
+```
+
+Use this when you want a focused battery, charging, and watchdog snapshot without the full smoke pass.
+
 ### Production systemd service
 
 ```bash

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -120,6 +120,14 @@ uv run python scripts/pisugar_rtc.py sync-to-rtc
 
 Use this when you want a focused RTC read/sync pass without running the full app.
 
+### PiSugar power drill
+
+```bash
+uv run python scripts/pisugar_power.py
+```
+
+Use this when you want a focused battery, charging, RTC, shutdown-threshold, and watchdog readout without the full smoke flow.
+
 ## Suggested Order On Hardware
 
 1. `uv sync --extra dev`

--- a/scripts/pi_remote.py
+++ b/scripts/pi_remote.py
@@ -168,6 +168,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Enable verbose RTC helper logging",
     )
 
+    power_parser = subparsers.add_parser(
+        "power",
+        help="Inspect PiSugar power telemetry remotely",
+    )
+    power_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose power helper logging",
+    )
+
     service_parser = subparsers.add_parser(
         "service",
         help="Install or inspect the production YoyoPod systemd service",
@@ -402,6 +412,14 @@ def build_rtc_command(args: argparse.Namespace) -> str:
     return " ".join(parts)
 
 
+def build_power_command(args: argparse.Namespace) -> str:
+    """Create the remote PiSugar power-status command."""
+    parts = ["uv run python scripts/pisugar_power.py"]
+    if args.verbose:
+        parts.append("--verbose")
+    return " ".join(parts)
+
+
 def build_service_command(args: argparse.Namespace) -> str:
     """Create the remote systemd service command."""
     service_name = 'yoyopod@"$(id -un)".service'
@@ -459,6 +477,7 @@ def build_local_preflight_commands() -> list[tuple[str, list[str]]]:
                 "scripts/pi_smoke.py",
                 "scripts/pi_remote.py",
                 "scripts/pisugar_rtc.py",
+                "scripts/pisugar_power.py",
                 "scripts/whisplay_tune.py",
             ],
         ),
@@ -514,6 +533,9 @@ def main() -> int:
 
     if args.command == "rtc":
         return run_remote(config, build_rtc_command(args))
+
+    if args.command == "power":
+        return run_remote(config, build_power_command(args))
 
     if args.command == "service":
         return run_remote(config, build_service_command(args))

--- a/scripts/pisugar_power.py
+++ b/scripts/pisugar_power.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""PiSugar power helper for current telemetry and policy status."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from loguru import logger
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from yoyopy.config import ConfigManager
+from yoyopy.power import PowerManager, PowerSnapshot
+
+
+def configure_logging(verbose: bool) -> None:
+    """Configure human-readable logging."""
+    logger.remove()
+    logger.add(
+        sys.stderr,
+        format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <level>{message}</level>",
+        level="DEBUG" if verbose else "INFO",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Inspect PiSugar power telemetry through YoyoPod's power module.",
+    )
+    parser.add_argument(
+        "--config-dir",
+        default="config",
+        help="Configuration directory to use (default: config)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG logging",
+    )
+    return parser
+
+
+def build_manager(config_dir: Path) -> PowerManager:
+    """Create a power manager for the configured PiSugar backend."""
+    config_manager = ConfigManager(config_dir=str(config_dir))
+    manager = PowerManager.from_config_manager(config_manager)
+    if not manager.config.enabled:
+        raise RuntimeError("power backend disabled in yoyopod_config.yaml")
+    return manager
+
+
+def format_snapshot(snapshot: PowerSnapshot, manager: PowerManager) -> list[str]:
+    """Return a readable summary of power telemetry and policy settings."""
+    return [
+        f"available={snapshot.available}",
+        f"source={snapshot.source}",
+        f"error={snapshot.error or 'none'}",
+        f"model={snapshot.device.model or 'unknown'}",
+        f"battery_percent={snapshot.battery.level_percent if snapshot.battery.level_percent is not None else 'unknown'}",
+        f"battery_voltage={snapshot.battery.voltage_volts if snapshot.battery.voltage_volts is not None else 'unknown'}",
+        f"temperature_celsius={snapshot.battery.temperature_celsius if snapshot.battery.temperature_celsius is not None else 'unknown'}",
+        f"charging={snapshot.battery.charging if snapshot.battery.charging is not None else 'unknown'}",
+        f"external_power={snapshot.battery.power_plugged if snapshot.battery.power_plugged is not None else 'unknown'}",
+        f"allow_charging={snapshot.battery.allow_charging if snapshot.battery.allow_charging is not None else 'unknown'}",
+        f"output_enabled={snapshot.battery.output_enabled if snapshot.battery.output_enabled is not None else 'unknown'}",
+        f"rtc_time={snapshot.rtc.time.isoformat() if snapshot.rtc.time is not None else 'unknown'}",
+        f"rtc_alarm_enabled={snapshot.rtc.alarm_enabled if snapshot.rtc.alarm_enabled is not None else 'unknown'}",
+        f"rtc_alarm_time={snapshot.rtc.alarm_time.isoformat() if snapshot.rtc.alarm_time is not None else 'none'}",
+        f"safe_shutdown_level={snapshot.shutdown.safe_shutdown_level_percent if snapshot.shutdown.safe_shutdown_level_percent is not None else 'unknown'}",
+        f"safe_shutdown_delay={snapshot.shutdown.safe_shutdown_delay_seconds if snapshot.shutdown.safe_shutdown_delay_seconds is not None else 'unknown'}",
+        f"warning_threshold={manager.config.low_battery_warning_percent}",
+        f"critical_threshold={manager.config.critical_shutdown_percent}",
+        f"shutdown_delay_seconds={manager.config.shutdown_delay_seconds}",
+        f"watchdog_enabled={manager.config.watchdog_enabled}",
+        f"watchdog_timeout_seconds={manager.config.watchdog_timeout_seconds}",
+        f"watchdog_feed_interval_seconds={manager.config.watchdog_feed_interval_seconds}",
+    ]
+
+
+def main() -> int:
+    """Program entry point."""
+    parser = build_parser()
+    args = parser.parse_args()
+    configure_logging(args.verbose)
+
+    config_dir = Path(args.config_dir)
+    if not config_dir.is_absolute():
+        config_dir = REPO_ROOT / config_dir
+
+    manager = build_manager(config_dir)
+    snapshot = manager.refresh()
+    if not snapshot.available:
+        logger.error(snapshot.error or "power backend unavailable")
+        return 1
+
+    print("")
+    print("PiSugar power status")
+    print("====================")
+    for line in format_snapshot(snapshot, manager):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -231,7 +231,7 @@ class FakePowerManager:
         self.refresh_calls += 1
         return self._snapshots[index]
 
-    def get_snapshot(self) -> PowerSnapshot:
+    def get_snapshot(self, refresh: bool = False) -> PowerSnapshot:
         index = max(0, min(self.refresh_calls - 1, len(self._snapshots) - 1))
         return self._snapshots[index]
 
@@ -315,6 +315,7 @@ def _build_app(playback_state: str = "stopped", auto_resume: bool = True) -> tup
     app.mopidy_client = mopidy
 
     app.menu_screen = FakeScreen()
+    app.power_screen = FakeScreen()
     app.now_playing_screen = FakeScreen()
     app.playlist_screen = FakeScreen()
     app.call_screen = FakeScreen()
@@ -326,6 +327,7 @@ def _build_app(playback_state: str = "stopped", auto_resume: bool = True) -> tup
     screen_manager = FakeScreenManager(
         {
             "menu": app.menu_screen,
+            "power": app.power_screen,
             "playlists": app.playlist_screen,
             "contacts": app.contact_list_screen,
             "incoming_call": app.incoming_call_screen,
@@ -362,6 +364,7 @@ def _build_app_with_power(
     app.mopidy_client = mopidy
 
     app.menu_screen = FakeScreen()
+    app.power_screen = FakeScreen()
     app.now_playing_screen = FakeScreen()
     app.playlist_screen = FakeScreen()
     app.call_screen = FakeScreen()
@@ -373,6 +376,7 @@ def _build_app_with_power(
     screen_manager = FakeScreenManager(
         {
             "menu": app.menu_screen,
+            "power": app.power_screen,
             "playlists": app.playlist_screen,
             "contacts": app.contact_list_screen,
             "incoming_call": app.incoming_call_screen,
@@ -582,6 +586,9 @@ def test_navigation_updates_runtime_base_state() -> None:
     screen_manager.push_screen("playlists")
     assert app.coordinator_runtime.current_app_state == AppRuntimeState.PLAYLIST_BROWSER
 
+    screen_manager.push_screen("power")
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.POWER
+
 
 def test_worker_navigation_waits_for_coordinator_drain_before_syncing_state() -> None:
     """Screen-change callbacks from worker threads should queue runtime sync onto the event bus."""
@@ -719,6 +726,20 @@ def test_power_poll_updates_context_runtime_and_visible_screen() -> None:
     assert app.coordinator_runtime.power_snapshot is not None
     assert app.coordinator_runtime.power_snapshot.battery.level_percent == 55.4
     assert app.menu_screen.render_calls == 1
+
+
+def test_periodic_power_refresh_only_renders_visible_power_screen() -> None:
+    """The main loop should only re-render the power screen while it is visible."""
+    app, _, screen_manager = _build_app_with_power(
+        FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+
+    app._update_power_screen_if_needed()
+    assert app.power_screen.render_calls == 0
+
+    screen_manager.push_screen("power")
+    app._update_power_screen_if_needed()
+    assert app.power_screen.render_calls == 1
 
 
 def test_power_poll_honors_interval_and_tracks_unavailable_backend() -> None:

--- a/tests/test_fsm_runtime.py
+++ b/tests/test_fsm_runtime.py
@@ -21,6 +21,7 @@ def _build_runtime() -> CoordinatorRuntime:
         power_manager=None,
         now_playing_screen=None,
         call_screen=None,
+        power_screen=None,
         incoming_call_screen=None,
         outgoing_call_screen=None,
         in_call_screen=None,

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -3,6 +3,7 @@
 from scripts.pi_remote import (
     RemoteConfig,
     build_local_preflight_commands,
+    build_power_command,
     build_rtc_command,
     build_service_command,
     build_smoke_command,
@@ -68,6 +69,7 @@ def test_build_local_preflight_commands_cover_compile_and_pytest() -> None:
     assert commands[0][0] == "compileall"
     assert commands[0][1][1:3] == ["-m", "compileall"]
     assert "scripts/pisugar_rtc.py" in commands[0][1]
+    assert "scripts/pisugar_power.py" in commands[0][1]
     assert "scripts/whisplay_tune.py" in commands[0][1]
     assert commands[1] == ("pytest", ["uv", "run", "pytest", "-q"])
 
@@ -117,6 +119,13 @@ def test_build_rtc_command_supports_status_and_set_alarm() -> None:
     assert set_alarm_command.startswith("uv run python scripts/pisugar_rtc.py --verbose set-alarm")
     assert "--time 2026-04-06T07:30:00+02:00" in set_alarm_command
     assert "--repeat-mask 31" in set_alarm_command
+
+
+def test_build_power_command_supports_verbose_status() -> None:
+    """Power helper command should forward the optional verbose flag."""
+    command = build_power_command(Namespace(verbose=True))
+
+    assert command == "uv run python scripts/pisugar_power.py --verbose"
 
 
 def test_build_status_command_reports_yoyopod_service_and_pisugar_server() -> None:

--- a/tests/test_power_screen.py
+++ b/tests/test_power_screen.py
@@ -1,0 +1,107 @@
+"""Tests for the user-facing power status screen."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from yoyopy.app_context import AppContext
+from yoyopy.power import BatteryState, PowerDeviceInfo, PowerSnapshot, RTCState, ShutdownState
+from yoyopy.ui.display import Display
+from yoyopy.ui.screens.navigation.power import PowerScreen
+
+
+class StubPowerManager:
+    """Minimal power manager double for screen tests."""
+
+    def __init__(self, snapshot: PowerSnapshot) -> None:
+        self._snapshot = snapshot
+
+    def get_snapshot(self) -> PowerSnapshot:
+        return self._snapshot
+
+
+def _snapshot() -> PowerSnapshot:
+    return PowerSnapshot(
+        available=True,
+        checked_at=datetime(2026, 4, 5, 12, 0, 0),
+        device=PowerDeviceInfo(model="PiSugar 3"),
+        battery=BatteryState(
+            level_percent=55.2,
+            voltage_volts=3.62,
+            charging=True,
+            power_plugged=True,
+            temperature_celsius=29.5,
+        ),
+        rtc=RTCState(
+            time=datetime(2026, 4, 5, 13, 30, 0),
+            alarm_enabled=True,
+            alarm_time=datetime(2026, 4, 6, 7, 30, 0),
+        ),
+        shutdown=ShutdownState(
+            safe_shutdown_level_percent=10.0,
+            safe_shutdown_delay_seconds=15,
+        ),
+    )
+
+
+def test_power_screen_builds_battery_and_runtime_pages() -> None:
+    """The power screen should expose both telemetry and runtime/safety pages."""
+    display = Display(simulate=True)
+    try:
+        status = {
+            "app_uptime_seconds": 3661,
+            "screen_on_seconds": 901,
+            "screen_idle_seconds": 32,
+            "screen_awake": True,
+            "screen_timeout_seconds": 30.0,
+            "warning_threshold_percent": 20.0,
+            "critical_shutdown_percent": 10.0,
+            "shutdown_delay_seconds": 15.0,
+            "shutdown_pending": False,
+            "watchdog_enabled": True,
+            "watchdog_active": True,
+            "watchdog_feed_suppressed": False,
+        }
+        screen = PowerScreen(
+            display,
+            AppContext(),
+            power_manager=StubPowerManager(_snapshot()),
+            status_provider=lambda: status,
+        )
+
+        pages = screen.build_pages(snapshot=screen.power_manager.get_snapshot(), status=status)
+
+        assert pages[0].title == "Power Status"
+        assert ("Model", "PiSugar 3") in pages[0].rows
+        assert ("Battery", "55% chg") in pages[0].rows
+        assert ("Alarm", "07:30") in pages[0].rows
+        assert pages[1].title == "Runtime & Safety"
+        assert ("Uptime", "1h01m") in pages[1].rows
+        assert ("Watchdog", "Active") in pages[1].rows
+    finally:
+        display.cleanup()
+
+
+def test_power_screen_formats_unavailable_snapshot() -> None:
+    """Unavailable power backends should still render a readable status page."""
+    display = Display(simulate=True)
+    try:
+        snapshot = PowerSnapshot(
+            available=False,
+            checked_at=datetime(2026, 4, 5, 12, 0, 0),
+            error="I2C not connected",
+        )
+        screen = PowerScreen(
+            display,
+            AppContext(),
+            power_manager=StubPowerManager(snapshot),
+            status_provider=lambda: {},
+        )
+
+        pages = screen.build_pages(snapshot=snapshot, status={})
+
+        assert ("Status", "Offline") in pages[0].rows
+        assert ("Reason", "I2C not connected") in pages[0].rows
+        assert ("Watchdog", "Off") in pages[1].rows
+    finally:
+        display.cleanup()

--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -56,6 +56,7 @@ def test_screen_router_covers_live_menu_labels() -> None:
         "VoIP Status": NavigationRequest.push("call"),
         "Call Contact": NavigationRequest.push("contacts"),
         "Contacts": NavigationRequest.push("contacts"),
+        "Power Status": NavigationRequest.push("power"),
     }
 
     for label, expected_request in expected_routes.items():
@@ -88,10 +89,12 @@ def test_screen_manager_routes_menu_labels_through_stack(display: Display) -> No
     home = HomeScreen(display, context)
     menu = MenuScreen(display, context, items=["Load Playlist", "Back"])
     playlists = RoutableStubScreen(display, context)
+    power = RoutableStubScreen(display, context)
 
     screen_manager.register_screen("home", home)
     screen_manager.register_screen("menu", menu)
     screen_manager.register_screen("playlists", playlists)
+    screen_manager.register_screen("power", power)
 
     screen_manager.replace_screen("home")
     assert screen_manager.current_screen is home
@@ -108,6 +111,24 @@ def test_screen_manager_routes_menu_labels_through_stack(display: Display) -> No
     menu.selected_index = 1
     input_manager.simulate_action(InputAction.SELECT)
     assert screen_manager.current_screen is home
+
+
+def test_screen_manager_routes_power_status_through_stack(display: Display) -> None:
+    """Power Status should route through the stack like any other menu destination."""
+    context = AppContext()
+    input_manager = InputManager()
+    screen_manager = ScreenManager(display, input_manager)
+
+    menu = MenuScreen(display, context, items=["Power Status"])
+    power = RoutableStubScreen(display, context)
+
+    screen_manager.register_screen("menu", menu)
+    screen_manager.register_screen("power", power)
+
+    screen_manager.replace_screen("menu")
+    input_manager.simulate_action(InputAction.SELECT)
+
+    assert screen_manager.current_screen is power
 
 
 def test_screen_manager_routes_whisplay_hub_cards_through_stack(display: Display) -> None:

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -52,6 +52,7 @@ from yoyopy.ui.screens import (
     NowPlayingScreen,
     OutgoingCallScreen,
     PlaylistScreen,
+    PowerScreen,
     ScreenManager,
 )
 from yoyopy.voip import VoIPConfig, VoIPManager
@@ -123,6 +124,7 @@ class YoyoPodApp:
         self.hub_screen: Optional[HubScreen] = None
         self.home_screen: Optional[HomeScreen] = None
         self.menu_screen: Optional[MenuScreen] = None
+        self.power_screen: Optional[PowerScreen] = None
         self.now_playing_screen: Optional[NowPlayingScreen] = None
         self.playlist_screen: Optional[PlaylistScreen] = None
         self.call_screen: Optional[CallScreen] = None
@@ -425,7 +427,7 @@ class YoyoPodApp:
                 "Browse Playlists",
                 "VoIP Status",
                 "Call Contact",
-                "Back",
+                "Power Status",
             ]
             self.hub_screen = HubScreen(
                 self.display,
@@ -435,6 +437,12 @@ class YoyoPodApp:
             )
             self.menu_screen = MenuScreen(self.display, self.context, items=menu_items)
             self.home_screen = HomeScreen(self.display, self.context)
+            self.power_screen = PowerScreen(
+                self.display,
+                self.context,
+                power_manager=self.power_manager,
+                status_provider=self.get_status,
+            )
             self.now_playing_screen = NowPlayingScreen(
                 self.display,
                 self.context,
@@ -480,6 +488,7 @@ class YoyoPodApp:
             self.screen_manager.register_screen("hub", self.hub_screen)
             self.screen_manager.register_screen("home", self.home_screen)
             self.screen_manager.register_screen("menu", self.menu_screen)
+            self.screen_manager.register_screen("power", self.power_screen)
             self.screen_manager.register_screen("now_playing", self.now_playing_screen)
             self.screen_manager.register_screen("playlists", self.playlist_screen)
             self.screen_manager.register_screen("call", self.call_screen)
@@ -491,6 +500,7 @@ class YoyoPodApp:
 
             logger.info("  ✓ All screens registered")
             logger.info("    - Music screens: now_playing, playlists")
+            logger.info("    - Power screen: power")
             logger.info("    - VoIP screens: call, contacts, incoming_call, outgoing_call, in_call")
             logger.info("    - Navigation: home, menu")
 
@@ -734,6 +744,7 @@ class YoyoPodApp:
             power_manager=self.power_manager,
             now_playing_screen=self.now_playing_screen,
             call_screen=self.call_screen,
+            power_screen=self.power_screen,
             incoming_call_screen=self.incoming_call_screen,
             outgoing_call_screen=self.outgoing_call_screen,
             in_call_screen=self.in_call_screen,
@@ -778,6 +789,11 @@ class YoyoPodApp:
         """Refresh the in-call screen from the main loop when it is visible."""
         self._ensure_coordinators()
         self.screen_coordinator.update_in_call_if_needed()
+
+    def _update_power_screen_if_needed(self) -> None:
+        """Refresh the power screen from the main loop when it is visible."""
+        self._ensure_coordinators()
+        self.screen_coordinator.update_power_screen_if_needed()
 
     def _start_ringing(self) -> None:
         """Compatibility wrapper for starting the call ring tone."""
@@ -1255,6 +1271,7 @@ class YoyoPodApp:
                 if current_time - last_screen_update >= screen_update_interval:
                     self._update_now_playing_if_needed()
                     self._update_in_call_if_needed()
+                    self._update_power_screen_if_needed()
                     last_screen_update = current_time
         except KeyboardInterrupt:
             logger.info("\n" + "=" * 60)
@@ -1317,6 +1334,8 @@ class YoyoPodApp:
                 self._pending_shutdown.execute_at - time.monotonic(),
             )
 
+        power_snapshot = self.power_manager.get_snapshot() if self.power_manager is not None else None
+
         return {
             "state": self.coordinator_runtime.get_state_name(),
             "voip_registered": self.voip_registered,
@@ -1324,7 +1343,7 @@ class YoyoPodApp:
             "auto_resume": self.auto_resume_after_call,
             "voip_available": self.voip_manager is not None and self.voip_manager.running,
             "music_available": self.mopidy_client is not None and self.mopidy_client.is_connected,
-            "power_available": self.power_manager is not None and self.power_manager.get_snapshot().available,
+            "power_available": power_snapshot.available if power_snapshot is not None else False,
             "battery_percent": self.context.battery_percent if self.context else None,
             "battery_charging": self.context.battery_charging if self.context else None,
             "external_power": self.context.external_power if self.context else None,
@@ -1336,6 +1355,35 @@ class YoyoPodApp:
             "shutdown_reason": self._pending_shutdown.reason if self._pending_shutdown else None,
             "shutdown_in_seconds": pending_shutdown_in_seconds,
             "shutdown_completed": self._shutdown_completed,
+            "warning_threshold_percent": (
+                self.power_manager.config.low_battery_warning_percent
+                if self.power_manager is not None
+                else None
+            ),
+            "critical_shutdown_percent": (
+                self.power_manager.config.critical_shutdown_percent
+                if self.power_manager is not None
+                else None
+            ),
+            "shutdown_delay_seconds": (
+                self.power_manager.config.shutdown_delay_seconds
+                if self.power_manager is not None
+                else None
+            ),
+            "screen_timeout_seconds": self._screen_timeout_seconds,
+            "power_model": power_snapshot.device.model if power_snapshot is not None else None,
+            "power_error": power_snapshot.error if power_snapshot is not None else None,
+            "power_voltage_volts": (
+                power_snapshot.battery.voltage_volts if power_snapshot is not None else None
+            ),
+            "power_temperature_celsius": (
+                power_snapshot.battery.temperature_celsius if power_snapshot is not None else None
+            ),
+            "rtc_time": power_snapshot.rtc.time if power_snapshot is not None else None,
+            "rtc_alarm_enabled": (
+                power_snapshot.rtc.alarm_enabled if power_snapshot is not None else None
+            ),
+            "rtc_alarm_time": power_snapshot.rtc.alarm_time if power_snapshot is not None else None,
             "watchdog_enabled": (
                 self.power_manager.config.watchdog_enabled
                 if self.power_manager is not None
@@ -1343,4 +1391,14 @@ class YoyoPodApp:
             ),
             "watchdog_active": self._watchdog_active,
             "watchdog_feed_suppressed": self._watchdog_feed_suppressed,
+            "watchdog_timeout_seconds": (
+                self.power_manager.config.watchdog_timeout_seconds
+                if self.power_manager is not None
+                else None
+            ),
+            "watchdog_feed_interval_seconds": (
+                self.power_manager.config.watchdog_feed_interval_seconds
+                if self.power_manager is not None
+                else None
+            ),
         }

--- a/yoyopy/coordinators/power.py
+++ b/yoyopy/coordinators/power.py
@@ -75,26 +75,20 @@ class PowerCoordinator:
 
     def handle_snapshot_updated(self, snapshot: PowerSnapshot) -> None:
         """Apply the latest power telemetry to runtime and UI state."""
-        previous_signature = (
-            self.context.battery_percent,
-            self.context.battery_charging,
-            self.context.external_power,
-            self.context.power_available,
-            self.context.power_error,
+        previous_signature = self._snapshot_signature(self.runtime.power_snapshot)
+        current_screen = (
+            self.runtime.screen_manager.get_current_screen()
+            if self.runtime.screen_manager is not None
+            else None
         )
+        current_route_name = current_screen.route_name if current_screen is not None else None
 
         self.runtime.set_power_snapshot(snapshot)
         self.context.update_power_status(snapshot)
 
-        current_signature = (
-            self.context.battery_percent,
-            self.context.battery_charging,
-            self.context.external_power,
-            self.context.power_available,
-            self.context.power_error,
-        )
+        current_signature = self._snapshot_signature(snapshot)
 
-        if current_signature != previous_signature:
+        if current_signature != previous_signature or current_route_name == "power":
             self.screen_coordinator.refresh_current_screen()
 
         if self.policy is None or self._event_bus is None:
@@ -114,3 +108,30 @@ class PowerCoordinator:
         if self.policy is not None:
             self.policy.shutdown_requested = False
             self.policy.next_warning_at = 0.0
+
+    @staticmethod
+    def _snapshot_signature(snapshot: PowerSnapshot | None) -> tuple[object, ...] | None:
+        """Return the stable, user-visible subset of a power snapshot."""
+        if snapshot is None:
+            return None
+
+        return (
+            snapshot.available,
+            snapshot.error,
+            snapshot.device.model,
+            snapshot.device.firmware_version,
+            snapshot.battery.level_percent,
+            snapshot.battery.voltage_volts,
+            snapshot.battery.charging,
+            snapshot.battery.power_plugged,
+            snapshot.battery.allow_charging,
+            snapshot.battery.output_enabled,
+            snapshot.battery.temperature_celsius,
+            snapshot.rtc.time,
+            snapshot.rtc.alarm_enabled,
+            snapshot.rtc.alarm_time,
+            snapshot.rtc.alarm_repeat_mask,
+            snapshot.rtc.adjust_ppm,
+            snapshot.shutdown.safe_shutdown_level_percent,
+            snapshot.shutdown.safe_shutdown_delay_seconds,
+        )

--- a/yoyopy/coordinators/runtime.py
+++ b/yoyopy/coordinators/runtime.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
         IncomingCallScreen,
         NowPlayingScreen,
         OutgoingCallScreen,
+        PowerScreen,
         ScreenManager,
     )
 
@@ -43,6 +44,7 @@ class AppRuntimeState(Enum):
     SETTINGS = "settings"
     PLAYLIST = "playlist"
     PLAYLIST_BROWSER = "playlist_browser"
+    POWER = "power"
     CALL_IDLE = "call_idle"
     CALL_INCOMING = "call_incoming"
     CALL_OUTGOING = "call_outgoing"
@@ -84,6 +86,7 @@ class CoordinatorRuntime:
     power_manager: PowerManager | None
     now_playing_screen: NowPlayingScreen | None
     call_screen: CallScreen | None
+    power_screen: PowerScreen | None
     incoming_call_screen: IncomingCallScreen | None
     outgoing_call_screen: OutgoingCallScreen | None
     in_call_screen: InCallScreen | None
@@ -104,6 +107,7 @@ class CoordinatorRuntime:
         AppRuntimeState.SETTINGS,
         AppRuntimeState.PLAYLIST,
         AppRuntimeState.PLAYLIST_BROWSER,
+        AppRuntimeState.POWER,
         AppRuntimeState.CALL_IDLE,
         AppRuntimeState.CONNECTING,
         AppRuntimeState.ERROR,
@@ -201,6 +205,7 @@ class CoordinatorRuntime:
             "hub": AppRuntimeState.HUB,
             "menu": AppRuntimeState.MENU,
             "playlists": AppRuntimeState.PLAYLIST_BROWSER,
+            "power": AppRuntimeState.POWER,
             "call": AppRuntimeState.CALL_IDLE,
             "contacts": AppRuntimeState.CALL_IDLE,
         }

--- a/yoyopy/coordinators/screen.py
+++ b/yoyopy/coordinators/screen.py
@@ -32,7 +32,11 @@ class ScreenCoordinator:
 
     def update_now_playing_if_needed(self) -> None:
         """Refresh the now playing screen for periodic progress updates."""
-        if self.runtime.screen_manager.current_screen != self.runtime.now_playing_screen:
+        if (
+            self.runtime.screen_manager is None
+            or self.runtime.now_playing_screen is None
+            or self.runtime.screen_manager.current_screen != self.runtime.now_playing_screen
+        ):
             return
 
         if self.runtime.mopidy_client and self.runtime.mopidy_client.is_connected:
@@ -42,8 +46,21 @@ class ScreenCoordinator:
 
     def update_in_call_if_needed(self) -> None:
         """Refresh the in-call screen for live duration and mute updates."""
-        if self.runtime.screen_manager.current_screen == self.runtime.in_call_screen:
+        if (
+            self.runtime.screen_manager is not None
+            and self.runtime.in_call_screen is not None
+            and self.runtime.screen_manager.current_screen == self.runtime.in_call_screen
+        ):
             self.runtime.in_call_screen.render()
+
+    def update_power_screen_if_needed(self) -> None:
+        """Refresh the power screen for live runtime metrics when visible."""
+        if (
+            self.runtime.screen_manager is not None
+            and self.runtime.power_screen is not None
+            and self.runtime.screen_manager.current_screen == self.runtime.power_screen
+        ):
+            self.runtime.power_screen.render()
 
     def refresh_current_screen(self) -> None:
         """Refresh whichever screen is currently visible."""

--- a/yoyopy/ui/screens/__init__.py
+++ b/yoyopy/ui/screens/__init__.py
@@ -17,7 +17,7 @@ from yoyopy.ui.screens.manager import ScreenManager
 from yoyopy.ui.screens.router import NavigationRequest, ScreenRouter
 
 # Navigation screens
-from yoyopy.ui.screens.navigation import HubScreen, HomeScreen, MenuScreen
+from yoyopy.ui.screens.navigation import HubScreen, HomeScreen, MenuScreen, PowerScreen
 
 # Music screens
 from yoyopy.ui.screens.music import NowPlayingScreen, PlaylistScreen
@@ -41,6 +41,7 @@ __all__ = [
     'HubScreen',
     'HomeScreen',
     'MenuScreen',
+    'PowerScreen',
     # Music
     'NowPlayingScreen',
     'PlaylistScreen',

--- a/yoyopy/ui/screens/navigation/__init__.py
+++ b/yoyopy/ui/screens/navigation/__init__.py
@@ -3,5 +3,6 @@
 from yoyopy.ui.screens.navigation.hub import HubScreen
 from yoyopy.ui.screens.navigation.home import HomeScreen
 from yoyopy.ui.screens.navigation.menu import MenuScreen
+from yoyopy.ui.screens.navigation.power import PowerScreen
 
-__all__ = ['HubScreen', 'HomeScreen', 'MenuScreen']
+__all__ = ['HubScreen', 'HomeScreen', 'MenuScreen', 'PowerScreen']

--- a/yoyopy/ui/screens/navigation/power.py
+++ b/yoyopy/ui/screens/navigation/power.py
@@ -1,0 +1,361 @@
+"""Power status screen for PiSugar-backed telemetry and policies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Optional
+
+from yoyopy.ui.display import Display
+from yoyopy.ui.screens.base import Screen
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.power import PowerManager, PowerSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class PowerPage:
+    """One page of compact power/status rows."""
+
+    title: str
+    rows: list[tuple[str, str]]
+
+
+class PowerScreen(Screen):
+    """Compact multi-page power and runtime status screen."""
+
+    def __init__(
+        self,
+        display: Display,
+        context: Optional["AppContext"] = None,
+        *,
+        power_manager: Optional["PowerManager"] = None,
+        status_provider: Optional[Callable[[], dict[str, object]]] = None,
+    ) -> None:
+        super().__init__(display, context, "PowerStatus")
+        self.power_manager = power_manager
+        self.status_provider = status_provider or (lambda: {})
+        self.page_index = 0
+
+    def render(self) -> None:
+        """Render the active power page."""
+        snapshot = self._get_snapshot()
+        status = self._get_status()
+        pages = self.build_pages(snapshot=snapshot, status=status)
+        self.page_index %= len(pages)
+        active_page = pages[self.page_index]
+
+        self.display.clear(self.display.COLOR_BLACK)
+        self._render_status_bar()
+
+        title = active_page.title
+        title_size = 18
+        title_width, title_height = self.display.get_text_size(title, title_size)
+        title_x = (self.display.WIDTH - title_width) // 2
+        title_y = self.display.STATUS_BAR_HEIGHT + 12
+        self.display.text(
+            title,
+            title_x,
+            title_y,
+            color=self.display.COLOR_WHITE,
+            font_size=title_size,
+        )
+
+        page_text = f"{self.page_index + 1}/{len(pages)}"
+        page_width, _ = self.display.get_text_size(page_text, 11)
+        self.display.text(
+            page_text,
+            self.display.WIDTH - page_width - 18,
+            title_y + 3,
+            color=self.display.COLOR_GRAY,
+            font_size=11,
+        )
+
+        separator_y = title_y + title_height + 8
+        self.display.line(
+            18,
+            separator_y,
+            self.display.WIDTH - 18,
+            separator_y,
+            color=self.display.COLOR_GRAY,
+            width=2,
+        )
+
+        row_y = separator_y + 14
+        row_gap = 23 if self.display.is_portrait() else 21
+        label_size = 12
+        value_size = 13
+
+        for label, value in active_page.rows:
+            self.display.text(
+                label,
+                16,
+                row_y,
+                color=self.display.COLOR_GRAY,
+                font_size=label_size,
+            )
+            value_width, _ = self.display.get_text_size(value, value_size)
+            value_x = max(90, self.display.WIDTH - value_width - 16)
+            self.display.text(
+                value,
+                value_x,
+                row_y,
+                color=self.display.COLOR_WHITE,
+                font_size=value_size,
+            )
+            row_y += row_gap
+
+        help_text = (
+            "Tap page | Double page | Hold back"
+            if self.is_one_button_mode()
+            else "X/Y page | A page | B back"
+        )
+        help_width, _ = self.display.get_text_size(help_text, 10)
+        self.display.text(
+            help_text,
+            (self.display.WIDTH - help_width) // 2,
+            self.display.HEIGHT - 15,
+            color=self.display.COLOR_GRAY,
+            font_size=10,
+        )
+        self.display.update()
+
+    def build_pages(
+        self,
+        *,
+        snapshot: Optional["PowerSnapshot"],
+        status: dict[str, object],
+    ) -> list[PowerPage]:
+        """Build the current compact pages for rendering and tests."""
+        battery_rows = self._build_battery_rows(snapshot=snapshot)
+        runtime_rows = self._build_runtime_rows(snapshot=snapshot, status=status)
+        return [
+            PowerPage(title="Power Status", rows=battery_rows),
+            PowerPage(title="Runtime & Safety", rows=runtime_rows),
+        ]
+
+    def _render_status_bar(self) -> None:
+        """Render the shared status bar using cached context telemetry."""
+        current_time = datetime.now().strftime("%H:%M")
+        battery = self.context.battery_percent if self.context else 100
+        charging = self.context.battery_charging if self.context else False
+        external_power = self.context.external_power if self.context else False
+        power_available = self.context.power_available if self.context else False
+        signal = self.context.signal_strength if self.context else 4
+        self.display.status_bar(
+            time_str=current_time,
+            battery_percent=battery,
+            signal_strength=signal,
+            charging=charging,
+            external_power=external_power,
+            power_available=power_available,
+        )
+
+    def _get_snapshot(self) -> Optional["PowerSnapshot"]:
+        """Return the latest cached power snapshot."""
+        if self.power_manager is None:
+            return None
+        return self.power_manager.get_snapshot()
+
+    def _get_status(self) -> dict[str, object]:
+        """Return the latest app runtime/policy status."""
+        try:
+            return self.status_provider()
+        except Exception:
+            return {}
+
+    def _build_battery_rows(self, *, snapshot: Optional["PowerSnapshot"]) -> list[tuple[str, str]]:
+        """Build the first page focused on PiSugar telemetry."""
+        if snapshot is None:
+            return [
+                ("Source", "Unavailable"),
+                ("Battery", "Unknown"),
+                ("Charging", "Unknown"),
+                ("External", "Unknown"),
+                ("RTC", "Unknown"),
+                ("Alarm", "Unknown"),
+            ]
+
+        if not snapshot.available:
+            error = snapshot.error or "Unavailable"
+            return [
+                ("Source", snapshot.source),
+                ("Model", snapshot.device.model or "Unknown"),
+                ("Status", "Offline"),
+                ("Reason", self._truncate(error, 18)),
+                ("RTC", self._format_datetime(snapshot.rtc.time)),
+                ("Alarm", self._format_alarm(snapshot)),
+            ]
+
+        return [
+            ("Model", snapshot.device.model or "Unknown"),
+            ("Battery", self._format_battery(snapshot)),
+            ("Charging", self._format_charging(snapshot)),
+            ("External", self._format_external_power(snapshot)),
+            ("Voltage", self._format_voltage(snapshot)),
+            ("RTC", self._format_datetime(snapshot.rtc.time)),
+            ("Alarm", self._format_alarm(snapshot)),
+        ]
+
+    def _build_runtime_rows(
+        self,
+        *,
+        snapshot: Optional["PowerSnapshot"],
+        status: dict[str, object],
+    ) -> list[tuple[str, str]]:
+        """Build the second page for runtime, watchdog, and shutdown state."""
+        warning_percent = self._format_percent(status.get("warning_threshold_percent"))
+        critical_percent = self._format_percent(status.get("critical_shutdown_percent"))
+        delay_seconds = self._format_duration_short(status.get("shutdown_delay_seconds"))
+        shutdown_value = "Ready"
+        if status.get("shutdown_pending"):
+            shutdown_value = f"In {self._format_duration_short(status.get('shutdown_in_seconds'))}"
+
+        rows = [
+            ("Uptime", self._format_duration_short(status.get("app_uptime_seconds"))),
+            ("Screen", self._format_screen_state(status)),
+            ("Idle", self._format_duration_short(status.get("screen_idle_seconds"))),
+            ("Timeout", self._format_duration_short(status.get("screen_timeout_seconds"))),
+            ("Warn/Crit", f"{warning_percent}/{critical_percent}"),
+            ("Shutdown", shutdown_value if delay_seconds == "0s" else f"{shutdown_value} ({delay_seconds})"),
+            ("Watchdog", self._format_watchdog(status)),
+        ]
+
+        if snapshot is not None and snapshot.shutdown.safe_shutdown_level_percent is not None:
+            rows[4] = (
+                "Warn/Crit",
+                f"{warning_percent}/{self._format_percent(snapshot.shutdown.safe_shutdown_level_percent)}",
+            )
+        return rows
+
+    def _format_battery(self, snapshot: "PowerSnapshot") -> str:
+        """Format the battery percentage with a compact status suffix."""
+        level = snapshot.battery.level_percent
+        if level is None:
+            return "Unknown"
+        suffix = " chg" if snapshot.battery.charging else ""
+        return f"{round(level)}%{suffix}"
+
+    def _format_charging(self, snapshot: "PowerSnapshot") -> str:
+        """Format the charging state."""
+        charging = snapshot.battery.charging
+        if charging is None:
+            return "Unknown"
+        return "Charging" if charging else "Idle"
+
+    def _format_external_power(self, snapshot: "PowerSnapshot") -> str:
+        """Format whether USB/external power is present."""
+        plugged = snapshot.battery.power_plugged
+        if plugged is None:
+            return "Unknown"
+        return "Plugged" if plugged else "Battery"
+
+    def _format_voltage(self, snapshot: "PowerSnapshot") -> str:
+        """Format battery voltage with optional temperature hint."""
+        voltage = snapshot.battery.voltage_volts
+        temperature = snapshot.battery.temperature_celsius
+        if voltage is None and temperature is None:
+            return "Unknown"
+        if voltage is None:
+            return f"{temperature:.1f} C"
+        if temperature is None:
+            return f"{voltage:.2f} V"
+        return f"{voltage:.2f}V {temperature:.0f}C"
+
+    def _format_alarm(self, snapshot: "PowerSnapshot") -> str:
+        """Format the current RTC alarm state."""
+        if snapshot.rtc.alarm_enabled is not True:
+            return "Off"
+        if snapshot.rtc.alarm_time is None:
+            return "On"
+        return snapshot.rtc.alarm_time.strftime("%H:%M")
+
+    @staticmethod
+    def _format_datetime(value: datetime | None) -> str:
+        """Format one datetime value for compact screen use."""
+        if value is None:
+            return "Unknown"
+        return value.strftime("%m-%d %H:%M")
+
+    @staticmethod
+    def _format_duration_short(value: object) -> str:
+        """Format short durations like 95 seconds -> 1m35s."""
+        if value is None:
+            return "0s"
+        total_seconds = max(0, int(float(value)))
+        hours, remainder = divmod(total_seconds, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        if hours > 0:
+            return f"{hours}h{minutes:02d}m"
+        if minutes > 0:
+            return f"{minutes}m{seconds:02d}s"
+        return f"{seconds}s"
+
+    @staticmethod
+    def _format_percent(value: object) -> str:
+        """Format a percentage-like value for screen use."""
+        if value is None:
+            return "--"
+        return f"{int(round(float(value)))}%"
+
+    @staticmethod
+    def _format_watchdog(status: dict[str, object]) -> str:
+        """Format the current watchdog state from app status."""
+        if not status.get("watchdog_enabled"):
+            return "Off"
+        if status.get("watchdog_feed_suppressed"):
+            return "Suppressed"
+        if status.get("watchdog_active"):
+            return "Active"
+        return "Ready"
+
+    @staticmethod
+    def _format_screen_state(status: dict[str, object]) -> str:
+        """Format current display-awake plus cumulative screen-on time."""
+        state = "Awake" if status.get("screen_awake") else "Sleep"
+        screen_on = PowerScreen._format_duration_short(status.get("screen_on_seconds"))
+        return f"{state} {screen_on}"
+
+    @staticmethod
+    def _truncate(text: str, max_length: int) -> str:
+        """Truncate strings that would overflow narrow labels."""
+        if len(text) <= max_length:
+            return text
+        return text[: max_length - 3] + "..."
+
+    def _next_page(self) -> None:
+        """Advance to the next power page with wraparound."""
+        self.page_index = (self.page_index + 1) % 2
+
+    def _previous_page(self) -> None:
+        """Return to the previous power page with wraparound."""
+        self.page_index = (self.page_index - 1) % 2
+
+    def on_advance(self, data=None) -> None:
+        """Single-button tap cycles pages."""
+        self._next_page()
+
+    def on_select(self, data=None) -> None:
+        """Double tap or standard select also cycles pages."""
+        self._next_page()
+
+    def on_back(self, data=None) -> None:
+        """Return to the previous screen."""
+        self.request_route("back")
+
+    def on_up(self, data=None) -> None:
+        """Standard up goes to the previous page."""
+        self._previous_page()
+
+    def on_down(self, data=None) -> None:
+        """Standard down goes to the next page."""
+        self._next_page()
+
+    def on_left(self, data=None) -> None:
+        """Standard left goes to the previous page."""
+        self._previous_page()
+
+    def on_right(self, data=None) -> None:
+        """Standard right goes to the next page."""
+        self._next_page()

--- a/yoyopy/ui/screens/router.py
+++ b/yoyopy/ui/screens/router.py
@@ -87,6 +87,10 @@ class ScreenRouter:
                 "select:Call": NavigationRequest.push("contacts"),
                 "select:Call Contact": NavigationRequest.push("contacts"),
                 "select:Contacts": NavigationRequest.push("contacts"),
+                "select:Power Status": NavigationRequest.push("power"),
+            },
+            "power": {
+                "back": NavigationRequest.pop(),
             },
             "now_playing": {
                 "back": NavigationRequest.pop(),


### PR DESCRIPTION
## Summary
- add a dedicated Power Status screen with runtime and PiSugar safety details
- wire power navigation and runtime state into the standard menu flow
- add PiSugar power diagnostics helpers for local and remote Raspberry Pi workflows

## Testing
- python -m compileall yoyopy tests demos scripts
- uv run pytest -q
- uv run python scripts/pisugar_power.py --help
- uv run python scripts/pi_remote.py power --help