### PR TITLE
Add dedicated power module documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ When in doubt, trust these files first:
 - `yoyopy/ui/screens/`
 - `README.md`
 - `docs/SYSTEM_ARCHITECTURE.md`
+- `docs/POWER_MODULE.md`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ yoyopy/
 - `docs/INTEGRATION_PLAN.md`: integration completion record and remaining cleanup
 - `docs/DISPLAY_HAL_ARCHITECTURE.md`: current display HAL design
 - `docs/INPUT_HAL_ARCHITECTURE.md`: current input HAL design and compatibility notes
+- `docs/POWER_MODULE.md`: PiSugar power architecture, config, safety, RTC, watchdog, and diagnostics
 - `docs/RPI_SMOKE_VALIDATION.md`: Raspberry Pi smoke checklist and manual follow-up drills
 - `docs/PI_DEV_WORKFLOW.md`: SSH-based Raspberry Pi sync/run workflow and release checklist
 - `docs/UI_RESTRUCTURE_PROPOSAL.md`: refactor status and remaining cleanup

--- a/docs/POWER_MODULE.md
+++ b/docs/POWER_MODULE.md
@@ -1,0 +1,368 @@
+# Power Module
+
+This document is the dedicated source of truth for YoyoPod's PiSugar-backed power subsystem.
+
+Current target hardware:
+- Raspberry Pi Zero 2W
+- PiSugar 3 battery HAT
+
+This module is responsible for:
+- UPS-style telemetry
+- low-battery warning
+- graceful delayed shutdown
+- shutdown-state persistence
+- screen timeout and wake-on-activity
+- app uptime and screen-on tracking
+- PiSugar RTC read/sync/alarm control
+- PiSugar software watchdog support
+- user-facing power status UI
+
+## Architecture
+
+Main files:
+- `yoyopy/power/models.py`
+- `yoyopy/power/backend.py`
+- `yoyopy/power/manager.py`
+- `yoyopy/power/policies.py`
+- `yoyopy/power/watchdog.py`
+- `yoyopy/power/events.py`
+- `yoyopy/coordinators/power.py`
+- `yoyopy/ui/screens/navigation/power.py`
+- `scripts/pisugar_power.py`
+- `scripts/pisugar_rtc.py`
+
+Runtime flow:
+
+```text
+YoyoPodApp
+  -> PowerManager
+     -> PiSugarBackend
+        -> Unix socket or TCP PiSugar server transport
+     -> PiSugarWatchdog
+        -> i2cget / i2cset
+  -> PowerCoordinator
+     -> EventBus
+     -> PowerSafetyPolicy
+     -> AppContext / CoordinatorRuntime
+     -> current screen refresh
+```
+
+The app polls PiSugar on the coordinator thread, publishes typed power events, updates shared runtime state, and then applies safety or UI behavior from those events.
+
+## Backends And Transports
+
+`PowerManager` is the app-facing facade.
+
+`PiSugarBackend` currently supports:
+- automatic transport selection
+- Unix socket transport via `/tmp/pisugar-server.sock`
+- local TCP transport via `127.0.0.1:8423`
+- model and firmware reads
+- battery and charger telemetry
+- RTC reads
+- RTC sync and alarm control
+- safe-shutdown configuration reads
+
+Transport selection is controlled by:
+- `power.transport: auto`
+- `power.transport: socket`
+- `power.transport: tcp`
+
+`auto` tries the Unix socket first and then local TCP.
+
+## Typed Data Model
+
+The main snapshot type is `PowerSnapshot`.
+
+It contains:
+- `available`
+- `checked_at`
+- `source`
+- `device`
+- `battery`
+- `rtc`
+- `shutdown`
+- `error`
+
+Important nested fields:
+
+`BatteryState`
+- `level_percent`
+- `voltage_volts`
+- `charging`
+- `power_plugged`
+- `allow_charging`
+- `output_enabled`
+- `temperature_celsius`
+
+`RTCState`
+- `time`
+- `alarm_enabled`
+- `alarm_time`
+- `alarm_repeat_mask`
+- `adjust_ppm`
+
+`ShutdownState`
+- `safe_shutdown_level_percent`
+- `safe_shutdown_delay_seconds`
+
+## Configuration
+
+Power configuration lives in `config/yoyopod_config.yaml` under `power:`.
+
+Current keys:
+- `enabled`
+- `backend`
+- `transport`
+- `socket_path`
+- `tcp_host`
+- `tcp_port`
+- `timeout_seconds`
+- `poll_interval_seconds`
+- `low_battery_warning_percent`
+- `low_battery_warning_cooldown_seconds`
+- `auto_shutdown_enabled`
+- `critical_shutdown_percent`
+- `shutdown_delay_seconds`
+- `shutdown_command`
+- `shutdown_state_file`
+- `watchdog_enabled`
+- `watchdog_timeout_seconds`
+- `watchdog_feed_interval_seconds`
+- `watchdog_i2c_bus`
+- `watchdog_i2c_address`
+- `watchdog_command_timeout_seconds`
+
+Current defaults on `main`:
+- poll interval: `30s`
+- low-battery warning: `20%`
+- critical shutdown: `10%`
+- shutdown delay: `15s`
+- watchdog: disabled by default
+
+## Safety Policy
+
+`PowerSafetyPolicy` is the rule layer for battery-driven behavior.
+
+Current behavior:
+- if PiSugar is unavailable, no safety decision is made
+- if battery percentage is unavailable, no safety decision is made
+- if external power is restored, a pending critical shutdown is cancelled
+- if battery is below the warning threshold, a warning event is emitted with cooldown protection
+- if battery is below the critical threshold and auto-shutdown is enabled, a delayed shutdown event is emitted once
+
+Current typed safety events:
+- `LowBatteryWarningRaised`
+- `GracefulShutdownRequested`
+- `GracefulShutdownCancelled`
+
+## Graceful Shutdown Flow
+
+When the critical threshold is crossed:
+1. the app schedules a delayed shutdown
+2. a fullscreen power overlay is shown
+3. registered shutdown hooks run
+4. the app stops
+5. the configured system shutdown command is executed
+
+The current persisted shutdown-state file is controlled by:
+- `power.shutdown_state_file`
+
+This is intended to save enough information for later debugging and future restore/recovery features.
+
+## Screen Timeout And Runtime Tracking
+
+The power module also owns inactivity-based display power behavior.
+
+Current app behavior:
+- track app uptime
+- track screen-on time
+- track idle time
+- sleep the backlight after the configured timeout
+- wake the screen on user activity
+- suppress sleep while a critical-battery overlay or shutdown countdown is active
+
+Relevant config:
+- `display.backlight_timeout_seconds`
+- fallback: `ui.screen_timeout_seconds`
+
+Runtime state exposed today includes:
+- `screen_awake`
+- `screen_idle_seconds`
+- `screen_on_seconds`
+- `app_uptime_seconds`
+
+## RTC Support
+
+Supported RTC operations:
+- read current RTC time
+- sync Pi system time to RTC
+- sync RTC time back to Pi
+- set a wake alarm
+- disable the wake alarm
+
+Primary helper:
+
+```bash
+uv run python scripts/pisugar_rtc.py status
+uv run python scripts/pisugar_rtc.py sync-to-rtc
+uv run python scripts/pisugar_rtc.py sync-from-rtc
+uv run python scripts/pisugar_rtc.py set-alarm --time 2026-04-06T07:30:00+02:00
+uv run python scripts/pisugar_rtc.py disable-alarm
+```
+
+Remote helper:
+
+```bash
+uv run python scripts/pi_remote.py rtc status --host rpi-zero
+```
+
+## Watchdog Support
+
+The watchdog implementation is intentionally app-centric.
+
+Current model:
+- the app loop enables the PiSugar software watchdog
+- the app feeds it at a configured interval while healthy
+- ordinary app shutdown disables the watchdog
+- battery-driven emergency shutdown suppresses feeding without disabling it
+
+That means the watchdog remains a recovery backstop if graceful shutdown hangs.
+
+The current implementation uses:
+- `i2cget`
+- `i2cset`
+
+Required system package:
+- `i2c-tools`
+
+Important expectation:
+- YoyoPod should be started by `systemd` on boot when watchdog mode is used
+
+Current production unit:
+- `deploy/systemd/yoyopod@.service`
+
+## User-Facing UI
+
+There is now a dedicated `Power Status` screen in the standard menu flow.
+
+Implementation:
+- `yoyopy/ui/screens/navigation/power.py`
+
+Current screen design:
+- page 1: battery / charging / external power / voltage / RTC / alarm
+- page 2: uptime / screen activity / timeout / warning and critical thresholds / shutdown state / watchdog state
+
+Current controls:
+- standard mode:
+  - `X/Y` or `left/right`: change page
+  - `A`: next page
+  - `B`: back
+- one-button mode:
+  - `tap`: next page
+  - `double tap`: next page
+  - `hold`: back
+
+Note:
+- the Whisplay root hub is intentionally still only `Now Playing`, `Playlists`, and `Calls`
+- power status is part of the standard menu flow, not the 3-card Whisplay hub
+
+## Diagnostics And Validation
+
+Focused power helper:
+
+```bash
+uv run python scripts/pisugar_power.py
+```
+
+This prints:
+- availability
+- model
+- battery percent
+- voltage
+- temperature
+- charging state
+- external power state
+- RTC state
+- safe-shutdown values
+- watchdog configuration
+
+Remote power helper:
+
+```bash
+uv run python scripts/pi_remote.py power --host rpi-zero
+```
+
+Smoke validation:
+
+```bash
+uv run python scripts/pi_smoke.py --with-power
+uv run python scripts/pi_smoke.py --with-power --with-rtc
+```
+
+Recommended hardware sequence:
+1. `uv run pytest -q`
+2. `uv run python scripts/pi_smoke.py --with-power --with-rtc`
+3. `uv run python scripts/pisugar_power.py`
+4. `uv run python scripts/pisugar_rtc.py status`
+
+## Dependencies On The Pi
+
+Expected packages or services:
+- `pisugar-server`
+- `i2c-tools`
+
+The PiSugar server should expose at least one of:
+- `/tmp/pisugar-server.sock`
+- `127.0.0.1:8423`
+
+## Troubleshooting
+
+If power telemetry fails:
+- check `pisugar-server` is running
+- check `/tmp/pisugar-server.sock` exists or TCP `8423` is listening
+- run `uv run python scripts/pisugar_power.py`
+- run `i2cdetect -y 1` on the Pi
+
+Expected PiSugar 3 visibility usually includes:
+- `0x57`
+- `0x68`
+
+If watchdog commands fail:
+- confirm `i2c-tools` is installed
+- confirm the configured bus/address matches the HAT
+- confirm passwordless `sudo` is not required for your chosen flow, because the watchdog uses direct I2C tools
+
+If RTC sync behaves strangely:
+- validate with `scripts/pisugar_rtc.py`
+- check whether the distro image has a working `hwclock` path
+
+If the app shuts down too aggressively:
+- raise `critical_shutdown_percent`
+- increase `shutdown_delay_seconds`
+- check whether the battery is reporting charging or external power correctly
+
+## Current Boundaries
+
+Supported today:
+- telemetry
+- warnings
+- graceful shutdown
+- runtime tracking
+- RTC tooling
+- watchdog tooling
+- user-facing power status UI
+
+Not yet productized:
+- power settings UI
+- RTC alarm scheduling from inside the app UI
+- battery-history graphs
+- adaptive brightness or battery-aware performance modes
+- resume/restore flow based on saved shutdown state
+
+## Related Documents
+
+- `README.md`
+- `docs/RPI_SMOKE_VALIDATION.md`
+- `docs/PI_DEV_WORKFLOW.md`
+- `deploy/systemd/yoyopod@.service`


### PR DESCRIPTION
## Summary
- add a dedicated power module document for the PiSugar subsystem
- link the new doc from the README documentation index
- add the doc to AGENTS as a source-of-truth reference

## Testing
- docs only