### PR TITLE
Add LVGL-backed Hub screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,18 @@ This file should reflect the repo as it exists on `main`. Older milestone notes 
 
 ---
 
+## Active LVGL Migration
+
+- Whisplay is beginning a rendering migration from PIL drawing to LVGL-backed widgets.
+- The migration plan lives in `docs/LVGL_MIGRATION_PLAN.md`.
+- Until cutover is complete:
+  - Whisplay defaults to `display.whisplay_renderer: pil`
+  - Pimoroni and simulation remain on the PIL path
+  - current screens, routes, coordinators, FSMs, and input grammar stay intact
+- Raw LVGL usage should remain confined to `yoyopy/ui/lvgl_binding/` and related display-layer code.
+
+---
+
 ## Source Of Truth
 
 When in doubt, trust these files first:

--- a/config/yoyopod_config.yaml
+++ b/config/yoyopod_config.yaml
@@ -66,6 +66,7 @@ power:
 # Display Settings
 display:
   hardware: "auto"                # auto, whisplay, pimoroni, simulation
+  whisplay_renderer: "pil"        # pil, lvgl (Whisplay-only; LVGL is experimental during migration)
   brightness: 80                  # 0-100
   rotation: 0                     # 0, 90, 180, 270
   backlight_timeout_seconds: 60   # Turn off backlight after 1 min

--- a/docs/LVGL_MIGRATION_PLAN.md
+++ b/docs/LVGL_MIGRATION_PLAN.md
@@ -1,0 +1,165 @@
+# LVGL CPython Migration Plan
+
+**Last Updated:** 2026-04-05
+**Scope:** Whisplay-first LVGL migration for the CPython YoyoPod runtime
+
+---
+
+## Summary
+
+- Keep the current CPython app, `EventBus`, FSMs, coordinators, router, and input grammar.
+- Target Whisplay first. Pimoroni and the current simulator stay on the PIL path during migration.
+- Pin LVGL `v9.5.0`.
+- Use a small native C shim between CPython and LVGL, then bind that shim from Python with `cffi`.
+- Do a fast cutover at the screen level, but preserve current screen class names and routes by turning each screen into a controller that delegates to a backend-specific view.
+
+---
+
+## Key Implementation Changes
+
+### Prep
+
+- Save this plan in-repo and keep `AGENTS.md` pointing here.
+- Add a new config switch:
+  - `display.whisplay_renderer: pil | lvgl`
+  - default: `pil`
+
+### Phase 0: Whisplay LVGL Proof
+
+- Build LVGL `v9.5.0` on the Pi as a shared library for the proof only.
+- Create a minimal native bridge under `yoyopy/ui/lvgl_binding/native/` that links to LVGL and exposes a narrow ABI:
+  - init/shutdown
+  - display registration
+  - input registration
+  - tick/timer pumping
+  - basic probe-scene helpers
+- Write a standalone probe script with no app dependency that renders:
+  - one card
+  - one list
+  - one footer
+- Flush to Whisplay through the existing `draw_image(x, y, width, height, pixel_data)` path using partial RGB565 area flushes.
+- Start with a partial draw buffer sized `240x40` pixels.
+
+### Phase 1: Production Backend Integration
+
+- Stop using `/usr/local` as the production contract after the proof; production must build from repo-pinned sources.
+- Add `LvglDisplayBackend` plus a Python binding layer under `yoyopy/ui/lvgl_binding/`.
+- Python binds to the shim header, not to all LVGL headers.
+- Keep `Display` as the app entrypoint, but add backend-aware accessors:
+  - `backend_kind`
+  - `get_ui_backend()`
+  - hard reset/clear on backend handoff
+- Keep PIL for non-Whisplay targets.
+
+### Phase 2: Main Loop and Input Bridge
+
+- Do not let LVGL own the loop.
+- In `YoyoPodApp.run()`, the coordinator thread becomes the only place that calls:
+  - `lv_tick_inc(delta_ms)`
+  - queued LVGL input processing
+  - `lv_timer_handler()`
+- Keep `PTTInputAdapter` unchanged.
+- Add `LvglInputBridge` that maps:
+  - `ADVANCE -> LV_KEY_RIGHT`
+  - `SELECT -> LV_KEY_ENTER`
+  - `BACK -> LV_KEY_ESC`
+- Use LVGL groups/encoder navigation for one-button focus order.
+- No LVGL calls from polling threads or background callbacks.
+
+### Phase 3: Screen Migration
+
+- Keep current screen classes and route names.
+- Each migrated screen becomes a controller with a backend-specific view lifecycle:
+  - `build()`
+  - `sync()`
+  - `destroy()`
+- Screen classes do not import raw `lvgl`; only LVGL view classes do.
+- Do not build a perfect shared widget API first.
+- Migrate in this order:
+  1. `HubScreen`
+  2. `ListenScreen`
+  3. `AskScreen`
+  4. `ContactListScreen`
+  5. `PlaylistScreen`
+  6. `NowPlayingScreen`
+  7. `IncomingCallScreen`
+  8. `OutgoingCallScreen`
+  9. `InCallScreen`
+  10. `CallScreen`
+  11. `PowerScreen`
+- Use LVGL image widgets for the current PNG icons; do not introduce an icon-font system during migration.
+
+### Phase 4: Cutover
+
+- When all Whisplay-target screens are stable, flip `display.whisplay_renderer` default to `lvgl`.
+- Remove Whisplay-specific PIL rendering/theme code that is no longer needed.
+- Keep Pimoroni and simulation on PIL until a separate follow-up plan.
+
+---
+
+## Public Interfaces / Types
+
+- `display.whisplay_renderer: Literal["pil", "lvgl"]`
+- `Display.backend_kind`
+- `Display.get_ui_backend()`
+- `LvglDisplayBackend`
+- `LvglInputBridge`
+- `ScreenView` protocol with `build()`, `sync()`, `destroy()`
+- Native shim ABI functions for:
+  - LVGL init/shutdown
+  - display registration + flush callback glue
+  - encoder/key indev registration
+  - tick/timer pump
+
+---
+
+## Test Plan
+
+- Phase 0 probe on real Whisplay:
+  - renders correctly
+  - partial flush works
+  - survives repeated redraws for 10 minutes
+- Binding/bridge tests:
+  - init/shutdown
+  - partial flush area correctness
+  - backend reset on PIL <-> LVGL handoff
+- Input tests:
+  - `ADVANCE/SELECT/BACK` map correctly to LVGL encoder/key events
+  - focus wrap works on one-button screens
+- Screen migration tests:
+  - `Hub -> Listen -> Playlist -> NowPlaying`
+  - incoming call push/pop flow
+  - Setup paging
+  - in-call live updates
+- Hardware acceptance:
+  - boots under systemd with LVGL enabled on Whisplay
+  - no corruption after 100 transitions
+  - no visible missed taps
+  - no sustained memory growth during 10 minutes of navigation/call/music activity
+
+---
+
+## Assumptions And Defaults
+
+- CPython remains the app runtime.
+- Whisplay is the only LVGL target in this migration.
+- The native shim is accepted as part of the product build/deploy story.
+- Raw LVGL is treated as a display-layer implementation detail, not a screen-layer dependency.
+- No feature work runs in parallel with this migration.
+- Current architecture stays intact above the display/UI backend boundary.
+
+---
+
+## References
+
+- LVGL latest release as of 2026-04-05: `v9.5.0`
+  - https://github.com/lvgl/lvgl/releases/tag/v9.5.0
+- LVGL display flush model
+  - https://docs.lvgl.io/9.4/details/main-modules/display/overview.html
+- LVGL display setup
+  - https://docs.lvgl.io/9.3/details/main-modules/display/setup.html
+- LVGL encoder/groups input model
+  - https://docs.lvgl.io/master/details/main-modules/indev/encoder.html
+  - https://docs.lvgl.io/latest/en/html/details/main-modules/indev/groups.html
+- Official MicroPython binding repo
+  - https://github.com/lvgl/lv_micropython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "cffi>=1.17.0",
     "pillow>=10.0.0",
     "pygame>=2.5.0",
     "requests>=2.31.0",

--- a/scripts/lvgl_build.py
+++ b/scripts/lvgl_build.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Build the pinned LVGL shim for the current platform."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+LVGL_VERSION = "9.5.0"
+LVGL_TAG = f"v{LVGL_VERSION}"
+LVGL_REPO = "https://github.com/lvgl/lvgl.git"
+
+
+def run(command: list[str], cwd: Path | None = None) -> None:
+    subprocess.run(command, cwd=str(cwd) if cwd else None, check=True)
+
+
+def ensure_lvgl_source(source_dir: Path) -> None:
+    if source_dir.exists():
+        return
+    source_dir.parent.mkdir(parents=True, exist_ok=True)
+    run(["git", "clone", "--depth", "1", "--branch", LVGL_TAG, LVGL_REPO, str(source_dir)])
+
+
+def build(native_dir: Path, source_dir: Path, build_dir: Path) -> None:
+    build_dir.mkdir(parents=True, exist_ok=True)
+    run(
+        [
+            "cmake",
+            "-S",
+            str(native_dir),
+            "-B",
+            str(build_dir),
+            "-DCMAKE_BUILD_TYPE=Release",
+            f"-DLVGL_SOURCE_DIR={source_dir}",
+        ]
+    )
+    run(["cmake", "--build", str(build_dir), "--parallel", str(os.cpu_count() or 2)])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    repo_root = Path(__file__).resolve().parents[1]
+    native_dir = repo_root / "yoyopy" / "ui" / "lvgl_binding" / "native"
+    cache_source = repo_root / ".cache" / "lvgl" / f"lvgl-{LVGL_VERSION}"
+    default_build = native_dir / "build"
+
+    parser.add_argument("--source-dir", type=Path, default=cache_source)
+    parser.add_argument("--build-dir", type=Path, default=default_build)
+    parser.add_argument("--skip-fetch", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    native_dir = repo_root / "yoyopy" / "ui" / "lvgl_binding" / "native"
+
+    if not args.skip_fetch:
+        ensure_lvgl_source(args.source_dir)
+
+    build(native_dir, args.source_dir, args.build_dir)
+    print(f"Built LVGL shim in {args.build_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lvgl_build.py
+++ b/scripts/lvgl_build.py
@@ -36,8 +36,8 @@ def build(native_dir: Path, source_dir: Path, build_dir: Path) -> None:
             str(build_dir),
             "-DCMAKE_BUILD_TYPE=Release",
             f"-DLVGL_SOURCE_DIR={source_dir}",
-            "-DLV_BUILD_EXAMPLES=OFF",
-            "-DLV_BUILD_DEMOS=OFF",
+            "-DCONFIG_LV_BUILD_EXAMPLES=OFF",
+            "-DCONFIG_LV_BUILD_DEMOS=OFF",
         ]
     )
     run(["cmake", "--build", str(build_dir), "--parallel", "2"])

--- a/scripts/lvgl_build.py
+++ b/scripts/lvgl_build.py
@@ -36,9 +36,11 @@ def build(native_dir: Path, source_dir: Path, build_dir: Path) -> None:
             str(build_dir),
             "-DCMAKE_BUILD_TYPE=Release",
             f"-DLVGL_SOURCE_DIR={source_dir}",
+            "-DLV_BUILD_EXAMPLES=OFF",
+            "-DLV_BUILD_DEMOS=OFF",
         ]
     )
