### PR TITLE
Add LVGL-backed Playlist screen

### DIFF
--- a/tests/test_playlist_lvgl_view.py
+++ b/tests/test_playlist_lvgl_view.py
@@ -1,0 +1,139 @@
+"""Focused tests for the LVGL-backed playlist screen delegation."""
+
+from __future__ import annotations
+
+from yoyopy.app_context import AppContext
+from yoyopy.ui.input import InteractionProfile
+from yoyopy.ui.screens import PlaylistScreen
+
+
+class FakeLvglBinding:
+    """Small native-binding double for playlist view tests."""
+
+    def __init__(self) -> None:
+        self.playlist_build_calls = 0
+        self.playlist_destroy_calls = 0
+        self.playlist_sync_payloads: list[dict] = []
+
+    def playlist_build(self) -> None:
+        self.playlist_build_calls += 1
+
+    def playlist_sync(self, **payload) -> None:
+        self.playlist_sync_payloads.append(payload)
+
+    def playlist_destroy(self) -> None:
+        self.playlist_destroy_calls += 1
+
+
+class FakeLvglBackend:
+    """Minimal LVGL backend double exposed through Display.get_ui_backend()."""
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self.binding = binding
+        self.initialized = True
+
+
+class FakeLvglDisplay:
+    """Tiny Display double for LVGL playlist delegation tests."""
+
+    backend_kind = "lvgl"
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self._ui_backend = FakeLvglBackend(binding)
+
+    def get_ui_backend(self) -> FakeLvglBackend:
+        return self._ui_backend
+
+    def is_portrait(self) -> bool:
+        return True
+
+
+class FakePlaylist:
+    """Minimal playlist record with track count metadata."""
+
+    def __init__(self, name: str, uri: str, track_count: int = 0) -> None:
+        self.name = name
+        self.uri = uri
+        self.track_count = track_count
+
+
+class FakeMopidyClient:
+    """Minimal Mopidy client for playlist view tests."""
+
+    def __init__(self, playlists: list[FakePlaylist], *, is_connected: bool = True) -> None:
+        self.playlists = playlists
+        self.is_connected = is_connected
+
+    def get_playlists(self, fetch_track_counts: bool = True) -> list[FakePlaylist]:
+        return list(self.playlists)
+
+
+def test_playlist_screen_builds_syncs_and_destroys_lvgl_view() -> None:
+    """PlaylistScreen should delegate lifecycle and visible-window state to LVGL."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+    context.update_voip_status(configured=True, ready=True)
+    context.battery_percent = 61
+    context.battery_charging = False
+    context.power_available = True
+    context.current_audio_source = "spotify"
+
+    mopidy = FakeMopidyClient(
+        [
+            FakePlaylist("Alpha", "playlist:alpha", 12),
+            FakePlaylist("Beta", "playlist:beta", 4),
+            FakePlaylist("Gamma", "playlist:gamma", 0),
+            FakePlaylist("Delta", "playlist:delta", 9),
+        ]
+    )
+    screen = PlaylistScreen(display, context, mopidy_client=mopidy)
+
+    screen.enter()
+
+    assert binding.playlist_build_calls == 1
+    assert len(binding.playlist_sync_payloads) >= 2
+
+    final_payload = binding.playlist_sync_payloads[-1]
+    assert final_payload["title_text"] == "Spotify"
+    assert final_payload["page_text"] == "1/4"
+    assert final_payload["items"] == ["Alpha", "Beta", "Gamma"]
+    assert final_payload["badges"] == ["12", "4", ""]
+    assert final_payload["selected_visible_index"] == 0
+    assert final_payload["voip_state"] == 1
+    assert final_payload["battery_percent"] == 61
+
+    screen.selected_index = 3
+    screen.render()
+
+    scrolled_payload = binding.playlist_sync_payloads[-1]
+    assert scrolled_payload["page_text"] == "4/4"
+    assert scrolled_payload["items"] == ["Beta", "Gamma", "Delta"]
+    assert scrolled_payload["badges"] == ["4", "", "9"]
+    assert scrolled_payload["selected_visible_index"] == 2
+
+    screen.exit()
+    assert binding.playlist_destroy_calls == 1
+
+
+def test_playlist_screen_syncs_error_state_through_lvgl() -> None:
+    """PlaylistScreen should send the music-offline empty state through LVGL."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+    screen = PlaylistScreen(
+        display,
+        context,
+        mopidy_client=FakeMopidyClient([], is_connected=False),
+    )
+
+    screen.enter()
+    screen.render()
+
+    payload = binding.playlist_sync_payloads[-1]
+    assert payload["items"] == []
+    assert payload["page_text"] is None
+    assert payload["empty_title"] == "Music hiccup"
+    assert payload["empty_subtitle"] == "Music offline"

