### PR TITLE
Add LVGL-backed Listen screen

### DIFF
--- a/tests/test_listen_lvgl_view.py
+++ b/tests/test_listen_lvgl_view.py
@@ -1,0 +1,118 @@
+"""Focused tests for the LVGL-backed Listen screen delegation."""
+
+from __future__ import annotations
+
+from yoyopy.app_context import AppContext
+from yoyopy.ui.input import InteractionProfile
+from yoyopy.ui.screens import ListenScreen
+
+
+class FakeLvglBinding:
+    """Small native-binding double for Listen view tests."""
+
+    def __init__(self) -> None:
+        self.listen_build_calls = 0
+        self.listen_destroy_calls = 0
+        self.listen_sync_payloads: list[dict] = []
+
+    def listen_build(self) -> None:
+        self.listen_build_calls += 1
+
+    def listen_sync(self, **payload) -> None:
+        self.listen_sync_payloads.append(payload)
+
+    def listen_destroy(self) -> None:
+        self.listen_destroy_calls += 1
+
+
+class FakeLvglBackend:
+    """Minimal LVGL backend double exposed through Display.get_ui_backend()."""
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self.binding = binding
+        self.initialized = True
+
+
+class FakeLvglDisplay:
+    """Tiny Display double for LVGL Listen delegation tests."""
+
+    backend_kind = "lvgl"
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self._ui_backend = FakeLvglBackend(binding)
+
+    def get_ui_backend(self) -> FakeLvglBackend:
+        return self._ui_backend
+
+
+class FakeConfigManager:
+    """Minimal config manager returning a stable source list."""
+
+    def __init__(self, sources: list[str]) -> None:
+        self.sources = sources
+
+    def get_listen_sources(self) -> list[str]:
+        return list(self.sources)
+
+
+def test_listen_screen_builds_syncs_and_destroys_lvgl_view() -> None:
+    """ListenScreen should delegate its lifecycle to an LVGL view when available."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+    context.update_voip_status(configured=True, ready=False)
+    context.battery_percent = 58
+    context.battery_charging = False
+    context.power_available = True
+    context.current_audio_source = "youtube"
+
+    screen = ListenScreen(
+        display,
+        context,
+        config_manager=FakeConfigManager(["spotify", "youtube", "local"]),
+    )
+
+    screen.enter()
+    screen.render()
+
+    assert binding.listen_build_calls == 1
+    assert len(binding.listen_sync_payloads) == 1
+    first_payload = binding.listen_sync_payloads[-1]
+    assert first_payload["page_text"] == "2/3"
+    assert first_payload["items"] == ["Spotify", "YouTube", "Local"]
+    assert first_payload["selected_index"] == 1
+    assert first_payload["voip_state"] == 2
+    assert first_payload["battery_percent"] == 58
+
+    screen.on_advance()
+    screen.render()
+
+    second_payload = binding.listen_sync_payloads[-1]
+    assert second_payload["page_text"] == "3/3"
+    assert second_payload["selected_index"] == 2
+
+    screen.exit()
+    assert binding.listen_destroy_calls == 1
+
+
+def test_listen_screen_syncs_empty_state_through_lvgl() -> None:
+    """ListenScreen should send an empty-state payload when no sources are configured."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+    screen = ListenScreen(
+        display,
+        context,
+        config_manager=FakeConfigManager([]),
+    )
+
+    screen.enter()
+    screen.render()
+
+    payload = binding.listen_sync_payloads[-1]
+    assert payload["page_text"] is None
+    assert payload["items"] == []
+    assert payload["selected_index"] == 0
+    assert payload["empty_title"] == "No sources"

--- a/yoyopy/ui/lvgl_binding/binding.py
+++ b/yoyopy/ui/lvgl_binding/binding.py
@@ -51,6 +51,27 @@ int yoyopy_lvgl_hub_sync(
     int32_t power_available
 );
 void yoyopy_lvgl_hub_destroy(void);
+int yoyopy_lvgl_listen_build(void);
+int yoyopy_lvgl_listen_sync(
+    const char * page_text,
+    const char * footer,
+    const char * item_0,
+    const char * item_1,
+    const char * item_2,
+    const char * item_3,
+    int32_t item_count,
+    int32_t selected_index,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b,
+    const char * empty_title,
+    const char * empty_subtitle
+);
+void yoyopy_lvgl_listen_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);
@@ -209,6 +230,67 @@ class LvglBinding:
 
     def hub_destroy(self) -> None:
         self.lib.yoyopy_lvgl_hub_destroy()