-    run(["cmake", "--build", str(build_dir), "--parallel", str(os.cpu_count() or 2)])
+    run(["cmake", "--build", str(build_dir), "--parallel", "2"])
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/lvgl_probe.py
+++ b/scripts/lvgl_probe.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Run the standalone LVGL Whisplay proof scenes."""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+from loguru import logger
+
+from yoyopy.ui.display.adapters.whisplay import WhisplayDisplayAdapter
+from yoyopy.ui.lvgl_binding import LvglBinding, LvglBindingError, LvglDisplayBackend
+
+SCENE_MAP = {
+    "card": LvglBinding.SCENE_CARD,
+    "list": LvglBinding.SCENE_LIST,
+    "footer": LvglBinding.SCENE_FOOTER,
+    "carousel": LvglBinding.SCENE_CAROUSEL,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scene",
+        choices=sorted(SCENE_MAP),
+        default="carousel",
+        help="Probe scene to render",
+    )
+    parser.add_argument(
+        "--duration-seconds",
+        type=float,
+        default=10.0,
+        help="How long to keep pumping the scene",
+    )
+    parser.add_argument(
+        "--simulate",
+        action="store_true",
+        help="Use the Whisplay adapter in simulation mode",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    adapter = WhisplayDisplayAdapter(simulate=args.simulate, renderer="pil")
+    backend = LvglDisplayBackend(adapter)
+
+    if not backend.available:
+        raise SystemExit(
+            "LVGL shim unavailable. Build it first with `uv run python scripts/lvgl_build.py`."
+        )
+
+    if not backend.initialize():
+        raise SystemExit("Failed to initialize the LVGL backend")
+
+    try:
+        backend.show_probe_scene(SCENE_MAP[args.scene])
+        logger.info("Running LVGL probe scene '{}' for {:.1f}s", args.scene, args.duration_seconds)
+        started_at = time.monotonic()
+        last_tick = started_at
+        while time.monotonic() - started_at < args.duration_seconds:
+            now = time.monotonic()
+            delta_ms = int(max(0.0, now - last_tick) * 1000.0)
+            last_tick = now
+            backend.pump(delta_ms)
+            time.sleep(0.016)
+    except LvglBindingError as exc:
+        raise SystemExit(f"LVGL probe failed: {exc}") from exc
+    finally:
+        backend.cleanup()
+        adapter.cleanup()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -48,6 +48,7 @@ def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> Non
     assert settings.power.watchdog_i2c_bus == 1
     assert settings.power.watchdog_i2c_address == 0x57
     assert settings.display.hardware == "auto"
+    assert settings.display.whisplay_renderer == "pil"
 
 
 def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) -> None:
@@ -90,6 +91,7 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     monkeypatch.setenv("YOYOPOD_POWER_WATCHDOG_FEED_INTERVAL_SECONDS", "30")
     monkeypatch.setenv("YOYOPOD_POWER_WATCHDOG_I2C_ADDRESS", "0x58")
     monkeypatch.setenv("YOYOPOD_DISPLAY", "whisplay")
+    monkeypatch.setenv("YOYOPOD_WHISPLAY_RENDERER", "lvgl")
 
     config_manager = ConfigManager(config_dir=str(tmp_path))
     settings = config_manager.get_app_settings()
@@ -113,9 +115,11 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     assert settings.power.watchdog_feed_interval_seconds == 30.0
     assert settings.power.watchdog_i2c_address == 0x58
     assert settings.display.hardware == "whisplay"
+    assert settings.display.whisplay_renderer == "lvgl"
     assert settings.logging.level == "DEBUG"
     assert config_dict["audio"]["mopidy_port"] == 7788
     assert config_dict["display"]["hardware"] == "whisplay"
+    assert config_dict["display"]["whisplay_renderer"] == "lvgl"
 
 
 def test_config_manager_keeps_typed_voip_audio_settings(tmp_path, monkeypatch) -> None:

--- a/tests/test_hub_lvgl_view.py
+++ b/tests/test_hub_lvgl_view.py
@@ -1,0 +1,99 @@
+"""Focused tests for the LVGL-backed Hub screen delegation."""
+
+from __future__ import annotations
+
+from yoyopy.app_context import AppContext
+from yoyopy.ui.input import InteractionProfile
+from yoyopy.ui.screens import HubScreen
+
+
+class FakeLvglBinding:
+    """Small native-binding double for Hub view tests."""
+
+    def __init__(self) -> None:
+        self.hub_build_calls = 0
+        self.hub_destroy_calls = 0
+        self.hub_sync_payloads: list[dict] = []
+
+    def hub_build(self) -> None:
+        self.hub_build_calls += 1
+
+    def hub_sync(self, **payload) -> None:
+        self.hub_sync_payloads.append(payload)
+
+    def hub_destroy(self) -> None:
+        self.hub_destroy_calls += 1
+
+
+class FakeLvglBackend:
+    """Minimal LVGL backend double exposed through Display.get_ui_backend()."""
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self.binding = binding
+        self.initialized = True
+
+
+class FakeLvglDisplay:
+    """Tiny Display double for LVGL Hub delegation tests."""
+
+    backend_kind = "lvgl"
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self._ui_backend = FakeLvglBackend(binding)
+
+    def get_ui_backend(self) -> FakeLvglBackend:
+        return self._ui_backend
+
+
+def test_hub_screen_builds_syncs_and_destroys_lvgl_view() -> None:
+    """HubScreen should delegate its lifecycle to an LVGL view when available."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+    context.update_voip_status(configured=True, ready=True)
+    context.battery_percent = 77
+    context.battery_charging = True
+    context.power_available = True
+
+    screen = HubScreen(display, context)
+
+    screen.enter()
+    screen.render()
+
+    assert binding.hub_build_calls == 1
+    assert len(binding.hub_sync_payloads) == 1
+    first_payload = binding.hub_sync_payloads[-1]
+    assert first_payload["title"] == "Listen"
+    assert first_payload["selected_index"] == 0
+    assert first_payload["total_cards"] == 4
+    assert first_payload["voip_state"] == 1
+    assert first_payload["battery_percent"] == 77
+    assert first_payload["charging"] is True
+    assert first_payload["power_available"] is True
+
+    screen.on_advance()
+    screen.render()
+
+    second_payload = binding.hub_sync_payloads[-1]
+    assert second_payload["title"] == "Talk"
+    assert second_payload["selected_index"] == 1
+
+    screen.exit()
+    assert binding.hub_destroy_calls == 1
+
+
+def test_hub_screen_falls_back_cleanly_when_lvgl_backend_is_unavailable() -> None:
+    """Missing LVGL backend state should leave the Hub without a delegated view."""
+
+    class MissingBackendDisplay:
+        backend_kind = "lvgl"
+
+        def get_ui_backend(self):
+            return None
+
+    screen = HubScreen(MissingBackendDisplay(), AppContext(interaction_profile=InteractionProfile.ONE_BUTTON))
+
+    screen.enter()
+
+    assert screen._lvgl_view is None

