### PR TITLE
Add LVGL incoming-call screen

### DIFF
--- a/tests/test_incoming_call_lvgl_view.py
+++ b/tests/test_incoming_call_lvgl_view.py
@@ -1,0 +1,103 @@
+"""Focused tests for the LVGL-backed incoming-call screen delegation."""
+
+from __future__ import annotations
+
+from yoyopy.app_context import AppContext
+from yoyopy.ui.input import InteractionProfile
+from yoyopy.ui.screens import IncomingCallScreen
+
+
+class FakeLvglBinding:
+    """Small native-binding double for incoming-call view tests."""
+
+    def __init__(self) -> None:
+        self.incoming_call_build_calls = 0
+        self.incoming_call_destroy_calls = 0
+        self.incoming_call_sync_payloads: list[dict] = []
+
+    def incoming_call_build(self) -> None:
+        self.incoming_call_build_calls += 1
+
+    def incoming_call_sync(self, **payload) -> None:
+        self.incoming_call_sync_payloads.append(payload)
+
+    def incoming_call_destroy(self) -> None:
+        self.incoming_call_destroy_calls += 1
+
+
+class FakeLvglBackend:
+    """Minimal LVGL backend double exposed through Display.get_ui_backend()."""
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self.binding = binding
+        self.initialized = True
+
+
+class FakeLvglDisplay:
+    """Tiny Display double for LVGL incoming-call delegation tests."""
+
+    backend_kind = "lvgl"
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self._ui_backend = FakeLvglBackend(binding)
+
+    def get_ui_backend(self) -> FakeLvglBackend:
+        return self._ui_backend
+
+
+def test_incoming_call_screen_builds_syncs_and_destroys_lvgl_view() -> None:
+    """IncomingCallScreen should delegate lifecycle and caller state to LVGL."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+    context.update_voip_status(configured=True, ready=True)
+    context.battery_percent = 49
+    context.battery_charging = False
+    context.power_available = True
+
+    screen = IncomingCallScreen(
+        display,
+        context,
+        caller_address="sip:parent@example.com",
+        caller_name="Parent",
+    )
+
+    screen.enter()
+    screen.render()
+
+    assert binding.incoming_call_build_calls == 1
+    assert len(binding.incoming_call_sync_payloads) == 1
+    payload = binding.incoming_call_sync_payloads[-1]
+    assert payload["caller_name"] == "Parent"
+    assert payload["caller_address"] == "sip:parent@example.com"
+    assert payload["voip_state"] == 1
+    assert payload["battery_percent"] == 49
+    assert payload["charging"] is False
+    assert payload["power_available"] is True
+    assert payload["footer"] == "Open answer / Hold reject"
+
+    screen.exit()
+    assert binding.incoming_call_destroy_calls == 1
+
+
+def test_incoming_call_screen_uses_safe_unknown_defaults_through_lvgl() -> None:
+    """IncomingCallScreen should normalize missing caller details for LVGL."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+
+    screen = IncomingCallScreen(
+        display,
+        context,
+        caller_address="",
+        caller_name="",
+    )
+
+    screen.enter()
+    screen.render()
+
+    payload = binding.incoming_call_sync_payloads[-1]
+    assert payload["caller_name"] == "Unknown"
+    assert payload["caller_address"] == "Unknown"

--- a/yoyopy/ui/lvgl_binding/binding.py
+++ b/yoyopy/ui/lvgl_binding/binding.py
@@ -115,6 +115,20 @@ int yoyopy_lvgl_now_playing_sync(
     uint8_t accent_b
 );
 void yoyopy_lvgl_now_playing_destroy(void);
+int yoyopy_lvgl_incoming_call_build(void);
+int yoyopy_lvgl_incoming_call_sync(
+    const char * caller_name,
+    const char * caller_address,
+    const char * footer,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_incoming_call_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);
@@ -457,6 +471,44 @@ class LvglBinding:
 
     def now_playing_destroy(self) -> None:
         self.lib.yoyopy_lvgl_now_playing_destroy()