+
+    def listen_build(self) -> None:
+        if self.lib.yoyopy_lvgl_listen_build() != 0:
+            raise LvglBindingError(self.last_error())
+
+    def listen_sync(
+        self,
+        *,
+        page_text: str | None,
+        footer: str,
+        items: list[str],
+        selected_index: int,
+        voip_state: int,
+        battery_percent: int,
+        charging: bool,
+        power_available: bool,
+        accent: tuple[int, int, int],
+        empty_title: str,
+        empty_subtitle: str,
+    ) -> None:
+        normalized_items = list(items[:4])
+        while len(normalized_items) < 4:
+            normalized_items.append("")
+
+        page_text_raw = (
+            self.ffi.new("char[]", page_text.encode("utf-8"))
+            if page_text
+            else self.ffi.NULL
+        )
+        footer_raw = self.ffi.new("char[]", footer.encode("utf-8"))
+        item_0_raw = self.ffi.new("char[]", normalized_items[0].encode("utf-8"))
+        item_1_raw = self.ffi.new("char[]", normalized_items[1].encode("utf-8"))
+        item_2_raw = self.ffi.new("char[]", normalized_items[2].encode("utf-8"))
+        item_3_raw = self.ffi.new("char[]", normalized_items[3].encode("utf-8"))
+        empty_title_raw = self.ffi.new("char[]", empty_title.encode("utf-8"))
+        empty_subtitle_raw = self.ffi.new("char[]", empty_subtitle.encode("utf-8"))
+
+        result = self.lib.yoyopy_lvgl_listen_sync(
+            page_text_raw,
+            footer_raw,
+            item_0_raw,
+            item_1_raw,
+            item_2_raw,
+            item_3_raw,
+            len(items),
+            selected_index,
+            voip_state,
+            battery_percent,
+            1 if charging else 0,
+            1 if power_available else 0,
+            accent[0],
+            accent[1],
+            accent[2],
+            empty_title_raw,
+            empty_subtitle_raw,
+        )
+        if result != 0:
+            raise LvglBindingError(self.last_error())
+
+    def listen_destroy(self) -> None:
+        self.lib.yoyopy_lvgl_listen_destroy()
 
     def clear_screen(self) -> None:
         self.lib.yoyopy_lvgl_clear_screen()

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
@@ -29,6 +29,27 @@ typedef struct {
     lv_obj_t * dots[4];
 } yoyopy_hub_scene_t;
 
+typedef struct {
+    int built;
+    lv_obj_t * screen;
+    lv_obj_t * voip_dot;
+    lv_obj_t * battery_outline;
+    lv_obj_t * battery_fill;
+    lv_obj_t * battery_tip;
+    lv_obj_t * title_label;
+    lv_obj_t * title_underline;
+    lv_obj_t * page_label;
+    lv_obj_t * panel;
+    lv_obj_t * item_panels[4];
+    lv_obj_t * item_titles[4];
+    lv_obj_t * dots[4];
+    lv_obj_t * empty_panel;
+    lv_obj_t * empty_icon;
+    lv_obj_t * empty_title;
+    lv_obj_t * empty_subtitle;
+    lv_obj_t * footer_label;
+} yoyopy_listen_scene_t;
+
 static int g_initialized = 0;
 static lv_display_t * g_display = NULL;
 static lv_indev_t * g_indev = NULL;
@@ -43,6 +64,7 @@ static int g_key_head = 0;
 static int g_key_tail = 0;
 static int g_key_count = 0;
 static yoyopy_hub_scene_t g_hub_scene = {0};
