### PR TITLE
Add LVGL now-playing screen

### DIFF
--- a/tests/test_now_playing_lvgl_view.py
+++ b/tests/test_now_playing_lvgl_view.py
@@ -1,0 +1,142 @@
+"""Focused tests for the LVGL-backed now-playing screen delegation."""
+
+from __future__ import annotations
+
+from yoyopy.app_context import AppContext
+from yoyopy.ui.input import InteractionProfile
+from yoyopy.ui.screens import NowPlayingScreen
+
+
+class FakeLvglBinding:
+    """Small native-binding double for now-playing view tests."""
+
+    def __init__(self) -> None:
+        self.now_playing_build_calls = 0
+        self.now_playing_destroy_calls = 0
+        self.now_playing_sync_payloads: list[dict] = []
+
+    def now_playing_build(self) -> None:
+        self.now_playing_build_calls += 1
+
+    def now_playing_sync(self, **payload) -> None:
+        self.now_playing_sync_payloads.append(payload)
+
+    def now_playing_destroy(self) -> None:
+        self.now_playing_destroy_calls += 1
+
+
+class FakeLvglBackend:
+    """Minimal LVGL backend double exposed through Display.get_ui_backend()."""
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self.binding = binding
+        self.initialized = True
+
+
+class FakeLvglDisplay:
+    """Tiny Display double for LVGL now-playing delegation tests."""
+
+    backend_kind = "lvgl"
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self._ui_backend = FakeLvglBackend(binding)
+
+    def get_ui_backend(self) -> FakeLvglBackend:
+        return self._ui_backend
+
+
+class FakeTrack:
+    """Minimal Mopidy track used by the now-playing tests."""
+
+    def __init__(self, name: str, artist: str, length: int) -> None:
+        self.name = name
+        self._artist = artist
+        self.length = length
+
+    def get_artist_string(self) -> str:
+        return self._artist
+
+
+class FakeMopidyClient:
+    """Minimal Mopidy client for now-playing view tests."""
+
+    def __init__(
+        self,
+        track: FakeTrack | None,
+        *,
+        playback_state: str = "playing",
+        position: int = 0,
+        is_connected: bool = True,
+    ) -> None:
+        self.track = track
+        self.playback_state = playback_state
+        self.position = position
+        self.is_connected = is_connected
+
+    def get_current_track(self) -> FakeTrack | None:
+        return self.track
+
+    def get_playback_state(self) -> str:
+        return self.playback_state
+
+    def get_time_position(self) -> int:
+        return self.position
+
+
+def test_now_playing_screen_builds_syncs_and_destroys_lvgl_view() -> None:
+    """NowPlayingScreen should delegate lifecycle and playback state to LVGL."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+    context.update_voip_status(configured=True, ready=True)
+    context.battery_percent = 84
+    context.battery_charging = True
+    context.power_available = True
+
+    mopidy = FakeMopidyClient(
+        FakeTrack("Adventure Song", "Kid Band", 200000),
+        playback_state="playing",
+        position=50000,
+    )
+    screen = NowPlayingScreen(display, context, mopidy_client=mopidy)
+
+    screen.enter()
+    screen.render()
+
+    assert binding.now_playing_build_calls == 1
+    assert len(binding.now_playing_sync_payloads) == 1
+    payload = binding.now_playing_sync_payloads[-1]
+    assert payload["title_text"] == "Adventure Song"
+    assert payload["artist_text"] == "Kid Band"
+    assert payload["state_text"] == "PLAYING"
+    assert payload["progress_permille"] == 250
+    assert payload["voip_state"] == 1
+    assert payload["battery_percent"] == 84
+    assert payload["charging"] is True
+    assert payload["power_available"] is True
+
+    screen.exit()
+    assert binding.now_playing_destroy_calls == 1
+
+
+def test_now_playing_screen_syncs_offline_state_through_lvgl() -> None:
+    """NowPlayingScreen should send the music-offline state through LVGL."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+    screen = NowPlayingScreen(
+        display,
+        context,
+        mopidy_client=FakeMopidyClient(None, is_connected=False),
+    )
+
+    screen.enter()
+    screen.render()
+
+    payload = binding.now_playing_sync_payloads[-1]
+    assert payload["title_text"] == "Music Offline"
+    assert payload["artist_text"] == "Trying to reconnect"
+    assert payload["state_text"] == "OFFLINE"
+    assert payload["progress_permille"] == 0