+
+    def incoming_call_build(self) -> None:
+        if self.lib.yoyopy_lvgl_incoming_call_build() != 0:
+            raise LvglBindingError(self.last_error())
+
+    def incoming_call_sync(
+        self,
+        *,
+        caller_name: str,
+        caller_address: str,
+        footer: str,
+        voip_state: int,
+        battery_percent: int,
+        charging: bool,
+        power_available: bool,
+        accent: tuple[int, int, int],
+    ) -> None:
+        caller_name_raw = self.ffi.new("char[]", caller_name.encode("utf-8"))
+        caller_address_raw = self.ffi.new("char[]", caller_address.encode("utf-8"))
+        footer_raw = self.ffi.new("char[]", footer.encode("utf-8"))
+
+        result = self.lib.yoyopy_lvgl_incoming_call_sync(
+            caller_name_raw,
+            caller_address_raw,
+            footer_raw,
+            voip_state,
+            battery_percent,
+            1 if charging else 0,
+            1 if power_available else 0,
+            accent[0],
+            accent[1],
+            accent[2],
+        )
+        if result != 0:
+            raise LvglBindingError(self.last_error())
+
+    def incoming_call_destroy(self) -> None:
+        self.lib.yoyopy_lvgl_incoming_call_destroy()
 
     def clear_screen(self) -> None:
         self.lib.yoyopy_lvgl_clear_screen()

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
@@ -90,6 +90,22 @@ typedef struct {
     lv_obj_t * footer_label;
 } yoyopy_now_playing_scene_t;
 
+typedef struct {
+    int built;
+    lv_obj_t * screen;
+    lv_obj_t * voip_dot;
+    lv_obj_t * battery_outline;
+    lv_obj_t * battery_fill;
+    lv_obj_t * battery_tip;
+    lv_obj_t * panel;
+    lv_obj_t * icon_halo;
+    lv_obj_t * icon_label;
+    lv_obj_t * state_label;
+    lv_obj_t * caller_name_label;
+    lv_obj_t * caller_address_label;
+    lv_obj_t * footer_label;
+} yoyopy_incoming_call_scene_t;
+
 static int g_initialized = 0;
 static lv_display_t * g_display = NULL;
 static lv_indev_t * g_indev = NULL;
@@ -107,6 +123,7 @@ static yoyopy_hub_scene_t g_hub_scene = {0};
 static yoyopy_listen_scene_t g_listen_scene = {0};
 static yoyopy_playlist_scene_t g_playlist_scene = {0};
 static yoyopy_now_playing_scene_t g_now_playing_scene = {0};