--- a/yoyopy/ui/lvgl_binding/binding.py
+++ b/yoyopy/ui/lvgl_binding/binding.py
@@ -72,6 +72,33 @@ int yoyopy_lvgl_listen_sync(
     const char * empty_subtitle
 );
 void yoyopy_lvgl_listen_destroy(void);
+int yoyopy_lvgl_playlist_build(void);
+int yoyopy_lvgl_playlist_sync(
+    const char * title_text,
+    const char * page_text,
+    const char * footer,
+    const char * item_0,
+    const char * item_1,
+    const char * item_2,
+    const char * item_3,
+    const char * badge_0,
+    const char * badge_1,
+    const char * badge_2,
+    const char * badge_3,
+    int32_t item_count,
+    int32_t selected_visible_index,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b,
+    const char * empty_title,
+    const char * empty_subtitle,
+    const char * empty_icon_key
+);
+void yoyopy_lvgl_playlist_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);
@@ -291,6 +318,86 @@ class LvglBinding:
 
     def listen_destroy(self) -> None:
         self.lib.yoyopy_lvgl_listen_destroy()
+
+    def playlist_build(self) -> None:
+        if self.lib.yoyopy_lvgl_playlist_build() != 0:
+            raise LvglBindingError(self.last_error())
+
+    def playlist_sync(
+        self,
+        *,
+        title_text: str,
+        page_text: str | None,
+        footer: str,
+        items: list[str],
+        badges: list[str],
+        selected_visible_index: int,
+        voip_state: int,
+        battery_percent: int,
+        charging: bool,
+        power_available: bool,
+        accent: tuple[int, int, int],
+        empty_title: str,
+        empty_subtitle: str,
+        empty_icon_key: str,
+    ) -> None:
+        normalized_items = list(items[:4])
+        while len(normalized_items) < 4:
+            normalized_items.append("")
+
+        normalized_badges = list(badges[:4])
+        while len(normalized_badges) < 4:
+            normalized_badges.append("")
+
+        title_raw = self.ffi.new("char[]", title_text.encode("utf-8"))
+        page_text_raw = (
+            self.ffi.new("char[]", page_text.encode("utf-8"))
+            if page_text
+            else self.ffi.NULL
+        )
+        footer_raw = self.ffi.new("char[]", footer.encode("utf-8"))
+        item_0_raw = self.ffi.new("char[]", normalized_items[0].encode("utf-8"))
+        item_1_raw = self.ffi.new("char[]", normalized_items[1].encode("utf-8"))
+        item_2_raw = self.ffi.new("char[]", normalized_items[2].encode("utf-8"))
+        item_3_raw = self.ffi.new("char[]", normalized_items[3].encode("utf-8"))
+        badge_0_raw = self.ffi.new("char[]", normalized_badges[0].encode("utf-8"))
+        badge_1_raw = self.ffi.new("char[]", normalized_badges[1].encode("utf-8"))
+        badge_2_raw = self.ffi.new("char[]", normalized_badges[2].encode("utf-8"))
+        badge_3_raw = self.ffi.new("char[]", normalized_badges[3].encode("utf-8"))
+        empty_title_raw = self.ffi.new("char[]", empty_title.encode("utf-8"))
+        empty_subtitle_raw = self.ffi.new("char[]", empty_subtitle.encode("utf-8"))
+        empty_icon_raw = self.ffi.new("char[]", empty_icon_key.encode("utf-8"))
+
+        result = self.lib.yoyopy_lvgl_playlist_sync(
+            title_raw,
+            page_text_raw,
+            footer_raw,
+            item_0_raw,
+            item_1_raw,
+            item_2_raw,
+            item_3_raw,
+            badge_0_raw,
+            badge_1_raw,
+            badge_2_raw,
+            badge_3_raw,
+            len(items),
+            selected_visible_index,
+            voip_state,
+            battery_percent,
+            1 if charging else 0,
+            1 if power_available else 0,
+            accent[0],
+            accent[1],
+            accent[2],
+            empty_title_raw,
+            empty_subtitle_raw,
+            empty_icon_raw,
+        )
+        if result != 0:
+            raise LvglBindingError(self.last_error())
+
+    def playlist_destroy(self) -> None:
+        self.lib.yoyopy_lvgl_playlist_destroy()
 
     def clear_screen(self) -> None:
         self.lib.yoyopy_lvgl_clear_screen()

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
@@ -50,6 +50,27 @@ typedef struct {
     lv_obj_t * footer_label;
 } yoyopy_listen_scene_t;
 