--- a/tests/test_lvgl_foundation.py
+++ b/tests/test_lvgl_foundation.py
@@ -1,0 +1,141 @@
+"""Focused tests for the LVGL migration foundation layer."""
+
+from __future__ import annotations
+
+from yoyopy.ui.input import InputAction
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend, LvglInputBridge
+
+
+class FakeBinding:
+    """Minimal native-shim double for backend tests."""
+
+    KEY_RIGHT = 1
+    KEY_ENTER = 2
+    KEY_ESC = 3
+
+    def __init__(self) -> None:
+        self.init_calls = 0
+        self.register_input_calls = 0
+        self.shutdown_calls = 0
+        self.clear_calls = 0
+        self.tick_calls: list[int] = []
+        self.key_events: list[tuple[int, bool]] = []
+        self.flush_callback = None
+        self.display_args: tuple[int, int, int] | None = None
+
+    def init(self) -> None:
+        self.init_calls += 1
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+    def register_display(self, width: int, height: int, buffer_pixel_count: int, flush_callback) -> None:
+        self.display_args = (width, height, buffer_pixel_count)
+        self.flush_callback = flush_callback
+
+    def register_input(self) -> None:
+        self.register_input_calls += 1
+
+    def tick_inc(self, milliseconds: int) -> None:
+        self.tick_calls.append(milliseconds)
+
+    def timer_handler(self) -> int:
+        return 7
+
+    def queue_key_event(self, key: int, pressed: bool) -> None:
+        self.key_events.append((key, pressed))
+
+    def show_probe_scene(self, scene_id: int) -> None:
+        self.scene_id = scene_id
+
+    def clear_screen(self) -> None:
+        self.clear_calls += 1
+
+    def to_bytes(self, pixel_data: object, byte_length: int) -> bytes:
+        return bytes(pixel_data[:byte_length])
+
+
+class FakeFlushTarget:
+    """Minimal RGB565 flush target."""
+
+    WIDTH = 240
+    HEIGHT = 280
+    simulate = False
+
+    def __init__(self) -> None:
+        self.flush_calls: list[tuple[int, int, int, int, bytes]] = []
+
+    def draw_rgb565_region(
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        pixel_data: bytes,
+    ) -> None:
+        self.flush_calls.append((x, y, width, height, pixel_data))
+
+
+def test_lvgl_backend_initializes_display_and_input_bridge() -> None:
+    """The LVGL backend should register both the display and input bridge."""
+
+    binding = FakeBinding()
+    target = FakeFlushTarget()
+    backend = LvglDisplayBackend(target, buffer_lines=40, binding=binding)
+
+    assert backend.initialize() is True
+    assert backend.initialized is True
+    assert binding.init_calls == 1
+    assert binding.register_input_calls == 1
+    assert binding.display_args == (240, 280, 240 * 40)
+
+
+def test_lvgl_backend_flush_callback_forwards_rgb565_regions() -> None:
+    """Partial flushes should be forwarded to the flush target unchanged."""
+
+    binding = FakeBinding()
+    target = FakeFlushTarget()
+    backend = LvglDisplayBackend(target, binding=binding)
+    backend.initialize()
+
+    assert binding.flush_callback is not None
+    binding.flush_callback(5, 6, 2, 1, b"\x12\x34\x56\x78", 4, None)
+
+    assert target.flush_calls == [(5, 6, 2, 1, b"\x12\x34\x56\x78")]
+
+
+def test_lvgl_input_bridge_maps_one_button_actions_to_key_events() -> None:
+    """ADVANCE/SELECT/BACK should become RIGHT/ENTER/ESC press-release pairs."""
+
+    binding = FakeBinding()
+    target = FakeFlushTarget()
+    backend = LvglDisplayBackend(target, binding=binding)
+    backend.initialize()
+    bridge = LvglInputBridge(backend)
+
+    assert bridge.enqueue_action(InputAction.ADVANCE) is True
+    assert bridge.enqueue_action(InputAction.SELECT) is True
+    assert bridge.enqueue_action(InputAction.BACK) is True
+    assert bridge.enqueue_action(InputAction.NEXT_TRACK) is False
+
+    assert bridge.process_pending() == 3
+    assert binding.key_events == [
+        (binding.KEY_RIGHT, True),
+        (binding.KEY_RIGHT, False),
+        (binding.KEY_ENTER, True),
+        (binding.KEY_ENTER, False),
+        (binding.KEY_ESC, True),
+        (binding.KEY_ESC, False),
+    ]
+
+
+def test_lvgl_backend_pump_advances_time_and_runs_timers() -> None:
+    """Coordinator-thread pumps should tick LVGL and run timer handling once."""
+
+    binding = FakeBinding()
+    target = FakeFlushTarget()
+    backend = LvglDisplayBackend(target, binding=binding)
+    backend.initialize()
+
+    assert backend.pump(16) == 7
+    assert binding.tick_calls == [16]

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -41,6 +41,7 @@ from yoyopy.power import (
 )
 from yoyopy.ui.display import Display
 from yoyopy.ui.input import InputManager, InteractionProfile, get_input_manager
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend, LvglInputBridge
 from yoyopy.ui.screens import (
     AskScreen,
     CallScreen,
@@ -200,6 +201,9 @@ class YoyoPodApp:
         self._watchdog_feed_suppressed = False
         self._next_watchdog_feed_at = 0.0
         self._stopped = False
+        self._lvgl_backend: Optional[LvglDisplayBackend] = None
+        self._lvgl_input_bridge: Optional[LvglInputBridge] = None
+        self._last_lvgl_pump_at = 0.0
 
         logger.info("=" * 60)
         logger.info("YoyoPod Application Initializing")
@@ -324,10 +328,28 @@ class YoyoPodApp:
             display_hardware = (
                 self.app_settings.display.hardware if self.app_settings else "auto"
             )
+            whisplay_renderer = (
+                self.app_settings.display.whisplay_renderer
+                if self.app_settings is not None
+                else "pil"
+            )
             logger.info(f"    Hardware: {display_hardware}")
-            self.display = Display(hardware=display_hardware, simulate=self.simulate)
+            logger.info(f"    Whisplay renderer: {whisplay_renderer}")
+            self.display = Display(
+                hardware=display_hardware,
+                simulate=self.simulate,
+                whisplay_renderer=whisplay_renderer,
+            )
             logger.info(f"    Dimensions: {self.display.WIDTH}x{self.display.HEIGHT}")
             logger.info(f"    Orientation: {self.display.ORIENTATION}")
+            self._lvgl_backend = self.display.get_ui_backend()
+            if self._lvgl_backend is not None and self._lvgl_backend.initialize():
+                self.display.refresh_backend_kind()
+                self._last_lvgl_pump_at = time.monotonic()
+            else:
+                self._lvgl_backend = None
+                self.display.refresh_backend_kind()
+            logger.info(f"    Active UI backend: {self.display.backend_kind}")
 
             self.display.clear(self.display.COLOR_BLACK)
             self.display.text(
@@ -369,6 +391,9 @@ class YoyoPodApp:
             if self.input_manager:
                 self.context.interaction_profile = self.input_manager.interaction_profile
                 self.input_manager.on_activity(self._queue_user_activity_event)
+                if self._lvgl_backend is not None:
+                    self._lvgl_input_bridge = LvglInputBridge(self._lvgl_backend)
+                    self.input_manager.on_activity(self._queue_lvgl_input_action)
                 self.input_manager.start()
                 logger.info("    ✓ Input system initialized")
             else:
@@ -611,6 +636,30 @@ class YoyoPodApp:
     def _process_pending_main_thread_actions(self, limit: Optional[int] = None) -> int:
         """Drain queued typed events scheduled by worker threads."""
         return self.event_bus.drain(limit)
+
+    def _queue_lvgl_input_action(self, action, _data: Optional[Any] = None) -> None:
+        """Queue semantic actions for LVGL from input polling threads."""
+
+        if self._lvgl_input_bridge is None:
+            return
+        self._lvgl_input_bridge.enqueue_action(action)
+
+    def _pump_lvgl_backend(self, now: float | None = None) -> None:
+        """Pump LVGL timers and queued input on the coordinator thread."""
+
+        if self._lvgl_backend is None or not self._lvgl_backend.initialized:
+            return
+
+        monotonic_now = time.monotonic() if now is None else now
+        if self._last_lvgl_pump_at <= 0.0:
+            delta_ms = 0
+        else:
+            delta_ms = int(max(0.0, monotonic_now - self._last_lvgl_pump_at) * 1000.0)
+        self._last_lvgl_pump_at = monotonic_now
+
+        if self._lvgl_input_bridge is not None:
+            self._lvgl_input_bridge.process_pending()
+        self._lvgl_backend.pump(delta_ms)
 
     def _handle_screen_changed_event(self, event: ScreenChangedEvent) -> None:
         """Apply queued screen-change state sync on the coordinator thread."""
@@ -1254,6 +1303,13 @@ class YoyoPodApp:
         else:
             logger.info("  Power backend not configured")
         logger.info("")
+        logger.info("Display Status:")
+        if self.display is not None:
+            logger.info(f"  Backend: {self.display.backend_kind}")
+            logger.info(f"  Orientation: {self.display.ORIENTATION}")
+        else:
+            logger.info("  Display not initialized")
+        logger.info("")
         logger.info("Integration Settings:")
         logger.info(f"  Auto-resume after call: {self.auto_resume_after_call}")
         logger.info("")
@@ -1284,6 +1340,7 @@ class YoyoPodApp:
                 self._attempt_manager_recovery()
                 self._poll_power_status()
                 monotonic_now = time.monotonic()
+                self._pump_lvgl_backend(monotonic_now)
                 self._feed_watchdog_if_due(monotonic_now)
                 self._process_pending_shutdown(monotonic_now)
                 if self._shutdown_completed:
@@ -1403,6 +1460,11 @@ class YoyoPodApp:
                 else None
             ),
             "screen_timeout_seconds": self._screen_timeout_seconds,
+            "display_backend": (
+                getattr(self.display, "backend_kind", "pil")
+                if self.display is not None
+                else "unknown"
+            ),
             "power_model": power_snapshot.device.model if power_snapshot is not None else None,
             "power_error": power_snapshot.error if power_snapshot is not None else None,
             "power_voltage_volts": (

--- a/yoyopy/config/models.py
+++ b/yoyopy/config/models.py
@@ -277,6 +277,10 @@ class AppDisplayConfig:
     """Display hardware configuration."""
 
     hardware: str = config_value(default="auto", env="YOYOPOD_DISPLAY")
+    whisplay_renderer: str = config_value(
+        default="pil",
+        env="YOYOPOD_WHISPLAY_RENDERER",
+    )
     brightness: int = 80
     rotation: int = 0
     backlight_timeout_seconds: int = 60

--- a/yoyopy/ui/display/adapters/whisplay.py
+++ b/yoyopy/ui/display/adapters/whisplay.py
@@ -61,7 +61,7 @@ class WhisplayDisplayAdapter(DisplayHAL):
     ORIENTATION = "portrait"
     STATUS_BAR_HEIGHT = 25  # Slightly taller for portrait mode
 
-    def __init__(self, simulate: bool = False) -> None:
+    def __init__(self, simulate: bool = False, renderer: str = "pil") -> None:
         """
         Initialize the Whisplay HAT display.
 
@@ -72,6 +72,8 @@ class WhisplayDisplayAdapter(DisplayHAL):
         self.buffer: Optional[Image.Image] = None
         self.draw: Optional[ImageDraw.ImageDraw] = None
         self.device = None
+        self.renderer = renderer.lower().strip() or "pil"
+        self.ui_backend = None
 
         # Create PIL drawing buffer
         self._create_buffer()
@@ -91,6 +93,18 @@ class WhisplayDisplayAdapter(DisplayHAL):
                 self.device = None
         else:
             logger.info("Whisplay display adapter running in simulation mode")
+
+        if self.renderer == "lvgl":
+            try:
+                from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+
+                self.ui_backend = LvglDisplayBackend(self)
+                if not self.ui_backend.available:
+                    logger.warning("Whisplay LVGL renderer requested but native shim is unavailable")
+            except Exception as e:
+                logger.warning(f"Failed to prepare LVGL backend: {e}")
+                self.ui_backend = None
+                self.renderer = "pil"
 
     def _create_buffer(self) -> None:
         """Create a new PIL drawing buffer."""
@@ -127,6 +141,47 @@ class WhisplayDisplayAdapter(DisplayHAL):
                 pixel_data.extend([(rgb565 >> 8) & 0xFF, rgb565 & 0xFF])
 
         return bytes(pixel_data)
+
+    def _paste_rgb565_region(
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        pixel_data: bytes,
+    ) -> None:
+        """Paste an RGB565 region into the PIL buffer for simulation/debugging."""
+
+        if self.buffer is None:
+            return
+
+        region = Image.new("RGB", (width, height))
+        pixels: list[tuple[int, int, int]] = []
+        for index in range(0, len(pixel_data), 2):
+            rgb565 = (pixel_data[index] << 8) | pixel_data[index + 1]
+            red = ((rgb565 >> 11) & 0x1F) * 255 // 31
+            green = ((rgb565 >> 5) & 0x3F) * 255 // 63
+            blue = (rgb565 & 0x1F) * 255 // 31
+            pixels.append((red, green, blue))
+
+        region.putdata(pixels)
+        self.buffer.paste(region, (x, y))
+
+    def draw_rgb565_region(
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        pixel_data: bytes,
+    ) -> None:
+        """Write an RGB565 region to hardware or the simulation buffer."""
+
+        if not self.simulate and self.device:
+            self.device.draw_image(x, y, width, height, pixel_data)
+            return
+
+        self._paste_rgb565_region(x, y, width, height, pixel_data)
 
     def clear(self, color: Optional[Tuple[int, int, int]] = None) -> None:
         """Clear the display with specified color."""
@@ -342,6 +397,28 @@ class WhisplayDisplayAdapter(DisplayHAL):
         else:
             logger.debug("Whisplay display update (simulated)")
 
+    def get_backend_kind(self) -> str:
+        """Return the active UI rendering backend."""
+
+        if (
+            self.ui_backend is not None
+            and self.renderer == "lvgl"
+            and getattr(self.ui_backend, "initialized", False)
+        ):
+            return "lvgl"
+        return "pil"
+
+    def get_ui_backend(self):
+        """Return the optional Whisplay LVGL backend."""
+
+        return self.ui_backend
+
+    def reset_ui_backend(self) -> None:
+        """Reset any active LVGL scene before handing off to another renderer."""
+
+        if self.ui_backend is not None:
+            self.ui_backend.reset()
+
     def set_backlight(self, brightness: float) -> None:
         """
         Set backlight brightness (0.0 to 1.0).
@@ -372,6 +449,12 @@ class WhisplayDisplayAdapter(DisplayHAL):
 
     def cleanup(self) -> None:
         """Cleanup Whisplay display resources."""
+        if self.ui_backend is not None:
+            try:
+                self.ui_backend.cleanup()
+            except Exception as e:
+                logger.error(f"Error during LVGL backend cleanup: {e}")
+
         if self.device:
             try:
                 self.device.set_backlight(0)    # Turn off backlight

--- a/yoyopy/ui/display/factory.py
+++ b/yoyopy/ui/display/factory.py
@@ -3,16 +3,9 @@ Display hardware factory for YoyoPod.
 
 This module provides factory functions to create the appropriate display
 adapter based on hardware detection or configuration.
-
-The factory supports:
-- Automatic hardware detection
-- Manual hardware selection
-- Environment variable override
-- Simulation mode for testing
-
-Author: YoyoPod Team
-Date: 2025-11-30
 """
+
+from __future__ import annotations
 
 import os
 
@@ -23,186 +16,103 @@ from yoyopy.ui.display.whisplay_paths import find_whisplay_driver
 
 
 def detect_hardware() -> str:
-    """
-    Auto-detect which display hardware is connected.
+    """Auto-detect which display hardware is connected."""
 
-    Detection logic (in order of priority):
-    1. Check environment variable YOYOPOD_DISPLAY
-    2. Check for Whisplay driver in configured/common locations
-    3. Check for DisplayHATMini library availability
-    4. Default to simulation mode
-
-    Returns:
-        Hardware type: "whisplay", "pimoroni", or "simulation"
-
-    Examples:
-        >>> detect_hardware()
-        'whisplay'  # If Whisplay driver found
-
-        >>> os.environ['YOYOPOD_DISPLAY'] = 'pimoroni'
-        >>> detect_hardware()
-        'pimoroni'  # Environment override
-    """
-    # Priority 1: Environment variable override
     env_display = os.getenv("YOYOPOD_DISPLAY")
     if env_display:
         hardware = env_display.lower()
-        logger.info(f"Display hardware set by YOYOPOD_DISPLAY={hardware}")
+        logger.info("Display hardware set by YOYOPOD_DISPLAY={}", hardware)
         return hardware
 
-    # Priority 2: Check for Whisplay driver file
     whisplay_driver_path = find_whisplay_driver()
     if whisplay_driver_path:
-        logger.info(f"Detected Whisplay HAT (driver found at {whisplay_driver_path})")
+        logger.info("Detected Whisplay HAT (driver found at {})", whisplay_driver_path)
         return "whisplay"
 
-    # Priority 3: Check for Pimoroni library
     try:
-        import displayhatmini
+        import displayhatmini  # noqa: F401
+
         logger.info("Detected Pimoroni Display HAT Mini (library imported successfully)")
         return "pimoroni"
-    except Exception as e:
-        logger.debug(f"DisplayHATMini import failed during detection: {e}")
+    except Exception as exc:
+        logger.debug("DisplayHATMini import failed during detection: {}", exc)
 
-    # Priority 4: No hardware detected, default to simulation
     logger.warning("No display hardware detected - defaulting to simulation mode")
     logger.info("To force hardware type, set YOYOPOD_DISPLAY environment variable")
     return "simulation"
 
 
-def get_display(hardware: str = "auto", simulate: bool = False) -> DisplayHAL:
-    """
-    Factory function to create the appropriate display adapter.
+def get_display(
+    hardware: str = "auto",
+    simulate: bool = False,
+    *,
+    whisplay_renderer: str = "pil",
+) -> DisplayHAL:
+    """Create the appropriate display adapter."""
 
-    This is the main entry point for creating display instances. It handles
-    hardware auto-detection, adapter selection, and initialization.
-
-    Args:
-        hardware: Hardware type selector:
-            - "auto": Auto-detect hardware (default)
-            - "whisplay": Force Whisplay HAT
-            - "pimoroni": Force Pimoroni Display HAT Mini
-            - "simulation": Force simulation mode
-        simulate: Force simulation mode regardless of hardware parameter
-
-    Returns:
-        DisplayHAL: Initialized display adapter instance
-
-    Raises:
-        ValueError: If hardware type is unknown
-
-    Examples:
-        >>> # Auto-detect hardware
-        >>> display = get_display()
-        >>> print(f"{display.WIDTH}x{display.HEIGHT}")
-        240x280  # If Whisplay detected
-
-        >>> # Force specific hardware
-        >>> display = get_display("whisplay")
-        >>> display.ORIENTATION
-        'portrait'
-
-        >>> # Simulation mode (no hardware required)
-        >>> display = get_display(simulate=True)
-        >>> display.clear()
-        >>> display.update()  # No-op in simulation
-
-        >>> # Override via hardware parameter
-        >>> display = get_display("pimoroni")
-        >>> display.WIDTH
-        320
-    """
-    # If simulate=True, force simulation hardware regardless of auto-detection
     if simulate:
         hardware = "simulation"
         logger.info("Forcing simulation mode (--simulate flag)")
 
-    # Auto-detect if requested (and not already forced to simulation)
     if hardware == "auto":
         hardware = detect_hardware()
 
-    # Normalize to lowercase
     hardware = hardware.lower()
 
-    # Create appropriate adapter
     if hardware == "whisplay":
-        logger.info("Creating Whisplay display adapter (240×280 portrait)")
+        logger.info(
+            "Creating Whisplay display adapter with renderer={}",
+            whisplay_renderer,
+        )
         from yoyopy.ui.display.adapters.whisplay import WhisplayDisplayAdapter
 
-        return WhisplayDisplayAdapter(simulate=simulate)
+        return WhisplayDisplayAdapter(
+            simulate=simulate,
+            renderer=whisplay_renderer,
+        )
 
-    elif hardware == "pimoroni":
-        logger.info("Creating Pimoroni display adapter (320×240 landscape)")
+    if hardware == "pimoroni":
+        logger.info("Creating Pimoroni display adapter (320x240 landscape)")
         from yoyopy.ui.display.adapters.pimoroni import PimoroniDisplayAdapter
 
         return PimoroniDisplayAdapter(simulate=simulate)
 
-    elif hardware == "simulation":
-        logger.info("Creating simulation display adapter (240×280 portrait)")
-        # Use dedicated simulation adapter with web server support
+    if hardware == "simulation":
+        logger.info("Creating simulation display adapter (240x280 portrait)")
         from yoyopy.ui.display.adapters.simulation import SimulationDisplayAdapter
 
         adapter = SimulationDisplayAdapter(simulate=True)
 
-        # Start web server for browser display
         if simulate or hardware == "simulation":
             try:
                 from yoyopy.ui.web_server import get_server
+
                 server = get_server()
                 adapter.web_server = server
                 server.start()
                 logger.info("Web server started - view display at http://localhost:5000")
-            except Exception as e:
-                logger.warning(f"Failed to start web server: {e}")
+            except Exception as exc:
+                logger.warning("Failed to start web server: {}", exc)
                 logger.warning("Simulation display will work without web view")
 
         return adapter
 
-    else:
-        # Unknown hardware type
-        valid_types = ["auto", "whisplay", "pimoroni", "simulation"]
-        raise ValueError(
-            f"Unknown display hardware type: '{hardware}'. "
-            f"Valid options: {', '.join(valid_types)}"
-        )
+    valid_types = ["auto", "whisplay", "pimoroni", "simulation"]
+    raise ValueError(
+        f"Unknown display hardware type: '{hardware}'. "
+        f"Valid options: {', '.join(valid_types)}"
+    )
 
 
-def get_hardware_info(adapter: DisplayHAL) -> dict:
-    """
-    Get information about a display adapter.
+def get_hardware_info(adapter: DisplayHAL) -> dict[str, object]:
+    """Return debugging information about a display adapter."""
 
-    Useful for debugging and logging hardware configuration.
-
-    Args:
-        adapter: Display adapter instance
-
-    Returns:
-        Dictionary with hardware information:
-            - type: Adapter class name
-            - width: Display width in pixels
-            - height: Display height in pixels
-            - orientation: "landscape" or "portrait"
-            - status_bar_height: Status bar height in pixels
-            - simulated: True if running in simulation mode
-
-    Example:
-        >>> display = get_display()
-        >>> info = get_hardware_info(display)
-        >>> print(info)
-        {
-            'type': 'WhisplayDisplayAdapter',
-            'width': 240,
-            'height': 280,
-            'orientation': 'portrait',
-            'status_bar_height': 25,
-            'simulated': False
-        }
-    """
     return {
-        'type': adapter.__class__.__name__,
-        'width': adapter.WIDTH,
-        'height': adapter.HEIGHT,
-        'orientation': adapter.ORIENTATION,
-        'status_bar_height': adapter.STATUS_BAR_HEIGHT,
-        'simulated': adapter.simulate
+        "type": adapter.__class__.__name__,
+        "width": adapter.WIDTH,
+        "height": adapter.HEIGHT,
+        "orientation": adapter.ORIENTATION,
+        "status_bar_height": adapter.STATUS_BAR_HEIGHT,
+        "simulated": adapter.simulate,
+        "renderer": adapter.get_backend_kind(),
     }

--- a/yoyopy/ui/display/hal.py
+++ b/yoyopy/ui/display/hal.py
@@ -10,7 +10,7 @@ Date: 2025-11-30
 """
 
 from abc import ABC, abstractmethod
-from typing import Tuple, Optional
+from typing import Any, Optional, Tuple
 from pathlib import Path
 
 
@@ -257,6 +257,21 @@ class DisplayHAL(ABC):
         - Free any allocated memory
         """
         pass
+
+    def get_backend_kind(self) -> str:
+        """Return the active UI backend kind for this display adapter."""
+
+        return "pil"
+
+    def get_ui_backend(self) -> Any | None:
+        """Return an optional backend-specific UI bridge."""
+
+        return None
+
+    def reset_ui_backend(self) -> None:
+        """Reset backend-specific UI state during renderer handoff."""
+
+        return None
 
     # Helper methods (default implementations, can be overridden)
     def get_orientation(self) -> str:

--- a/yoyopy/ui/display/manager.py
+++ b/yoyopy/ui/display/manager.py
@@ -15,7 +15,7 @@ Date: 2025-11-30
 """
 
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from yoyopy.ui.display.factory import get_display
 from yoyopy.ui.display.hal import DisplayHAL
@@ -57,7 +57,12 @@ class Display:
         >>> display.update()
     """
 
-    def __init__(self, hardware: str = "auto", simulate: bool = False) -> None:
+    def __init__(
+        self,
+        hardware: str = "auto",
+        simulate: bool = False,
+        whisplay_renderer: str = "pil",
+    ) -> None:
         """
         Initialize display with hardware abstraction.
 
@@ -73,7 +78,11 @@ class Display:
             ValueError: If hardware type is unknown
         """
         # Create appropriate adapter using factory
-        self._adapter: DisplayHAL = get_display(hardware, simulate)
+        self._adapter: DisplayHAL = get_display(
+            hardware,
+            simulate,
+            whisplay_renderer=whisplay_renderer,
+        )
 
         # Expose adapter properties as Display properties for backward compatibility
         self.WIDTH = self._adapter.WIDTH
@@ -95,6 +104,7 @@ class Display:
 
         # Expose simulate flag for compatibility
         self.simulate = self._adapter.simulate
+        self.backend_kind = self._adapter.get_backend_kind()
 
     # Delegate all methods to adapter
     def clear(self, color: Optional[Tuple[int, int, int]] = None) -> None:
@@ -229,3 +239,19 @@ class Display:
             DisplayHAL: The hardware adapter instance
         """
         return self._adapter
+
+    def get_ui_backend(self) -> Any | None:
+        """Return the optional backend-specific UI bridge."""
+
+        return self._adapter.get_ui_backend()
+
+    def reset_ui_backend(self) -> None:
+        """Reset backend-specific UI state during renderer handoff."""
+
+        self._adapter.reset_ui_backend()
+
+    def refresh_backend_kind(self) -> str:
+        """Refresh and return the active backend kind from the adapter."""
+
+        self.backend_kind = self._adapter.get_backend_kind()
+        return self.backend_kind

--- a/yoyopy/ui/lvgl_binding/__init__.py
+++ b/yoyopy/ui/lvgl_binding/__init__.py
@@ -1,0 +1,12 @@
+"""LVGL binding and backend helpers for the Whisplay migration."""
+
+from yoyopy.ui.lvgl_binding.backend import LvglDisplayBackend
+from yoyopy.ui.lvgl_binding.binding import LvglBinding, LvglBindingError
+from yoyopy.ui.lvgl_binding.input_driver import LvglInputBridge
+
+__all__ = [
+    "LvglBinding",
+    "LvglBindingError",
+    "LvglDisplayBackend",
+    "LvglInputBridge",
+]

--- a/yoyopy/ui/lvgl_binding/backend.py
+++ b/yoyopy/ui/lvgl_binding/backend.py
@@ -1,0 +1,143 @@
+"""Whisplay-focused LVGL display backend."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from loguru import logger
+
+from yoyopy.ui.lvgl_binding.binding import LvglBinding, LvglBindingError
+
+
+class Rgb565FlushTarget(Protocol):
+    """Minimal adapter contract for receiving RGB565 partial flushes."""
+
+    WIDTH: int
+    HEIGHT: int
+    simulate: bool
+
+    def draw_rgb565_region(
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        pixel_data: bytes,
+    ) -> None: ...
+
+
+@dataclass(slots=True)
+class LvglDisplayBackend:
+    """Own LVGL init, display/input registration, and timer pumping."""
+
+    flush_target: Rgb565FlushTarget
+    buffer_lines: int = 40
+    binding: LvglBinding | None = None
+    initialized: bool = field(init=False, default=False)
+    width: int = field(init=False, default=0)
+    height: int = field(init=False, default=0)
+
+    def __post_init__(self) -> None:
+        self.binding = self.binding or LvglBinding.try_load()
+        self.width = int(self.flush_target.WIDTH)
+        self.height = int(self.flush_target.HEIGHT)
+
+    @property
+    def available(self) -> bool:
+        """Return True when the native shim is available."""
+
+        return self.binding is not None
+
+    @property
+    def buffer_pixel_count(self) -> int:
+        return self.width * self.buffer_lines
+
+    def initialize(self) -> bool:
+        """Initialize LVGL and register display/input bridges."""
+
+        if self.initialized:
+            return True
+        if self.binding is None:
+            logger.warning("LVGL backend requested but native shim is unavailable")
+            return False
+
+        try:
+            self.binding.init()
+            self.binding.register_display(
+                self.width,
+                self.height,
+                self.buffer_pixel_count,
+                self._flush_callback,
+            )
+            self.binding.register_input()
+        except LvglBindingError as exc:
+            logger.error("Failed to initialize LVGL backend: {}", exc)
+            return False
+
+        self.initialized = True
+        logger.info(
+            "LVGL backend initialized ({}x{}, buffer_lines={})",
+            self.width,
+            self.height,
+            self.buffer_lines,
+        )
+        return True
+
+    def _flush_callback(
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        pixel_data: object,
+        byte_length: int,
+        _user_data: object,
+    ) -> None:
+        if self.binding is None:
+            return
+        payload = self.binding.to_bytes(pixel_data, byte_length)
+        self.flush_target.draw_rgb565_region(x, y, width, height, payload)
+
+    def tick(self, milliseconds: int) -> None:
+        if not self.initialized or self.binding is None:
+            return
+        self.binding.tick_inc(milliseconds)
+
+    def timer_handler(self) -> int:
+        if not self.initialized or self.binding is None:
+            return 0
+        return self.binding.timer_handler()
+
+    def pump(self, milliseconds: int) -> int:
+        """Advance LVGL time and run timers once on the coordinator thread."""
+
+        if not self.initialized:
+            return 0
+        self.tick(milliseconds)
+        return self.timer_handler()
+
+    def queue_key_event(self, key: int, pressed: bool) -> None:
+        if not self.initialized or self.binding is None:
+            return
+        self.binding.queue_key_event(key, pressed)
+
+    def show_probe_scene(self, scene_id: int) -> None:
+        if not self.initialized or self.binding is None:
+            raise LvglBindingError("LVGL backend is not initialized")
+        self.binding.show_probe_scene(scene_id)
+
+    def clear(self) -> None:
+        if self.initialized and self.binding is not None:
+            self.binding.clear_screen()
+
+    def reset(self) -> None:
+        """Clear LVGL-managed content before a hard backend handoff."""
+
+        self.clear()
+
+    def cleanup(self) -> None:
+        if not self.initialized or self.binding is None:
+            return
+        self.binding.shutdown()
+        self.initialized = False

--- a/yoyopy/ui/lvgl_binding/binding.py
+++ b/yoyopy/ui/lvgl_binding/binding.py
@@ -1,0 +1,160 @@
+"""Low-level cffi binding for the native YoyoPod LVGL shim."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from cffi import FFI
+from loguru import logger
+
+SHIM_CDEF = """
+typedef void (*yoyopy_lvgl_flush_cb_t)(
+    int32_t x,
+    int32_t y,
+    int32_t width,
+    int32_t height,
+    const unsigned char * pixel_data,
+    uint32_t byte_length,
+    void * user_data
+);
+
+int yoyopy_lvgl_init(void);
+void yoyopy_lvgl_shutdown(void);
+int yoyopy_lvgl_register_display(
+    int32_t width,
+    int32_t height,
+    uint32_t buffer_pixel_count,
+    yoyopy_lvgl_flush_cb_t flush_cb,
+    void * user_data
+);
+int yoyopy_lvgl_register_input(void);
+void yoyopy_lvgl_tick_inc(uint32_t ms);
+uint32_t yoyopy_lvgl_timer_handler(void);
+int yoyopy_lvgl_queue_key_event(int32_t key, int32_t pressed);
+int yoyopy_lvgl_show_probe_scene(int32_t scene_id);
+void yoyopy_lvgl_clear_screen(void);
+const char * yoyopy_lvgl_last_error(void);
+const char * yoyopy_lvgl_version(void);
+"""
+
+
+class LvglBindingError(RuntimeError):
+    """Raised when the native LVGL shim cannot be loaded or initialized."""
+
+
+class LvglBinding:
+    """Thin ABI-mode wrapper over the native LVGL shim."""
+
+    KEY_NONE = 0
+    KEY_RIGHT = 1
+    KEY_ENTER = 2
+    KEY_ESC = 3
+
+    SCENE_CARD = 1
+    SCENE_LIST = 2
+    SCENE_FOOTER = 3
+    SCENE_CAROUSEL = 4
+
+    def __init__(self, library_path: Path | None = None) -> None:
+        self.ffi = FFI()
+        self.ffi.cdef(SHIM_CDEF)
+        self.library_path = library_path or self._resolve_library_path()
+        if self.library_path is None:
+            raise LvglBindingError(
+                "LVGL shim library not found; run scripts/lvgl_build.py on the target platform",
+            )
+
+        self.lib = self.ffi.dlopen(str(self.library_path))
+        self._flush_callback = None
+        logger.info("Loaded LVGL shim from {}", self.library_path)
+
+    @classmethod
+    def try_load(cls, library_path: Path | None = None) -> "LvglBinding | None":
+        """Attempt to load the native shim without raising."""
+
+        try:
+            return cls(library_path=library_path)
+        except Exception as exc:
+            logger.debug("LVGL shim not available: {}", exc)
+            return None
+
+    def _resolve_library_path(self) -> Path | None:
+        env_override = os.getenv("YOYOPOD_LVGL_SHIM_PATH")
+        candidates: list[Path] = []
+        if env_override:
+            candidates.append(Path(env_override))
+
+        base_dir = Path(__file__).resolve().parent
+        candidates.extend(
+            [
+                base_dir / "native" / "build" / "libyoyopy_lvgl_shim.so",
+                base_dir / "native" / "build" / "yoyopy_lvgl_shim.dll",
+                base_dir / "native" / "build" / "libyoyopy_lvgl_shim.dylib",
+                Path.cwd() / "build" / "lvgl" / "libyoyopy_lvgl_shim.so",
+            ]
+        )
+
+        for candidate in candidates:
+            if candidate.exists():
+                return candidate
+        return None
+
+    def init(self) -> None:
+        if self.lib.yoyopy_lvgl_init() != 0:
+            raise LvglBindingError(self.last_error())
+
+    def shutdown(self) -> None:
+        self.lib.yoyopy_lvgl_shutdown()
+
+    def register_display(self, width: int, height: int, buffer_pixel_count: int, flush_callback) -> None:
+        callback = self.ffi.callback(
+            "void(int32_t, int32_t, int32_t, int32_t, const unsigned char *, uint32_t, void *)",
+            flush_callback,
+        )
+        result = self.lib.yoyopy_lvgl_register_display(
+            width,
+            height,
+            buffer_pixel_count,
+            callback,
+            self.ffi.NULL,
+        )
+        if result != 0:
+            raise LvglBindingError(self.last_error())
+        self._flush_callback = callback
+
+    def register_input(self) -> None:
+        if self.lib.yoyopy_lvgl_register_input() != 0:
+            raise LvglBindingError(self.last_error())
+
+    def tick_inc(self, milliseconds: int) -> None:
+        self.lib.yoyopy_lvgl_tick_inc(max(0, int(milliseconds)))
+
+    def timer_handler(self) -> int:
+        return int(self.lib.yoyopy_lvgl_timer_handler())
+
+    def queue_key_event(self, key: int, pressed: bool) -> None:
+        if self.lib.yoyopy_lvgl_queue_key_event(int(key), 1 if pressed else 0) != 0:
+            raise LvglBindingError(self.last_error())
+
+    def show_probe_scene(self, scene_id: int) -> None:
+        if self.lib.yoyopy_lvgl_show_probe_scene(scene_id) != 0:
+            raise LvglBindingError(self.last_error())
+
+    def clear_screen(self) -> None:
+        self.lib.yoyopy_lvgl_clear_screen()
+
+    def to_bytes(self, pixel_data: object, byte_length: int) -> bytes:
+        return bytes(self.ffi.buffer(pixel_data, byte_length))
+
+    def last_error(self) -> str:
+        raw = self.lib.yoyopy_lvgl_last_error()
+        if raw == self.ffi.NULL:
+            return "unknown LVGL shim error"
+        return self.ffi.string(raw).decode("utf-8", errors="replace")
+
+    def version(self) -> str:
+        raw = self.lib.yoyopy_lvgl_version()
+        if raw == self.ffi.NULL:
+            return "unknown"
+        return self.ffi.string(raw).decode("utf-8", errors="replace")

--- a/yoyopy/ui/lvgl_binding/binding.py
+++ b/yoyopy/ui/lvgl_binding/binding.py
@@ -33,6 +33,24 @@ void yoyopy_lvgl_tick_inc(uint32_t ms);
 uint32_t yoyopy_lvgl_timer_handler(void);
 int yoyopy_lvgl_queue_key_event(int32_t key, int32_t pressed);
 int yoyopy_lvgl_show_probe_scene(int32_t scene_id);
+int yoyopy_lvgl_hub_build(void);
+int yoyopy_lvgl_hub_sync(
+    const char * icon_key,
+    const char * title,
+    const char * subtitle,
+    const char * footer,
+    const char * time_text,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b,
+    int32_t selected_index,
+    int32_t total_cards,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available
+);
+void yoyopy_lvgl_hub_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);
@@ -140,6 +158,57 @@ class LvglBinding:
     def show_probe_scene(self, scene_id: int) -> None:
         if self.lib.yoyopy_lvgl_show_probe_scene(scene_id) != 0:
             raise LvglBindingError(self.last_error())
+
+    def hub_build(self) -> None:
+        if self.lib.yoyopy_lvgl_hub_build() != 0:
+            raise LvglBindingError(self.last_error())
+
+    def hub_sync(
+        self,
+        *,
+        icon_key: str,
+        title: str,
+        subtitle: str,
+        footer: str,
+        time_text: str | None,
+        accent: tuple[int, int, int],
+        selected_index: int,
+        total_cards: int,
+        voip_state: int,
+        battery_percent: int,
+        charging: bool,
+        power_available: bool,
+    ) -> None:
+        icon_key_raw = self.ffi.new("char[]", icon_key.encode("utf-8"))
+        title_raw = self.ffi.new("char[]", title.encode("utf-8"))
+        subtitle_raw = self.ffi.new("char[]", subtitle.encode("utf-8"))
+        footer_raw = self.ffi.new("char[]", footer.encode("utf-8"))
+        if time_text:
+            time_raw = self.ffi.new("char[]", time_text.encode("utf-8"))
+        else:
+            time_raw = self.ffi.NULL
+
+        result = self.lib.yoyopy_lvgl_hub_sync(
+            icon_key_raw,
+            title_raw,
+            subtitle_raw,
+            footer_raw,
+            time_raw,
+            accent[0],
+            accent[1],
+            accent[2],
+            selected_index,
+            total_cards,
+            voip_state,
+            battery_percent,
+            1 if charging else 0,
+            1 if power_available else 0,
+        )
+        if result != 0:
+            raise LvglBindingError(self.last_error())
+
+    def hub_destroy(self) -> None:
+        self.lib.yoyopy_lvgl_hub_destroy()
 
     def clear_screen(self) -> None:
         self.lib.yoyopy_lvgl_clear_screen()

--- a/yoyopy/ui/lvgl_binding/input_driver.py
+++ b/yoyopy/ui/lvgl_binding/input_driver.py
@@ -1,0 +1,51 @@
+"""Main-thread LVGL input bridge."""
+
+from __future__ import annotations
+
+from queue import SimpleQueue
+
+from loguru import logger
+
+from yoyopy.ui.input import InputAction
+from yoyopy.ui.lvgl_binding.backend import LvglDisplayBackend
+from yoyopy.ui.lvgl_binding.binding import LvglBinding
+
+
+class LvglInputBridge:
+    """Queue semantic actions and translate them into LVGL key events."""
+
+    ACTION_TO_KEY = {
+        InputAction.ADVANCE: LvglBinding.KEY_RIGHT,
+        InputAction.SELECT: LvglBinding.KEY_ENTER,
+        InputAction.BACK: LvglBinding.KEY_ESC,
+    }
+
+    def __init__(self, backend: LvglDisplayBackend) -> None:
+        self.backend = backend
+        self._pending: SimpleQueue[int] = SimpleQueue()
+
+    def enqueue_action(self, action: InputAction) -> bool:
+        """Store a semantic action for later main-thread dispatch."""
+
+        mapped_key = self.ACTION_TO_KEY.get(action)
+        if mapped_key is None:
+            return False
+        self._pending.put(mapped_key)
+        return True
+
+    def process_pending(self) -> int:
+        """Send queued actions into LVGL from the coordinator thread."""
+
+        if not self.backend.initialized:
+            return 0
+
+        processed = 0
+        while not self._pending.empty():
+            key = self._pending.get()
+            self.backend.queue_key_event(key, True)
+            self.backend.queue_key_event(key, False)
+            processed += 1
+
+        if processed:
+            logger.trace("Delivered {} queued LVGL input events", processed)
+        return processed

--- a/yoyopy/ui/lvgl_binding/native/CMakeLists.txt
+++ b/yoyopy/ui/lvgl_binding/native/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.16)
+project(yoyopy_lvgl_binding C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+set(LVGL_SOURCE_DIR "" CACHE PATH "Path to a checked-out LVGL source tree")
+
+if(NOT LVGL_SOURCE_DIR)
+  message(FATAL_ERROR "LVGL_SOURCE_DIR must point to an LVGL checkout")
+endif()
+
+add_subdirectory(${LVGL_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/lvgl)
+
+if(TARGET lvgl)
+  target_include_directories(lvgl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+  target_compile_definitions(lvgl PUBLIC LV_CONF_INCLUDE_SIMPLE)
+endif()
+
+add_library(yoyopy_lvgl_shim SHARED lvgl_shim.c)
+target_include_directories(
+  yoyopy_lvgl_shim
+  PRIVATE
+    ${LVGL_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_compile_definitions(yoyopy_lvgl_shim PRIVATE LV_CONF_INCLUDE_SIMPLE)
+target_link_libraries(yoyopy_lvgl_shim PRIVATE lvgl m)
+
+set_target_properties(
+  yoyopy_lvgl_shim
+  PROPERTIES
+    OUTPUT_NAME "yoyopy_lvgl_shim"
+)

--- a/yoyopy/ui/lvgl_binding/native/CMakeLists.txt
+++ b/yoyopy/ui/lvgl_binding/native/CMakeLists.txt
@@ -12,8 +12,8 @@ if(NOT LVGL_SOURCE_DIR)
   message(FATAL_ERROR "LVGL_SOURCE_DIR must point to an LVGL checkout")
 endif()
 
-set(LV_BUILD_EXAMPLES OFF CACHE BOOL "Disable LVGL examples" FORCE)
-set(LV_BUILD_DEMOS OFF CACHE BOOL "Disable LVGL demos" FORCE)
+set(CONFIG_LV_BUILD_EXAMPLES OFF CACHE BOOL "Disable LVGL examples" FORCE)
+set(CONFIG_LV_BUILD_DEMOS OFF CACHE BOOL "Disable LVGL demos" FORCE)
 
 add_subdirectory(${LVGL_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/lvgl)
 

--- a/yoyopy/ui/lvgl_binding/native/CMakeLists.txt
+++ b/yoyopy/ui/lvgl_binding/native/CMakeLists.txt
@@ -10,6 +10,9 @@ if(NOT LVGL_SOURCE_DIR)
   message(FATAL_ERROR "LVGL_SOURCE_DIR must point to an LVGL checkout")
 endif()
 
+set(LV_BUILD_EXAMPLES OFF CACHE BOOL "Disable LVGL examples" FORCE)
+set(LV_BUILD_DEMOS OFF CACHE BOOL "Disable LVGL demos" FORCE)
+
 add_subdirectory(${LVGL_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/lvgl)
 
 if(TARGET lvgl)

--- a/yoyopy/ui/lvgl_binding/native/CMakeLists.txt
+++ b/yoyopy/ui/lvgl_binding/native/CMakeLists.txt
@@ -4,6 +4,7 @@ project(yoyopy_lvgl_binding C)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries" FORCE)
 
 set(LVGL_SOURCE_DIR "" CACHE PATH "Path to a checked-out LVGL source tree")
 

--- a/yoyopy/ui/lvgl_binding/native/CMakeLists.txt
+++ b/yoyopy/ui/lvgl_binding/native/CMakeLists.txt
@@ -3,6 +3,7 @@ project(yoyopy_lvgl_binding C)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(LVGL_SOURCE_DIR "" CACHE PATH "Path to a checked-out LVGL source tree")
 

--- a/yoyopy/ui/lvgl_binding/native/lv_conf.h
+++ b/yoyopy/ui/lvgl_binding/native/lv_conf.h
@@ -1,0 +1,30 @@
+#ifndef LV_CONF_H
+#define LV_CONF_H
+
+#define LV_COLOR_DEPTH 16
+#define LV_USE_OS LV_OS_NONE
+
+#define LV_MEM_CUSTOM 0
+#define LV_MEM_SIZE (256U * 1024U)
+
+#define LV_USE_LOG 0
+#define LV_USE_ASSERT_NULL 1
+#define LV_USE_ASSERT_MALLOC 1
+#define LV_USE_ASSERT_STYLE 0
+#define LV_USE_ASSERT_MEM_INTEGRITY 0
+#define LV_USE_ASSERT_OBJ 0
+
+#define LV_FONT_MONTSERRAT_12 1
+#define LV_FONT_MONTSERRAT_14 1
+#define LV_FONT_MONTSERRAT_16 1
+#define LV_FONT_MONTSERRAT_18 1
+#define LV_FONT_MONTSERRAT_24 1
+
+#define LV_USE_THEME_DEFAULT 1
+#define LV_USE_LIST 1
+#define LV_USE_LABEL 1
+#define LV_USE_BUTTON 1
+#define LV_USE_IMAGE 1
+#define LV_USE_FLEX 1
+
+#endif

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
@@ -1,0 +1,380 @@
+#include "lvgl.h"
+#include "lvgl_shim.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define KEY_QUEUE_CAPACITY 32
+
+typedef struct {
+    int32_t key;
+    int32_t pressed;
+} yoyopy_key_event_t;
+
+static int g_initialized = 0;
+static lv_display_t * g_display = NULL;
+static lv_indev_t * g_indev = NULL;
+static lv_group_t * g_group = NULL;
+static lv_color_t * g_draw_buf = NULL;
+static uint32_t g_draw_buf_bytes = 0;
+static yoyopy_lvgl_flush_cb_t g_flush_cb = NULL;
+static void * g_flush_user_data = NULL;
+static char g_last_error[256] = "";
+static yoyopy_key_event_t g_key_queue[KEY_QUEUE_CAPACITY];
+static int g_key_head = 0;
+static int g_key_tail = 0;
+static int g_key_count = 0;
+
+static void yoyopy_set_error(const char * message) {
+    if(message == NULL) {
+        g_last_error[0] = '\0';
+        return;
+    }
+
+    strncpy(g_last_error, message, sizeof(g_last_error) - 1);
+    g_last_error[sizeof(g_last_error) - 1] = '\0';
+}
+
+static int yoyopy_translate_key(int32_t key) {
+    switch(key) {
+        case YOYOPY_LVGL_KEY_RIGHT:
+            return LV_KEY_RIGHT;
+        case YOYOPY_LVGL_KEY_ENTER:
+            return LV_KEY_ENTER;
+        case YOYOPY_LVGL_KEY_ESC:
+            return LV_KEY_ESC;
+        default:
+            return 0;
+    }
+}
+
+static void yoyopy_flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * px_map) {
+    int32_t width = lv_area_get_width(area);
+    int32_t height = lv_area_get_height(area);
+    uint32_t byte_length = (uint32_t)(width * height * sizeof(lv_color_t));
+
+    if(g_flush_cb != NULL) {
+        g_flush_cb(
+            area->x1,
+            area->y1,
+            width,
+            height,
+            (const unsigned char *)px_map,
+            byte_length,
+            g_flush_user_data
+        );
+    }
+
+    lv_display_flush_ready(disp);
+}
+
+static void yoyopy_indev_read_cb(lv_indev_t * indev, lv_indev_data_t * data) {
+    (void)indev;
+
+    if(g_key_count == 0) {
+        data->state = LV_INDEV_STATE_RELEASED;
+        data->key = 0;
+        data->continue_reading = 0;
+        return;
+    }
+
+    yoyopy_key_event_t event = g_key_queue[g_key_head];
+    g_key_head = (g_key_head + 1) % KEY_QUEUE_CAPACITY;
+    g_key_count--;
+
+    data->key = yoyopy_translate_key(event.key);
+    data->state = event.pressed ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
+    data->continue_reading = g_key_count > 0 ? 1 : 0;
+}
+
+static void yoyopy_clear_group(void) {
+    if(g_group != NULL) {
+        lv_group_remove_all_objs(g_group);
+    }
+}
+
+static lv_obj_t * yoyopy_create_card(lv_obj_t * screen, const char * title, const char * subtitle, lv_color_t accent) {
+    lv_obj_t * panel = lv_obj_create(screen);
+    lv_obj_set_size(panel, 200, 190);
+    lv_obj_align(panel, LV_ALIGN_CENTER, 0, 8);
+    lv_obj_set_style_radius(panel, 24, 0);
+    lv_obj_set_style_border_width(panel, 2, 0);
+    lv_obj_set_style_border_color(panel, accent, 0);
+    lv_obj_set_style_bg_color(panel, lv_color_hex(0x222634), 0);
+    lv_obj_set_style_bg_opa(panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_pad_all(panel, 16, 0);
+    lv_obj_set_layout(panel, LV_LAYOUT_FLEX);
+    lv_obj_set_flex_flow(panel, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(panel, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+    lv_obj_t * icon = lv_obj_create(panel);
+    lv_obj_set_size(icon, 72, 72);
+    lv_obj_set_style_radius(icon, 20, 0);
+    lv_obj_set_style_bg_color(icon, accent, 0);
+    lv_obj_set_style_bg_opa(icon, LV_OPA_20, 0);
+    lv_obj_set_style_border_width(icon, 2, 0);
+    lv_obj_set_style_border_color(icon, accent, 0);
+
+    lv_obj_t * title_label = lv_label_create(panel);
+    lv_label_set_text(title_label, title);
+    lv_obj_set_style_text_font(title_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(title_label, lv_color_hex(0xF6F6F8), 0);
+
+    lv_obj_t * subtitle_label = lv_label_create(panel);
+    lv_label_set_text(subtitle_label, subtitle);
+    lv_obj_set_style_text_font(subtitle_label, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(subtitle_label, accent, 0);
+
+    return panel;
+}
+
+static void yoyopy_build_card_scene(void) {
+    lv_obj_t * screen = lv_screen_active();
+    lv_obj_clean(screen);
+    yoyopy_clear_group();
+    yoyopy_create_card(screen, "Listen", "LVGL card proof", lv_color_hex(0x98D94C));
+}
+
+static void yoyopy_build_list_scene(void) {
+    lv_obj_t * screen = lv_screen_active();
+    lv_obj_clean(screen);
+    yoyopy_clear_group();
+
+    lv_obj_t * list = lv_list_create(screen);
+    lv_obj_set_size(list, 208, 210);
+    lv_obj_align(list, LV_ALIGN_CENTER, 0, 8);
+    lv_obj_set_style_radius(list, 22, 0);
+    lv_obj_set_style_bg_color(list, lv_color_hex(0x222634), 0);
+    lv_obj_set_style_border_color(list, lv_color_hex(0x4CCAE4), 0);
+    lv_obj_set_style_border_width(list, 2, 0);
+
+    lv_obj_t * button = NULL;
+
+    button = lv_list_add_button(list, NULL, "Spotify");
+    if(g_group != NULL) lv_group_add_obj(g_group, button);
+
+    button = lv_list_add_button(list, NULL, "Amazon");
+    if(g_group != NULL) lv_group_add_obj(g_group, button);
+
+    button = lv_list_add_button(list, NULL, "YouTube");
+    if(g_group != NULL) lv_group_add_obj(g_group, button);
+
+    button = lv_list_add_button(list, NULL, "Local");
+    if(g_group != NULL) lv_group_add_obj(g_group, button);
+}
+
+static void yoyopy_build_footer_scene(void) {
+    lv_obj_t * screen = lv_screen_active();
+    lv_obj_clean(screen);
+    yoyopy_clear_group();
+
+    lv_obj_t * label = lv_label_create(screen);
+    lv_label_set_text(label, "Tap next / Double open / Hold back");
+    lv_obj_align(label, LV_ALIGN_BOTTOM_MID, 0, -10);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(label, lv_color_hex(0xE8E8EF), 0);
+}
+
+static void yoyopy_build_carousel_scene(void) {
+    lv_obj_t * screen = lv_screen_active();
+    lv_obj_clean(screen);
+    yoyopy_clear_group();
+    yoyopy_create_card(screen, "Talk", "Carousel proof", lv_color_hex(0x4CCAE4));
+
+    lv_obj_t * footer = lv_label_create(screen);
+    lv_label_set_text(footer, "Tap next / Open");
+    lv_obj_align(footer, LV_ALIGN_BOTTOM_MID, 0, -10);
+    lv_obj_set_style_text_font(footer, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(footer, lv_color_hex(0xF6F6F8), 0);
+}
+
+int yoyopy_lvgl_init(void) {
+    if(g_initialized) {
+        return 0;
+    }
+
+    yoyopy_set_error(NULL);
+    lv_init();
+    g_initialized = 1;
+    return 0;
+}
+
+void yoyopy_lvgl_shutdown(void) {
+    if(g_draw_buf != NULL) {
+        lv_free(g_draw_buf);
+        g_draw_buf = NULL;
+    }
+
+    if(g_group != NULL) {
+        lv_group_delete(g_group);
+        g_group = NULL;
+    }
+
+    g_display = NULL;
+    g_indev = NULL;
+    g_flush_cb = NULL;
+    g_flush_user_data = NULL;
+    g_draw_buf_bytes = 0;
+    g_key_head = 0;
+    g_key_tail = 0;
+    g_key_count = 0;
+    g_initialized = 0;
+    yoyopy_set_error(NULL);
+}
+
+int yoyopy_lvgl_register_display(
+    int32_t width,
+    int32_t height,
+    uint32_t buffer_pixel_count,
+    yoyopy_lvgl_flush_cb_t flush_cb,
+    void * user_data
+) {
+    if(!g_initialized) {
+        yoyopy_set_error("LVGL must be initialized before registering a display");
+        return -1;
+    }
+
+    if(g_display != NULL) {
+        yoyopy_set_error("display already registered");
+        return -1;
+    }
+
+    if(flush_cb == NULL) {
+        yoyopy_set_error("flush callback is required");
+        return -1;
+    }
+
+    g_display = lv_display_create(width, height);
+    if(g_display == NULL) {
+        yoyopy_set_error("lv_display_create failed");
+        return -1;
+    }
+
+    g_draw_buf_bytes = buffer_pixel_count * sizeof(lv_color_t);
+    g_draw_buf = lv_malloc(g_draw_buf_bytes);
+    if(g_draw_buf == NULL) {
+        yoyopy_set_error("draw buffer allocation failed");
+        return -1;
+    }
+
+    g_flush_cb = flush_cb;
+    g_flush_user_data = user_data;
+
+    lv_display_set_flush_cb(g_display, yoyopy_flush_cb);
+    lv_display_set_buffers(
+        g_display,
+        g_draw_buf,
+        NULL,
+        g_draw_buf_bytes,
+        LV_DISPLAY_RENDER_MODE_PARTIAL
+    );
+
+    return 0;
+}
+
+int yoyopy_lvgl_register_input(void) {
+    if(!g_initialized || g_display == NULL) {
+        yoyopy_set_error("display must be registered before input");
+        return -1;
+    }
+
+    if(g_group == NULL) {
+        g_group = lv_group_create();
+        lv_group_set_default(g_group);
+    }
+
+    if(g_indev == NULL) {
+        g_indev = lv_indev_create();
+        if(g_indev == NULL) {
+            yoyopy_set_error("lv_indev_create failed");
+            return -1;
+        }
+        lv_indev_set_type(g_indev, LV_INDEV_TYPE_KEYPAD);
+        lv_indev_set_read_cb(g_indev, yoyopy_indev_read_cb);
+        lv_indev_set_group(g_indev, g_group);
+    }
+
+    return 0;
+}
+
+void yoyopy_lvgl_tick_inc(uint32_t ms) {
+    if(g_initialized) {
+        lv_tick_inc(ms);
+    }
+}
+
+uint32_t yoyopy_lvgl_timer_handler(void) {
+    if(!g_initialized) {
+        return 0U;
+    }
+
+    return lv_timer_handler();
+}
+
+int yoyopy_lvgl_queue_key_event(int32_t key, int32_t pressed) {
+    if(g_key_count >= KEY_QUEUE_CAPACITY) {
+        yoyopy_set_error("input queue full");
+        return -1;
+    }
+
+    g_key_queue[g_key_tail].key = key;
+    g_key_queue[g_key_tail].pressed = pressed;
+    g_key_tail = (g_key_tail + 1) % KEY_QUEUE_CAPACITY;
+    g_key_count++;
+    return 0;
+}
+
+int yoyopy_lvgl_show_probe_scene(int32_t scene_id) {
+    if(!g_initialized || g_display == NULL) {
+        yoyopy_set_error("display must be registered before showing a scene");
+        return -1;
+    }
+
+    switch(scene_id) {
+        case YOYOPY_LVGL_SCENE_CARD:
+            yoyopy_build_card_scene();
+            break;
+        case YOYOPY_LVGL_SCENE_LIST:
+            yoyopy_build_list_scene();
+            break;
+        case YOYOPY_LVGL_SCENE_FOOTER:
+            yoyopy_build_footer_scene();
+            break;
+        case YOYOPY_LVGL_SCENE_CAROUSEL:
+            yoyopy_build_carousel_scene();
+            break;
+        default:
+            yoyopy_set_error("unknown probe scene");
+            return -1;
+    }
+
+    return 0;
+}
+
+void yoyopy_lvgl_clear_screen(void) {
+    if(!g_initialized || g_display == NULL) {
+        return;
+    }
+
+    lv_obj_t * screen = lv_screen_active();
+    lv_obj_clean(screen);
+    yoyopy_clear_group();
+}
+
+const char * yoyopy_lvgl_last_error(void) {
+    return g_last_error;
+}
+
+const char * yoyopy_lvgl_version(void) {
+    static char version[32];
+    snprintf(
+        version,
+        sizeof(version),
+        "%d.%d.%d",
+        LVGL_VERSION_MAJOR,
+        LVGL_VERSION_MINOR,
+        LVGL_VERSION_PATCH
+    );
+    return version;
+}

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
@@ -12,6 +12,23 @@ typedef struct {
     int32_t pressed;
 } yoyopy_key_event_t;
 
+typedef struct {
+    int built;
+    lv_obj_t * screen;
+    lv_obj_t * voip_dot;
+    lv_obj_t * time_label;
+    lv_obj_t * battery_outline;
+    lv_obj_t * battery_fill;
+    lv_obj_t * battery_tip;
+    lv_obj_t * card_panel;
+    lv_obj_t * icon_halo;
+    lv_obj_t * icon_label;
+    lv_obj_t * title_label;
+    lv_obj_t * subtitle_label;
+    lv_obj_t * footer_label;
+    lv_obj_t * dots[4];
+} yoyopy_hub_scene_t;
+
 static int g_initialized = 0;
 static lv_display_t * g_display = NULL;
 static lv_indev_t * g_indev = NULL;
@@ -25,6 +42,32 @@ static yoyopy_key_event_t g_key_queue[KEY_QUEUE_CAPACITY];
 static int g_key_head = 0;
 static int g_key_tail = 0;
 static int g_key_count = 0;
+static yoyopy_hub_scene_t g_hub_scene = {0};
+
+static lv_color_t yoyopy_color_rgb(uint8_t red, uint8_t green, uint8_t blue) {
+    uint32_t raw = ((uint32_t)red << 16) | ((uint32_t)green << 8) | (uint32_t)blue;
+    return lv_color_hex(raw);
+}
+
+static lv_color_t yoyopy_mix_rgb(
+    uint8_t primary_red,
+    uint8_t primary_green,
+    uint8_t primary_blue,
+    uint8_t secondary_red,
+    uint8_t secondary_green,
+    uint8_t secondary_blue,
+    uint8_t secondary_ratio_percent
+) {
+    uint8_t primary_ratio = (uint8_t)(100U - secondary_ratio_percent);
+    uint8_t mixed_red = (uint8_t)(((uint16_t)primary_red * primary_ratio + (uint16_t)secondary_red * secondary_ratio_percent) / 100U);
+    uint8_t mixed_green = (uint8_t)(((uint16_t)primary_green * primary_ratio + (uint16_t)secondary_green * secondary_ratio_percent) / 100U);
+    uint8_t mixed_blue = (uint8_t)(((uint16_t)primary_blue * primary_ratio + (uint16_t)secondary_blue * secondary_ratio_percent) / 100U);
+    return yoyopy_color_rgb(mixed_red, mixed_green, mixed_blue);
+}
+
+static void yoyopy_reset_hub_scene_refs(void) {
+    memset(&g_hub_scene, 0, sizeof(g_hub_scene));
+}
 
 static void yoyopy_set_error(const char * message) {
     if(message == NULL) {
@@ -94,6 +137,13 @@ static void yoyopy_clear_group(void) {
     }
 }
 
+static void yoyopy_prepare_active_screen(void) {
+    lv_obj_t * screen = lv_screen_active();
+    lv_obj_clean(screen);
+    yoyopy_clear_group();
+    yoyopy_reset_hub_scene_refs();
+}
+
 static lv_obj_t * yoyopy_create_card(lv_obj_t * screen, const char * title, const char * subtitle, lv_color_t accent) {
     lv_obj_t * panel = lv_obj_create(screen);
     lv_obj_set_size(panel, 200, 190);
@@ -131,15 +181,13 @@ static lv_obj_t * yoyopy_create_card(lv_obj_t * screen, const char * title, cons
 
 static void yoyopy_build_card_scene(void) {
     lv_obj_t * screen = lv_screen_active();
-    lv_obj_clean(screen);
-    yoyopy_clear_group();
+    yoyopy_prepare_active_screen();
     yoyopy_create_card(screen, "Listen", "LVGL card proof", lv_color_hex(0x98D94C));
 }
 
 static void yoyopy_build_list_scene(void) {
     lv_obj_t * screen = lv_screen_active();
-    lv_obj_clean(screen);
-    yoyopy_clear_group();
+    yoyopy_prepare_active_screen();
 
     lv_obj_t * list = lv_list_create(screen);
     lv_obj_set_size(list, 208, 210);
@@ -166,8 +214,7 @@ static void yoyopy_build_list_scene(void) {
 
 static void yoyopy_build_footer_scene(void) {
     lv_obj_t * screen = lv_screen_active();
-    lv_obj_clean(screen);
-    yoyopy_clear_group();
+    yoyopy_prepare_active_screen();
 
     lv_obj_t * label = lv_label_create(screen);
     lv_label_set_text(label, "Tap next / Double open / Hold back");
@@ -178,8 +225,7 @@ static void yoyopy_build_footer_scene(void) {
 
 static void yoyopy_build_carousel_scene(void) {
     lv_obj_t * screen = lv_screen_active();
-    lv_obj_clean(screen);
-    yoyopy_clear_group();
+    yoyopy_prepare_active_screen();
     yoyopy_create_card(screen, "Talk", "Carousel proof", lv_color_hex(0x4CCAE4));
 
     lv_obj_t * footer = lv_label_create(screen);
@@ -187,6 +233,280 @@ static void yoyopy_build_carousel_scene(void) {
     lv_obj_align(footer, LV_ALIGN_BOTTOM_MID, 0, -10);
     lv_obj_set_style_text_font(footer, &lv_font_montserrat_14, 0);
     lv_obj_set_style_text_color(footer, lv_color_hex(0xF6F6F8), 0);
+}
+
+static const char * yoyopy_hub_symbol_for_icon(const char * icon_key) {
+    if(icon_key == NULL) {
+        return LV_SYMBOL_SETTINGS;
+    }
+
+    if(strcmp(icon_key, "listen") == 0) {
+        return LV_SYMBOL_AUDIO;
+    }
+    if(strcmp(icon_key, "talk") == 0) {
+        return LV_SYMBOL_CALL;
+    }
+    if(strcmp(icon_key, "ask") == 0) {
+        return LV_SYMBOL_EDIT;
+    }
+    if(strcmp(icon_key, "setup") == 0 || strcmp(icon_key, "power") == 0) {
+        return LV_SYMBOL_SETTINGS;
+    }
+
+    return LV_SYMBOL_SETTINGS;
+}
+
+static void yoyopy_hub_style_dot(lv_obj_t * dot, lv_color_t color, int selected) {
+    int size = selected ? 8 : 6;
+    lv_obj_set_size(dot, size, size);
+    lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_bg_color(dot, color, 0);
+    lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_width(dot, 0, 0);
+}
+
+int yoyopy_lvgl_hub_build(void) {
+    if(!g_initialized || g_display == NULL) {
+        yoyopy_set_error("display must be registered before building the hub");
+        return -1;
+    }
+
+    if(g_hub_scene.built) {
+        return 0;
+    }
+
+    yoyopy_prepare_active_screen();
+
+    g_hub_scene.screen = lv_screen_active();
+    lv_obj_set_style_bg_color(g_hub_scene.screen, yoyopy_color_rgb(18, 21, 28), 0);
+    lv_obj_set_style_bg_opa(g_hub_scene.screen, LV_OPA_COVER, 0);
+
+    g_hub_scene.voip_dot = lv_obj_create(g_hub_scene.screen);
+    lv_obj_remove_style_all(g_hub_scene.voip_dot);
+    lv_obj_set_size(g_hub_scene.voip_dot, 8, 8);
+    lv_obj_set_style_radius(g_hub_scene.voip_dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_pos(g_hub_scene.voip_dot, 16, 10);
+
+    g_hub_scene.time_label = lv_label_create(g_hub_scene.screen);
+    lv_obj_set_pos(g_hub_scene.time_label, 28, 5);
+    lv_obj_set_style_text_font(g_hub_scene.time_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(g_hub_scene.time_label, yoyopy_color_rgb(243, 247, 250), 0);
+
+    g_hub_scene.battery_outline = lv_obj_create(g_hub_scene.screen);
+    lv_obj_remove_style_all(g_hub_scene.battery_outline);
+    lv_obj_set_size(g_hub_scene.battery_outline, 20, 10);
+    lv_obj_set_pos(g_hub_scene.battery_outline, 202, 6);
+    lv_obj_set_style_border_width(g_hub_scene.battery_outline, 1, 0);
+    lv_obj_set_style_border_color(g_hub_scene.battery_outline, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_radius(g_hub_scene.battery_outline, 2, 0);
+    lv_obj_set_style_bg_opa(g_hub_scene.battery_outline, LV_OPA_TRANSP, 0);
+
+    g_hub_scene.battery_fill = lv_obj_create(g_hub_scene.battery_outline);
+    lv_obj_remove_style_all(g_hub_scene.battery_fill);
+    lv_obj_set_pos(g_hub_scene.battery_fill, 1, 1);
+    lv_obj_set_size(g_hub_scene.battery_fill, 18, 8);
+    lv_obj_set_style_radius(g_hub_scene.battery_fill, 1, 0);
+    lv_obj_set_style_bg_opa(g_hub_scene.battery_fill, LV_OPA_COVER, 0);
+
+    g_hub_scene.battery_tip = lv_obj_create(g_hub_scene.screen);
+    lv_obj_remove_style_all(g_hub_scene.battery_tip);
+    lv_obj_set_size(g_hub_scene.battery_tip, 2, 4);
+    lv_obj_set_pos(g_hub_scene.battery_tip, 222, 9);
+    lv_obj_set_style_bg_color(g_hub_scene.battery_tip, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_bg_opa(g_hub_scene.battery_tip, LV_OPA_COVER, 0);
+
+    g_hub_scene.card_panel = lv_obj_create(g_hub_scene.screen);
+    lv_obj_set_size(g_hub_scene.card_panel, 208, 194);
+    lv_obj_set_pos(g_hub_scene.card_panel, 16, 42);
+    lv_obj_set_style_radius(g_hub_scene.card_panel, 28, 0);
+    lv_obj_set_style_border_width(g_hub_scene.card_panel, 2, 0);
+    lv_obj_set_style_pad_all(g_hub_scene.card_panel, 0, 0);
+    lv_obj_set_style_shadow_width(g_hub_scene.card_panel, 0, 0);
+    lv_obj_set_style_outline_width(g_hub_scene.card_panel, 0, 0);
+    lv_obj_set_scrollbar_mode(g_hub_scene.card_panel, LV_SCROLLBAR_MODE_OFF);
+
+    g_hub_scene.icon_halo = lv_obj_create(g_hub_scene.card_panel);
+    lv_obj_set_size(g_hub_scene.icon_halo, 84, 64);
+    lv_obj_set_pos(g_hub_scene.icon_halo, 62, 18);
+    lv_obj_set_style_radius(g_hub_scene.icon_halo, 20, 0);
+    lv_obj_set_style_border_width(g_hub_scene.icon_halo, 2, 0);
+    lv_obj_set_style_shadow_width(g_hub_scene.icon_halo, 0, 0);
+    lv_obj_set_style_outline_width(g_hub_scene.icon_halo, 0, 0);
+    lv_obj_set_scrollbar_mode(g_hub_scene.icon_halo, LV_SCROLLBAR_MODE_OFF);
+
+    g_hub_scene.icon_label = lv_label_create(g_hub_scene.icon_halo);
+    lv_obj_set_style_text_font(g_hub_scene.icon_label, &lv_font_montserrat_24, 0);
+    lv_obj_center(g_hub_scene.icon_label);
+
+    g_hub_scene.title_label = lv_label_create(g_hub_scene.card_panel);
+    lv_obj_set_width(g_hub_scene.title_label, 172);
+    lv_obj_set_pos(g_hub_scene.title_label, 18, 106);
+    lv_obj_set_style_text_font(g_hub_scene.title_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_align(g_hub_scene.title_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_hub_scene.subtitle_label = lv_label_create(g_hub_scene.card_panel);
+    lv_obj_set_width(g_hub_scene.subtitle_label, 172);
+    lv_obj_set_pos(g_hub_scene.subtitle_label, 18, 140);
+    lv_label_set_long_mode(g_hub_scene.subtitle_label, LV_LABEL_LONG_MODE_CLIP);
+    lv_obj_set_style_text_font(g_hub_scene.subtitle_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_align(g_hub_scene.subtitle_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    for(int index = 0; index < 4; ++index) {
+        g_hub_scene.dots[index] = lv_obj_create(g_hub_scene.card_panel);
+        lv_obj_remove_style_all(g_hub_scene.dots[index]);
+        lv_obj_set_style_bg_opa(g_hub_scene.dots[index], LV_OPA_COVER, 0);
+        lv_obj_set_style_radius(g_hub_scene.dots[index], LV_RADIUS_CIRCLE, 0);
+    }
+
+    g_hub_scene.footer_label = lv_label_create(g_hub_scene.screen);
+    lv_obj_set_style_text_font(g_hub_scene.footer_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_hub_scene.footer_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(g_hub_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    g_hub_scene.built = 1;
+    return 0;
+}
+
+int yoyopy_lvgl_hub_sync(
+    const char * icon_key,
+    const char * title,
+    const char * subtitle,
+    const char * footer,
+    const char * time_text,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b,
+    int32_t selected_index,
+    int32_t total_cards,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available
+) {
+    if(!g_hub_scene.built) {
+        yoyopy_set_error("hub scene must be built before sync");
+        return -1;
+    }
+
+    const lv_color_t background = yoyopy_color_rgb(18, 21, 28);
+    const lv_color_t surface = yoyopy_color_rgb(28, 33, 42);
+    const lv_color_t ink = yoyopy_color_rgb(243, 247, 250);
+    const lv_color_t muted = yoyopy_color_rgb(153, 160, 173);
+    const lv_color_t success = yoyopy_color_rgb(61, 221, 83);
+    const lv_color_t error = yoyopy_color_rgb(255, 103, 93);
+    const lv_color_t accent = yoyopy_color_rgb(accent_r, accent_g, accent_b);
+    const lv_color_t accent_dim = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 65);
+    const lv_color_t card_fill = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 28, 33, 42, 90);
+    const lv_color_t halo_fill = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 80);
+    const lv_color_t halo_border = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 60);
+
+    lv_obj_set_style_bg_color(g_hub_scene.screen, background, 0);
+    lv_obj_set_style_bg_opa(g_hub_scene.screen, LV_OPA_COVER, 0);
+
+    if(voip_state == 0) {
+        lv_obj_add_flag(g_hub_scene.voip_dot, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_obj_clear_flag(g_hub_scene.voip_dot, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_style_bg_color(g_hub_scene.voip_dot, voip_state == 1 ? success : error, 0);
+        lv_obj_set_style_bg_opa(g_hub_scene.voip_dot, LV_OPA_COVER, 0);
+    }
+
+    if(time_text == NULL || time_text[0] == '\0') {
+        lv_label_set_text(g_hub_scene.time_label, "");
+        lv_obj_add_flag(g_hub_scene.time_label, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_label_set_text(g_hub_scene.time_label, time_text);
+        lv_obj_clear_flag(g_hub_scene.time_label, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    lv_obj_set_style_border_color(g_hub_scene.battery_outline, muted, 0);
+    lv_obj_set_style_bg_color(g_hub_scene.battery_tip, muted, 0);
+
+    if(battery_percent < 0) {
+        battery_percent = 0;
+    }
+    if(battery_percent > 100) {
+        battery_percent = 100;
+    }
+
+    int fill_width = (battery_percent * 18) / 100;
+    lv_color_t battery_fill = muted;
+    if(power_available) {
+        if(battery_percent <= 20) {
+            battery_fill = error;
+        } else if(charging) {
+            battery_fill = success;
+        } else {
+            battery_fill = ink;
+        }
+    }
+
+    lv_obj_set_size(g_hub_scene.battery_fill, fill_width, 8);
+    lv_obj_set_style_bg_color(g_hub_scene.battery_fill, battery_fill, 0);
+    if(fill_width <= 0) {
+        lv_obj_add_flag(g_hub_scene.battery_fill, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_obj_clear_flag(g_hub_scene.battery_fill, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    lv_obj_set_style_bg_color(g_hub_scene.card_panel, card_fill, 0);
+    lv_obj_set_style_bg_opa(g_hub_scene.card_panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_hub_scene.card_panel, accent_dim, 0);
+    lv_obj_set_style_bg_color(g_hub_scene.icon_halo, halo_fill, 0);
+    lv_obj_set_style_bg_opa(g_hub_scene.icon_halo, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_hub_scene.icon_halo, halo_border, 0);
+
+    lv_label_set_text(g_hub_scene.icon_label, yoyopy_hub_symbol_for_icon(icon_key));
+    lv_obj_set_style_text_color(g_hub_scene.icon_label, accent, 0);
+    lv_obj_center(g_hub_scene.icon_label);
+    lv_label_set_text(g_hub_scene.title_label, title != NULL ? title : "");
+    lv_obj_set_style_text_color(g_hub_scene.title_label, accent, 0);
+    lv_label_set_text(g_hub_scene.subtitle_label, subtitle != NULL ? subtitle : "");
+    lv_obj_set_style_text_color(g_hub_scene.subtitle_label, ink, 0);
+    lv_label_set_text(g_hub_scene.footer_label, footer != NULL ? footer : "");
+    lv_obj_set_style_text_color(g_hub_scene.footer_label, accent_dim, 0);
+    lv_obj_align(g_hub_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    if(total_cards < 1) {
+        total_cards = 1;
+    }
+    if(total_cards > 4) {
+        total_cards = 4;
+    }
+
+    selected_index = selected_index % total_cards;
+    if(selected_index < 0) {
+        selected_index += total_cards;
+    }
+
+    int center_x = 104;
+    int first_x = center_x - (((total_cards - 1) * 18) / 2);
+    for(int index = 0; index < 4; ++index) {
+        if(index >= total_cards) {
+            lv_obj_add_flag(g_hub_scene.dots[index], LV_OBJ_FLAG_HIDDEN);
+            continue;
+        }
+
+        int selected = index == selected_index;
+        int size = selected ? 8 : 6;
+        lv_obj_clear_flag(g_hub_scene.dots[index], LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_pos(g_hub_scene.dots[index], first_x + (index * 18) - (size / 2), 172 - (size / 2));
+        yoyopy_hub_style_dot(g_hub_scene.dots[index], selected ? accent : accent_dim, selected);
+    }
+
+    return 0;
+}
+
+void yoyopy_lvgl_hub_destroy(void) {
+    if(!g_hub_scene.built) {
+        return;
+    }
+
+    if(g_hub_scene.screen != NULL) {
+        lv_obj_clean(g_hub_scene.screen);
+    }
+    yoyopy_clear_group();
+    yoyopy_reset_hub_scene_refs();
 }
 
 int yoyopy_lvgl_init(void) {
@@ -360,6 +680,7 @@ void yoyopy_lvgl_clear_screen(void) {
     lv_obj_t * screen = lv_screen_active();
     lv_obj_clean(screen);
     yoyopy_clear_group();
+    yoyopy_reset_hub_scene_refs();
 }
 
 const char * yoyopy_lvgl_last_error(void) {

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
@@ -1,0 +1,56 @@
+#ifndef YOYOPY_LVGL_SHIM_H
+#define YOYOPY_LVGL_SHIM_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*yoyopy_lvgl_flush_cb_t)(
+    int32_t x,
+    int32_t y,
+    int32_t width,
+    int32_t height,
+    const unsigned char * pixel_data,
+    uint32_t byte_length,
+    void * user_data
+);
+
+enum yoyopy_lvgl_key {
+    YOYOPY_LVGL_KEY_NONE = 0,
+    YOYOPY_LVGL_KEY_RIGHT = 1,
+    YOYOPY_LVGL_KEY_ENTER = 2,
+    YOYOPY_LVGL_KEY_ESC = 3
+};
+
+enum yoyopy_lvgl_probe_scene {
+    YOYOPY_LVGL_SCENE_CARD = 1,
+    YOYOPY_LVGL_SCENE_LIST = 2,
+    YOYOPY_LVGL_SCENE_FOOTER = 3,
+    YOYOPY_LVGL_SCENE_CAROUSEL = 4
+};
+
+int yoyopy_lvgl_init(void);
+void yoyopy_lvgl_shutdown(void);
+int yoyopy_lvgl_register_display(
+    int32_t width,
+    int32_t height,
+    uint32_t buffer_pixel_count,
+    yoyopy_lvgl_flush_cb_t flush_cb,
+    void * user_data
+);
+int yoyopy_lvgl_register_input(void);
+void yoyopy_lvgl_tick_inc(uint32_t ms);
+uint32_t yoyopy_lvgl_timer_handler(void);
+int yoyopy_lvgl_queue_key_event(int32_t key, int32_t pressed);
+int yoyopy_lvgl_show_probe_scene(int32_t scene_id);
+void yoyopy_lvgl_clear_screen(void);
+const char * yoyopy_lvgl_last_error(void);
+const char * yoyopy_lvgl_version(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
@@ -45,6 +45,24 @@ void yoyopy_lvgl_tick_inc(uint32_t ms);
 uint32_t yoyopy_lvgl_timer_handler(void);
 int yoyopy_lvgl_queue_key_event(int32_t key, int32_t pressed);
 int yoyopy_lvgl_show_probe_scene(int32_t scene_id);
+int yoyopy_lvgl_hub_build(void);
+int yoyopy_lvgl_hub_sync(
+    const char * icon_key,
+    const char * title,
+    const char * subtitle,
+    const char * footer,
+    const char * time_text,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b,
+    int32_t selected_index,
+    int32_t total_cards,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available
+);
+void yoyopy_lvgl_hub_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);

--- a/yoyopy/ui/screens/__init__.py
+++ b/yoyopy/ui/screens/__init__.py
@@ -11,6 +11,7 @@ Provides screen implementations organized by feature:
 
 # Base screen class
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.view import ScreenView
 
 # Screen manager
 from yoyopy.ui.screens.manager import ScreenManager
@@ -34,6 +35,7 @@ from yoyopy.ui.screens.voip import (
 __all__ = [
     # Base & Manager
     'Screen',
+    'ScreenView',
     'ScreenManager',
     'NavigationRequest',
     'ScreenRouter',

--- a/yoyopy/ui/screens/navigation/hub.py
+++ b/yoyopy/ui/screens/navigation/hub.py
@@ -7,12 +7,14 @@ from typing import TYPE_CHECKING, Optional
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.navigation.lvgl import LvglHubView
 from yoyopy.ui.screens.theme import BACKGROUND, INK, SURFACE, draw_icon, format_battery_compact, mix, render_backdrop, render_footer, render_status_bar, rounded_panel, text_fit, theme_for
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
     from yoyopy.audio.mopidy_client import MopidyClient
     from yoyopy.voip import VoIPManager
+    from yoyopy.ui.screens import ScreenView
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,11 +42,36 @@ class HubScreen(Screen):
         self.voip_manager = voip_manager
         self.selected_index = 0
         self._playlist_count: int | None = None
+        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Refresh lightweight summaries when the hub becomes active."""
         super().enter()
         self._refresh_playlist_count()
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving the hub."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Create an LVGL view when the Whisplay renderer is active."""
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglHubView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
 
     def _refresh_playlist_count(self) -> None:
         """Refresh the cached playlist count for the Listen card."""
@@ -137,6 +164,11 @@ class HubScreen(Screen):
 
     def render(self) -> None:
         """Render the selected root card."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
         cards = self._cards()
         self.selected_index %= len(cards)
         selected_card = cards[self.selected_index]

--- a/yoyopy/ui/screens/navigation/lvgl/__init__.py
+++ b/yoyopy/ui/screens/navigation/lvgl/__init__.py
@@ -1,0 +1,5 @@
+"""LVGL-backed navigation screen views."""
+
+from yoyopy.ui.screens.navigation.lvgl.hub_view import LvglHubView
+
+__all__ = ["LvglHubView"]

--- a/yoyopy/ui/screens/navigation/lvgl/hub_view.py
+++ b/yoyopy/ui/screens/navigation/lvgl/hub_view.py
@@ -1,0 +1,77 @@
+"""LVGL-backed view for the Whisplay root hub."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+from yoyopy.ui.screens.theme import theme_for
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens.navigation.hub import HubScreen
+
+
+@dataclass(slots=True)
+class LvglHubView:
+    """Own the LVGL object lifecycle for the root Hub screen."""
+
+    screen: "HubScreen"
+    backend: LvglDisplayBackend
+    _built: bool = False
+
+    def build(self) -> None:
+        """Create the native LVGL Hub scene once."""
+
+        if self._built or self.backend.binding is None:
+            return
+        self.backend.binding.hub_build()
+        self._built = True
+
+    def sync(self) -> None:
+        """Push the current Hub controller state into the native scene."""
+
+        if not self._built or self.backend.binding is None:
+            return
+
+        cards = self.screen._cards()
+        selected_card = cards[self.screen.selected_index % len(cards)]
+        theme = theme_for(selected_card.mode)
+        context = self.screen.context
+
+        self.backend.binding.hub_sync(
+            icon_key=selected_card.icon,
+            title=selected_card.title,
+            subtitle=selected_card.subtitle,
+            footer="Tap next / Open",
+            time_text=datetime.now().strftime("%H:%M"),
+            accent=theme.accent,
+            selected_index=self.screen.selected_index,
+            total_cards=len(cards),
+            voip_state=self._voip_state(context),
+            battery_percent=self._battery_percent(context),
+            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+        )
+
+    def destroy(self) -> None:
+        """Tear down the native Hub scene and clear the screen."""
+
+        if not self._built or self.backend.binding is None:
+            return
+        self.backend.binding.hub_destroy()
+        self._built = False
+
+    @staticmethod
+    def _battery_percent(context: "AppContext | None") -> int:
+        if context is None:
+            return 100
+        return max(0, min(100, int(getattr(context, "battery_percent", 100))))
+
+    @staticmethod
+    def _voip_state(context: "AppContext | None") -> int:
+        if context is None or not getattr(context, "voip_configured", False):
+            return 0
+        return 1 if getattr(context, "voip_ready", False) else 2

--- a/yoyopy/ui/screens/view.py
+++ b/yoyopy/ui/screens/view.py
@@ -1,0 +1,18 @@
+"""Backend-specific screen view lifecycle protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ScreenView(Protocol):
+    """Lifecycle shared by backend-specific screen view implementations."""
+
+    def build(self) -> None:
+        """Create widget/object state once when a screen becomes active."""
+
+    def sync(self) -> None:
+        """Update an already-built view from the current controller state."""
+
+    def destroy(self) -> None:
+        """Tear down widgets, callbacks, and timers when leaving the screen."""


### PR DESCRIPTION
## Summary\n- add a native LVGL hub scene lifecycle to the shim and expose it through the CPython binding\n- delegate HubScreen to a backend-specific LVGL view when the Whisplay renderer is LVGL\n- add focused tests for LVGL hub delegation while preserving the current PIL fallback\n\n## Verification\n- python -m compileall yoyopy tests\n- uv run pytest -q