+static yoyopy_incoming_call_scene_t g_incoming_call_scene = {0};
 
 static lv_color_t yoyopy_color_rgb(uint8_t red, uint8_t green, uint8_t blue) {
     uint32_t raw = ((uint32_t)red << 16) | ((uint32_t)green << 8) | (uint32_t)blue;
@@ -145,11 +162,16 @@ static void yoyopy_reset_now_playing_scene_refs(void) {
     memset(&g_now_playing_scene, 0, sizeof(g_now_playing_scene));
 }
 
+static void yoyopy_reset_incoming_call_scene_refs(void) {
+    memset(&g_incoming_call_scene, 0, sizeof(g_incoming_call_scene));
+}
+
 static void yoyopy_reset_scene_refs(void) {
     yoyopy_reset_hub_scene_refs();
     yoyopy_reset_listen_scene_refs();
     yoyopy_reset_playlist_scene_refs();
     yoyopy_reset_now_playing_scene_refs();
+    yoyopy_reset_incoming_call_scene_refs();
 }
 
 static void yoyopy_set_error(const char * message) {
@@ -1400,6 +1422,178 @@ void yoyopy_lvgl_now_playing_destroy(void) {
     }
     yoyopy_clear_group();
     yoyopy_reset_now_playing_scene_refs();
+}
+
+int yoyopy_lvgl_incoming_call_build(void) {
+    if(!g_initialized || g_display == NULL) {
+        yoyopy_set_error("display must be registered before building the incoming-call scene");
+        return -1;
+    }
+
+    if(g_incoming_call_scene.built) {
+        return 0;
+    }
+
+    yoyopy_prepare_active_screen();
+
+    g_incoming_call_scene.screen = lv_screen_active();
+    lv_obj_set_style_bg_color(g_incoming_call_scene.screen, yoyopy_color_rgb(18, 21, 28), 0);
+    lv_obj_set_style_bg_opa(g_incoming_call_scene.screen, LV_OPA_COVER, 0);
+
+    g_incoming_call_scene.voip_dot = lv_obj_create(g_incoming_call_scene.screen);
+    lv_obj_remove_style_all(g_incoming_call_scene.voip_dot);
+    lv_obj_set_size(g_incoming_call_scene.voip_dot, 8, 8);
+    lv_obj_set_style_radius(g_incoming_call_scene.voip_dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_pos(g_incoming_call_scene.voip_dot, 16, 10);
+
+    g_incoming_call_scene.battery_outline = lv_obj_create(g_incoming_call_scene.screen);
+    lv_obj_remove_style_all(g_incoming_call_scene.battery_outline);
+    lv_obj_set_size(g_incoming_call_scene.battery_outline, 20, 10);
+    lv_obj_set_pos(g_incoming_call_scene.battery_outline, 202, 6);
+    lv_obj_set_style_border_width(g_incoming_call_scene.battery_outline, 1, 0);
+    lv_obj_set_style_border_color(g_incoming_call_scene.battery_outline, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_radius(g_incoming_call_scene.battery_outline, 2, 0);
+    lv_obj_set_style_bg_opa(g_incoming_call_scene.battery_outline, LV_OPA_TRANSP, 0);
+
+    g_incoming_call_scene.battery_fill = lv_obj_create(g_incoming_call_scene.battery_outline);
+    lv_obj_remove_style_all(g_incoming_call_scene.battery_fill);
+    lv_obj_set_pos(g_incoming_call_scene.battery_fill, 1, 1);
+    lv_obj_set_size(g_incoming_call_scene.battery_fill, 18, 8);
+    lv_obj_set_style_radius(g_incoming_call_scene.battery_fill, 1, 0);
+    lv_obj_set_style_bg_opa(g_incoming_call_scene.battery_fill, LV_OPA_COVER, 0);
+
+    g_incoming_call_scene.battery_tip = lv_obj_create(g_incoming_call_scene.screen);
+    lv_obj_remove_style_all(g_incoming_call_scene.battery_tip);
+    lv_obj_set_size(g_incoming_call_scene.battery_tip, 2, 4);
+    lv_obj_set_pos(g_incoming_call_scene.battery_tip, 222, 9);
+    lv_obj_set_style_bg_color(g_incoming_call_scene.battery_tip, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_bg_opa(g_incoming_call_scene.battery_tip, LV_OPA_COVER, 0);
+
+    g_incoming_call_scene.panel = lv_obj_create(g_incoming_call_scene.screen);
+    lv_obj_set_size(g_incoming_call_scene.panel, 208, 194);
+    lv_obj_set_pos(g_incoming_call_scene.panel, 16, 42);
+    lv_obj_set_style_radius(g_incoming_call_scene.panel, 28, 0);
+    lv_obj_set_style_border_width(g_incoming_call_scene.panel, 2, 0);
+    lv_obj_set_style_pad_all(g_incoming_call_scene.panel, 0, 0);
+    lv_obj_set_style_shadow_width(g_incoming_call_scene.panel, 0, 0);
+    lv_obj_set_style_outline_width(g_incoming_call_scene.panel, 0, 0);
+    lv_obj_set_scrollbar_mode(g_incoming_call_scene.panel, LV_SCROLLBAR_MODE_OFF);
+
+    g_incoming_call_scene.icon_halo = lv_obj_create(g_incoming_call_scene.panel);
+    lv_obj_set_size(g_incoming_call_scene.icon_halo, 76, 58);
+    lv_obj_set_pos(g_incoming_call_scene.icon_halo, 66, 18);
+    lv_obj_set_style_radius(g_incoming_call_scene.icon_halo, 20, 0);
+    lv_obj_set_style_border_width(g_incoming_call_scene.icon_halo, 2, 0);
+    lv_obj_set_style_shadow_width(g_incoming_call_scene.icon_halo, 0, 0);
+    lv_obj_set_style_outline_width(g_incoming_call_scene.icon_halo, 0, 0);
+    lv_obj_set_scrollbar_mode(g_incoming_call_scene.icon_halo, LV_SCROLLBAR_MODE_OFF);
+
+    g_incoming_call_scene.icon_label = lv_label_create(g_incoming_call_scene.icon_halo);
+    lv_label_set_text(g_incoming_call_scene.icon_label, LV_SYMBOL_CALL);
+    lv_obj_set_style_text_font(g_incoming_call_scene.icon_label, &lv_font_montserrat_24, 0);
+    lv_obj_center(g_incoming_call_scene.icon_label);
+
+    g_incoming_call_scene.state_label = lv_label_create(g_incoming_call_scene.panel);
+    lv_label_set_text(g_incoming_call_scene.state_label, "Incoming");
+    lv_obj_set_width(g_incoming_call_scene.state_label, 160);
+    lv_obj_set_pos(g_incoming_call_scene.state_label, 24, 88);
+    lv_obj_set_style_text_font(g_incoming_call_scene.state_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_align(g_incoming_call_scene.state_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_incoming_call_scene.caller_name_label = lv_label_create(g_incoming_call_scene.panel);
+    lv_obj_set_width(g_incoming_call_scene.caller_name_label, 176);
+    lv_obj_set_pos(g_incoming_call_scene.caller_name_label, 16, 114);
+    lv_label_set_long_mode(g_incoming_call_scene.caller_name_label, LV_LABEL_LONG_MODE_DOTS);
+    lv_obj_set_style_text_font(g_incoming_call_scene.caller_name_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_align(g_incoming_call_scene.caller_name_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_incoming_call_scene.caller_address_label = lv_label_create(g_incoming_call_scene.panel);
+    lv_obj_set_width(g_incoming_call_scene.caller_address_label, 176);
+    lv_obj_set_pos(g_incoming_call_scene.caller_address_label, 16, 148);
+    lv_label_set_long_mode(g_incoming_call_scene.caller_address_label, LV_LABEL_LONG_MODE_DOTS);
+    lv_obj_set_style_text_font(g_incoming_call_scene.caller_address_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_incoming_call_scene.caller_address_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_incoming_call_scene.footer_label = lv_label_create(g_incoming_call_scene.screen);
+    lv_obj_set_style_text_font(g_incoming_call_scene.footer_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_incoming_call_scene.footer_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(g_incoming_call_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    g_incoming_call_scene.built = 1;
+    return 0;
+}
+
+int yoyopy_lvgl_incoming_call_sync(
+    const char * caller_name,
+    const char * caller_address,
+    const char * footer,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+) {
+    if(!g_incoming_call_scene.built) {
+        yoyopy_set_error("incoming-call scene must be built before sync");
+        return -1;
+    }
+
+    const lv_color_t background = yoyopy_color_rgb(18, 21, 28);
+    const lv_color_t surface = yoyopy_color_rgb(32, 35, 42);
+    const lv_color_t ink = yoyopy_color_rgb(243, 247, 250);
+    const lv_color_t muted = yoyopy_color_rgb(153, 160, 173);
+    const lv_color_t accent = yoyopy_color_rgb(accent_r, accent_g, accent_b);
+    const lv_color_t accent_dim = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 65);
+    const lv_color_t halo_fill = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 80);
+    const lv_color_t halo_border = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 60);
+
+    lv_obj_set_style_bg_color(g_incoming_call_scene.screen, background, 0);
+    lv_obj_set_style_bg_opa(g_incoming_call_scene.screen, LV_OPA_COVER, 0);
+    yoyopy_apply_voip_dot(g_incoming_call_scene.voip_dot, voip_state);
+    yoyopy_apply_battery(
+        g_incoming_call_scene.battery_outline,
+        g_incoming_call_scene.battery_fill,
+        g_incoming_call_scene.battery_tip,
+        battery_percent,
+        charging,
+        power_available
+    );
+
+    lv_obj_set_style_bg_color(g_incoming_call_scene.panel, surface, 0);
+    lv_obj_set_style_bg_opa(g_incoming_call_scene.panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_incoming_call_scene.panel, accent_dim, 0);
+
+    lv_obj_set_style_bg_color(g_incoming_call_scene.icon_halo, halo_fill, 0);
+    lv_obj_set_style_bg_opa(g_incoming_call_scene.icon_halo, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_incoming_call_scene.icon_halo, halo_border, 0);
+    lv_obj_set_style_text_color(g_incoming_call_scene.icon_label, accent, 0);
+    lv_obj_center(g_incoming_call_scene.icon_label);
+
+    lv_obj_set_style_text_color(g_incoming_call_scene.state_label, accent, 0);
+    lv_label_set_text(g_incoming_call_scene.caller_name_label, caller_name != NULL ? caller_name : "");
+    lv_obj_set_style_text_color(g_incoming_call_scene.caller_name_label, ink, 0);
+    lv_label_set_text(g_incoming_call_scene.caller_address_label, caller_address != NULL ? caller_address : "");
+    lv_obj_set_style_text_color(g_incoming_call_scene.caller_address_label, muted, 0);
+
+    lv_label_set_text(g_incoming_call_scene.footer_label, footer != NULL ? footer : "");
+    lv_obj_set_style_text_color(g_incoming_call_scene.footer_label, accent_dim, 0);
+    lv_obj_align(g_incoming_call_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    return 0;
+}
+
+void yoyopy_lvgl_incoming_call_destroy(void) {
+    if(!g_incoming_call_scene.built) {
+        return;
+    }
+
+    if(g_incoming_call_scene.screen != NULL) {
+        lv_obj_clean(g_incoming_call_scene.screen);
+    }
+    yoyopy_clear_group();
+    yoyopy_reset_incoming_call_scene_refs();
 }
 
 int yoyopy_lvgl_init(void) {

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
@@ -127,6 +127,20 @@ int yoyopy_lvgl_now_playing_sync(
     uint8_t accent_b
 );
 void yoyopy_lvgl_now_playing_destroy(void);
+int yoyopy_lvgl_incoming_call_build(void);
+int yoyopy_lvgl_incoming_call_sync(
+    const char * caller_name,
+    const char * caller_address,
+    const char * footer,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_incoming_call_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);

--- a/yoyopy/ui/screens/voip/incoming_call.py
+++ b/yoyopy/ui/screens/voip/incoming_call.py
@@ -8,10 +8,12 @@ from loguru import logger
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.voip.lvgl import LvglIncomingCallView
 from yoyopy.ui.screens.theme import INK, MUTED, TALK, draw_icon, render_footer, render_header, rounded_panel, text_fit, wrap_text
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens import ScreenView
 
 
 class IncomingCallScreen(Screen):
@@ -30,14 +32,48 @@ class IncomingCallScreen(Screen):
         self.caller_address = caller_address
         self.caller_name = caller_name
         self.ring_animation_frame = 0
+        self._lvgl_view: "ScreenView | None" = None
+
+    def enter(self) -> None:
+        """Create the LVGL view when the screen becomes active."""
+        super().enter()
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving incoming call."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Create an LVGL view when the Whisplay renderer is active."""
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglIncomingCallView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
 
     def render(self) -> None:
         """Render the incoming call screen."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
         content_top = render_header(
             self.display,
             self.context,
             mode="talk",
-            title="Incoming call",
+            title="Incoming",
             show_time=False,
             show_mode_chip=False,
         )
@@ -65,28 +101,15 @@ class IncomingCallScreen(Screen):
         name_width, name_height = self.display.get_text_size(display_name, 20)
         self.display.text(display_name, (self.display.WIDTH - name_width) // 2, panel_top + 76, color=INK, font_size=20)
 
-        lines = wrap_text(self.display, self.caller_address or "Unknown address", self.display.WIDTH - 56, 11, max_lines=2)
+        lines = wrap_text(self.display, self.caller_address or "Unknown", self.display.WIDTH - 56, 11, max_lines=1)
         line_y = panel_top + 106
         for line in lines:
             width, _ = self.display.get_text_size(line, 11)
             self.display.text(line, (self.display.WIDTH - width) // 2, line_y, color=MUTED, font_size=11)
             line_y += 13
 
-        rounded_panel(
-            self.display,
-            28,
-            panel_bottom - 58,
-            self.display.WIDTH - 28,
-            panel_bottom - 18,
-            fill=(24, 27, 33),
-            outline=None,
-            radius=18,
-        )
-        answer_line = "Double answer" if self.is_one_button_mode() else "A answer"
-        reject_line = "Hold reject" if self.is_one_button_mode() else "B reject"
-        self.display.text(answer_line, 40, panel_bottom - 48, color=TALK.accent, font_size=12)
-        self.display.text(reject_line, 40, panel_bottom - 32, color=(255, 103, 93), font_size=12)
-
+        footer = "Open answer / Hold reject" if self.is_one_button_mode() else "A answer | B reject"
+        render_footer(self.display, footer, mode="talk")
         self.display.update()
 
     def _answer_call(self) -> None:

--- a/yoyopy/ui/screens/voip/lvgl/__init__.py
+++ b/yoyopy/ui/screens/voip/lvgl/__init__.py
@@ -1,0 +1,5 @@
+"""LVGL-backed VoIP screen views."""
+
+from yoyopy.ui.screens.voip.lvgl.incoming_call_view import LvglIncomingCallView
+
+__all__ = ["LvglIncomingCallView"]

--- a/yoyopy/ui/screens/voip/lvgl/incoming_call_view.py
+++ b/yoyopy/ui/screens/voip/lvgl/incoming_call_view.py
@@ -1,0 +1,70 @@
+"""LVGL-backed view for the incoming-call screen."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+from yoyopy.ui.screens.theme import TALK
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens.voip.incoming_call import IncomingCallScreen
+
+
+@dataclass(slots=True)
+class LvglIncomingCallView:
+    """Own the LVGL object lifecycle for IncomingCallScreen."""
+
+    screen: "IncomingCallScreen"
+    backend: LvglDisplayBackend
+    _built: bool = False
+
+    def build(self) -> None:
+        """Create the native incoming-call scene once."""
+
+        if self._built or self.backend.binding is None:
+            return
+        self.backend.binding.incoming_call_build()
+        self._built = True
+
+    def sync(self) -> None:
+        """Push the current caller state into the native scene."""
+
+        if not self._built or self.backend.binding is None:
+            return
+
+        footer = "Open answer / Hold reject" if self.screen.is_one_button_mode() else "A answer | B reject"
+        context = self.screen.context
+
+        self.backend.binding.incoming_call_sync(
+            caller_name=self.screen.caller_name or "Unknown",
+            caller_address=self.screen.caller_address or "Unknown",
+            footer=footer,
+            voip_state=self._voip_state(context),
+            battery_percent=self._battery_percent(context),
+            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            accent=TALK.accent,
+        )
+
+    def destroy(self) -> None:
+        """Tear down the native incoming-call scene."""
+
+        if not self._built or self.backend.binding is None:
+            return
+        self.backend.binding.incoming_call_destroy()
+        self._built = False
+
+    @staticmethod
+    def _battery_percent(context: "AppContext | None") -> int:
+        if context is None:
+            return 100
+        return max(0, min(100, int(getattr(context, "battery_percent", 100))))
+
+    @staticmethod
+    def _voip_state(context: "AppContext | None") -> int:
+        if context is None or not getattr(context, "voip_configured", False):
+            return 0
+        return 1 if getattr(context, "voip_ready", False) else 2


### PR DESCRIPTION
## Summary
- add a native LVGL incoming-call scene lifecycle to the shim and expose it through the CPython binding
- delegate IncomingCallScreen to a backend-specific LVGL view when the Whisplay renderer is LVGL
- trim the incoming-call copy so the screen stays focused on caller identity and the answer/reject action only

## Verification
- python -m compileall yoyopy tests
- uv run pytest tests/test_incoming_call_lvgl_view.py -q
- uv run pytest -q
- Pi hardware smoke on pi-zero with a real Whisplay LVGL render/update flow (LVGL_INCOMING_CALL_OK)