--- a/yoyopy/ui/lvgl_binding/binding.py
+++ b/yoyopy/ui/lvgl_binding/binding.py
@@ -99,6 +99,22 @@ int yoyopy_lvgl_playlist_sync(
     const char * empty_icon_key
 );
 void yoyopy_lvgl_playlist_destroy(void);
+int yoyopy_lvgl_now_playing_build(void);
+int yoyopy_lvgl_now_playing_sync(
+    const char * title_text,
+    const char * artist_text,
+    const char * state_text,
+    const char * footer,
+    int32_t progress_permille,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_now_playing_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);
@@ -398,6 +414,49 @@ class LvglBinding:
 
     def playlist_destroy(self) -> None:
         self.lib.yoyopy_lvgl_playlist_destroy()
+
+    def now_playing_build(self) -> None:
+        if self.lib.yoyopy_lvgl_now_playing_build() != 0:
+            raise LvglBindingError(self.last_error())
+
+    def now_playing_sync(
+        self,
+        *,
+        title_text: str,
+        artist_text: str,
+        state_text: str,
+        footer: str,
+        progress_permille: int,
+        voip_state: int,
+        battery_percent: int,
+        charging: bool,
+        power_available: bool,
+        accent: tuple[int, int, int],
+    ) -> None:
+        title_raw = self.ffi.new("char[]", title_text.encode("utf-8"))
+        artist_raw = self.ffi.new("char[]", artist_text.encode("utf-8"))
+        state_raw = self.ffi.new("char[]", state_text.encode("utf-8"))
+        footer_raw = self.ffi.new("char[]", footer.encode("utf-8"))
+
+        result = self.lib.yoyopy_lvgl_now_playing_sync(
+            title_raw,
+            artist_raw,
+            state_raw,
+            footer_raw,
+            max(0, min(1000, int(progress_permille))),
+            voip_state,
+            battery_percent,
+            1 if charging else 0,
+            1 if power_available else 0,
+            accent[0],
+            accent[1],
+            accent[2],
+        )
+        if result != 0:
+            raise LvglBindingError(self.last_error())
+
+    def now_playing_destroy(self) -> None:
+        self.lib.yoyopy_lvgl_now_playing_destroy()
 
     def clear_screen(self) -> None:
         self.lib.yoyopy_lvgl_clear_screen()

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
@@ -71,6 +71,25 @@ typedef struct {
     lv_obj_t * footer_label;
 } yoyopy_playlist_scene_t;
 
+typedef struct {
+    int built;
+    lv_obj_t * screen;
+    lv_obj_t * voip_dot;
+    lv_obj_t * battery_outline;
+    lv_obj_t * battery_fill;
+    lv_obj_t * battery_tip;
+    lv_obj_t * panel;
+    lv_obj_t * icon_halo;
+    lv_obj_t * icon_label;
+    lv_obj_t * state_chip;
+    lv_obj_t * state_label;
+    lv_obj_t * title_label;
+    lv_obj_t * artist_label;
+    lv_obj_t * progress_track;
+    lv_obj_t * progress_fill;
+    lv_obj_t * footer_label;
+} yoyopy_now_playing_scene_t;
+
 static int g_initialized = 0;
 static lv_display_t * g_display = NULL;
 static lv_indev_t * g_indev = NULL;
@@ -87,6 +106,7 @@ static int g_key_count = 0;
 static yoyopy_hub_scene_t g_hub_scene = {0};
 static yoyopy_listen_scene_t g_listen_scene = {0};
 static yoyopy_playlist_scene_t g_playlist_scene = {0};
