### PR TITLE
Expose power screen from Whisplay hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ The current codebase supports three display/input modes:
 - PiSugar Whisplay HAT: 240x280 portrait display with a single PTT-style button
 - Simulation mode: browser display plus keyboard and web-button input
 
+On Whisplay, the one-button root hub currently exposes four cards:
+- `Now Playing`
+- `Playlists`
+- `Calls`
+- `Power`
+
 ## Current Status
 
 - VoIP and music integration is implemented in the production app

--- a/docs/POWER_MODULE.md
+++ b/docs/POWER_MODULE.md
@@ -264,8 +264,8 @@ Current controls:
   - `hold`: back
 
 Note:
-- the Whisplay root hub is intentionally still only `Now Playing`, `Playlists`, and `Calls`
-- power status is part of the standard menu flow, not the 3-card Whisplay hub
+- the Whisplay root hub now includes `Power` as a 4th card beside `Now Playing`, `Playlists`, and `Calls`
+- the same `Power Status` screen is still available from the standard menu flow on multi-button devices
 
 ## Diagnostics And Validation
 

--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -78,6 +78,7 @@ def test_screen_router_covers_whisplay_hub_routes() -> None:
     assert router.resolve("hub", "select", payload="Now Playing") == NavigationRequest.push("now_playing")
     assert router.resolve("hub", "select", payload="Playlists") == NavigationRequest.push("playlists")
     assert router.resolve("hub", "select", payload="Calls") == NavigationRequest.push("call")
+    assert router.resolve("hub", "select", payload="Power") == NavigationRequest.push("power")
 
 
 def test_screen_manager_routes_menu_labels_through_stack(display: Display) -> None:
@@ -141,11 +142,13 @@ def test_screen_manager_routes_whisplay_hub_cards_through_stack(display: Display
     now_playing = RoutableStubScreen(display, context)
     playlists = RoutableStubScreen(display, context)
     call = RoutableStubScreen(display, context)
+    power = RoutableStubScreen(display, context)
 
     screen_manager.register_screen("hub", hub)
     screen_manager.register_screen("now_playing", now_playing)
     screen_manager.register_screen("playlists", playlists)
     screen_manager.register_screen("call", call)
+    screen_manager.register_screen("power", power)
 
     screen_manager.replace_screen("hub")
     assert screen_manager.current_screen is hub
@@ -162,3 +165,8 @@ def test_screen_manager_routes_whisplay_hub_cards_through_stack(display: Display
     hub.selected_index = 2
     input_manager.simulate_action(InputAction.SELECT)
     assert screen_manager.current_screen is call
+
+    screen_manager.replace_screen("hub")
+    hub.selected_index = 3
+    input_manager.simulate_action(InputAction.SELECT)
+    assert screen_manager.current_screen is power

--- a/tests/test_whisplay_one_button.py
+++ b/tests/test_whisplay_one_button.py
@@ -189,10 +189,28 @@ def test_hub_advance_wraps_from_last_card_to_first(
         voip_manager=FakeVoIPManager(),
     )
 
-    hub.selected_index = 2
+    hub.selected_index = 3
     hub.on_advance()
 
     assert hub.selected_index == 0
+
+
+def test_hub_select_requests_power_route_for_power_card(
+    display: Display,
+    one_button_context: AppContext,
+) -> None:
+    """The Whisplay hub should open the power screen from its new Power card."""
+    hub = HubScreen(
+        display,
+        one_button_context,
+        mopidy_client=FakeMopidyClient(),
+        voip_manager=FakeVoIPManager(),
+    )
+
+    hub.selected_index = 3
+    hub.on_select()
+
+    assert hub.consume_navigation_request() == NavigationRequest.route("select", payload="Power")
 
 
 def test_now_playing_advance_and_select_follow_one_button_mapping(

--- a/yoyopy/ui/screens/navigation/hub.py
+++ b/yoyopy/ui/screens/navigation/hub.py
@@ -63,6 +63,7 @@ class HubScreen(Screen):
             HubCard(title="Now Playing", subtitle=self._music_subtitle()),
             HubCard(title="Playlists", subtitle=self._playlist_subtitle()),
             HubCard(title="Calls", subtitle=self._calls_subtitle()),
+            HubCard(title="Power", subtitle=self._power_subtitle()),
         ]
 
     def _music_subtitle(self) -> str:
@@ -115,6 +116,16 @@ class HubScreen(Screen):
         if registration_state == "failed":
             return "Registration failed"
         return "VoIP unavailable"
+
+    def _power_subtitle(self) -> str:
+        """Return the compact power status subtitle."""
+        if self.context is None or not self.context.power_available:
+            return "Power offline"
+
+        battery = f"{self.context.battery_percent}%"
+        if self.context.external_power or self.context.battery_charging:
+            return f"{battery} charging"
+        return f"{battery} battery"
 
     def render(self) -> None:
         """Render the Whisplay-first root carousel."""
@@ -253,6 +264,7 @@ class HubScreen(Screen):
             "Now Playing": "N",
             "Playlists": "P",
             "Calls": "C",
+            "Power": "B",
         }.get(title, "?")
 
     @staticmethod

--- a/yoyopy/ui/screens/router.py
+++ b/yoyopy/ui/screens/router.py
@@ -68,6 +68,7 @@ class ScreenRouter:
                 "select:Now Playing": NavigationRequest.push("now_playing"),
                 "select:Playlists": NavigationRequest.push("playlists"),
                 "select:Calls": NavigationRequest.push("call"),
+                "select:Power": NavigationRequest.push("power"),
             },
             "home": {
                 "select": NavigationRequest.push("menu"),


### PR DESCRIPTION
## Summary
- add a new Power card to the Whisplay one-button root hub
- route the new card to the existing Power Status screen
- update Whisplay routing tests and power docs to reflect the 4-card hub

## Testing
- python -m compileall yoyopy tests
- uv run pytest tests/test_screen_routing.py tests/test_whisplay_one_button.py -q
- uv run pytest -q