+typedef struct {
+    int built;
+    lv_obj_t * screen;
+    lv_obj_t * voip_dot;
+    lv_obj_t * battery_outline;
+    lv_obj_t * battery_fill;
+    lv_obj_t * battery_tip;
+    lv_obj_t * title_label;
+    lv_obj_t * title_underline;
+    lv_obj_t * page_label;
+    lv_obj_t * panel;
+    lv_obj_t * item_panels[4];
+    lv_obj_t * item_titles[4];
+    lv_obj_t * item_badges[4];
+    lv_obj_t * empty_panel;
+    lv_obj_t * empty_icon;
+    lv_obj_t * empty_title;
+    lv_obj_t * empty_subtitle;
+    lv_obj_t * footer_label;
+} yoyopy_playlist_scene_t;
+
 static int g_initialized = 0;
 static lv_display_t * g_display = NULL;
 static lv_indev_t * g_indev = NULL;
@@ -65,6 +86,7 @@ static int g_key_tail = 0;
 static int g_key_count = 0;
 static yoyopy_hub_scene_t g_hub_scene = {0};
 static yoyopy_listen_scene_t g_listen_scene = {0};
+static yoyopy_playlist_scene_t g_playlist_scene = {0};
 
 static lv_color_t yoyopy_color_rgb(uint8_t red, uint8_t green, uint8_t blue) {
     uint32_t raw = ((uint32_t)red << 16) | ((uint32_t)green << 8) | (uint32_t)blue;
@@ -95,9 +117,14 @@ static void yoyopy_reset_listen_scene_refs(void) {
     memset(&g_listen_scene, 0, sizeof(g_listen_scene));
 }
 
+static void yoyopy_reset_playlist_scene_refs(void) {
+    memset(&g_playlist_scene, 0, sizeof(g_playlist_scene));
+}
+
 static void yoyopy_reset_scene_refs(void) {
     yoyopy_reset_hub_scene_refs();
     yoyopy_reset_listen_scene_refs();
+    yoyopy_reset_playlist_scene_refs();
 }
 
 static void yoyopy_set_error(const char * message) {
@@ -322,6 +349,30 @@ static void yoyopy_apply_battery(
     } else {
         lv_obj_clear_flag(fill, LV_OBJ_FLAG_HIDDEN);
     }
+}
+
+static const char * yoyopy_symbol_for_empty_icon(const char * icon_key) {
+    if(icon_key == NULL) {
+        return LV_SYMBOL_LIST;
+    }
+
+    if(strcmp(icon_key, "playlist") == 0) {
+        return LV_SYMBOL_LIST;
+    }
+    if(strcmp(icon_key, "listen") == 0) {
+        return LV_SYMBOL_AUDIO;
+    }
+    if(strcmp(icon_key, "talk") == 0) {
+        return LV_SYMBOL_CALL;
+    }
+    if(strcmp(icon_key, "ask") == 0) {
+        return LV_SYMBOL_EDIT;
+    }
+    if(strcmp(icon_key, "setup") == 0 || strcmp(icon_key, "power") == 0) {
+        return LV_SYMBOL_SETTINGS;
+    }
+
+    return LV_SYMBOL_LIST;
 }
 
 static const char * yoyopy_hub_symbol_for_icon(const char * icon_key) {
@@ -827,6 +878,274 @@ void yoyopy_lvgl_listen_destroy(void) {
     }
     yoyopy_clear_group();
     yoyopy_reset_listen_scene_refs();
+}
+
+int yoyopy_lvgl_playlist_build(void) {
+    if(!g_initialized || g_display == NULL) {
+        yoyopy_set_error("display must be registered before building the playlist scene");
+        return -1;
+    }
+
+    if(g_playlist_scene.built) {
+        return 0;
+    }
+
+    yoyopy_prepare_active_screen();
+
+    g_playlist_scene.screen = lv_screen_active();
+    lv_obj_set_style_bg_color(g_playlist_scene.screen, yoyopy_color_rgb(18, 21, 28), 0);
+    lv_obj_set_style_bg_opa(g_playlist_scene.screen, LV_OPA_COVER, 0);
+
+    g_playlist_scene.voip_dot = lv_obj_create(g_playlist_scene.screen);
+    lv_obj_remove_style_all(g_playlist_scene.voip_dot);
+    lv_obj_set_size(g_playlist_scene.voip_dot, 8, 8);
+    lv_obj_set_style_radius(g_playlist_scene.voip_dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_pos(g_playlist_scene.voip_dot, 16, 10);
+
+    g_playlist_scene.battery_outline = lv_obj_create(g_playlist_scene.screen);
+    lv_obj_remove_style_all(g_playlist_scene.battery_outline);
+    lv_obj_set_size(g_playlist_scene.battery_outline, 20, 10);
+    lv_obj_set_pos(g_playlist_scene.battery_outline, 202, 6);
+    lv_obj_set_style_border_width(g_playlist_scene.battery_outline, 1, 0);
+    lv_obj_set_style_border_color(g_playlist_scene.battery_outline, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_radius(g_playlist_scene.battery_outline, 2, 0);
+    lv_obj_set_style_bg_opa(g_playlist_scene.battery_outline, LV_OPA_TRANSP, 0);
+
+    g_playlist_scene.battery_fill = lv_obj_create(g_playlist_scene.battery_outline);
+    lv_obj_remove_style_all(g_playlist_scene.battery_fill);
+    lv_obj_set_pos(g_playlist_scene.battery_fill, 1, 1);
+    lv_obj_set_size(g_playlist_scene.battery_fill, 18, 8);
+    lv_obj_set_style_radius(g_playlist_scene.battery_fill, 1, 0);
+    lv_obj_set_style_bg_opa(g_playlist_scene.battery_fill, LV_OPA_COVER, 0);
+
+    g_playlist_scene.battery_tip = lv_obj_create(g_playlist_scene.screen);
+    lv_obj_remove_style_all(g_playlist_scene.battery_tip);
+    lv_obj_set_size(g_playlist_scene.battery_tip, 2, 4);
+    lv_obj_set_pos(g_playlist_scene.battery_tip, 222, 9);
+    lv_obj_set_style_bg_color(g_playlist_scene.battery_tip, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_bg_opa(g_playlist_scene.battery_tip, LV_OPA_COVER, 0);
+
+    g_playlist_scene.title_label = lv_label_create(g_playlist_scene.screen);
+    lv_obj_set_pos(g_playlist_scene.title_label, 18, 36);
+    lv_obj_set_style_text_font(g_playlist_scene.title_label, &lv_font_montserrat_24, 0);
+
+    g_playlist_scene.title_underline = lv_obj_create(g_playlist_scene.screen);
+    lv_obj_remove_style_all(g_playlist_scene.title_underline);
+    lv_obj_set_pos(g_playlist_scene.title_underline, 18, 66);
+    lv_obj_set_size(g_playlist_scene.title_underline, 96, 3);
+    lv_obj_set_style_radius(g_playlist_scene.title_underline, 2, 0);
+    lv_obj_set_style_bg_opa(g_playlist_scene.title_underline, LV_OPA_COVER, 0);
+
+    g_playlist_scene.page_label = lv_label_create(g_playlist_scene.screen);
+    lv_obj_set_pos(g_playlist_scene.page_label, 184, 39);
+    lv_obj_set_style_text_font(g_playlist_scene.page_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(g_playlist_scene.page_label, yoyopy_color_rgb(153, 160, 173), 0);
+
+    g_playlist_scene.panel = lv_obj_create(g_playlist_scene.screen);
+    lv_obj_set_size(g_playlist_scene.panel, 216, 166);
+    lv_obj_set_pos(g_playlist_scene.panel, 12, 86);
+    lv_obj_set_style_radius(g_playlist_scene.panel, 24, 0);
+    lv_obj_set_style_border_width(g_playlist_scene.panel, 0, 0);
+    lv_obj_set_style_bg_color(g_playlist_scene.panel, yoyopy_color_rgb(28, 33, 42), 0);
+    lv_obj_set_style_bg_opa(g_playlist_scene.panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_pad_all(g_playlist_scene.panel, 0, 0);
+    lv_obj_set_style_shadow_width(g_playlist_scene.panel, 0, 0);
+    lv_obj_set_style_outline_width(g_playlist_scene.panel, 0, 0);
+    lv_obj_set_scrollbar_mode(g_playlist_scene.panel, LV_SCROLLBAR_MODE_OFF);
+
+    for(int index = 0; index < 4; ++index) {
+        g_playlist_scene.item_panels[index] = lv_obj_create(g_playlist_scene.panel);
+        lv_obj_set_size(g_playlist_scene.item_panels[index], 184, 42);
+        lv_obj_set_pos(g_playlist_scene.item_panels[index], 16, 10 + (index * 50));
+        lv_obj_set_style_radius(g_playlist_scene.item_panels[index], 16, 0);
+        lv_obj_set_style_border_width(g_playlist_scene.item_panels[index], 2, 0);
+        lv_obj_set_style_pad_all(g_playlist_scene.item_panels[index], 0, 0);
+        lv_obj_set_style_shadow_width(g_playlist_scene.item_panels[index], 0, 0);
+        lv_obj_set_style_outline_width(g_playlist_scene.item_panels[index], 0, 0);
+        lv_obj_set_scrollbar_mode(g_playlist_scene.item_panels[index], LV_SCROLLBAR_MODE_OFF);
+
+        g_playlist_scene.item_titles[index] = lv_label_create(g_playlist_scene.item_panels[index]);
+        lv_obj_set_width(g_playlist_scene.item_titles[index], 118);
+        lv_obj_set_pos(g_playlist_scene.item_titles[index], 14, 11);
+        lv_label_set_long_mode(g_playlist_scene.item_titles[index], LV_LABEL_LONG_MODE_CLIP);
+        lv_obj_set_style_text_font(g_playlist_scene.item_titles[index], &lv_font_montserrat_16, 0);
+
+        g_playlist_scene.item_badges[index] = lv_label_create(g_playlist_scene.item_panels[index]);
+        lv_obj_set_pos(g_playlist_scene.item_badges[index], 146, 12);
+        lv_obj_set_style_text_font(g_playlist_scene.item_badges[index], &lv_font_montserrat_12, 0);
+    }
+
+    g_playlist_scene.empty_panel = lv_obj_create(g_playlist_scene.screen);
+    lv_obj_set_size(g_playlist_scene.empty_panel, 204, 136);
+    lv_obj_set_pos(g_playlist_scene.empty_panel, 18, 96);
+    lv_obj_set_style_radius(g_playlist_scene.empty_panel, 22, 0);
+    lv_obj_set_style_border_width(g_playlist_scene.empty_panel, 2, 0);
+    lv_obj_set_style_pad_all(g_playlist_scene.empty_panel, 0, 0);
+    lv_obj_set_style_shadow_width(g_playlist_scene.empty_panel, 0, 0);
+    lv_obj_set_style_outline_width(g_playlist_scene.empty_panel, 0, 0);
+    lv_obj_set_scrollbar_mode(g_playlist_scene.empty_panel, LV_SCROLLBAR_MODE_OFF);
+
+    g_playlist_scene.empty_icon = lv_label_create(g_playlist_scene.empty_panel);
+    lv_obj_set_style_text_font(g_playlist_scene.empty_icon, &lv_font_montserrat_24, 0);
+    lv_obj_align(g_playlist_scene.empty_icon, LV_ALIGN_TOP_MID, 0, 16);
+
+    g_playlist_scene.empty_title = lv_label_create(g_playlist_scene.empty_panel);
+    lv_obj_set_width(g_playlist_scene.empty_title, 168);
+    lv_obj_set_pos(g_playlist_scene.empty_title, 18, 60);
+    lv_obj_set_style_text_font(g_playlist_scene.empty_title, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_align(g_playlist_scene.empty_title, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_playlist_scene.empty_subtitle = lv_label_create(g_playlist_scene.empty_panel);
+    lv_obj_set_width(g_playlist_scene.empty_subtitle, 168);
+    lv_obj_set_pos(g_playlist_scene.empty_subtitle, 18, 86);
+    lv_label_set_long_mode(g_playlist_scene.empty_subtitle, LV_LABEL_LONG_MODE_WRAP);
+    lv_obj_set_style_text_font(g_playlist_scene.empty_subtitle, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_playlist_scene.empty_subtitle, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_playlist_scene.footer_label = lv_label_create(g_playlist_scene.screen);
+    lv_obj_set_style_text_font(g_playlist_scene.footer_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_playlist_scene.footer_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(g_playlist_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    g_playlist_scene.built = 1;
+    return 0;
+}
+
+int yoyopy_lvgl_playlist_sync(
+    const char * title_text,
+    const char * page_text,
+    const char * footer,
+    const char * item_0,
+    const char * item_1,
+    const char * item_2,
+    const char * item_3,
+    const char * badge_0,
+    const char * badge_1,
+    const char * badge_2,
+    const char * badge_3,
+    int32_t item_count,
+    int32_t selected_visible_index,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b,
+    const char * empty_title,
+    const char * empty_subtitle,
+    const char * empty_icon_key
+) {
+    if(!g_playlist_scene.built) {
+        yoyopy_set_error("playlist scene must be built before sync");
+        return -1;
+    }
+
+    const lv_color_t background = yoyopy_color_rgb(18, 21, 28);
+    const lv_color_t surface = yoyopy_color_rgb(28, 33, 42);
+    const lv_color_t ink = yoyopy_color_rgb(243, 247, 250);
+    const lv_color_t muted = yoyopy_color_rgb(153, 160, 173);
+    const lv_color_t accent = yoyopy_color_rgb(accent_r, accent_g, accent_b);
+    const lv_color_t accent_soft = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 28, 33, 42, 55);
+    const lv_color_t accent_dim = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 65);
+    const lv_color_t selected_fill = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 28, 33, 42, 88);
+    const lv_color_t border = yoyopy_color_rgb(74, 79, 92);
+
+    const char * items[4] = {item_0, item_1, item_2, item_3};
+    const char * badges[4] = {badge_0, badge_1, badge_2, badge_3};
+
+    lv_obj_set_style_bg_color(g_playlist_scene.screen, background, 0);
+    lv_obj_set_style_bg_opa(g_playlist_scene.screen, LV_OPA_COVER, 0);
+    yoyopy_apply_voip_dot(g_playlist_scene.voip_dot, voip_state);
+    yoyopy_apply_battery(
+        g_playlist_scene.battery_outline,
+        g_playlist_scene.battery_fill,
+        g_playlist_scene.battery_tip,
+        battery_percent,
+        charging,
+        power_available
+    );
+
+    lv_label_set_text(g_playlist_scene.title_label, title_text != NULL ? title_text : "");
+    lv_obj_set_style_text_color(g_playlist_scene.title_label, ink, 0);
+    lv_obj_set_style_bg_color(g_playlist_scene.title_underline, accent, 0);
+    lv_label_set_text(g_playlist_scene.page_label, page_text != NULL ? page_text : "");
+
+    if(item_count < 0) {
+        item_count = 0;
+    }
+    if(item_count > 4) {
+        item_count = 4;
+    }
+
+    if(item_count == 0) {
+        lv_obj_add_flag(g_playlist_scene.panel, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(g_playlist_scene.empty_panel, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_style_bg_color(g_playlist_scene.empty_panel, surface, 0);
+        lv_obj_set_style_bg_opa(g_playlist_scene.empty_panel, LV_OPA_COVER, 0);
+        lv_obj_set_style_border_color(g_playlist_scene.empty_panel, accent_dim, 0);
+        lv_label_set_text(g_playlist_scene.empty_icon, yoyopy_symbol_for_empty_icon(empty_icon_key));
+        lv_obj_set_style_text_color(g_playlist_scene.empty_icon, accent, 0);
+        lv_label_set_text(g_playlist_scene.empty_title, empty_title != NULL ? empty_title : "");
+        lv_obj_set_style_text_color(g_playlist_scene.empty_title, ink, 0);
+        lv_label_set_text(g_playlist_scene.empty_subtitle, empty_subtitle != NULL ? empty_subtitle : "");
+        lv_obj_set_style_text_color(g_playlist_scene.empty_subtitle, muted, 0);
+    } else {
+        lv_obj_clear_flag(g_playlist_scene.panel, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(g_playlist_scene.empty_panel, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    if(item_count > 0) {
+        selected_visible_index = selected_visible_index % item_count;
+        if(selected_visible_index < 0) {
+            selected_visible_index += item_count;
+        }
+    } else {
+        selected_visible_index = 0;
+    }
+
+    for(int index = 0; index < 4; ++index) {
+        if(index >= item_count) {
+            lv_obj_add_flag(g_playlist_scene.item_panels[index], LV_OBJ_FLAG_HIDDEN);
+            continue;
+        }
+
+        int selected = index == selected_visible_index;
+        const char * badge_text = badges[index] != NULL ? badges[index] : "";
+        lv_obj_clear_flag(g_playlist_scene.item_panels[index], LV_OBJ_FLAG_HIDDEN);
+        lv_label_set_text(g_playlist_scene.item_titles[index], items[index] != NULL ? items[index] : "");
+        lv_obj_set_style_bg_color(g_playlist_scene.item_panels[index], selected ? selected_fill : surface, 0);
+        lv_obj_set_style_bg_opa(g_playlist_scene.item_panels[index], LV_OPA_COVER, 0);
+        lv_obj_set_style_border_color(g_playlist_scene.item_panels[index], selected ? accent_soft : border, 0);
+        lv_obj_set_style_text_color(g_playlist_scene.item_titles[index], selected ? ink : yoyopy_mix_rgb(243, 247, 250, 153, 160, 173, 12), 0);
+
+        if(badge_text[0] == '\0') {
+            lv_obj_add_flag(g_playlist_scene.item_badges[index], LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_clear_flag(g_playlist_scene.item_badges[index], LV_OBJ_FLAG_HIDDEN);
+            lv_label_set_text(g_playlist_scene.item_badges[index], badge_text);
+            lv_obj_set_style_text_color(g_playlist_scene.item_badges[index], selected ? accent : muted, 0);
+            lv_obj_set_x(g_playlist_scene.item_badges[index], 184 - (int)lv_obj_get_width(g_playlist_scene.item_badges[index]) - 16);
+        }
+    }
+
+    lv_label_set_text(g_playlist_scene.footer_label, footer != NULL ? footer : "");
+    lv_obj_set_style_text_color(g_playlist_scene.footer_label, accent_dim, 0);
+    lv_obj_align(g_playlist_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    return 0;
+}
+
+void yoyopy_lvgl_playlist_destroy(void) {
+    if(!g_playlist_scene.built) {
+        return;
+    }
+
+    if(g_playlist_scene.screen != NULL) {
+        lv_obj_clean(g_playlist_scene.screen);
+    }
+    yoyopy_clear_group();
+    yoyopy_reset_playlist_scene_refs();
 }
 
 int yoyopy_lvgl_init(void) {

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
@@ -84,6 +84,33 @@ int yoyopy_lvgl_listen_sync(
     const char * empty_subtitle
 );
 void yoyopy_lvgl_listen_destroy(void);
+int yoyopy_lvgl_playlist_build(void);
+int yoyopy_lvgl_playlist_sync(
+    const char * title_text,
+    const char * page_text,
+    const char * footer,
+    const char * item_0,
+    const char * item_1,
+    const char * item_2,
+    const char * item_3,
+    const char * badge_0,
+    const char * badge_1,
+    const char * badge_2,
+    const char * badge_3,
+    int32_t item_count,
+    int32_t selected_visible_index,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b,
+    const char * empty_title,
+    const char * empty_subtitle,
+    const char * empty_icon_key
+);
+void yoyopy_lvgl_playlist_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);

--- a/yoyopy/ui/screens/music/lvgl/__init__.py
+++ b/yoyopy/ui/screens/music/lvgl/__init__.py
@@ -1,0 +1,5 @@
+"""LVGL-backed music screen views."""
+
+from yoyopy.ui.screens.music.lvgl.playlist_view import LvglPlaylistView
+
+__all__ = ["LvglPlaylistView"]

--- a/yoyopy/ui/screens/music/lvgl/playlist_view.py
+++ b/yoyopy/ui/screens/music/lvgl/playlist_view.py
@@ -1,0 +1,88 @@
+"""LVGL-backed view for the playlist browser."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+from yoyopy.ui.screens.theme import LISTEN, audio_source_label
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens.music.playlist import PlaylistScreen
+
+
+@dataclass(slots=True)
+class LvglPlaylistView:
+    """Own the LVGL object lifecycle for PlaylistScreen."""
+
+    screen: "PlaylistScreen"
+    backend: LvglDisplayBackend
+    _built: bool = False
+
+    def build(self) -> None:
+        """Create the native playlist scene once."""
+
+        if self._built or self.backend.binding is None:
+            return
+        self.backend.binding.playlist_build()
+        self._built = True
+
+    def sync(self) -> None:
+        """Push the current playlist controller state into the native scene."""
+
+        if not self._built or self.backend.binding is None:
+            return
+
+        title_text = audio_source_label(getattr(self.screen.context, "current_audio_source", "local"))
+        footer = "Tap next / Load / Hold back" if self.screen.is_one_button_mode() else "A load | B back | X/Y move"
+        context = self.screen.context
+
+        visible_items, visible_badges, selected_visible_index = self.screen.get_visible_window()
+
+        empty_title, empty_subtitle = self._empty_state_copy()
+
+        self.backend.binding.playlist_sync(
+            title_text=title_text,
+            page_text=self.screen.get_page_text(),
+            footer=footer,
+            items=visible_items,
+            badges=visible_badges,
+            selected_visible_index=selected_visible_index,
+            voip_state=self._voip_state(context),
+            battery_percent=self._battery_percent(context),
+            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            accent=LISTEN.accent,
+            empty_title=empty_title,
+            empty_subtitle=empty_subtitle,
+            empty_icon_key="playlist",
+        )
+
+    def destroy(self) -> None:
+        """Tear down the native playlist scene."""
+
+        if not self._built or self.backend.binding is None:
+            return
+        self.backend.binding.playlist_destroy()
+        self._built = False
+
+    def _empty_state_copy(self) -> tuple[str, str]:
+        if self.screen.loading:
+            return ("Loading playlists", "Hold on while your lists come in.")
+        if self.screen.error_message:
+            return ("Music hiccup", self.screen.error_message)
+        return ("No playlists", "Add playlists to see them here.")
+
+    @staticmethod
+    def _battery_percent(context: "AppContext | None") -> int:
+        if context is None:
+            return 100
+        return max(0, min(100, int(getattr(context, "battery_percent", 100))))
+
+    @staticmethod
+    def _voip_state(context: "AppContext | None") -> int:
+        if context is None or not getattr(context, "voip_configured", False):
+            return 0
+        return 1 if getattr(context, "voip_ready", False) else 2

--- a/yoyopy/ui/screens/music/playlist.py
+++ b/yoyopy/ui/screens/music/playlist.py
@@ -8,10 +8,12 @@ from loguru import logger
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.music.lvgl import LvglPlaylistView
 from yoyopy.ui.screens.theme import LISTEN, MUTED, SURFACE, audio_source_label, draw_empty_state, draw_list_item, render_footer, render_header, rounded_panel, text_fit
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens import ScreenView
 
 
 class PlaylistScreen(Screen):
@@ -31,11 +33,74 @@ class PlaylistScreen(Screen):
         self.max_visible_items = 3 if display.is_portrait() else 4
         self.loading = False
         self.error_message: str | None = None
+        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Refresh playlists when the screen becomes active."""
         super().enter()
+        self._ensure_lvgl_view()
         self.fetch_playlists()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving playlists."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Create an LVGL view when the Whisplay renderer is active."""
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglPlaylistView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
+
+    def _update_scroll_window(self) -> None:
+        """Keep the selected item visible within the current scroll window."""
+        if self.selected_index < self.scroll_offset:
+            self.scroll_offset = self.selected_index
+        elif self.selected_index >= self.scroll_offset + self.max_visible_items:
+            self.scroll_offset = self.selected_index - self.max_visible_items + 1
+
+    def get_page_text(self) -> str | None:
+        """Return the compact page indicator for the current playlist selection."""
+        if not self.playlists:
+            return None
+        return f"{self.selected_index + 1}/{len(self.playlists)}"
+
+    def get_visible_window(self) -> tuple[list[str], list[str], int]:
+        """Return the visible playlist titles, badges, and selected row index."""
+        if not self.playlists:
+            return [], [], 0
+
+        self._update_scroll_window()
+
+        visible_titles: list[str] = []
+        visible_badges: list[str] = []
+        selected_visible_index = 0
+
+        for row in range(self.max_visible_items):
+            playlist_index = self.scroll_offset + row
+            if playlist_index >= len(self.playlists):
+                break
+
+            playlist = self.playlists[playlist_index]
+            badge = f"{playlist.track_count}" if getattr(playlist, "track_count", 0) else ""
+            visible_titles.append(playlist.name)
+            visible_badges.append(badge)
+            if playlist_index == self.selected_index:
+                selected_visible_index = row
+
+        return visible_titles, visible_badges, selected_visible_index
 
     def fetch_playlists(self) -> None:
         """Fetch playlists from Mopidy."""
@@ -65,10 +130,13 @@ class PlaylistScreen(Screen):
 
     def render(self) -> None:
         """Render the source-themed playlist browser."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
         source_label = audio_source_label(getattr(self.context, "current_audio_source", "local"))
-        page_text = None
-        if self.playlists:
-            page_text = f"{self.selected_index + 1}/{len(self.playlists)}"
+        page_text = self.get_page_text()
 
         content_top = render_header(
             self.display,
@@ -119,10 +187,7 @@ class PlaylistScreen(Screen):
             self.display.update()
             return
 
-        if self.selected_index < self.scroll_offset:
-            self.scroll_offset = self.selected_index
-        elif self.selected_index >= self.scroll_offset + self.max_visible_items:
-            self.scroll_offset = self.selected_index - self.max_visible_items + 1
+        self._update_scroll_window()
 
         panel_top = content_top + 6
         panel_bottom = self.display.HEIGHT - 28


### PR DESCRIPTION
## Summary\n- add a native LVGL playlist scene lifecycle to the shim and expose it through the CPython binding\n- delegate PlaylistScreen to a backend-specific LVGL view when the Whisplay renderer is LVGL\n- add focused tests for LVGL playlist delegation while preserving the current PIL fallback\n\n## Verification\n- python -m compileall yoyopy tests\n- uv run pytest -q