+static yoyopy_now_playing_scene_t g_now_playing_scene = {0};
 
 static lv_color_t yoyopy_color_rgb(uint8_t red, uint8_t green, uint8_t blue) {
     uint32_t raw = ((uint32_t)red << 16) | ((uint32_t)green << 8) | (uint32_t)blue;
@@ -121,10 +141,15 @@ static void yoyopy_reset_playlist_scene_refs(void) {
     memset(&g_playlist_scene, 0, sizeof(g_playlist_scene));
 }
 
+static void yoyopy_reset_now_playing_scene_refs(void) {
+    memset(&g_now_playing_scene, 0, sizeof(g_now_playing_scene));
+}
+
 static void yoyopy_reset_scene_refs(void) {
     yoyopy_reset_hub_scene_refs();
     yoyopy_reset_listen_scene_refs();
     yoyopy_reset_playlist_scene_refs();
+    yoyopy_reset_now_playing_scene_refs();
 }
 
 static void yoyopy_set_error(const char * message) {
@@ -1146,6 +1171,235 @@ void yoyopy_lvgl_playlist_destroy(void) {
     }
     yoyopy_clear_group();
     yoyopy_reset_playlist_scene_refs();
+}
+
+int yoyopy_lvgl_now_playing_build(void) {
+    if(!g_initialized || g_display == NULL) {
+        yoyopy_set_error("display must be registered before building the now-playing scene");
+        return -1;
+    }
+
+    if(g_now_playing_scene.built) {
+        return 0;
+    }
+
+    yoyopy_prepare_active_screen();
+
+    g_now_playing_scene.screen = lv_screen_active();
+    lv_obj_set_style_bg_color(g_now_playing_scene.screen, yoyopy_color_rgb(18, 21, 28), 0);
+    lv_obj_set_style_bg_opa(g_now_playing_scene.screen, LV_OPA_COVER, 0);
+
+    g_now_playing_scene.voip_dot = lv_obj_create(g_now_playing_scene.screen);
+    lv_obj_remove_style_all(g_now_playing_scene.voip_dot);
+    lv_obj_set_size(g_now_playing_scene.voip_dot, 8, 8);
+    lv_obj_set_style_radius(g_now_playing_scene.voip_dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_pos(g_now_playing_scene.voip_dot, 16, 10);
+
+    g_now_playing_scene.battery_outline = lv_obj_create(g_now_playing_scene.screen);
+    lv_obj_remove_style_all(g_now_playing_scene.battery_outline);
+    lv_obj_set_size(g_now_playing_scene.battery_outline, 20, 10);
+    lv_obj_set_pos(g_now_playing_scene.battery_outline, 202, 6);
+    lv_obj_set_style_border_width(g_now_playing_scene.battery_outline, 1, 0);
+    lv_obj_set_style_border_color(g_now_playing_scene.battery_outline, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_radius(g_now_playing_scene.battery_outline, 2, 0);
+    lv_obj_set_style_bg_opa(g_now_playing_scene.battery_outline, LV_OPA_TRANSP, 0);
+
+    g_now_playing_scene.battery_fill = lv_obj_create(g_now_playing_scene.battery_outline);
+    lv_obj_remove_style_all(g_now_playing_scene.battery_fill);
+    lv_obj_set_pos(g_now_playing_scene.battery_fill, 1, 1);
+    lv_obj_set_size(g_now_playing_scene.battery_fill, 18, 8);
+    lv_obj_set_style_radius(g_now_playing_scene.battery_fill, 1, 0);
+    lv_obj_set_style_bg_opa(g_now_playing_scene.battery_fill, LV_OPA_COVER, 0);
+
+    g_now_playing_scene.battery_tip = lv_obj_create(g_now_playing_scene.screen);
+    lv_obj_remove_style_all(g_now_playing_scene.battery_tip);
+    lv_obj_set_size(g_now_playing_scene.battery_tip, 2, 4);
+    lv_obj_set_pos(g_now_playing_scene.battery_tip, 222, 9);
+    lv_obj_set_style_bg_color(g_now_playing_scene.battery_tip, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_bg_opa(g_now_playing_scene.battery_tip, LV_OPA_COVER, 0);
+
+    g_now_playing_scene.panel = lv_obj_create(g_now_playing_scene.screen);
+    lv_obj_set_size(g_now_playing_scene.panel, 208, 194);
+    lv_obj_set_pos(g_now_playing_scene.panel, 16, 42);
+    lv_obj_set_style_radius(g_now_playing_scene.panel, 28, 0);
+    lv_obj_set_style_border_width(g_now_playing_scene.panel, 2, 0);
+    lv_obj_set_style_pad_all(g_now_playing_scene.panel, 0, 0);
+    lv_obj_set_style_shadow_width(g_now_playing_scene.panel, 0, 0);
+    lv_obj_set_style_outline_width(g_now_playing_scene.panel, 0, 0);
+    lv_obj_set_scrollbar_mode(g_now_playing_scene.panel, LV_SCROLLBAR_MODE_OFF);
+
+    g_now_playing_scene.icon_halo = lv_obj_create(g_now_playing_scene.panel);
+    lv_obj_set_size(g_now_playing_scene.icon_halo, 76, 58);
+    lv_obj_set_pos(g_now_playing_scene.icon_halo, 66, 16);
+    lv_obj_set_style_radius(g_now_playing_scene.icon_halo, 20, 0);
+    lv_obj_set_style_border_width(g_now_playing_scene.icon_halo, 2, 0);
+    lv_obj_set_style_shadow_width(g_now_playing_scene.icon_halo, 0, 0);
+    lv_obj_set_style_outline_width(g_now_playing_scene.icon_halo, 0, 0);
+    lv_obj_set_scrollbar_mode(g_now_playing_scene.icon_halo, LV_SCROLLBAR_MODE_OFF);
+
+    g_now_playing_scene.icon_label = lv_label_create(g_now_playing_scene.icon_halo);
+    lv_label_set_text(g_now_playing_scene.icon_label, LV_SYMBOL_AUDIO);
+    lv_obj_set_style_text_font(g_now_playing_scene.icon_label, &lv_font_montserrat_24, 0);
+    lv_obj_center(g_now_playing_scene.icon_label);
+
+    g_now_playing_scene.state_chip = lv_obj_create(g_now_playing_scene.panel);
+    lv_obj_set_size(g_now_playing_scene.state_chip, 92, 24);
+    lv_obj_set_pos(g_now_playing_scene.state_chip, 58, 84);
+    lv_obj_set_style_radius(g_now_playing_scene.state_chip, 12, 0);
+    lv_obj_set_style_border_width(g_now_playing_scene.state_chip, 0, 0);
+    lv_obj_set_style_pad_all(g_now_playing_scene.state_chip, 0, 0);
+    lv_obj_set_style_shadow_width(g_now_playing_scene.state_chip, 0, 0);
+    lv_obj_set_style_outline_width(g_now_playing_scene.state_chip, 0, 0);
+    lv_obj_set_scrollbar_mode(g_now_playing_scene.state_chip, LV_SCROLLBAR_MODE_OFF);
+
+    g_now_playing_scene.state_label = lv_label_create(g_now_playing_scene.state_chip);
+    lv_obj_set_style_text_font(g_now_playing_scene.state_label, &lv_font_montserrat_12, 0);
+    lv_obj_center(g_now_playing_scene.state_label);
+
+    g_now_playing_scene.title_label = lv_label_create(g_now_playing_scene.panel);
+    lv_obj_set_width(g_now_playing_scene.title_label, 176);
+    lv_obj_set_pos(g_now_playing_scene.title_label, 16, 118);
+    lv_label_set_long_mode(g_now_playing_scene.title_label, LV_LABEL_LONG_MODE_DOTS);
+    lv_obj_set_style_text_font(g_now_playing_scene.title_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_align(g_now_playing_scene.title_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_now_playing_scene.artist_label = lv_label_create(g_now_playing_scene.panel);
+    lv_obj_set_width(g_now_playing_scene.artist_label, 176);
+    lv_obj_set_pos(g_now_playing_scene.artist_label, 16, 148);
+    lv_label_set_long_mode(g_now_playing_scene.artist_label, LV_LABEL_LONG_MODE_DOTS);
+    lv_obj_set_style_text_font(g_now_playing_scene.artist_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_align(g_now_playing_scene.artist_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_now_playing_scene.progress_track = lv_obj_create(g_now_playing_scene.panel);
+    lv_obj_set_size(g_now_playing_scene.progress_track, 156, 8);
+    lv_obj_set_pos(g_now_playing_scene.progress_track, 26, 174);
+    lv_obj_set_style_radius(g_now_playing_scene.progress_track, 4, 0);
+    lv_obj_set_style_border_width(g_now_playing_scene.progress_track, 0, 0);
+    lv_obj_set_style_pad_all(g_now_playing_scene.progress_track, 0, 0);
+    lv_obj_set_style_shadow_width(g_now_playing_scene.progress_track, 0, 0);
+    lv_obj_set_style_outline_width(g_now_playing_scene.progress_track, 0, 0);
+    lv_obj_set_scrollbar_mode(g_now_playing_scene.progress_track, LV_SCROLLBAR_MODE_OFF);
+
+    g_now_playing_scene.progress_fill = lv_obj_create(g_now_playing_scene.progress_track);
+    lv_obj_set_size(g_now_playing_scene.progress_fill, 0, 8);
+    lv_obj_set_pos(g_now_playing_scene.progress_fill, 0, 0);
+    lv_obj_set_style_radius(g_now_playing_scene.progress_fill, 4, 0);
+    lv_obj_set_style_border_width(g_now_playing_scene.progress_fill, 0, 0);
+    lv_obj_set_style_pad_all(g_now_playing_scene.progress_fill, 0, 0);
+    lv_obj_set_style_shadow_width(g_now_playing_scene.progress_fill, 0, 0);
+    lv_obj_set_style_outline_width(g_now_playing_scene.progress_fill, 0, 0);
+    lv_obj_set_scrollbar_mode(g_now_playing_scene.progress_fill, LV_SCROLLBAR_MODE_OFF);
+
+    g_now_playing_scene.footer_label = lv_label_create(g_now_playing_scene.screen);
+    lv_obj_set_style_text_font(g_now_playing_scene.footer_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_now_playing_scene.footer_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(g_now_playing_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    g_now_playing_scene.built = 1;
+    return 0;
+}
+
+int yoyopy_lvgl_now_playing_sync(
+    const char * title_text,
+    const char * artist_text,
+    const char * state_text,
+    const char * footer,
+    int32_t progress_permille,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+) {
+    if(!g_now_playing_scene.built) {
+        yoyopy_set_error("now-playing scene must be built before sync");
+        return -1;
+    }
+
+    const lv_color_t background = yoyopy_color_rgb(18, 21, 28);
+    const lv_color_t surface = yoyopy_color_rgb(28, 33, 42);
+    const lv_color_t ink = yoyopy_color_rgb(243, 247, 250);
+    const lv_color_t muted = yoyopy_color_rgb(153, 160, 173);
+    const lv_color_t progress_bg = yoyopy_color_rgb(22, 25, 32);
+    const lv_color_t accent = yoyopy_color_rgb(accent_r, accent_g, accent_b);
+    const lv_color_t accent_dim = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 65);
+    const lv_color_t accent_soft = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 28, 33, 42, 55);
+    const lv_color_t halo_fill = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 80);
+    const lv_color_t halo_border = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 60);
+
+    if(progress_permille < 0) {
+        progress_permille = 0;
+    }
+    if(progress_permille > 1000) {
+        progress_permille = 1000;
+    }
+
+    lv_obj_set_style_bg_color(g_now_playing_scene.screen, background, 0);
+    lv_obj_set_style_bg_opa(g_now_playing_scene.screen, LV_OPA_COVER, 0);
+    yoyopy_apply_voip_dot(g_now_playing_scene.voip_dot, voip_state);
+    yoyopy_apply_battery(
+        g_now_playing_scene.battery_outline,
+        g_now_playing_scene.battery_fill,
+        g_now_playing_scene.battery_tip,
+        battery_percent,
+        charging,
+        power_available
+    );
+
+    lv_obj_set_style_bg_color(g_now_playing_scene.panel, surface, 0);
+    lv_obj_set_style_bg_opa(g_now_playing_scene.panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_now_playing_scene.panel, accent_dim, 0);
+
+    lv_obj_set_style_bg_color(g_now_playing_scene.icon_halo, halo_fill, 0);
+    lv_obj_set_style_bg_opa(g_now_playing_scene.icon_halo, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_now_playing_scene.icon_halo, halo_border, 0);
+    lv_obj_set_style_text_color(g_now_playing_scene.icon_label, accent, 0);
+    lv_obj_center(g_now_playing_scene.icon_label);
+
+    lv_obj_set_style_bg_color(g_now_playing_scene.state_chip, accent_dim, 0);
+    lv_obj_set_style_bg_opa(g_now_playing_scene.state_chip, LV_OPA_COVER, 0);
+    lv_label_set_text(g_now_playing_scene.state_label, state_text != NULL ? state_text : "");
+    lv_obj_set_style_text_color(g_now_playing_scene.state_label, accent, 0);
+    lv_obj_center(g_now_playing_scene.state_label);
+
+    lv_label_set_text(g_now_playing_scene.title_label, title_text != NULL ? title_text : "");
+    lv_obj_set_style_text_color(g_now_playing_scene.title_label, ink, 0);
+
+    lv_label_set_text(g_now_playing_scene.artist_label, artist_text != NULL ? artist_text : "");
+    lv_obj_set_style_text_color(g_now_playing_scene.artist_label, muted, 0);
+
+    lv_obj_set_style_bg_color(g_now_playing_scene.progress_track, progress_bg, 0);
+    lv_obj_set_style_bg_opa(g_now_playing_scene.progress_track, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(g_now_playing_scene.progress_fill, accent, 0);
+    lv_obj_set_style_bg_opa(g_now_playing_scene.progress_fill, LV_OPA_COVER, 0);
+
+    int fill_width = (156 * progress_permille) / 1000;
+    if(fill_width <= 0) {
+        lv_obj_add_flag(g_now_playing_scene.progress_fill, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_obj_clear_flag(g_now_playing_scene.progress_fill, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_size(g_now_playing_scene.progress_fill, fill_width, 8);
+    }
+
+    lv_label_set_text(g_now_playing_scene.footer_label, footer != NULL ? footer : "");
+    lv_obj_set_style_text_color(g_now_playing_scene.footer_label, accent_soft, 0);
+    lv_obj_align(g_now_playing_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    return 0;
+}
+
+void yoyopy_lvgl_now_playing_destroy(void) {
+    if(!g_now_playing_scene.built) {
+        return;
+    }
+
+    if(g_now_playing_scene.screen != NULL) {
+        lv_obj_clean(g_now_playing_scene.screen);
+    }
+    yoyopy_clear_group();
+    yoyopy_reset_now_playing_scene_refs();
 }
 
 int yoyopy_lvgl_init(void) {

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
@@ -111,6 +111,22 @@ int yoyopy_lvgl_playlist_sync(
     const char * empty_icon_key
 );
 void yoyopy_lvgl_playlist_destroy(void);
+int yoyopy_lvgl_now_playing_build(void);
+int yoyopy_lvgl_now_playing_sync(
+    const char * title_text,
+    const char * artist_text,
+    const char * state_text,
+    const char * footer,
+    int32_t progress_permille,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_now_playing_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);

--- a/yoyopy/ui/screens/music/lvgl/__init__.py
+++ b/yoyopy/ui/screens/music/lvgl/__init__.py
@@ -1,5 +1,6 @@
 """LVGL-backed music screen views."""
 
+from yoyopy.ui.screens.music.lvgl.now_playing_view import LvglNowPlayingView
 from yoyopy.ui.screens.music.lvgl.playlist_view import LvglPlaylistView
 
-__all__ = ["LvglPlaylistView"]
+__all__ = ["LvglNowPlayingView", "LvglPlaylistView"]

--- a/yoyopy/ui/screens/music/lvgl/now_playing_view.py
+++ b/yoyopy/ui/screens/music/lvgl/now_playing_view.py
@@ -1,0 +1,73 @@
+"""LVGL-backed view for the now-playing screen."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+from yoyopy.ui.screens.theme import LISTEN
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens.music.now_playing import NowPlayingScreen
+
+
+@dataclass(slots=True)
+class LvglNowPlayingView:
+    """Own the LVGL object lifecycle for NowPlayingScreen."""
+
+    screen: "NowPlayingScreen"
+    backend: LvglDisplayBackend
+    _built: bool = False
+
+    def build(self) -> None:
+        """Create the native now-playing scene once."""
+
+        if self._built or self.backend.binding is None:
+            return
+        self.backend.binding.now_playing_build()
+        self._built = True
+
+    def sync(self) -> None:
+        """Push the current playback controller state into the native scene."""
+
+        if not self._built or self.backend.binding is None:
+            return
+
+        track_title, artist, progress, state_label, _is_playing = self.screen._track_snapshot()
+        footer = "Tap skip / Play / Hold back" if self.screen.is_one_button_mode() else "A play | B back | X/Y tracks"
+        context = self.screen.context
+
+        self.backend.binding.now_playing_sync(
+            title_text=track_title,
+            artist_text=artist,
+            state_text=state_label,
+            footer=footer,
+            progress_permille=max(0, min(1000, int(progress * 1000))),
+            voip_state=self._voip_state(context),
+            battery_percent=self._battery_percent(context),
+            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            accent=LISTEN.accent,
+        )
+
+    def destroy(self) -> None:
+        """Tear down the native now-playing scene."""
+
+        if not self._built or self.backend.binding is None:
+            return
+        self.backend.binding.now_playing_destroy()
+        self._built = False
+
+    @staticmethod
+    def _battery_percent(context: "AppContext | None") -> int:
+        if context is None:
+            return 100
+        return max(0, min(100, int(getattr(context, "battery_percent", 100))))
+
+    @staticmethod
+    def _voip_state(context: "AppContext | None") -> int:
+        if context is None or not getattr(context, "voip_configured", False):
+            return 0
+        return 1 if getattr(context, "voip_ready", False) else 2

--- a/yoyopy/ui/screens/music/now_playing.py
+++ b/yoyopy/ui/screens/music/now_playing.py
@@ -6,10 +6,12 @@ from typing import TYPE_CHECKING, Optional
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.music.lvgl import LvglNowPlayingView
 from yoyopy.ui.screens.theme import INK, LISTEN, MUTED, SURFACE, draw_icon, render_footer, render_header, rounded_panel, text_fit
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens import ScreenView
 
 
 class NowPlayingScreen(Screen):
@@ -23,9 +25,43 @@ class NowPlayingScreen(Screen):
     ) -> None:
         super().__init__(display, context, "NowPlaying")
         self.mopidy_client = mopidy_client
+        self._lvgl_view: "ScreenView | None" = None
+
+    def enter(self) -> None:
+        """Create the LVGL view when the screen becomes active."""
+        super().enter()
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving now playing."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Create an LVGL view when the Whisplay renderer is active."""
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglNowPlayingView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
 
     def render(self) -> None:
         """Render the now-playing view."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
         track_title, artist, progress, state_label, _is_playing = self._track_snapshot()
 
         content_top = render_header(


### PR DESCRIPTION
## Summary
- add a native LVGL now-playing scene lifecycle to the shim and expose it through the CPython binding
- delegate NowPlayingScreen to a backend-specific LVGL view when the Whisplay renderer is LVGL
- add focused tests for LVGL now-playing delegation while preserving the current PIL fallback

## Verification
- python -m compileall yoyopy tests
- uv run pytest tests/test_now_playing_lvgl_view.py -q
- uv run pytest -q
- Pi hardware smoke on pi-zero with a real Whisplay LVGL render/update flow (LVGL_NOW_PLAYING_OK)