+static yoyopy_listen_scene_t g_listen_scene = {0};
 
 static lv_color_t yoyopy_color_rgb(uint8_t red, uint8_t green, uint8_t blue) {
     uint32_t raw = ((uint32_t)red << 16) | ((uint32_t)green << 8) | (uint32_t)blue;
@@ -67,6 +89,15 @@ static lv_color_t yoyopy_mix_rgb(
 
 static void yoyopy_reset_hub_scene_refs(void) {
     memset(&g_hub_scene, 0, sizeof(g_hub_scene));
+}
+
+static void yoyopy_reset_listen_scene_refs(void) {
+    memset(&g_listen_scene, 0, sizeof(g_listen_scene));
+}
+
+static void yoyopy_reset_scene_refs(void) {
+    yoyopy_reset_hub_scene_refs();
+    yoyopy_reset_listen_scene_refs();
 }
 
 static void yoyopy_set_error(const char * message) {
@@ -141,7 +172,7 @@ static void yoyopy_prepare_active_screen(void) {
     lv_obj_t * screen = lv_screen_active();
     lv_obj_clean(screen);
     yoyopy_clear_group();
-    yoyopy_reset_hub_scene_refs();
+    yoyopy_reset_scene_refs();
 }
 
 static lv_obj_t * yoyopy_create_card(lv_obj_t * screen, const char * title, const char * subtitle, lv_color_t accent) {
@@ -233,6 +264,64 @@ static void yoyopy_build_carousel_scene(void) {
     lv_obj_align(footer, LV_ALIGN_BOTTOM_MID, 0, -10);
     lv_obj_set_style_text_font(footer, &lv_font_montserrat_14, 0);
     lv_obj_set_style_text_color(footer, lv_color_hex(0xF6F6F8), 0);
+}
+
+static void yoyopy_apply_voip_dot(lv_obj_t * dot, int32_t voip_state) {
+    const lv_color_t success = yoyopy_color_rgb(61, 221, 83);
+    const lv_color_t error = yoyopy_color_rgb(255, 103, 93);
+
+    if(voip_state == 0) {
+        lv_obj_add_flag(dot, LV_OBJ_FLAG_HIDDEN);
+        return;
+    }
+
+    lv_obj_clear_flag(dot, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_set_style_bg_color(dot, voip_state == 1 ? success : error, 0);
+    lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
+}
+
+static void yoyopy_apply_battery(
+    lv_obj_t * outline,
+    lv_obj_t * fill,
+    lv_obj_t * tip,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available
+) {
+    const lv_color_t muted = yoyopy_color_rgb(153, 160, 173);
+    const lv_color_t ink = yoyopy_color_rgb(243, 247, 250);
+    const lv_color_t success = yoyopy_color_rgb(61, 221, 83);
+    const lv_color_t error = yoyopy_color_rgb(255, 103, 93);
+
+    if(battery_percent < 0) {
+        battery_percent = 0;
+    }
+    if(battery_percent > 100) {
+        battery_percent = 100;
+    }
+
+    lv_obj_set_style_border_color(outline, muted, 0);
+    lv_obj_set_style_bg_color(tip, muted, 0);
+
+    int fill_width = (battery_percent * 18) / 100;
+    lv_color_t fill_color = muted;
+    if(power_available) {
+        if(battery_percent <= 20) {
+            fill_color = error;
+        } else if(charging) {
+            fill_color = success;
+        } else {
+            fill_color = ink;
+        }
+    }
+
+    lv_obj_set_size(fill, fill_width, 8);
+    lv_obj_set_style_bg_color(fill, fill_color, 0);
+    if(fill_width <= 0) {
+        lv_obj_add_flag(fill, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_obj_clear_flag(fill, LV_OBJ_FLAG_HIDDEN);
+    }
 }
 
 static const char * yoyopy_hub_symbol_for_icon(const char * icon_key) {
@@ -391,9 +480,6 @@ int yoyopy_lvgl_hub_sync(
     const lv_color_t background = yoyopy_color_rgb(18, 21, 28);
     const lv_color_t surface = yoyopy_color_rgb(28, 33, 42);
     const lv_color_t ink = yoyopy_color_rgb(243, 247, 250);
-    const lv_color_t muted = yoyopy_color_rgb(153, 160, 173);
-    const lv_color_t success = yoyopy_color_rgb(61, 221, 83);
-    const lv_color_t error = yoyopy_color_rgb(255, 103, 93);
     const lv_color_t accent = yoyopy_color_rgb(accent_r, accent_g, accent_b);
     const lv_color_t accent_dim = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 65);
     const lv_color_t card_fill = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 28, 33, 42, 90);
@@ -402,14 +488,7 @@ int yoyopy_lvgl_hub_sync(
 
     lv_obj_set_style_bg_color(g_hub_scene.screen, background, 0);
     lv_obj_set_style_bg_opa(g_hub_scene.screen, LV_OPA_COVER, 0);
-
-    if(voip_state == 0) {
-        lv_obj_add_flag(g_hub_scene.voip_dot, LV_OBJ_FLAG_HIDDEN);
-    } else {
-        lv_obj_clear_flag(g_hub_scene.voip_dot, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_set_style_bg_color(g_hub_scene.voip_dot, voip_state == 1 ? success : error, 0);
-        lv_obj_set_style_bg_opa(g_hub_scene.voip_dot, LV_OPA_COVER, 0);
-    }
+    yoyopy_apply_voip_dot(g_hub_scene.voip_dot, voip_state);
 
     if(time_text == NULL || time_text[0] == '\0') {
         lv_label_set_text(g_hub_scene.time_label, "");
@@ -418,36 +497,14 @@ int yoyopy_lvgl_hub_sync(
         lv_label_set_text(g_hub_scene.time_label, time_text);
         lv_obj_clear_flag(g_hub_scene.time_label, LV_OBJ_FLAG_HIDDEN);
     }
-
-    lv_obj_set_style_border_color(g_hub_scene.battery_outline, muted, 0);
-    lv_obj_set_style_bg_color(g_hub_scene.battery_tip, muted, 0);
-
-    if(battery_percent < 0) {
-        battery_percent = 0;
-    }
-    if(battery_percent > 100) {
-        battery_percent = 100;
-    }
-
-    int fill_width = (battery_percent * 18) / 100;
-    lv_color_t battery_fill = muted;
-    if(power_available) {
-        if(battery_percent <= 20) {
-            battery_fill = error;
-        } else if(charging) {
-            battery_fill = success;
-        } else {
-            battery_fill = ink;
-        }
-    }
-
-    lv_obj_set_size(g_hub_scene.battery_fill, fill_width, 8);
-    lv_obj_set_style_bg_color(g_hub_scene.battery_fill, battery_fill, 0);
-    if(fill_width <= 0) {
-        lv_obj_add_flag(g_hub_scene.battery_fill, LV_OBJ_FLAG_HIDDEN);
-    } else {
-        lv_obj_clear_flag(g_hub_scene.battery_fill, LV_OBJ_FLAG_HIDDEN);
-    }
+    yoyopy_apply_battery(
+        g_hub_scene.battery_outline,
+        g_hub_scene.battery_fill,
+        g_hub_scene.battery_tip,
+        battery_percent,
+        charging,
+        power_available
+    );
 
     lv_obj_set_style_bg_color(g_hub_scene.card_panel, card_fill, 0);
     lv_obj_set_style_bg_opa(g_hub_scene.card_panel, LV_OPA_COVER, 0);
@@ -507,6 +564,269 @@ void yoyopy_lvgl_hub_destroy(void) {
     }
     yoyopy_clear_group();
     yoyopy_reset_hub_scene_refs();
+}
+
+int yoyopy_lvgl_listen_build(void) {
+    if(!g_initialized || g_display == NULL) {
+        yoyopy_set_error("display must be registered before building the listen scene");
+        return -1;
+    }
+
+    if(g_listen_scene.built) {
+        return 0;
+    }
+
+    yoyopy_prepare_active_screen();
+
+    g_listen_scene.screen = lv_screen_active();
+    lv_obj_set_style_bg_color(g_listen_scene.screen, yoyopy_color_rgb(18, 21, 28), 0);
+    lv_obj_set_style_bg_opa(g_listen_scene.screen, LV_OPA_COVER, 0);
+
+    g_listen_scene.voip_dot = lv_obj_create(g_listen_scene.screen);
+    lv_obj_remove_style_all(g_listen_scene.voip_dot);
+    lv_obj_set_size(g_listen_scene.voip_dot, 8, 8);
+    lv_obj_set_style_radius(g_listen_scene.voip_dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_pos(g_listen_scene.voip_dot, 16, 10);
+
+    g_listen_scene.battery_outline = lv_obj_create(g_listen_scene.screen);
+    lv_obj_remove_style_all(g_listen_scene.battery_outline);
+    lv_obj_set_size(g_listen_scene.battery_outline, 20, 10);
+    lv_obj_set_pos(g_listen_scene.battery_outline, 202, 6);
+    lv_obj_set_style_border_width(g_listen_scene.battery_outline, 1, 0);
+    lv_obj_set_style_border_color(g_listen_scene.battery_outline, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_radius(g_listen_scene.battery_outline, 2, 0);
+    lv_obj_set_style_bg_opa(g_listen_scene.battery_outline, LV_OPA_TRANSP, 0);
+
+    g_listen_scene.battery_fill = lv_obj_create(g_listen_scene.battery_outline);
+    lv_obj_remove_style_all(g_listen_scene.battery_fill);
+    lv_obj_set_pos(g_listen_scene.battery_fill, 1, 1);
+    lv_obj_set_size(g_listen_scene.battery_fill, 18, 8);
+    lv_obj_set_style_radius(g_listen_scene.battery_fill, 1, 0);
+    lv_obj_set_style_bg_opa(g_listen_scene.battery_fill, LV_OPA_COVER, 0);
+
+    g_listen_scene.battery_tip = lv_obj_create(g_listen_scene.screen);
+    lv_obj_remove_style_all(g_listen_scene.battery_tip);
+    lv_obj_set_size(g_listen_scene.battery_tip, 2, 4);
+    lv_obj_set_pos(g_listen_scene.battery_tip, 222, 9);
+    lv_obj_set_style_bg_color(g_listen_scene.battery_tip, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_bg_opa(g_listen_scene.battery_tip, LV_OPA_COVER, 0);
+
+    g_listen_scene.title_label = lv_label_create(g_listen_scene.screen);
+    lv_label_set_text(g_listen_scene.title_label, "Listen");
+    lv_obj_set_pos(g_listen_scene.title_label, 18, 36);
+    lv_obj_set_style_text_font(g_listen_scene.title_label, &lv_font_montserrat_24, 0);
+
+    g_listen_scene.title_underline = lv_obj_create(g_listen_scene.screen);
+    lv_obj_remove_style_all(g_listen_scene.title_underline);
+    lv_obj_set_pos(g_listen_scene.title_underline, 18, 66);
+    lv_obj_set_size(g_listen_scene.title_underline, 88, 3);
+    lv_obj_set_style_radius(g_listen_scene.title_underline, 2, 0);
+    lv_obj_set_style_bg_opa(g_listen_scene.title_underline, LV_OPA_COVER, 0);
+
+    g_listen_scene.page_label = lv_label_create(g_listen_scene.screen);
+    lv_obj_set_pos(g_listen_scene.page_label, 188, 39);
+    lv_obj_set_style_text_font(g_listen_scene.page_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(g_listen_scene.page_label, yoyopy_color_rgb(153, 160, 173), 0);
+
+    g_listen_scene.panel = lv_obj_create(g_listen_scene.screen);
+    lv_obj_set_size(g_listen_scene.panel, 216, 164);
+    lv_obj_set_pos(g_listen_scene.panel, 12, 84);
+    lv_obj_set_style_radius(g_listen_scene.panel, 22, 0);
+    lv_obj_set_style_border_width(g_listen_scene.panel, 0, 0);
+    lv_obj_set_style_bg_color(g_listen_scene.panel, yoyopy_color_rgb(28, 33, 42), 0);
+    lv_obj_set_style_bg_opa(g_listen_scene.panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_pad_all(g_listen_scene.panel, 0, 0);
+    lv_obj_set_style_shadow_width(g_listen_scene.panel, 0, 0);
+    lv_obj_set_style_outline_width(g_listen_scene.panel, 0, 0);
+    lv_obj_set_scrollbar_mode(g_listen_scene.panel, LV_SCROLLBAR_MODE_OFF);
+
+    for(int index = 0; index < 4; ++index) {
+        g_listen_scene.item_panels[index] = lv_obj_create(g_listen_scene.panel);
+        lv_obj_set_size(g_listen_scene.item_panels[index], 184, 30);
+        lv_obj_set_pos(g_listen_scene.item_panels[index], 16, 14 + (index * 34));
+        lv_obj_set_style_radius(g_listen_scene.item_panels[index], 15, 0);
+        lv_obj_set_style_border_width(g_listen_scene.item_panels[index], 2, 0);
+        lv_obj_set_style_pad_all(g_listen_scene.item_panels[index], 0, 0);
+        lv_obj_set_style_shadow_width(g_listen_scene.item_panels[index], 0, 0);
+        lv_obj_set_style_outline_width(g_listen_scene.item_panels[index], 0, 0);
+        lv_obj_set_scrollbar_mode(g_listen_scene.item_panels[index], LV_SCROLLBAR_MODE_OFF);
+
+        g_listen_scene.item_titles[index] = lv_label_create(g_listen_scene.item_panels[index]);
+        lv_obj_set_width(g_listen_scene.item_titles[index], 148);
+        lv_obj_set_pos(g_listen_scene.item_titles[index], 16, 7);
+        lv_label_set_long_mode(g_listen_scene.item_titles[index], LV_LABEL_LONG_MODE_CLIP);
+        lv_obj_set_style_text_font(g_listen_scene.item_titles[index], &lv_font_montserrat_16, 0);
+    }
+
+    for(int index = 0; index < 4; ++index) {
+        g_listen_scene.dots[index] = lv_obj_create(g_listen_scene.panel);
+        lv_obj_remove_style_all(g_listen_scene.dots[index]);
+        lv_obj_set_style_bg_opa(g_listen_scene.dots[index], LV_OPA_COVER, 0);
+        lv_obj_set_style_radius(g_listen_scene.dots[index], LV_RADIUS_CIRCLE, 0);
+    }
+
+    g_listen_scene.empty_panel = lv_obj_create(g_listen_scene.screen);
+    lv_obj_set_size(g_listen_scene.empty_panel, 204, 136);
+    lv_obj_set_pos(g_listen_scene.empty_panel, 18, 94);
+    lv_obj_set_style_radius(g_listen_scene.empty_panel, 22, 0);
+    lv_obj_set_style_border_width(g_listen_scene.empty_panel, 2, 0);
+    lv_obj_set_style_pad_all(g_listen_scene.empty_panel, 0, 0);
+    lv_obj_set_style_shadow_width(g_listen_scene.empty_panel, 0, 0);
+    lv_obj_set_style_outline_width(g_listen_scene.empty_panel, 0, 0);
+    lv_obj_set_scrollbar_mode(g_listen_scene.empty_panel, LV_SCROLLBAR_MODE_OFF);
+
+    g_listen_scene.empty_icon = lv_label_create(g_listen_scene.empty_panel);
+    lv_label_set_text(g_listen_scene.empty_icon, LV_SYMBOL_AUDIO);
+    lv_obj_set_style_text_font(g_listen_scene.empty_icon, &lv_font_montserrat_24, 0);
+    lv_obj_align(g_listen_scene.empty_icon, LV_ALIGN_TOP_MID, 0, 16);
+
+    g_listen_scene.empty_title = lv_label_create(g_listen_scene.empty_panel);
+    lv_obj_set_width(g_listen_scene.empty_title, 168);
+    lv_obj_set_pos(g_listen_scene.empty_title, 18, 60);
+    lv_obj_set_style_text_font(g_listen_scene.empty_title, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_align(g_listen_scene.empty_title, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_listen_scene.empty_subtitle = lv_label_create(g_listen_scene.empty_panel);
+    lv_obj_set_width(g_listen_scene.empty_subtitle, 168);
+    lv_obj_set_pos(g_listen_scene.empty_subtitle, 18, 86);
+    lv_label_set_long_mode(g_listen_scene.empty_subtitle, LV_LABEL_LONG_MODE_WRAP);
+    lv_obj_set_style_text_font(g_listen_scene.empty_subtitle, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_listen_scene.empty_subtitle, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_listen_scene.footer_label = lv_label_create(g_listen_scene.screen);
+    lv_obj_set_style_text_font(g_listen_scene.footer_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_listen_scene.footer_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(g_listen_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    g_listen_scene.built = 1;
+    return 0;
+}
+
+int yoyopy_lvgl_listen_sync(
+    const char * page_text,
+    const char * footer,
+    const char * item_0,
+    const char * item_1,
+    const char * item_2,
+    const char * item_3,
+    int32_t item_count,
+    int32_t selected_index,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b,
+    const char * empty_title,
+    const char * empty_subtitle
+) {
+    if(!g_listen_scene.built) {
+        yoyopy_set_error("listen scene must be built before sync");
+        return -1;
+    }
+
+    const lv_color_t background = yoyopy_color_rgb(18, 21, 28);
+    const lv_color_t surface = yoyopy_color_rgb(28, 33, 42);
+    const lv_color_t ink = yoyopy_color_rgb(243, 247, 250);
+    const lv_color_t muted = yoyopy_color_rgb(153, 160, 173);
+    const lv_color_t accent = yoyopy_color_rgb(accent_r, accent_g, accent_b);
+    const lv_color_t accent_soft = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 28, 33, 42, 55);
+    const lv_color_t accent_dim = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 65);
+    const lv_color_t selected_fill = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 28, 33, 42, 88);
+
+    const char * items[4] = {item_0, item_1, item_2, item_3};
+
+    lv_obj_set_style_bg_color(g_listen_scene.screen, background, 0);
+    lv_obj_set_style_bg_opa(g_listen_scene.screen, LV_OPA_COVER, 0);
+    yoyopy_apply_voip_dot(g_listen_scene.voip_dot, voip_state);
+    yoyopy_apply_battery(
+        g_listen_scene.battery_outline,
+        g_listen_scene.battery_fill,
+        g_listen_scene.battery_tip,
+        battery_percent,
+        charging,
+        power_available
+    );
+
+    lv_obj_set_style_text_color(g_listen_scene.title_label, ink, 0);
+    lv_obj_set_style_bg_color(g_listen_scene.title_underline, accent, 0);
+    lv_label_set_text(g_listen_scene.page_label, page_text != NULL ? page_text : "");
+
+    if(item_count < 0) {
+        item_count = 0;
+    }
+    if(item_count > 4) {
+        item_count = 4;
+    }
+
+    if(item_count == 0) {
+        lv_obj_add_flag(g_listen_scene.panel, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(g_listen_scene.empty_panel, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_style_bg_color(g_listen_scene.empty_panel, surface, 0);
+        lv_obj_set_style_bg_opa(g_listen_scene.empty_panel, LV_OPA_COVER, 0);
+        lv_obj_set_style_border_color(g_listen_scene.empty_panel, accent_dim, 0);
+        lv_obj_set_style_text_color(g_listen_scene.empty_icon, accent, 0);
+        lv_obj_set_style_text_color(g_listen_scene.empty_title, ink, 0);
+        lv_obj_set_style_text_color(g_listen_scene.empty_subtitle, muted, 0);
+        lv_label_set_text(g_listen_scene.empty_title, empty_title != NULL ? empty_title : "No sources");
+        lv_label_set_text(
+            g_listen_scene.empty_subtitle,
+            empty_subtitle != NULL ? empty_subtitle : "Add music sources in config to fill this page."
+        );
+    } else {
+        lv_obj_clear_flag(g_listen_scene.panel, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(g_listen_scene.empty_panel, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    if(item_count > 0) {
+        selected_index = selected_index % item_count;
+        if(selected_index < 0) {
+            selected_index += item_count;
+        }
+    } else {
+        selected_index = 0;
+    }
+
+    for(int index = 0; index < 4; ++index) {
+        if(index >= item_count) {
+            lv_obj_add_flag(g_listen_scene.item_panels[index], LV_OBJ_FLAG_HIDDEN);
+            lv_obj_add_flag(g_listen_scene.dots[index], LV_OBJ_FLAG_HIDDEN);
+            continue;
+        }
+
+        int selected = index == selected_index;
+        lv_obj_clear_flag(g_listen_scene.item_panels[index], LV_OBJ_FLAG_HIDDEN);
+        lv_label_set_text(g_listen_scene.item_titles[index], items[index] != NULL ? items[index] : "");
+        lv_obj_set_style_bg_color(g_listen_scene.item_panels[index], selected ? selected_fill : surface, 0);
+        lv_obj_set_style_bg_opa(g_listen_scene.item_panels[index], LV_OPA_COVER, 0);
+        lv_obj_set_style_border_color(g_listen_scene.item_panels[index], selected ? accent_soft : yoyopy_color_rgb(74, 79, 92), 0);
+        lv_obj_set_style_text_color(g_listen_scene.item_titles[index], selected ? ink : yoyopy_mix_rgb(243, 247, 250, 153, 160, 173, 12), 0);
+
+        lv_obj_clear_flag(g_listen_scene.dots[index], LV_OBJ_FLAG_HIDDEN);
+        int size = 6;
+        int first_x = 108 - (((item_count - 1) * 16) / 2);
+        lv_obj_set_pos(g_listen_scene.dots[index], first_x + (index * 16) - (size / 2), 146);
+        yoyopy_hub_style_dot(g_listen_scene.dots[index], selected ? accent : muted, selected ? 1 : 0);
+    }
+
+    lv_label_set_text(g_listen_scene.footer_label, footer != NULL ? footer : "");
+    lv_obj_set_style_text_color(g_listen_scene.footer_label, accent_dim, 0);
+    lv_obj_align(g_listen_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    return 0;
+}
+
+void yoyopy_lvgl_listen_destroy(void) {
+    if(!g_listen_scene.built) {
+        return;
+    }
+
+    if(g_listen_scene.screen != NULL) {
+        lv_obj_clean(g_listen_scene.screen);
+    }
+    yoyopy_clear_group();
+    yoyopy_reset_listen_scene_refs();
 }
 
 int yoyopy_lvgl_init(void) {
@@ -680,7 +1000,7 @@ void yoyopy_lvgl_clear_screen(void) {
     lv_obj_t * screen = lv_screen_active();
     lv_obj_clean(screen);
     yoyopy_clear_group();
-    yoyopy_reset_hub_scene_refs();
+    yoyopy_reset_scene_refs();
 }
 
 const char * yoyopy_lvgl_last_error(void) {

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
@@ -63,6 +63,27 @@ int yoyopy_lvgl_hub_sync(
     int32_t power_available
 );
 void yoyopy_lvgl_hub_destroy(void);
+int yoyopy_lvgl_listen_build(void);
+int yoyopy_lvgl_listen_sync(
+    const char * page_text,
+    const char * footer,
+    const char * item_0,
+    const char * item_1,
+    const char * item_2,
+    const char * item_3,
+    int32_t item_count,
+    int32_t selected_index,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b,
+    const char * empty_title,
+    const char * empty_subtitle
+);
+void yoyopy_lvgl_listen_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);

--- a/yoyopy/ui/screens/navigation/listen.py
+++ b/yoyopy/ui/screens/navigation/listen.py
@@ -7,11 +7,13 @@ from typing import TYPE_CHECKING, Optional
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.navigation.lvgl import LvglListenView
 from yoyopy.ui.screens.theme import LISTEN, MUTED, SURFACE, audio_source_label, audio_source_subtitle, draw_empty_state, draw_list_item, render_footer, render_header, rounded_panel
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
     from yoyopy.config import ConfigManager
+    from yoyopy.ui.screens import ScreenView
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,11 +39,36 @@ class ListenScreen(Screen):
         self.config_manager = config_manager
         self.sources: list[ListenSource] = []
         self.selected_index = 0
+        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Refresh configured sources when entering the screen."""
         super().enter()
         self._load_sources()
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving Listen."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Create an LVGL view when the Whisplay renderer is active."""
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglListenView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
 
     def _load_sources(self) -> None:
         """Load configured music sources from the app config."""
@@ -78,6 +105,11 @@ class ListenScreen(Screen):
 
     def render(self) -> None:
         """Render the configured Listen sources."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
         position_text = None
         if self.sources:
             position_text = f"{self.selected_index + 1}/{len(self.sources)}"

--- a/yoyopy/ui/screens/navigation/lvgl/__init__.py
+++ b/yoyopy/ui/screens/navigation/lvgl/__init__.py
@@ -1,5 +1,6 @@
 """LVGL-backed navigation screen views."""
 
 from yoyopy.ui.screens.navigation.lvgl.hub_view import LvglHubView
+from yoyopy.ui.screens.navigation.lvgl.listen_view import LvglListenView
 
-__all__ = ["LvglHubView"]
+__all__ = ["LvglHubView", "LvglListenView"]

--- a/yoyopy/ui/screens/navigation/lvgl/listen_view.py
+++ b/yoyopy/ui/screens/navigation/lvgl/listen_view.py
@@ -1,0 +1,77 @@
+"""LVGL-backed view for the Listen source screen."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+from yoyopy.ui.screens.theme import LISTEN
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens.navigation.listen import ListenScreen
+
+
+@dataclass(slots=True)
+class LvglListenView:
+    """Own the LVGL object lifecycle for ListenScreen."""
+
+    screen: "ListenScreen"
+    backend: LvglDisplayBackend
+    _built: bool = False
+
+    def build(self) -> None:
+        """Create the native Listen scene once."""
+
+        if self._built or self.backend.binding is None:
+            return
+        self.backend.binding.listen_build()
+        self._built = True
+
+    def sync(self) -> None:
+        """Push the current Listen controller state into the native scene."""
+
+        if not self._built or self.backend.binding is None:
+            return
+
+        sources = self.screen.sources
+        page_text = f"{self.screen.selected_index + 1}/{len(sources)}" if sources else None
+        items = [source.title for source in sources[:4]]
+
+        footer = "Tap next / Open / Hold back" if self.screen.is_one_button_mode() else "A open | B back | X/Y move"
+
+        context = self.screen.context
+        self.backend.binding.listen_sync(
+            page_text=page_text,
+            footer=footer,
+            items=items,
+            selected_index=self.screen.selected_index,
+            voip_state=self._voip_state(context),
+            battery_percent=self._battery_percent(context),
+            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            accent=LISTEN.accent,
+            empty_title="No sources",
+            empty_subtitle="Add music sources in config to fill this page.",
+        )
+
+    def destroy(self) -> None:
+        """Tear down the native Listen scene."""
+
+        if not self._built or self.backend.binding is None:
+            return
+        self.backend.binding.listen_destroy()
+        self._built = False
+
+    @staticmethod
+    def _battery_percent(context: "AppContext | None") -> int:
+        if context is None:
+            return 100
+        return max(0, min(100, int(getattr(context, "battery_percent", 100))))
+
+    @staticmethod
+    def _voip_state(context: "AppContext | None") -> int:
+        if context is None or not getattr(context, "voip_configured", False):
+            return 0
+        return 1 if getattr(context, "voip_ready", False) else 2


### PR DESCRIPTION
## Summary\n- add a native LVGL Listen scene lifecycle to the shim and expose it through the CPython binding\n- delegate ListenScreen to a backend-specific LVGL view when the Whisplay renderer is LVGL\n- add focused tests for LVGL Listen delegation while preserving the current PIL fallback\n\n## Verification\n- python -m compileall yoyopy tests\n- uv run pytest -q