### PR TITLE
Complete Whisplay LVGL Cutover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
   - RTC helpers
   - PiSugar software watchdog support
 - Production Raspberry Pi deployment now has a committed systemd unit template under `deploy/systemd/`.
+- Whisplay now has an in-progress LVGL rendering path under `yoyopy/ui/lvgl_binding/`, and the Whisplay renderer default is `lvgl`.
 - CI validates the Python test suite with `uv sync --extra dev` and `uv run pytest -q`.
 - Raspberry Pi validation has a defined path through `scripts/pi_smoke.py` and `scripts/pi_remote.py`.
 
@@ -55,11 +56,13 @@ When in doubt, trust these files first:
 - `yoyopy/voip/`
 - `yoyopy/power/`
 - `yoyopy/ui/display/`
+- `yoyopy/ui/lvgl_binding/`
 - `yoyopy/ui/input/`
 - `yoyopy/ui/screens/`
 - `README.md`
 - `docs/SYSTEM_ARCHITECTURE.md`
 - `docs/POWER_MODULE.md`
+- `docs/LVGL_MIGRATION_PLAN.md`
 
 ---
 
@@ -140,6 +143,7 @@ Key design points:
 ### UI
 
 - `yoyopy/ui/display/` - display HAL, factory, facade, and adapters
+- `yoyopy/ui/lvgl_binding/` - native LVGL shim, CPython binding, backend bridge, and input bridge
 - `yoyopy/ui/input/` - input HAL, factory, manager, and adapters
 - `yoyopy/ui/screens/manager.py` - stack navigation and input binding
 - `yoyopy/ui/screens/router.py` - declarative route resolution

--- a/config/yoyopod_config.yaml
+++ b/config/yoyopod_config.yaml
@@ -66,7 +66,7 @@ power:
 # Display Settings
 display:
   hardware: "auto"                # auto, whisplay, pimoroni, simulation
-  whisplay_renderer: "pil"        # pil, lvgl (Whisplay-only; LVGL is experimental during migration)
+  whisplay_renderer: "lvgl"       # pil, lvgl (Whisplay defaults to LVGL; PIL remains for fallback/debug)
   brightness: 80                  # 0-100
   rotation: 0                     # 0, 90, 180, 270
   backlight_timeout_seconds: 60   # Turn off backlight after 1 min

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -48,7 +48,7 @@ def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> Non
     assert settings.power.watchdog_i2c_bus == 1
     assert settings.power.watchdog_i2c_address == 0x57
     assert settings.display.hardware == "auto"
-    assert settings.display.whisplay_renderer == "pil"
+    assert settings.display.whisplay_renderer == "lvgl"
 
 
 def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) -> None:

--- a/tests/test_remaining_lvgl_views.py
+++ b/tests/test_remaining_lvgl_views.py
@@ -1,0 +1,362 @@
+"""Focused tests for the remaining LVGL-backed screen delegations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from yoyopy.app_context import AppContext
+from yoyopy.ui.input import InteractionProfile
+from yoyopy.ui.screens import AskScreen, CallScreen, ContactListScreen, InCallScreen, OutgoingCallScreen, PowerScreen
+
+
+class FakeLvglBinding:
+    """Small native-binding double for the remaining LVGL views."""
+
+    def __init__(self) -> None:
+        self.playlist_build_calls = 0
+        self.playlist_destroy_calls = 0
+        self.playlist_sync_payloads: list[dict] = []
+        self.outgoing_call_build_calls = 0
+        self.outgoing_call_destroy_calls = 0
+        self.outgoing_call_sync_payloads: list[dict] = []
+        self.in_call_build_calls = 0
+        self.in_call_destroy_calls = 0
+        self.in_call_sync_payloads: list[dict] = []
+        self.ask_build_calls = 0
+        self.ask_destroy_calls = 0
+        self.ask_sync_payloads: list[dict] = []
+        self.power_build_calls = 0
+        self.power_destroy_calls = 0
+        self.power_sync_payloads: list[dict] = []
+
+    def playlist_build(self) -> None:
+        self.playlist_build_calls += 1
+
+    def playlist_sync(self, **payload) -> None:
+        self.playlist_sync_payloads.append(payload)
+
+    def playlist_destroy(self) -> None:
+        self.playlist_destroy_calls += 1
+
+    def outgoing_call_build(self) -> None:
+        self.outgoing_call_build_calls += 1
+
+    def outgoing_call_sync(self, **payload) -> None:
+        self.outgoing_call_sync_payloads.append(payload)
+
+    def outgoing_call_destroy(self) -> None:
+        self.outgoing_call_destroy_calls += 1
+
+    def in_call_build(self) -> None:
+        self.in_call_build_calls += 1
+
+    def in_call_sync(self, **payload) -> None:
+        self.in_call_sync_payloads.append(payload)
+
+    def in_call_destroy(self) -> None:
+        self.in_call_destroy_calls += 1
+
+    def ask_build(self) -> None:
+        self.ask_build_calls += 1
+
+    def ask_sync(self, **payload) -> None:
+        self.ask_sync_payloads.append(payload)
+
+    def ask_destroy(self) -> None:
+        self.ask_destroy_calls += 1
+
+    def power_build(self) -> None:
+        self.power_build_calls += 1
+
+    def power_sync(self, **payload) -> None:
+        self.power_sync_payloads.append(payload)
+
+    def power_destroy(self) -> None:
+        self.power_destroy_calls += 1
+
+
+class FakeLvglBackend:
+    """Minimal LVGL backend double exposed through Display.get_ui_backend()."""
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self.binding = binding
+        self.initialized = True
+
+
+class FakeLvglDisplay:
+    """Tiny Display double for LVGL screen delegation tests."""
+
+    backend_kind = "lvgl"
+    COLOR_RED = (255, 0, 0)
+    COLOR_GREEN = (0, 255, 0)
+    COLOR_YELLOW = (255, 255, 0)
+    COLOR_GRAY = (128, 128, 128)
+
+    def __init__(self, binding: FakeLvglBinding) -> None:
+        self._ui_backend = FakeLvglBackend(binding)
+
+    def get_ui_backend(self) -> FakeLvglBackend:
+        return self._ui_backend
+
+    def is_portrait(self) -> bool:
+        return True
+
+
+@dataclass(slots=True)
+class FakeContact:
+    """Minimal contact model for Talk screen tests."""
+
+    name: str
+    sip_address: str
+    favorite: bool = False
+
+
+class FakeConfigManager:
+    """Minimal config manager returning a stable contact list."""
+
+    def __init__(self, contacts: list[FakeContact]) -> None:
+        self._contacts = list(contacts)
+
+    def get_contacts(self) -> list[FakeContact]:
+        return list(self._contacts)
+
+
+class FakeVoipManager:
+    """Minimal VoIP manager for Talk/call LVGL delegation tests."""
+
+    def __init__(
+        self,
+        *,
+        status: dict | None = None,
+        caller_info: dict | None = None,
+        duration_seconds: int = 0,
+        muted: bool = False,
+    ) -> None:
+        self._status = status or {
+            "sip_identity": "sip:kid@example.com",
+            "running": True,
+            "registered": True,
+            "registration_state": "ok",
+            "call_state": "idle",
+        }
+        self._caller_info = caller_info or {}
+        self._duration_seconds = duration_seconds
+        self.is_muted = muted
+
+    def get_status(self) -> dict:
+        return dict(self._status)
+
+    def get_caller_info(self) -> dict:
+        return dict(self._caller_info)
+
+    def get_call_duration(self) -> int:
+        return self._duration_seconds
+
+
+def make_one_button_context() -> AppContext:
+    """Create a stable one-button app context for LVGL tests."""
+
+    context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+    context.update_voip_status(configured=True, ready=True)
+    context.battery_percent = 64
+    context.battery_charging = False
+    context.power_available = True
+    return context
+
+
+def test_call_screen_builds_syncs_and_destroys_lvgl_view() -> None:
+    """CallScreen should delegate the Talk hub list state through LVGL."""
+
+    binding = FakeLvglBinding()
+    screen = CallScreen(
+        FakeLvglDisplay(binding),
+        make_one_button_context(),
+        voip_manager=FakeVoipManager(),
+        config_manager=FakeConfigManager(
+            [
+                FakeContact("Echo Test Service", "sip:echo@sip.linphone.org", True),
+                FakeContact("Hagar", "sip:hagar@example.com", True),
+            ]
+        ),
+    )
+
+    screen.enter()
+    screen.render()
+
+    assert binding.playlist_build_calls == 1
+    payload = binding.playlist_sync_payloads[-1]
+    assert payload["title_text"] == "Calls ready"
+    assert payload["page_text"] == "1/2"
+    assert payload["items"] == ["Echo Test Service", "Hagar"]
+    assert payload["badges"] == ["FAV", "FAV"]
+    assert payload["selected_visible_index"] == 0
+
+    screen.on_advance()
+    screen.render()
+
+    payload = binding.playlist_sync_payloads[-1]
+    assert payload["page_text"] == "2/2"
+    assert payload["selected_visible_index"] == 1
+
+    screen.exit()
+    assert binding.playlist_destroy_calls == 1
+
+
+def test_contact_list_screen_syncs_sorted_contacts_through_lvgl() -> None:
+    """ContactListScreen should delegate its visible list window to LVGL."""
+
+    binding = FakeLvglBinding()
+    screen = ContactListScreen(
+        FakeLvglDisplay(binding),
+        make_one_button_context(),
+        voip_manager=FakeVoipManager(),
+        config_manager=FakeConfigManager(
+            [
+                FakeContact("Zed", "sip:zed@example.com", False),
+                FakeContact("Amy", "sip:amy@example.com", True),
+                FakeContact("Mona", "sip:mona@example.com", False),
+            ]
+        ),
+    )
+
+    screen.enter()
+    screen.render()
+
+    assert binding.playlist_build_calls == 1
+    payload = binding.playlist_sync_payloads[-1]
+    assert payload["title_text"] == "Contacts"
+    assert payload["page_text"] == "1/3"
+    assert payload["items"] == ["Amy", "Mona", "Zed"]
+    assert payload["badges"] == ["FAV", "", ""]
+
+    screen.exit()
+    assert binding.playlist_destroy_calls == 1
+
+
+def test_outgoing_call_screen_syncs_current_callee_through_lvgl() -> None:
+    """OutgoingCallScreen should send callee and footer state through LVGL."""
+
+    binding = FakeLvglBinding()
+    screen = OutgoingCallScreen(
+        FakeLvglDisplay(binding),
+        make_one_button_context(),
+        voip_manager=FakeVoipManager(
+            caller_info={
+                "display_name": "Parent",
+                "address": "sip:parent@example.com",
+            }
+        ),
+    )
+
+    screen.enter()
+    screen.render()
+
+    assert binding.outgoing_call_build_calls == 1
+    payload = binding.outgoing_call_sync_payloads[-1]
+    assert payload["callee_name"] == "Parent"
+    assert payload["callee_address"] == "sip:parent@example.com"
+    assert payload["footer"] == "Hold cancel"
+
+    screen.exit()
+    assert binding.outgoing_call_destroy_calls == 1
+
+
+def test_in_call_screen_syncs_duration_and_mute_state_through_lvgl() -> None:
+    """InCallScreen should delegate live call state through LVGL."""
+
+    binding = FakeLvglBinding()
+    screen = InCallScreen(
+        FakeLvglDisplay(binding),
+        make_one_button_context(),
+        voip_manager=FakeVoipManager(
+            caller_info={"display_name": "Parent"},
+            duration_seconds=83,
+            muted=True,
+        ),
+    )
+
+    screen.enter()
+    screen.render()
+
+    assert binding.in_call_build_calls == 1
+    payload = binding.in_call_sync_payloads[-1]
+    assert payload["caller_name"] == "Parent"
+    assert payload["duration_text"] == "01:23"
+    assert payload["mute_text"] == "Muted"
+    assert payload["muted"] is True
+    assert payload["footer"] == "Tap unmute / Hold end"
+
+    screen.exit()
+    assert binding.in_call_destroy_calls == 1
+
+
+def test_ask_screen_syncs_minimal_placeholder_through_lvgl() -> None:
+    """AskScreen should keep its LVGL payload intentionally minimal."""
+
+    binding = FakeLvglBinding()
+    screen = AskScreen(FakeLvglDisplay(binding), make_one_button_context())
+
+    screen.enter()
+    screen.render()
+
+    assert binding.ask_build_calls == 1
+    payload = binding.ask_sync_payloads[-1]
+    assert payload["title_text"] == "Coming soon"
+    assert payload["subtitle_text"] == "Safe questions later."
+    assert payload["footer"] == "Hold back"
+
+    screen.exit()
+    assert binding.ask_destroy_calls == 1
+
+
+def test_power_screen_cycles_three_lvgl_pages() -> None:
+    """PowerScreen should expose all three Setup pages through LVGL."""
+
+    binding = FakeLvglBinding()
+    screen = PowerScreen(
+        FakeLvglDisplay(binding),
+        make_one_button_context(),
+        power_manager=None,
+        status_provider=lambda: {
+            "app_uptime_seconds": 99,
+            "screen_awake": True,
+            "screen_on_seconds": 42,
+            "screen_idle_seconds": 3,
+            "screen_timeout_seconds": 60,
+            "warning_threshold_percent": 20,
+            "critical_shutdown_percent": 10,
+            "shutdown_delay_seconds": 15,
+            "shutdown_pending": False,
+            "watchdog_enabled": True,
+            "watchdog_active": True,
+            "watchdog_feed_suppressed": False,
+        },
+    )
+
+    screen.enter()
+    screen.render()
+
+    assert binding.power_build_calls == 1
+    payload = binding.power_sync_payloads[-1]
+    assert payload["title_text"] == "Power"
+    assert payload["page_text"] == "1/3"
+    assert payload["items"] == [
+        "Source: Unavailable",
+        "Battery: Unknown",
+        "Charging: Unknown",
+        "RTC: Unknown",
+    ]
+
+    screen.on_advance()
+    screen.render()
+    assert binding.power_sync_payloads[-1]["title_text"] == "Time"
+    assert binding.power_sync_payloads[-1]["page_text"] == "2/3"
+
+    screen.on_advance()
+    screen.render()
+    payload = binding.power_sync_payloads[-1]
+    assert payload["title_text"] == "Care"
+    assert payload["page_text"] == "3/3"
+
+    screen.exit()
+    assert binding.power_destroy_calls == 1

--- a/yoyopy/config/models.py
+++ b/yoyopy/config/models.py
@@ -278,7 +278,7 @@ class AppDisplayConfig:
 
     hardware: str = config_value(default="auto", env="YOYOPOD_DISPLAY")
     whisplay_renderer: str = config_value(
-        default="pil",
+        default="lvgl",
         env="YOYOPOD_WHISPLAY_RENDERER",
     )
     brightness: int = 80

--- a/yoyopy/ui/lvgl_binding/binding.py
+++ b/yoyopy/ui/lvgl_binding/binding.py
@@ -129,6 +129,69 @@ int yoyopy_lvgl_incoming_call_sync(
     uint8_t accent_b
 );
 void yoyopy_lvgl_incoming_call_destroy(void);
+int yoyopy_lvgl_outgoing_call_build(void);
+int yoyopy_lvgl_outgoing_call_sync(
+    const char * callee_name,
+    const char * callee_address,
+    const char * footer,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_outgoing_call_destroy(void);
+int yoyopy_lvgl_in_call_build(void);
+int yoyopy_lvgl_in_call_sync(
+    const char * caller_name,
+    const char * duration_text,
+    const char * mute_text,
+    const char * footer,
+    int32_t muted,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_in_call_destroy(void);
+int yoyopy_lvgl_ask_build(void);
+int yoyopy_lvgl_ask_sync(
+    const char * title_text,
+    const char * subtitle_text,
+    const char * footer,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_ask_destroy(void);
+int yoyopy_lvgl_power_build(void);
+int yoyopy_lvgl_power_sync(
+    const char * title_text,
+    const char * page_text,
+    const char * footer,
+    const char * item_0,
+    const char * item_1,
+    const char * item_2,
+    const char * item_3,
+    int32_t item_count,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_power_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);
@@ -509,6 +572,173 @@ class LvglBinding:
 
     def incoming_call_destroy(self) -> None:
         self.lib.yoyopy_lvgl_incoming_call_destroy()
+
+    def outgoing_call_build(self) -> None:
+        if self.lib.yoyopy_lvgl_outgoing_call_build() != 0:
+            raise LvglBindingError(self.last_error())
+
+    def outgoing_call_sync(
+        self,
+        *,
+        callee_name: str,
+        callee_address: str,
+        footer: str,
+        voip_state: int,
+        battery_percent: int,
+        charging: bool,
+        power_available: bool,
+        accent: tuple[int, int, int],
+    ) -> None:
+        callee_name_raw = self.ffi.new("char[]", callee_name.encode("utf-8"))
+        callee_address_raw = self.ffi.new("char[]", callee_address.encode("utf-8"))
+        footer_raw = self.ffi.new("char[]", footer.encode("utf-8"))
+        result = self.lib.yoyopy_lvgl_outgoing_call_sync(
+            callee_name_raw,
+            callee_address_raw,
+            footer_raw,
+            voip_state,
+            battery_percent,
+            1 if charging else 0,
+            1 if power_available else 0,
+            accent[0],
+            accent[1],
+            accent[2],
+        )
+        if result != 0:
+            raise LvglBindingError(self.last_error())
+
+    def outgoing_call_destroy(self) -> None:
+        self.lib.yoyopy_lvgl_outgoing_call_destroy()
+
+    def in_call_build(self) -> None:
+        if self.lib.yoyopy_lvgl_in_call_build() != 0:
+            raise LvglBindingError(self.last_error())
+
+    def in_call_sync(
+        self,
+        *,
+        caller_name: str,
+        duration_text: str,
+        mute_text: str,
+        footer: str,
+        muted: bool,
+        voip_state: int,
+        battery_percent: int,
+        charging: bool,
+        power_available: bool,
+        accent: tuple[int, int, int],
+    ) -> None:
+        caller_name_raw = self.ffi.new("char[]", caller_name.encode("utf-8"))
+        duration_raw = self.ffi.new("char[]", duration_text.encode("utf-8"))
+        mute_raw = self.ffi.new("char[]", mute_text.encode("utf-8"))
+        footer_raw = self.ffi.new("char[]", footer.encode("utf-8"))
+        result = self.lib.yoyopy_lvgl_in_call_sync(
+            caller_name_raw,
+            duration_raw,
+            mute_raw,
+            footer_raw,
+            1 if muted else 0,
+            voip_state,
+            battery_percent,
+            1 if charging else 0,
+            1 if power_available else 0,
+            accent[0],
+            accent[1],
+            accent[2],
+        )
+        if result != 0:
+            raise LvglBindingError(self.last_error())
+
+    def in_call_destroy(self) -> None:
+        self.lib.yoyopy_lvgl_in_call_destroy()
+
+    def ask_build(self) -> None:
+        if self.lib.yoyopy_lvgl_ask_build() != 0:
+            raise LvglBindingError(self.last_error())
+
+    def ask_sync(
+        self,
+        *,
+        title_text: str,
+        subtitle_text: str,
+        footer: str,
+        voip_state: int,
+        battery_percent: int,
+        charging: bool,
+        power_available: bool,
+        accent: tuple[int, int, int],
+    ) -> None:
+        title_raw = self.ffi.new("char[]", title_text.encode("utf-8"))
+        subtitle_raw = self.ffi.new("char[]", subtitle_text.encode("utf-8"))
+        footer_raw = self.ffi.new("char[]", footer.encode("utf-8"))
+        result = self.lib.yoyopy_lvgl_ask_sync(
+            title_raw,
+            subtitle_raw,
+            footer_raw,
+            voip_state,
+            battery_percent,
+            1 if charging else 0,
+            1 if power_available else 0,
+            accent[0],
+            accent[1],
+            accent[2],
+        )
+        if result != 0:
+            raise LvglBindingError(self.last_error())
+
+    def ask_destroy(self) -> None:
+        self.lib.yoyopy_lvgl_ask_destroy()
+
+    def power_build(self) -> None:
+        if self.lib.yoyopy_lvgl_power_build() != 0:
+            raise LvglBindingError(self.last_error())
+
+    def power_sync(
+        self,
+        *,
+        title_text: str,
+        page_text: str | None,
+        footer: str,
+        items: list[str],
+        voip_state: int,
+        battery_percent: int,
+        charging: bool,
+        power_available: bool,
+        accent: tuple[int, int, int],
+    ) -> None:
+        normalized_items = list(items[:4])
+        while len(normalized_items) < 4:
+            normalized_items.append("")
+
+        title_raw = self.ffi.new("char[]", title_text.encode("utf-8"))
+        page_text_raw = self.ffi.new("char[]", page_text.encode("utf-8")) if page_text else self.ffi.NULL
+        footer_raw = self.ffi.new("char[]", footer.encode("utf-8"))
+        item_0_raw = self.ffi.new("char[]", normalized_items[0].encode("utf-8"))
+        item_1_raw = self.ffi.new("char[]", normalized_items[1].encode("utf-8"))
+        item_2_raw = self.ffi.new("char[]", normalized_items[2].encode("utf-8"))
+        item_3_raw = self.ffi.new("char[]", normalized_items[3].encode("utf-8"))
+        result = self.lib.yoyopy_lvgl_power_sync(
+            title_raw,
+            page_text_raw,
+            footer_raw,
+            item_0_raw,
+            item_1_raw,
+            item_2_raw,
+            item_3_raw,
+            len(items),
+            voip_state,
+            battery_percent,
+            1 if charging else 0,
+            1 if power_available else 0,
+            accent[0],
+            accent[1],
+            accent[2],
+        )
+        if result != 0:
+            raise LvglBindingError(self.last_error())
+
+    def power_destroy(self) -> None:
+        self.lib.yoyopy_lvgl_power_destroy()
 
     def clear_screen(self) -> None:
         self.lib.yoyopy_lvgl_clear_screen()

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
@@ -106,6 +106,70 @@ typedef struct {
     lv_obj_t * footer_label;
 } yoyopy_incoming_call_scene_t;
 
+typedef struct {
+    int built;
+    lv_obj_t * screen;
+    lv_obj_t * voip_dot;
+    lv_obj_t * battery_outline;
+    lv_obj_t * battery_fill;
+    lv_obj_t * battery_tip;
+    lv_obj_t * panel;
+    lv_obj_t * icon_halo;
+    lv_obj_t * icon_label;
+    lv_obj_t * state_label;
+    lv_obj_t * callee_name_label;
+    lv_obj_t * callee_address_label;
+    lv_obj_t * footer_label;
+} yoyopy_outgoing_call_scene_t;
+
+typedef struct {
+    int built;
+    lv_obj_t * screen;
+    lv_obj_t * voip_dot;
+    lv_obj_t * battery_outline;
+    lv_obj_t * battery_fill;
+    lv_obj_t * battery_tip;
+    lv_obj_t * panel;
+    lv_obj_t * icon_halo;
+    lv_obj_t * icon_label;
+    lv_obj_t * caller_name_label;
+    lv_obj_t * duration_label;
+    lv_obj_t * mute_chip;
+    lv_obj_t * mute_label;
+    lv_obj_t * footer_label;
+} yoyopy_in_call_scene_t;
+
+typedef struct {
+    int built;
+    lv_obj_t * screen;
+    lv_obj_t * voip_dot;
+    lv_obj_t * battery_outline;
+    lv_obj_t * battery_fill;
+    lv_obj_t * battery_tip;
+    lv_obj_t * panel;
+    lv_obj_t * icon_halo;
+    lv_obj_t * icon_label;
+    lv_obj_t * title_label;
+    lv_obj_t * subtitle_label;
+    lv_obj_t * footer_label;
+} yoyopy_ask_scene_t;
+
+typedef struct {
+    int built;
+    lv_obj_t * screen;
+    lv_obj_t * voip_dot;
+    lv_obj_t * battery_outline;
+    lv_obj_t * battery_fill;
+    lv_obj_t * battery_tip;
+    lv_obj_t * title_label;
+    lv_obj_t * title_underline;
+    lv_obj_t * page_label;
+    lv_obj_t * panel;
+    lv_obj_t * item_panels[4];
+    lv_obj_t * item_titles[4];
+    lv_obj_t * footer_label;
+} yoyopy_power_scene_t;
+
 static int g_initialized = 0;
 static lv_display_t * g_display = NULL;
 static lv_indev_t * g_indev = NULL;
@@ -124,6 +188,10 @@ static yoyopy_listen_scene_t g_listen_scene = {0};
 static yoyopy_playlist_scene_t g_playlist_scene = {0};
 static yoyopy_now_playing_scene_t g_now_playing_scene = {0};
 static yoyopy_incoming_call_scene_t g_incoming_call_scene = {0};
+static yoyopy_outgoing_call_scene_t g_outgoing_call_scene = {0};
+static yoyopy_in_call_scene_t g_in_call_scene = {0};
+static yoyopy_ask_scene_t g_ask_scene = {0};
+static yoyopy_power_scene_t g_power_scene = {0};
 
 static lv_color_t yoyopy_color_rgb(uint8_t red, uint8_t green, uint8_t blue) {
     uint32_t raw = ((uint32_t)red << 16) | ((uint32_t)green << 8) | (uint32_t)blue;
@@ -166,12 +234,32 @@ static void yoyopy_reset_incoming_call_scene_refs(void) {
     memset(&g_incoming_call_scene, 0, sizeof(g_incoming_call_scene));
 }
 
+static void yoyopy_reset_outgoing_call_scene_refs(void) {
+    memset(&g_outgoing_call_scene, 0, sizeof(g_outgoing_call_scene));
+}
+
+static void yoyopy_reset_in_call_scene_refs(void) {
+    memset(&g_in_call_scene, 0, sizeof(g_in_call_scene));
+}
+
+static void yoyopy_reset_ask_scene_refs(void) {
+    memset(&g_ask_scene, 0, sizeof(g_ask_scene));
+}
+
+static void yoyopy_reset_power_scene_refs(void) {
+    memset(&g_power_scene, 0, sizeof(g_power_scene));
+}
+
 static void yoyopy_reset_scene_refs(void) {
     yoyopy_reset_hub_scene_refs();
     yoyopy_reset_listen_scene_refs();
     yoyopy_reset_playlist_scene_refs();
     yoyopy_reset_now_playing_scene_refs();
     yoyopy_reset_incoming_call_scene_refs();
+    yoyopy_reset_outgoing_call_scene_refs();
+    yoyopy_reset_in_call_scene_refs();
+    yoyopy_reset_ask_scene_refs();
+    yoyopy_reset_power_scene_refs();
 }
 
 static void yoyopy_set_error(const char * message) {
@@ -1594,6 +1682,714 @@ void yoyopy_lvgl_incoming_call_destroy(void) {
     }
     yoyopy_clear_group();
     yoyopy_reset_incoming_call_scene_refs();
+}
+
+int yoyopy_lvgl_outgoing_call_build(void) {
+    if(!g_initialized || g_display == NULL) {
+        yoyopy_set_error("display must be registered before building the outgoing-call scene");
+        return -1;
+    }
+
+    if(g_outgoing_call_scene.built) {
+        return 0;
+    }
+
+    yoyopy_prepare_active_screen();
+
+    g_outgoing_call_scene.screen = lv_screen_active();
+    lv_obj_set_style_bg_color(g_outgoing_call_scene.screen, yoyopy_color_rgb(18, 21, 28), 0);
+    lv_obj_set_style_bg_opa(g_outgoing_call_scene.screen, LV_OPA_COVER, 0);
+
+    g_outgoing_call_scene.voip_dot = lv_obj_create(g_outgoing_call_scene.screen);
+    lv_obj_remove_style_all(g_outgoing_call_scene.voip_dot);
+    lv_obj_set_size(g_outgoing_call_scene.voip_dot, 8, 8);
+    lv_obj_set_style_radius(g_outgoing_call_scene.voip_dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_pos(g_outgoing_call_scene.voip_dot, 16, 10);
+
+    g_outgoing_call_scene.battery_outline = lv_obj_create(g_outgoing_call_scene.screen);
+    lv_obj_remove_style_all(g_outgoing_call_scene.battery_outline);
+    lv_obj_set_size(g_outgoing_call_scene.battery_outline, 20, 10);
+    lv_obj_set_pos(g_outgoing_call_scene.battery_outline, 202, 6);
+    lv_obj_set_style_border_width(g_outgoing_call_scene.battery_outline, 1, 0);
+    lv_obj_set_style_border_color(g_outgoing_call_scene.battery_outline, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_radius(g_outgoing_call_scene.battery_outline, 2, 0);
+    lv_obj_set_style_bg_opa(g_outgoing_call_scene.battery_outline, LV_OPA_TRANSP, 0);
+
+    g_outgoing_call_scene.battery_fill = lv_obj_create(g_outgoing_call_scene.battery_outline);
+    lv_obj_remove_style_all(g_outgoing_call_scene.battery_fill);
+    lv_obj_set_pos(g_outgoing_call_scene.battery_fill, 1, 1);
+    lv_obj_set_size(g_outgoing_call_scene.battery_fill, 18, 8);
+    lv_obj_set_style_radius(g_outgoing_call_scene.battery_fill, 1, 0);
+    lv_obj_set_style_bg_opa(g_outgoing_call_scene.battery_fill, LV_OPA_COVER, 0);
+
+    g_outgoing_call_scene.battery_tip = lv_obj_create(g_outgoing_call_scene.screen);
+    lv_obj_remove_style_all(g_outgoing_call_scene.battery_tip);
+    lv_obj_set_size(g_outgoing_call_scene.battery_tip, 2, 4);
+    lv_obj_set_pos(g_outgoing_call_scene.battery_tip, 222, 9);
+    lv_obj_set_style_bg_color(g_outgoing_call_scene.battery_tip, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_bg_opa(g_outgoing_call_scene.battery_tip, LV_OPA_COVER, 0);
+
+    g_outgoing_call_scene.panel = lv_obj_create(g_outgoing_call_scene.screen);
+    lv_obj_set_size(g_outgoing_call_scene.panel, 208, 194);
+    lv_obj_set_pos(g_outgoing_call_scene.panel, 16, 42);
+    lv_obj_set_style_radius(g_outgoing_call_scene.panel, 28, 0);
+    lv_obj_set_style_border_width(g_outgoing_call_scene.panel, 2, 0);
+    lv_obj_set_style_pad_all(g_outgoing_call_scene.panel, 0, 0);
+    lv_obj_set_style_shadow_width(g_outgoing_call_scene.panel, 0, 0);
+    lv_obj_set_style_outline_width(g_outgoing_call_scene.panel, 0, 0);
+    lv_obj_set_scrollbar_mode(g_outgoing_call_scene.panel, LV_SCROLLBAR_MODE_OFF);
+
+    g_outgoing_call_scene.icon_halo = lv_obj_create(g_outgoing_call_scene.panel);
+    lv_obj_set_size(g_outgoing_call_scene.icon_halo, 76, 58);
+    lv_obj_set_pos(g_outgoing_call_scene.icon_halo, 66, 18);
+    lv_obj_set_style_radius(g_outgoing_call_scene.icon_halo, 20, 0);
+    lv_obj_set_style_border_width(g_outgoing_call_scene.icon_halo, 2, 0);
+    lv_obj_set_style_shadow_width(g_outgoing_call_scene.icon_halo, 0, 0);
+    lv_obj_set_style_outline_width(g_outgoing_call_scene.icon_halo, 0, 0);
+    lv_obj_set_scrollbar_mode(g_outgoing_call_scene.icon_halo, LV_SCROLLBAR_MODE_OFF);
+
+    g_outgoing_call_scene.icon_label = lv_label_create(g_outgoing_call_scene.icon_halo);
+    lv_label_set_text(g_outgoing_call_scene.icon_label, LV_SYMBOL_CALL);
+    lv_obj_set_style_text_font(g_outgoing_call_scene.icon_label, &lv_font_montserrat_24, 0);
+    lv_obj_center(g_outgoing_call_scene.icon_label);
+
+    g_outgoing_call_scene.state_label = lv_label_create(g_outgoing_call_scene.panel);
+    lv_label_set_text(g_outgoing_call_scene.state_label, "Calling");
+    lv_obj_set_width(g_outgoing_call_scene.state_label, 160);
+    lv_obj_set_pos(g_outgoing_call_scene.state_label, 24, 88);
+    lv_obj_set_style_text_font(g_outgoing_call_scene.state_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_align(g_outgoing_call_scene.state_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_outgoing_call_scene.callee_name_label = lv_label_create(g_outgoing_call_scene.panel);
+    lv_obj_set_width(g_outgoing_call_scene.callee_name_label, 176);
+    lv_obj_set_pos(g_outgoing_call_scene.callee_name_label, 16, 114);
+    lv_label_set_long_mode(g_outgoing_call_scene.callee_name_label, LV_LABEL_LONG_MODE_DOTS);
+    lv_obj_set_style_text_font(g_outgoing_call_scene.callee_name_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_align(g_outgoing_call_scene.callee_name_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_outgoing_call_scene.callee_address_label = lv_label_create(g_outgoing_call_scene.panel);
+    lv_obj_set_width(g_outgoing_call_scene.callee_address_label, 176);
+    lv_obj_set_pos(g_outgoing_call_scene.callee_address_label, 16, 148);
+    lv_label_set_long_mode(g_outgoing_call_scene.callee_address_label, LV_LABEL_LONG_MODE_DOTS);
+    lv_obj_set_style_text_font(g_outgoing_call_scene.callee_address_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_outgoing_call_scene.callee_address_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_outgoing_call_scene.footer_label = lv_label_create(g_outgoing_call_scene.screen);
+    lv_obj_set_style_text_font(g_outgoing_call_scene.footer_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_outgoing_call_scene.footer_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(g_outgoing_call_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    g_outgoing_call_scene.built = 1;
+    return 0;
+}
+
+int yoyopy_lvgl_outgoing_call_sync(
+    const char * callee_name,
+    const char * callee_address,
+    const char * footer,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+) {
+    if(!g_outgoing_call_scene.built) {
+        yoyopy_set_error("outgoing-call scene must be built before sync");
+        return -1;
+    }
+
+    const lv_color_t background = yoyopy_color_rgb(18, 21, 28);
+    const lv_color_t surface = yoyopy_color_rgb(32, 35, 42);
+    const lv_color_t ink = yoyopy_color_rgb(243, 247, 250);
+    const lv_color_t muted = yoyopy_color_rgb(153, 160, 173);
+    const lv_color_t accent = yoyopy_color_rgb(accent_r, accent_g, accent_b);
+    const lv_color_t accent_dim = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 65);
+    const lv_color_t halo_fill = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 80);
+    const lv_color_t halo_border = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 60);
+
+    lv_obj_set_style_bg_color(g_outgoing_call_scene.screen, background, 0);
+    lv_obj_set_style_bg_opa(g_outgoing_call_scene.screen, LV_OPA_COVER, 0);
+    yoyopy_apply_voip_dot(g_outgoing_call_scene.voip_dot, voip_state);
+    yoyopy_apply_battery(
+        g_outgoing_call_scene.battery_outline,
+        g_outgoing_call_scene.battery_fill,
+        g_outgoing_call_scene.battery_tip,
+        battery_percent,
+        charging,
+        power_available
+    );
+
+    lv_obj_set_style_bg_color(g_outgoing_call_scene.panel, surface, 0);
+    lv_obj_set_style_bg_opa(g_outgoing_call_scene.panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_outgoing_call_scene.panel, accent_dim, 0);
+
+    lv_obj_set_style_bg_color(g_outgoing_call_scene.icon_halo, halo_fill, 0);
+    lv_obj_set_style_bg_opa(g_outgoing_call_scene.icon_halo, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_outgoing_call_scene.icon_halo, halo_border, 0);
+    lv_obj_set_style_text_color(g_outgoing_call_scene.icon_label, accent, 0);
+    lv_obj_center(g_outgoing_call_scene.icon_label);
+
+    lv_obj_set_style_text_color(g_outgoing_call_scene.state_label, accent, 0);
+    lv_label_set_text(g_outgoing_call_scene.callee_name_label, callee_name != NULL ? callee_name : "");
+    lv_obj_set_style_text_color(g_outgoing_call_scene.callee_name_label, ink, 0);
+    lv_label_set_text(g_outgoing_call_scene.callee_address_label, callee_address != NULL ? callee_address : "");
+    lv_obj_set_style_text_color(g_outgoing_call_scene.callee_address_label, muted, 0);
+
+    lv_label_set_text(g_outgoing_call_scene.footer_label, footer != NULL ? footer : "");
+    lv_obj_set_style_text_color(g_outgoing_call_scene.footer_label, accent_dim, 0);
+    lv_obj_align(g_outgoing_call_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    return 0;
+}
+
+void yoyopy_lvgl_outgoing_call_destroy(void) {
+    if(!g_outgoing_call_scene.built) {
+        return;
+    }
+
+    if(g_outgoing_call_scene.screen != NULL) {
+        lv_obj_clean(g_outgoing_call_scene.screen);
+    }
+    yoyopy_clear_group();
+    yoyopy_reset_outgoing_call_scene_refs();
+}
+
+int yoyopy_lvgl_in_call_build(void) {
+    if(!g_initialized || g_display == NULL) {
+        yoyopy_set_error("display must be registered before building the in-call scene");
+        return -1;
+    }
+
+    if(g_in_call_scene.built) {
+        return 0;
+    }
+
+    yoyopy_prepare_active_screen();
+
+    g_in_call_scene.screen = lv_screen_active();
+    lv_obj_set_style_bg_color(g_in_call_scene.screen, yoyopy_color_rgb(18, 21, 28), 0);
+    lv_obj_set_style_bg_opa(g_in_call_scene.screen, LV_OPA_COVER, 0);
+
+    g_in_call_scene.voip_dot = lv_obj_create(g_in_call_scene.screen);
+    lv_obj_remove_style_all(g_in_call_scene.voip_dot);
+    lv_obj_set_size(g_in_call_scene.voip_dot, 8, 8);
+    lv_obj_set_style_radius(g_in_call_scene.voip_dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_pos(g_in_call_scene.voip_dot, 16, 10);
+
+    g_in_call_scene.battery_outline = lv_obj_create(g_in_call_scene.screen);
+    lv_obj_remove_style_all(g_in_call_scene.battery_outline);
+    lv_obj_set_size(g_in_call_scene.battery_outline, 20, 10);
+    lv_obj_set_pos(g_in_call_scene.battery_outline, 202, 6);
+    lv_obj_set_style_border_width(g_in_call_scene.battery_outline, 1, 0);
+    lv_obj_set_style_border_color(g_in_call_scene.battery_outline, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_radius(g_in_call_scene.battery_outline, 2, 0);
+    lv_obj_set_style_bg_opa(g_in_call_scene.battery_outline, LV_OPA_TRANSP, 0);
+
+    g_in_call_scene.battery_fill = lv_obj_create(g_in_call_scene.battery_outline);
+    lv_obj_remove_style_all(g_in_call_scene.battery_fill);
+    lv_obj_set_pos(g_in_call_scene.battery_fill, 1, 1);
+    lv_obj_set_size(g_in_call_scene.battery_fill, 18, 8);
+    lv_obj_set_style_radius(g_in_call_scene.battery_fill, 1, 0);
+    lv_obj_set_style_bg_opa(g_in_call_scene.battery_fill, LV_OPA_COVER, 0);
+
+    g_in_call_scene.battery_tip = lv_obj_create(g_in_call_scene.screen);
+    lv_obj_remove_style_all(g_in_call_scene.battery_tip);
+    lv_obj_set_size(g_in_call_scene.battery_tip, 2, 4);
+    lv_obj_set_pos(g_in_call_scene.battery_tip, 222, 9);
+    lv_obj_set_style_bg_color(g_in_call_scene.battery_tip, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_bg_opa(g_in_call_scene.battery_tip, LV_OPA_COVER, 0);
+
+    g_in_call_scene.panel = lv_obj_create(g_in_call_scene.screen);
+    lv_obj_set_size(g_in_call_scene.panel, 208, 194);
+    lv_obj_set_pos(g_in_call_scene.panel, 16, 42);
+    lv_obj_set_style_radius(g_in_call_scene.panel, 28, 0);
+    lv_obj_set_style_border_width(g_in_call_scene.panel, 2, 0);
+    lv_obj_set_style_pad_all(g_in_call_scene.panel, 0, 0);
+    lv_obj_set_style_shadow_width(g_in_call_scene.panel, 0, 0);
+    lv_obj_set_style_outline_width(g_in_call_scene.panel, 0, 0);
+    lv_obj_set_scrollbar_mode(g_in_call_scene.panel, LV_SCROLLBAR_MODE_OFF);
+
+    g_in_call_scene.icon_halo = lv_obj_create(g_in_call_scene.panel);
+    lv_obj_set_size(g_in_call_scene.icon_halo, 76, 58);
+    lv_obj_set_pos(g_in_call_scene.icon_halo, 66, 18);
+    lv_obj_set_style_radius(g_in_call_scene.icon_halo, 20, 0);
+    lv_obj_set_style_border_width(g_in_call_scene.icon_halo, 2, 0);
+    lv_obj_set_style_shadow_width(g_in_call_scene.icon_halo, 0, 0);
+    lv_obj_set_style_outline_width(g_in_call_scene.icon_halo, 0, 0);
+    lv_obj_set_scrollbar_mode(g_in_call_scene.icon_halo, LV_SCROLLBAR_MODE_OFF);
+
+    g_in_call_scene.icon_label = lv_label_create(g_in_call_scene.icon_halo);
+    lv_label_set_text(g_in_call_scene.icon_label, LV_SYMBOL_CALL);
+    lv_obj_set_style_text_font(g_in_call_scene.icon_label, &lv_font_montserrat_24, 0);
+    lv_obj_center(g_in_call_scene.icon_label);
+
+    g_in_call_scene.caller_name_label = lv_label_create(g_in_call_scene.panel);
+    lv_obj_set_width(g_in_call_scene.caller_name_label, 176);
+    lv_obj_set_pos(g_in_call_scene.caller_name_label, 16, 92);
+    lv_label_set_long_mode(g_in_call_scene.caller_name_label, LV_LABEL_LONG_MODE_DOTS);
+    lv_obj_set_style_text_font(g_in_call_scene.caller_name_label, &lv_font_montserrat_22, 0);
+    lv_obj_set_style_text_align(g_in_call_scene.caller_name_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_in_call_scene.duration_label = lv_label_create(g_in_call_scene.panel);
+    lv_obj_set_width(g_in_call_scene.duration_label, 176);
+    lv_obj_set_pos(g_in_call_scene.duration_label, 16, 126);
+    lv_obj_set_style_text_font(g_in_call_scene.duration_label, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_align(g_in_call_scene.duration_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_in_call_scene.mute_chip = lv_obj_create(g_in_call_scene.panel);
+    lv_obj_set_size(g_in_call_scene.mute_chip, 104, 26);
+    lv_obj_set_pos(g_in_call_scene.mute_chip, 52, 166);
+    lv_obj_set_style_radius(g_in_call_scene.mute_chip, 13, 0);
+    lv_obj_set_style_border_width(g_in_call_scene.mute_chip, 1, 0);
+    lv_obj_set_style_pad_all(g_in_call_scene.mute_chip, 0, 0);
+    lv_obj_set_style_shadow_width(g_in_call_scene.mute_chip, 0, 0);
+    lv_obj_set_style_outline_width(g_in_call_scene.mute_chip, 0, 0);
+    lv_obj_set_scrollbar_mode(g_in_call_scene.mute_chip, LV_SCROLLBAR_MODE_OFF);
+
+    g_in_call_scene.mute_label = lv_label_create(g_in_call_scene.mute_chip);
+    lv_obj_set_style_text_font(g_in_call_scene.mute_label, &lv_font_montserrat_12, 0);
+    lv_obj_center(g_in_call_scene.mute_label);
+
+    g_in_call_scene.footer_label = lv_label_create(g_in_call_scene.screen);
+    lv_obj_set_style_text_font(g_in_call_scene.footer_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_in_call_scene.footer_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(g_in_call_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    g_in_call_scene.built = 1;
+    return 0;
+}
+
+int yoyopy_lvgl_in_call_sync(
+    const char * caller_name,
+    const char * duration_text,
+    const char * mute_text,
+    const char * footer,
+    int32_t muted,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+) {
+    if(!g_in_call_scene.built) {
+        yoyopy_set_error("in-call scene must be built before sync");
+        return -1;
+    }
+
+    const lv_color_t background = yoyopy_color_rgb(18, 21, 28);
+    const lv_color_t surface = yoyopy_color_rgb(32, 35, 42);
+    const lv_color_t ink = yoyopy_color_rgb(243, 247, 250);
+    const lv_color_t muted_text = yoyopy_color_rgb(153, 160, 173);
+    const lv_color_t accent = yoyopy_color_rgb(accent_r, accent_g, accent_b);
+    const lv_color_t accent_dim = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 65);
+    const lv_color_t halo_fill = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 80);
+    const lv_color_t halo_border = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 60);
+
+    lv_obj_set_style_bg_color(g_in_call_scene.screen, background, 0);
+    lv_obj_set_style_bg_opa(g_in_call_scene.screen, LV_OPA_COVER, 0);
+    yoyopy_apply_voip_dot(g_in_call_scene.voip_dot, voip_state);
+    yoyopy_apply_battery(
+        g_in_call_scene.battery_outline,
+        g_in_call_scene.battery_fill,
+        g_in_call_scene.battery_tip,
+        battery_percent,
+        charging,
+        power_available
+    );
+
+    lv_obj_set_style_bg_color(g_in_call_scene.panel, surface, 0);
+    lv_obj_set_style_bg_opa(g_in_call_scene.panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_in_call_scene.panel, accent_dim, 0);
+
+    lv_obj_set_style_bg_color(g_in_call_scene.icon_halo, halo_fill, 0);
+    lv_obj_set_style_bg_opa(g_in_call_scene.icon_halo, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_in_call_scene.icon_halo, halo_border, 0);
+    lv_obj_set_style_text_color(g_in_call_scene.icon_label, accent, 0);
+    lv_obj_center(g_in_call_scene.icon_label);
+
+    lv_label_set_text(g_in_call_scene.caller_name_label, caller_name != NULL ? caller_name : "");
+    lv_obj_set_style_text_color(g_in_call_scene.caller_name_label, ink, 0);
+    lv_label_set_text(g_in_call_scene.duration_label, duration_text != NULL ? duration_text : "00:00");
+    lv_obj_set_style_text_color(g_in_call_scene.duration_label, accent, 0);
+
+    lv_obj_set_style_bg_color(g_in_call_scene.mute_chip, muted ? accent_dim : yoyopy_color_rgb(24, 28, 34), 0);
+    lv_obj_set_style_bg_opa(g_in_call_scene.mute_chip, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_in_call_scene.mute_chip, muted ? accent : accent_dim, 0);
+    lv_label_set_text(g_in_call_scene.mute_label, mute_text != NULL ? mute_text : "");
+    lv_obj_set_style_text_color(g_in_call_scene.mute_label, muted ? ink : muted_text, 0);
+    lv_obj_center(g_in_call_scene.mute_label);
+
+    lv_label_set_text(g_in_call_scene.footer_label, footer != NULL ? footer : "");
+    lv_obj_set_style_text_color(g_in_call_scene.footer_label, accent_dim, 0);
+    lv_obj_align(g_in_call_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    return 0;
+}
+
+void yoyopy_lvgl_in_call_destroy(void) {
+    if(!g_in_call_scene.built) {
+        return;
+    }
+
+    if(g_in_call_scene.screen != NULL) {
+        lv_obj_clean(g_in_call_scene.screen);
+    }
+    yoyopy_clear_group();
+    yoyopy_reset_in_call_scene_refs();
+}
+
+int yoyopy_lvgl_ask_build(void) {
+    if(!g_initialized || g_display == NULL) {
+        yoyopy_set_error("display must be registered before building the ask scene");
+        return -1;
+    }
+
+    if(g_ask_scene.built) {
+        return 0;
+    }
+
+    yoyopy_prepare_active_screen();
+
+    g_ask_scene.screen = lv_screen_active();
+    lv_obj_set_style_bg_color(g_ask_scene.screen, yoyopy_color_rgb(18, 21, 28), 0);
+    lv_obj_set_style_bg_opa(g_ask_scene.screen, LV_OPA_COVER, 0);
+
+    g_ask_scene.voip_dot = lv_obj_create(g_ask_scene.screen);
+    lv_obj_remove_style_all(g_ask_scene.voip_dot);
+    lv_obj_set_size(g_ask_scene.voip_dot, 8, 8);
+    lv_obj_set_style_radius(g_ask_scene.voip_dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_pos(g_ask_scene.voip_dot, 16, 10);
+
+    g_ask_scene.battery_outline = lv_obj_create(g_ask_scene.screen);
+    lv_obj_remove_style_all(g_ask_scene.battery_outline);
+    lv_obj_set_size(g_ask_scene.battery_outline, 20, 10);
+    lv_obj_set_pos(g_ask_scene.battery_outline, 202, 6);
+    lv_obj_set_style_border_width(g_ask_scene.battery_outline, 1, 0);
+    lv_obj_set_style_border_color(g_ask_scene.battery_outline, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_radius(g_ask_scene.battery_outline, 2, 0);
+    lv_obj_set_style_bg_opa(g_ask_scene.battery_outline, LV_OPA_TRANSP, 0);
+
+    g_ask_scene.battery_fill = lv_obj_create(g_ask_scene.battery_outline);
+    lv_obj_remove_style_all(g_ask_scene.battery_fill);
+    lv_obj_set_pos(g_ask_scene.battery_fill, 1, 1);
+    lv_obj_set_size(g_ask_scene.battery_fill, 18, 8);
+    lv_obj_set_style_radius(g_ask_scene.battery_fill, 1, 0);
+    lv_obj_set_style_bg_opa(g_ask_scene.battery_fill, LV_OPA_COVER, 0);
+
+    g_ask_scene.battery_tip = lv_obj_create(g_ask_scene.screen);
+    lv_obj_remove_style_all(g_ask_scene.battery_tip);
+    lv_obj_set_size(g_ask_scene.battery_tip, 2, 4);
+    lv_obj_set_pos(g_ask_scene.battery_tip, 222, 9);
+    lv_obj_set_style_bg_color(g_ask_scene.battery_tip, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_bg_opa(g_ask_scene.battery_tip, LV_OPA_COVER, 0);
+
+    g_ask_scene.panel = lv_obj_create(g_ask_scene.screen);
+    lv_obj_set_size(g_ask_scene.panel, 208, 194);
+    lv_obj_set_pos(g_ask_scene.panel, 16, 42);
+    lv_obj_set_style_radius(g_ask_scene.panel, 28, 0);
+    lv_obj_set_style_border_width(g_ask_scene.panel, 2, 0);
+    lv_obj_set_style_pad_all(g_ask_scene.panel, 0, 0);
+    lv_obj_set_style_shadow_width(g_ask_scene.panel, 0, 0);
+    lv_obj_set_style_outline_width(g_ask_scene.panel, 0, 0);
+    lv_obj_set_scrollbar_mode(g_ask_scene.panel, LV_SCROLLBAR_MODE_OFF);
+
+    g_ask_scene.icon_halo = lv_obj_create(g_ask_scene.panel);
+    lv_obj_set_size(g_ask_scene.icon_halo, 84, 64);
+    lv_obj_set_pos(g_ask_scene.icon_halo, 62, 22);
+    lv_obj_set_style_radius(g_ask_scene.icon_halo, 22, 0);
+    lv_obj_set_style_border_width(g_ask_scene.icon_halo, 2, 0);
+    lv_obj_set_style_shadow_width(g_ask_scene.icon_halo, 0, 0);
+    lv_obj_set_style_outline_width(g_ask_scene.icon_halo, 0, 0);
+    lv_obj_set_scrollbar_mode(g_ask_scene.icon_halo, LV_SCROLLBAR_MODE_OFF);
+
+    g_ask_scene.icon_label = lv_label_create(g_ask_scene.icon_halo);
+    lv_label_set_text(g_ask_scene.icon_label, LV_SYMBOL_EDIT);
+    lv_obj_set_style_text_font(g_ask_scene.icon_label, &lv_font_montserrat_24, 0);
+    lv_obj_center(g_ask_scene.icon_label);
+
+    g_ask_scene.title_label = lv_label_create(g_ask_scene.panel);
+    lv_obj_set_width(g_ask_scene.title_label, 176);
+    lv_obj_set_pos(g_ask_scene.title_label, 16, 108);
+    lv_obj_set_style_text_font(g_ask_scene.title_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_align(g_ask_scene.title_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_ask_scene.subtitle_label = lv_label_create(g_ask_scene.panel);
+    lv_obj_set_width(g_ask_scene.subtitle_label, 176);
+    lv_obj_set_pos(g_ask_scene.subtitle_label, 16, 144);
+    lv_label_set_long_mode(g_ask_scene.subtitle_label, LV_LABEL_LONG_MODE_WRAP);
+    lv_obj_set_style_text_font(g_ask_scene.subtitle_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_align(g_ask_scene.subtitle_label, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_ask_scene.footer_label = lv_label_create(g_ask_scene.screen);
+    lv_obj_set_style_text_font(g_ask_scene.footer_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_ask_scene.footer_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(g_ask_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    g_ask_scene.built = 1;
+    return 0;
+}
+
+int yoyopy_lvgl_ask_sync(
+    const char * title_text,
+    const char * subtitle_text,
+    const char * footer,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+) {
+    if(!g_ask_scene.built) {
+        yoyopy_set_error("ask scene must be built before sync");
+        return -1;
+    }
+
+    const lv_color_t background = yoyopy_color_rgb(18, 21, 28);
+    const lv_color_t surface = yoyopy_color_rgb(32, 35, 42);
+    const lv_color_t ink = yoyopy_color_rgb(243, 247, 250);
+    const lv_color_t muted = yoyopy_color_rgb(153, 160, 173);
+    const lv_color_t accent = yoyopy_color_rgb(accent_r, accent_g, accent_b);
+    const lv_color_t accent_dim = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 65);
+    const lv_color_t halo_fill = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 80);
+    const lv_color_t halo_border = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 60);
+
+    lv_obj_set_style_bg_color(g_ask_scene.screen, background, 0);
+    lv_obj_set_style_bg_opa(g_ask_scene.screen, LV_OPA_COVER, 0);
+    yoyopy_apply_voip_dot(g_ask_scene.voip_dot, voip_state);
+    yoyopy_apply_battery(
+        g_ask_scene.battery_outline,
+        g_ask_scene.battery_fill,
+        g_ask_scene.battery_tip,
+        battery_percent,
+        charging,
+        power_available
+    );
+
+    lv_obj_set_style_bg_color(g_ask_scene.panel, surface, 0);
+    lv_obj_set_style_bg_opa(g_ask_scene.panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_ask_scene.panel, accent_dim, 0);
+
+    lv_obj_set_style_bg_color(g_ask_scene.icon_halo, halo_fill, 0);
+    lv_obj_set_style_bg_opa(g_ask_scene.icon_halo, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_ask_scene.icon_halo, halo_border, 0);
+    lv_obj_set_style_text_color(g_ask_scene.icon_label, accent, 0);
+    lv_obj_center(g_ask_scene.icon_label);
+
+    lv_label_set_text(g_ask_scene.title_label, title_text != NULL ? title_text : "");
+    lv_obj_set_style_text_color(g_ask_scene.title_label, ink, 0);
+    lv_label_set_text(g_ask_scene.subtitle_label, subtitle_text != NULL ? subtitle_text : "");
+    lv_obj_set_style_text_color(g_ask_scene.subtitle_label, muted, 0);
+
+    lv_label_set_text(g_ask_scene.footer_label, footer != NULL ? footer : "");
+    lv_obj_set_style_text_color(g_ask_scene.footer_label, accent_dim, 0);
+    lv_obj_align(g_ask_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+    return 0;
+}
+
+void yoyopy_lvgl_ask_destroy(void) {
+    if(!g_ask_scene.built) {
+        return;
+    }
+
+    if(g_ask_scene.screen != NULL) {
+        lv_obj_clean(g_ask_scene.screen);
+    }
+    yoyopy_clear_group();
+    yoyopy_reset_ask_scene_refs();
+}
+
+int yoyopy_lvgl_power_build(void) {
+    if(!g_initialized || g_display == NULL) {
+        yoyopy_set_error("display must be registered before building the power scene");
+        return -1;
+    }
+
+    if(g_power_scene.built) {
+        return 0;
+    }
+
+    yoyopy_prepare_active_screen();
+
+    g_power_scene.screen = lv_screen_active();
+    lv_obj_set_style_bg_color(g_power_scene.screen, yoyopy_color_rgb(18, 21, 28), 0);
+    lv_obj_set_style_bg_opa(g_power_scene.screen, LV_OPA_COVER, 0);
+
+    g_power_scene.voip_dot = lv_obj_create(g_power_scene.screen);
+    lv_obj_remove_style_all(g_power_scene.voip_dot);
+    lv_obj_set_size(g_power_scene.voip_dot, 8, 8);
+    lv_obj_set_style_radius(g_power_scene.voip_dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_pos(g_power_scene.voip_dot, 16, 10);
+
+    g_power_scene.battery_outline = lv_obj_create(g_power_scene.screen);
+    lv_obj_remove_style_all(g_power_scene.battery_outline);
+    lv_obj_set_size(g_power_scene.battery_outline, 20, 10);
+    lv_obj_set_pos(g_power_scene.battery_outline, 202, 6);
+    lv_obj_set_style_border_width(g_power_scene.battery_outline, 1, 0);
+    lv_obj_set_style_border_color(g_power_scene.battery_outline, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_radius(g_power_scene.battery_outline, 2, 0);
+    lv_obj_set_style_bg_opa(g_power_scene.battery_outline, LV_OPA_TRANSP, 0);
+
+    g_power_scene.battery_fill = lv_obj_create(g_power_scene.battery_outline);
+    lv_obj_remove_style_all(g_power_scene.battery_fill);
+    lv_obj_set_pos(g_power_scene.battery_fill, 1, 1);
+    lv_obj_set_size(g_power_scene.battery_fill, 18, 8);
+    lv_obj_set_style_radius(g_power_scene.battery_fill, 1, 0);
+    lv_obj_set_style_bg_opa(g_power_scene.battery_fill, LV_OPA_COVER, 0);
+
+    g_power_scene.battery_tip = lv_obj_create(g_power_scene.screen);
+    lv_obj_remove_style_all(g_power_scene.battery_tip);
+    lv_obj_set_size(g_power_scene.battery_tip, 2, 4);
+    lv_obj_set_pos(g_power_scene.battery_tip, 222, 9);
+    lv_obj_set_style_bg_color(g_power_scene.battery_tip, yoyopy_color_rgb(153, 160, 173), 0);
+    lv_obj_set_style_bg_opa(g_power_scene.battery_tip, LV_OPA_COVER, 0);
+
+    g_power_scene.title_label = lv_label_create(g_power_scene.screen);
+    lv_label_set_text(g_power_scene.title_label, "Setup");
+    lv_obj_set_pos(g_power_scene.title_label, 18, 36);
+    lv_obj_set_style_text_font(g_power_scene.title_label, &lv_font_montserrat_24, 0);
+
+    g_power_scene.title_underline = lv_obj_create(g_power_scene.screen);
+    lv_obj_remove_style_all(g_power_scene.title_underline);
+    lv_obj_set_pos(g_power_scene.title_underline, 18, 66);
+    lv_obj_set_size(g_power_scene.title_underline, 82, 3);
+    lv_obj_set_style_radius(g_power_scene.title_underline, 2, 0);
+    lv_obj_set_style_bg_opa(g_power_scene.title_underline, LV_OPA_COVER, 0);
+
+    g_power_scene.page_label = lv_label_create(g_power_scene.screen);
+    lv_obj_set_pos(g_power_scene.page_label, 188, 39);
+    lv_obj_set_style_text_font(g_power_scene.page_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(g_power_scene.page_label, yoyopy_color_rgb(153, 160, 173), 0);
+
+    g_power_scene.panel = lv_obj_create(g_power_scene.screen);
+    lv_obj_set_size(g_power_scene.panel, 216, 164);
+    lv_obj_set_pos(g_power_scene.panel, 12, 78);
+    lv_obj_set_style_radius(g_power_scene.panel, 24, 0);
+    lv_obj_set_style_border_width(g_power_scene.panel, 2, 0);
+    lv_obj_set_style_pad_all(g_power_scene.panel, 0, 0);
+    lv_obj_set_style_shadow_width(g_power_scene.panel, 0, 0);
+    lv_obj_set_style_outline_width(g_power_scene.panel, 0, 0);
+    lv_obj_set_scrollbar_mode(g_power_scene.panel, LV_SCROLLBAR_MODE_OFF);
+
+    for(int index = 0; index < 4; ++index) {
+        g_power_scene.item_panels[index] = lv_obj_create(g_power_scene.panel);
+        lv_obj_set_size(g_power_scene.item_panels[index], 184, 28);
+        lv_obj_set_pos(g_power_scene.item_panels[index], 16, 14 + (index * 34));
+        lv_obj_set_style_radius(g_power_scene.item_panels[index], 14, 0);
+        lv_obj_set_style_border_width(g_power_scene.item_panels[index], 1, 0);
+        lv_obj_set_style_pad_left(g_power_scene.item_panels[index], 10, 0);
+        lv_obj_set_style_pad_right(g_power_scene.item_panels[index], 10, 0);
+        lv_obj_set_style_pad_top(g_power_scene.item_panels[index], 6, 0);
+        lv_obj_set_style_pad_bottom(g_power_scene.item_panels[index], 6, 0);
+        lv_obj_set_style_shadow_width(g_power_scene.item_panels[index], 0, 0);
+        lv_obj_set_style_outline_width(g_power_scene.item_panels[index], 0, 0);
+        lv_obj_set_scrollbar_mode(g_power_scene.item_panels[index], LV_SCROLLBAR_MODE_OFF);
+
+        g_power_scene.item_titles[index] = lv_label_create(g_power_scene.item_panels[index]);
+        lv_obj_set_width(g_power_scene.item_titles[index], 160);
+        lv_label_set_long_mode(g_power_scene.item_titles[index], LV_LABEL_LONG_MODE_CLIP);
+        lv_obj_set_style_text_font(g_power_scene.item_titles[index], &lv_font_montserrat_12, 0);
+        lv_obj_set_style_text_align(g_power_scene.item_titles[index], LV_TEXT_ALIGN_LEFT, 0);
+        lv_obj_center(g_power_scene.item_titles[index]);
+    }
+
+    g_power_scene.footer_label = lv_label_create(g_power_scene.screen);
+    lv_obj_set_style_text_font(g_power_scene.footer_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_align(g_power_scene.footer_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(g_power_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    g_power_scene.built = 1;
+    return 0;
+}
+
+int yoyopy_lvgl_power_sync(
+    const char * title_text,
+    const char * page_text,
+    const char * footer,
+    const char * item_0,
+    const char * item_1,
+    const char * item_2,
+    const char * item_3,
+    int32_t item_count,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+) {
+    if(!g_power_scene.built) {
+        yoyopy_set_error("power scene must be built before sync");
+        return -1;
+    }
+
+    const lv_color_t background = yoyopy_color_rgb(18, 21, 28);
+    const lv_color_t surface = yoyopy_color_rgb(32, 35, 42);
+    const lv_color_t row_fill = yoyopy_color_rgb(24, 28, 34);
+    const lv_color_t ink = yoyopy_color_rgb(243, 247, 250);
+    const lv_color_t accent = yoyopy_color_rgb(accent_r, accent_g, accent_b);
+    const lv_color_t accent_dim = yoyopy_mix_rgb(accent_r, accent_g, accent_b, 18, 21, 28, 65);
+    const char * rows[4] = {item_0, item_1, item_2, item_3};
+
+    lv_obj_set_style_bg_color(g_power_scene.screen, background, 0);
+    lv_obj_set_style_bg_opa(g_power_scene.screen, LV_OPA_COVER, 0);
+    yoyopy_apply_voip_dot(g_power_scene.voip_dot, voip_state);
+    yoyopy_apply_battery(
+        g_power_scene.battery_outline,
+        g_power_scene.battery_fill,
+        g_power_scene.battery_tip,
+        battery_percent,
+        charging,
+        power_available
+    );
+
+    lv_label_set_text(g_power_scene.title_label, title_text != NULL ? title_text : "Setup");
+    lv_obj_set_style_text_color(g_power_scene.title_label, ink, 0);
+    lv_obj_set_style_bg_color(g_power_scene.title_underline, accent, 0);
+    lv_label_set_text(g_power_scene.page_label, page_text != NULL ? page_text : "");
+    lv_obj_set_style_text_color(g_power_scene.page_label, accent_dim, 0);
+
+    lv_obj_set_style_bg_color(g_power_scene.panel, surface, 0);
+    lv_obj_set_style_bg_opa(g_power_scene.panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(g_power_scene.panel, accent_dim, 0);
+
+    for(int index = 0; index < 4; ++index) {
+        if(index < item_count && rows[index] != NULL && rows[index][0] != '\0') {
+            lv_obj_clear_flag(g_power_scene.item_panels[index], LV_OBJ_FLAG_HIDDEN);
+            lv_obj_set_style_bg_color(g_power_scene.item_panels[index], row_fill, 0);
+            lv_obj_set_style_bg_opa(g_power_scene.item_panels[index], LV_OPA_COVER, 0);
+            lv_obj_set_style_border_color(g_power_scene.item_panels[index], accent_dim, 0);
+            lv_label_set_text(g_power_scene.item_titles[index], rows[index]);
+            lv_obj_set_style_text_color(g_power_scene.item_titles[index], ink, 0);
+            lv_obj_center(g_power_scene.item_titles[index]);
+        } else {
+            lv_obj_add_flag(g_power_scene.item_panels[index], LV_OBJ_FLAG_HIDDEN);
+        }
+    }
+
+    lv_label_set_text(g_power_scene.footer_label, footer != NULL ? footer : "");
+    lv_obj_set_style_text_color(g_power_scene.footer_label, accent_dim, 0);
+    lv_obj_align(g_power_scene.footer_label, LV_ALIGN_BOTTOM_MID, 0, -5);
+
+    return 0;
+}
+
+void yoyopy_lvgl_power_destroy(void) {
+    if(!g_power_scene.built) {
+        return;
+    }
+
+    if(g_power_scene.screen != NULL) {
+        lv_obj_clean(g_power_scene.screen);
+    }
+    yoyopy_clear_group();
+    yoyopy_reset_power_scene_refs();
 }
 
 int yoyopy_lvgl_init(void) {

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
@@ -1929,13 +1929,13 @@ int yoyopy_lvgl_in_call_build(void) {
     lv_obj_set_width(g_in_call_scene.caller_name_label, 176);
     lv_obj_set_pos(g_in_call_scene.caller_name_label, 16, 92);
     lv_label_set_long_mode(g_in_call_scene.caller_name_label, LV_LABEL_LONG_MODE_DOTS);
-    lv_obj_set_style_text_font(g_in_call_scene.caller_name_label, &lv_font_montserrat_22, 0);
+    lv_obj_set_style_text_font(g_in_call_scene.caller_name_label, &lv_font_montserrat_24, 0);
     lv_obj_set_style_text_align(g_in_call_scene.caller_name_label, LV_TEXT_ALIGN_CENTER, 0);
 
     g_in_call_scene.duration_label = lv_label_create(g_in_call_scene.panel);
     lv_obj_set_width(g_in_call_scene.duration_label, 176);
     lv_obj_set_pos(g_in_call_scene.duration_label, 16, 126);
-    lv_obj_set_style_text_font(g_in_call_scene.duration_label, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_font(g_in_call_scene.duration_label, &lv_font_montserrat_24, 0);
     lv_obj_set_style_text_align(g_in_call_scene.duration_label, LV_TEXT_ALIGN_CENTER, 0);
 
     g_in_call_scene.mute_chip = lv_obj_create(g_in_call_scene.panel);

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
@@ -141,6 +141,69 @@ int yoyopy_lvgl_incoming_call_sync(
     uint8_t accent_b
 );
 void yoyopy_lvgl_incoming_call_destroy(void);
+int yoyopy_lvgl_outgoing_call_build(void);
+int yoyopy_lvgl_outgoing_call_sync(
+    const char * callee_name,
+    const char * callee_address,
+    const char * footer,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_outgoing_call_destroy(void);
+int yoyopy_lvgl_in_call_build(void);
+int yoyopy_lvgl_in_call_sync(
+    const char * caller_name,
+    const char * duration_text,
+    const char * mute_text,
+    const char * footer,
+    int32_t muted,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_in_call_destroy(void);
+int yoyopy_lvgl_ask_build(void);
+int yoyopy_lvgl_ask_sync(
+    const char * title_text,
+    const char * subtitle_text,
+    const char * footer,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_ask_destroy(void);
+int yoyopy_lvgl_power_build(void);
+int yoyopy_lvgl_power_sync(
+    const char * title_text,
+    const char * page_text,
+    const char * footer,
+    const char * item_0,
+    const char * item_1,
+    const char * item_2,
+    const char * item_3,
+    int32_t item_count,
+    int32_t voip_state,
+    int32_t battery_percent,
+    int32_t charging,
+    int32_t power_available,
+    uint8_t accent_r,
+    uint8_t accent_g,
+    uint8_t accent_b
+);
+void yoyopy_lvgl_power_destroy(void);
 void yoyopy_lvgl_clear_screen(void);
 const char * yoyopy_lvgl_last_error(void);
 const char * yoyopy_lvgl_version(void);

--- a/yoyopy/ui/screens/navigation/ask.py
+++ b/yoyopy/ui/screens/navigation/ask.py
@@ -6,10 +6,12 @@ from typing import TYPE_CHECKING, Optional
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.navigation.lvgl import LvglAskView
 from yoyopy.ui.screens.theme import ASK, INK, MUTED, draw_icon, render_footer, render_header, rounded_panel, wrap_text
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens import ScreenView
 
 
 class AskScreen(Screen):
@@ -17,9 +19,43 @@ class AskScreen(Screen):
 
     def __init__(self, display: Display, context: Optional["AppContext"] = None) -> None:
         super().__init__(display, context, "Ask")
+        self._lvgl_view: "ScreenView | None" = None
+
+    def enter(self) -> None:
+        """Create the LVGL view when the screen becomes active."""
+        super().enter()
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving Ask."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Create an LVGL view when the Whisplay renderer is active."""
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglAskView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
 
     def render(self) -> None:
         """Render the future Ask mode preview."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
         content_top = render_header(
             self.display,
             self.context,
@@ -50,29 +86,16 @@ class AskScreen(Screen):
 
         copy_lines = wrap_text(
             self.display,
-            "Safe questions and calm answers will live here soon.",
+            "Safe questions will live here soon.",
             self.display.WIDTH - 52,
             12,
-            max_lines=2,
+            max_lines=1,
         )
         line_y = panel_top + 108
         for line in copy_lines:
             line_width, _ = self.display.get_text_size(line, 12)
             self.display.text(line, (self.display.WIDTH - line_width) // 2, line_y, color=INK, font_size=12)
             line_y += 15
-
-        note_lines = wrap_text(
-            self.display,
-            "Voice prompts and guided asks are next.",
-            self.display.WIDTH - 56,
-            10,
-            max_lines=2,
-        )
-        line_y += 10
-        for line in note_lines:
-            line_width, _ = self.display.get_text_size(line, 10)
-            self.display.text(line, (self.display.WIDTH - line_width) // 2, line_y, color=MUTED, font_size=10)
-            line_y += 13
 
         help_text = "Hold back" if self.is_one_button_mode() else "B back"
         render_footer(self.display, help_text, mode="ask")

--- a/yoyopy/ui/screens/navigation/lvgl/__init__.py
+++ b/yoyopy/ui/screens/navigation/lvgl/__init__.py
@@ -1,6 +1,8 @@
 """LVGL-backed navigation screen views."""
 
+from yoyopy.ui.screens.navigation.lvgl.ask_view import LvglAskView
 from yoyopy.ui.screens.navigation.lvgl.hub_view import LvglHubView
 from yoyopy.ui.screens.navigation.lvgl.listen_view import LvglListenView
+from yoyopy.ui.screens.navigation.lvgl.power_view import LvglPowerView
 
-__all__ = ["LvglHubView", "LvglListenView"]
+__all__ = ["LvglAskView", "LvglHubView", "LvglListenView", "LvglPowerView"]

--- a/yoyopy/ui/screens/navigation/lvgl/ask_view.py
+++ b/yoyopy/ui/screens/navigation/lvgl/ask_view.py
@@ -1,0 +1,62 @@
+"""LVGL-backed view for the Ask placeholder screen."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+from yoyopy.ui.screens.theme import ASK
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens.navigation.ask import AskScreen
+
+
+@dataclass(slots=True)
+class LvglAskView:
+    """Own the LVGL object lifecycle for AskScreen."""
+
+    screen: "AskScreen"
+    backend: LvglDisplayBackend
+    _built: bool = False
+
+    def build(self) -> None:
+        if self._built or self.backend.binding is None:
+            return
+        self.backend.binding.ask_build()
+        self._built = True
+
+    def sync(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+
+        context = self.screen.context
+        self.backend.binding.ask_sync(
+            title_text="Coming soon",
+            subtitle_text="Safe questions later.",
+            footer="Hold back" if self.screen.is_one_button_mode() else "B back",
+            voip_state=self._voip_state(context),
+            battery_percent=self._battery_percent(context),
+            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            accent=ASK.accent,
+        )
+
+    def destroy(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+        self.backend.binding.ask_destroy()
+        self._built = False
+
+    @staticmethod
+    def _battery_percent(context: "AppContext | None") -> int:
+        if context is None:
+            return 100
+        return max(0, min(100, int(getattr(context, "battery_percent", 100))))
+
+    @staticmethod
+    def _voip_state(context: "AppContext | None") -> int:
+        if context is None or not getattr(context, "voip_configured", False):
+            return 0
+        return 1 if getattr(context, "voip_ready", False) else 2

--- a/yoyopy/ui/screens/navigation/lvgl/power_view.py
+++ b/yoyopy/ui/screens/navigation/lvgl/power_view.py
@@ -1,0 +1,73 @@
+"""LVGL-backed view for the Setup screen."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+from yoyopy.ui.screens.theme import SETUP
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens.navigation.power import PowerScreen
+
+
+@dataclass(slots=True)
+class LvglPowerView:
+    """Own the LVGL object lifecycle for PowerScreen."""
+
+    screen: "PowerScreen"
+    backend: LvglDisplayBackend
+    _built: bool = False
+
+    def build(self) -> None:
+        if self._built or self.backend.binding is None:
+            return
+        self.backend.binding.power_build()
+        self._built = True
+
+    def sync(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+
+        snapshot = self.screen._get_snapshot()
+        status = self.screen._get_status()
+        pages = self.screen.build_pages(snapshot=snapshot, status=status)
+        if not pages:
+            return
+
+        self.screen.page_index %= len(pages)
+        active_page = pages[self.screen.page_index]
+        items = [f"{label}: {value}" for label, value in active_page.rows[:4]]
+        context = self.screen.context
+
+        self.backend.binding.power_sync(
+            title_text=active_page.title,
+            page_text=f"{self.screen.page_index + 1}/{len(pages)}",
+            footer="Tap page / Hold back" if self.screen.is_one_button_mode() else "A page | B back",
+            items=items,
+            voip_state=self._voip_state(context),
+            battery_percent=self._battery_percent(context),
+            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            accent=SETUP.accent,
+        )
+
+    def destroy(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+        self.backend.binding.power_destroy()
+        self._built = False
+
+    @staticmethod
+    def _battery_percent(context: "AppContext | None") -> int:
+        if context is None:
+            return 100
+        return max(0, min(100, int(getattr(context, "battery_percent", 100))))
+
+    @staticmethod
+    def _voip_state(context: "AppContext | None") -> int:
+        if context is None or not getattr(context, "voip_configured", False):
+            return 0
+        return 1 if getattr(context, "voip_ready", False) else 2

--- a/yoyopy/ui/screens/navigation/power.py
+++ b/yoyopy/ui/screens/navigation/power.py
@@ -8,11 +8,13 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.navigation.lvgl import LvglPowerView
 from yoyopy.ui.screens.theme import INK, MUTED, SETUP, SURFACE_RAISED, render_footer, render_header, rounded_panel, text_fit
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
     from yoyopy.power import PowerManager, PowerSnapshot
+    from yoyopy.ui.screens import ScreenView
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,9 +40,43 @@ class PowerScreen(Screen):
         self.power_manager = power_manager
         self.status_provider = status_provider or (lambda: {})
         self.page_index = 0
+        self._lvgl_view: "ScreenView | None" = None
+
+    def enter(self) -> None:
+        """Create the LVGL view when the screen becomes active."""
+        super().enter()
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving Setup."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Create an LVGL view when the Whisplay renderer is active."""
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglPowerView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
 
     def render(self) -> None:
         """Render the active Setup page."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
         snapshot = self._get_snapshot()
         status = self._get_status()
         pages = self.build_pages(snapshot=snapshot, status=status)
@@ -288,11 +324,11 @@ class PowerScreen(Screen):
 
     def _next_page(self) -> None:
         """Advance to the next page with wraparound."""
-        self.page_index = (self.page_index + 1) % 2
+        self.page_index = (self.page_index + 1) % 3
 
     def _previous_page(self) -> None:
         """Return to the previous page with wraparound."""
-        self.page_index = (self.page_index - 1) % 2
+        self.page_index = (self.page_index - 1) % 3
 
     def on_advance(self, data=None) -> None:
         """Single-button tap cycles pages."""

--- a/yoyopy/ui/screens/voip/contact_list.py
+++ b/yoyopy/ui/screens/voip/contact_list.py
@@ -8,10 +8,12 @@ from loguru import logger
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.voip.lvgl import LvglContactListView
 from yoyopy.ui.screens.theme import SURFACE, draw_empty_state, draw_list_item, render_footer, render_header, rounded_panel, text_fit
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens import ScreenView
 
 
 class ContactListScreen(Screen):
@@ -31,11 +33,36 @@ class ContactListScreen(Screen):
         self.selected_index = 0
         self.scroll_offset = 0
         self.max_visible_items = 4 if display.is_portrait() else 5
+        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Load contacts when the screen becomes active."""
         super().enter()
         self.load_contacts()
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving contacts."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Create an LVGL view when the Whisplay renderer is active."""
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglContactListView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
 
     def load_contacts(self) -> None:
         """Load contacts from config manager."""
@@ -49,6 +76,11 @@ class ContactListScreen(Screen):
 
     def render(self) -> None:
         """Render the contact list."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
         page_text = None
         if self.contacts:
             page_text = f"{self.selected_index + 1}/{len(self.contacts)}"
@@ -120,6 +152,38 @@ class ContactListScreen(Screen):
         help_text = "Tap next / Call / Hold back" if self.is_one_button_mode() else "A call | B back | X/Y move"
         render_footer(self.display, help_text, mode="talk")
         self.display.update()
+
+    def get_page_text(self) -> str | None:
+        """Return the compact page indicator for the current contact selection."""
+        if not self.contacts:
+            return None
+        return f"{self.selected_index + 1}/{len(self.contacts)}"
+
+    def get_visible_window(self) -> tuple[list[str], list[str], int]:
+        """Return the visible contact titles, badges, and selected row index."""
+        if not self.contacts:
+            return [], [], 0
+
+        if self.selected_index < self.scroll_offset:
+            self.scroll_offset = self.selected_index
+        elif self.selected_index >= self.scroll_offset + self.max_visible_items:
+            self.scroll_offset = self.selected_index - self.max_visible_items + 1
+
+        visible_titles: list[str] = []
+        visible_badges: list[str] = []
+        selected_visible_index = 0
+        for row in range(self.max_visible_items):
+            contact_index = self.scroll_offset + row
+            if contact_index >= len(self.contacts):
+                break
+
+            contact = self.contacts[contact_index]
+            visible_titles.append(contact.name)
+            visible_badges.append("FAV" if contact.favorite else "")
+            if contact_index == self.selected_index:
+                selected_visible_index = row
+
+        return visible_titles, visible_badges, selected_visible_index
 
     def select_next(self) -> None:
         """Move selection to next contact."""

--- a/yoyopy/ui/screens/voip/hub.py
+++ b/yoyopy/ui/screens/voip/hub.py
@@ -9,11 +9,13 @@ from loguru import logger
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.voip.lvgl import LvglCallView
 from yoyopy.ui.screens.theme import INK, MUTED, SURFACE, TALK, draw_empty_state, draw_list_item, render_footer, render_header, rounded_panel, text_fit
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
     from yoyopy.config import ConfigManager, Contact
+    from yoyopy.ui.screens import ScreenView
     from yoyopy.voip import VoIPManager
 
 
@@ -47,11 +49,36 @@ class CallScreen(Screen):
         self.selected_index = 0
         self.scroll_offset = 0
         self.max_visible_items = 3 if display.is_portrait() else 4
+        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Refresh quick-call shortcuts whenever the screen becomes active."""
         super().enter()
         self._load_quick_targets()
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving Talk."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Create an LVGL view when the Whisplay renderer is active."""
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglCallView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
 
     def _load_quick_targets(self) -> None:
         """Load favorite or regular contacts for quick calling."""
@@ -100,6 +127,11 @@ class CallScreen(Screen):
 
     def render(self) -> None:
         """Render the Talk hub with status and quick-call cards."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
         status = self._get_status_snapshot()
         status_text, _status_color, _detail_text = self._status_lines(status)
         call_state_text, caller_text = self._call_context_lines(status)
@@ -180,6 +212,37 @@ class CallScreen(Screen):
 
         render_footer(self.display, self._instruction_text(), mode="talk")
         self.display.update()
+
+    def get_page_text(self) -> str | None:
+        """Return the compact page indicator for the current quick target."""
+        if not self.quick_targets:
+            return None
+        return f"{self.selected_index + 1}/{len(self.quick_targets)}"
+
+    def get_visible_window(self) -> tuple[list[str], list[str], int]:
+        """Return the visible quick-target titles, badges, and selected row index."""
+        if not self.quick_targets:
+            return [], [], 0
+
+        visible_items = max(1, min(self.max_visible_items, len(self.quick_targets)))
+        self._ensure_selection_visible(visible_items)
+
+        visible_titles: list[str] = []
+        visible_badges: list[str] = []
+        selected_visible_index = 0
+
+        for row in range(visible_items):
+            target_index = self.scroll_offset + row
+            if target_index >= len(self.quick_targets):
+                break
+
+            target = self.quick_targets[target_index]
+            visible_titles.append(target.title)
+            visible_badges.append("ALL" if target.kind == "browse_contacts" else "FAV" if target.favorite else "")
+            if target_index == self.selected_index:
+                selected_visible_index = row
+
+        return visible_titles, visible_badges, selected_visible_index
 
     def _get_status_snapshot(self) -> dict:
         """Return a stable VoIP status dict for rendering and actions."""

--- a/yoyopy/ui/screens/voip/in_call.py
+++ b/yoyopy/ui/screens/voip/in_call.py
@@ -8,10 +8,12 @@ from loguru import logger
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.voip.lvgl import LvglInCallView
 from yoyopy.ui.screens.theme import INK, MUTED, TALK, draw_icon, render_footer, render_header, rounded_panel
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens import ScreenView
 
 
 class InCallScreen(Screen):
@@ -25,6 +27,35 @@ class InCallScreen(Screen):
     ) -> None:
         super().__init__(display, context, "InCall")
         self.voip_manager = voip_manager
+        self._lvgl_view: "ScreenView | None" = None
+
+    def enter(self) -> None:
+        """Create the LVGL view when the screen becomes active."""
+        super().enter()
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving the live call."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Create an LVGL view when the Whisplay renderer is active."""
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglInCallView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
 
     @staticmethod
     def format_duration(seconds: int) -> str:
@@ -35,6 +66,11 @@ class InCallScreen(Screen):
 
     def render(self) -> None:
         """Render the active-call screen."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
         caller_info = {"display_name": "Unknown", "address": ""}
         duration = 0
         is_muted = False
@@ -47,7 +83,7 @@ class InCallScreen(Screen):
             self.display,
             self.context,
             mode="talk",
-            title="On call",
+            title="Talk",
             show_time=False,
             show_mode_chip=False,
         )

--- a/yoyopy/ui/screens/voip/lvgl/__init__.py
+++ b/yoyopy/ui/screens/voip/lvgl/__init__.py
@@ -1,5 +1,15 @@
 """LVGL-backed VoIP screen views."""
 
+from yoyopy.ui.screens.voip.lvgl.call_view import LvglCallView
+from yoyopy.ui.screens.voip.lvgl.contact_list_view import LvglContactListView
+from yoyopy.ui.screens.voip.lvgl.in_call_view import LvglInCallView
 from yoyopy.ui.screens.voip.lvgl.incoming_call_view import LvglIncomingCallView
+from yoyopy.ui.screens.voip.lvgl.outgoing_call_view import LvglOutgoingCallView
 
-__all__ = ["LvglIncomingCallView"]
+__all__ = [
+    "LvglCallView",
+    "LvglContactListView",
+    "LvglInCallView",
+    "LvglIncomingCallView",
+    "LvglOutgoingCallView",
+]

--- a/yoyopy/ui/screens/voip/lvgl/call_view.py
+++ b/yoyopy/ui/screens/voip/lvgl/call_view.py
@@ -1,0 +1,73 @@
+"""LVGL-backed view for the Talk hub screen."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+from yoyopy.ui.screens.theme import TALK
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens.voip.hub import CallScreen
+
+
+@dataclass(slots=True)
+class LvglCallView:
+    """Own the LVGL object lifecycle for CallScreen."""
+
+    screen: "CallScreen"
+    backend: LvglDisplayBackend
+    _built: bool = False
+
+    def build(self) -> None:
+        if self._built or self.backend.binding is None:
+            return
+        self.backend.binding.playlist_build()
+        self._built = True
+
+    def sync(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+
+        visible_items, visible_badges, selected_visible_index = self.screen.get_visible_window()
+        status = self.screen._get_status_snapshot()
+        status_text, _status_color, _detail = self.screen._status_lines(status)
+        call_state_text, _caller_text = self.screen._call_context_lines(status)
+        context = self.screen.context
+
+        self.backend.binding.playlist_sync(
+            title_text=call_state_text or status_text or "Talk",
+            page_text=self.screen.get_page_text(),
+            footer=self.screen._instruction_text(),
+            items=visible_items,
+            badges=visible_badges,
+            selected_visible_index=selected_visible_index,
+            voip_state=self._voip_state(context),
+            battery_percent=self._battery_percent(context),
+            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            accent=TALK.accent,
+            empty_title="No contacts",
+            empty_subtitle="Add favorites to Talk.",
+            empty_icon_key="talk",
+        )
+
+    def destroy(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+        self.backend.binding.playlist_destroy()
+        self._built = False
+
+    @staticmethod
+    def _battery_percent(context: "AppContext | None") -> int:
+        if context is None:
+            return 100
+        return max(0, min(100, int(getattr(context, "battery_percent", 100))))
+
+    @staticmethod
+    def _voip_state(context: "AppContext | None") -> int:
+        if context is None or not getattr(context, "voip_configured", False):
+            return 0
+        return 1 if getattr(context, "voip_ready", False) else 2

--- a/yoyopy/ui/screens/voip/lvgl/contact_list_view.py
+++ b/yoyopy/ui/screens/voip/lvgl/contact_list_view.py
@@ -1,0 +1,70 @@
+"""LVGL-backed view for the contact list screen."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+from yoyopy.ui.screens.theme import TALK
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens.voip.contact_list import ContactListScreen
+
+
+@dataclass(slots=True)
+class LvglContactListView:
+    """Own the LVGL object lifecycle for ContactListScreen."""
+
+    screen: "ContactListScreen"
+    backend: LvglDisplayBackend
+    _built: bool = False
+
+    def build(self) -> None:
+        if self._built or self.backend.binding is None:
+            return
+        self.backend.binding.playlist_build()
+        self._built = True
+
+    def sync(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+
+        visible_items, visible_badges, selected_visible_index = self.screen.get_visible_window()
+        context = self.screen.context
+
+        self.backend.binding.playlist_sync(
+            title_text="Contacts",
+            page_text=self.screen.get_page_text(),
+            footer="Tap next / Call / Hold back" if self.screen.is_one_button_mode() else "A call | B back | X/Y move",
+            items=visible_items,
+            badges=visible_badges,
+            selected_visible_index=selected_visible_index,
+            voip_state=self._voip_state(context),
+            battery_percent=self._battery_percent(context),
+            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            accent=TALK.accent,
+            empty_title="No contacts",
+            empty_subtitle="Add contacts to call them here.",
+            empty_icon_key="talk",
+        )
+
+    def destroy(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+        self.backend.binding.playlist_destroy()
+        self._built = False
+
+    @staticmethod
+    def _battery_percent(context: "AppContext | None") -> int:
+        if context is None:
+            return 100
+        return max(0, min(100, int(getattr(context, "battery_percent", 100))))
+
+    @staticmethod
+    def _voip_state(context: "AppContext | None") -> int:
+        if context is None or not getattr(context, "voip_configured", False):
+            return 0
+        return 1 if getattr(context, "voip_ready", False) else 2

--- a/yoyopy/ui/screens/voip/lvgl/in_call_view.py
+++ b/yoyopy/ui/screens/voip/lvgl/in_call_view.py
@@ -1,0 +1,79 @@
+"""LVGL-backed view for the in-call screen."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+from yoyopy.ui.screens.theme import TALK
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens.voip.in_call import InCallScreen
+
+
+@dataclass(slots=True)
+class LvglInCallView:
+    """Own the LVGL object lifecycle for InCallScreen."""
+
+    screen: "InCallScreen"
+    backend: LvglDisplayBackend
+    _built: bool = False
+
+    def build(self) -> None:
+        if self._built or self.backend.binding is None:
+            return
+        self.backend.binding.in_call_build()
+        self._built = True
+
+    def sync(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+
+        caller_name = "Unknown"
+        duration_seconds = 0
+        is_muted = False
+        if self.screen.voip_manager:
+            caller_info = self.screen.voip_manager.get_caller_info()
+            caller_name = caller_info.get("display_name", caller_name) or "Unknown"
+            duration_seconds = self.screen.voip_manager.get_call_duration()
+            is_muted = self.screen.voip_manager.is_muted
+
+        footer = (
+            f"Tap {'unmute' if is_muted else 'mute'} / Hold end"
+            if self.screen.is_one_button_mode()
+            else f"X {'unmute' if is_muted else 'mute'} | B end"
+        )
+        context = self.screen.context
+
+        self.backend.binding.in_call_sync(
+            caller_name=caller_name,
+            duration_text=self.screen.format_duration(duration_seconds),
+            mute_text="Muted" if is_muted else "Mic on",
+            footer=footer,
+            muted=is_muted,
+            voip_state=self._voip_state(context),
+            battery_percent=self._battery_percent(context),
+            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            accent=TALK.accent,
+        )
+
+    def destroy(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+        self.backend.binding.in_call_destroy()
+        self._built = False
+
+    @staticmethod
+    def _battery_percent(context: "AppContext | None") -> int:
+        if context is None:
+            return 100
+        return max(0, min(100, int(getattr(context, "battery_percent", 100))))
+
+    @staticmethod
+    def _voip_state(context: "AppContext | None") -> int:
+        if context is None or not getattr(context, "voip_configured", False):
+            return 0
+        return 1 if getattr(context, "voip_ready", False) else 2

--- a/yoyopy/ui/screens/voip/lvgl/outgoing_call_view.py
+++ b/yoyopy/ui/screens/voip/lvgl/outgoing_call_view.py
@@ -1,0 +1,71 @@
+"""LVGL-backed view for the outgoing-call screen."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from yoyopy.ui.lvgl_binding import LvglDisplayBackend
+from yoyopy.ui.screens.theme import TALK
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens.voip.outgoing_call import OutgoingCallScreen
+
+
+@dataclass(slots=True)
+class LvglOutgoingCallView:
+    """Own the LVGL object lifecycle for OutgoingCallScreen."""
+
+    screen: "OutgoingCallScreen"
+    backend: LvglDisplayBackend
+    _built: bool = False
+
+    def build(self) -> None:
+        if self._built or self.backend.binding is None:
+            return
+        self.backend.binding.outgoing_call_build()
+        self._built = True
+
+    def sync(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+
+        callee_name = self.screen.callee_name or "Unknown"
+        callee_address = self.screen.callee_address or "Unknown"
+        if self.screen.voip_manager:
+            caller_info = self.screen.voip_manager.get_caller_info()
+            callee_name = caller_info.get("display_name", callee_name) or "Unknown"
+            callee_address = caller_info.get("address", callee_address) or "Unknown"
+
+        footer = "Hold cancel" if self.screen.is_one_button_mode() else "B cancel"
+        context = self.screen.context
+
+        self.backend.binding.outgoing_call_sync(
+            callee_name=callee_name,
+            callee_address=callee_address,
+            footer=footer,
+            voip_state=self._voip_state(context),
+            battery_percent=self._battery_percent(context),
+            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            accent=TALK.accent,
+        )
+
+    def destroy(self) -> None:
+        if not self._built or self.backend.binding is None:
+            return
+        self.backend.binding.outgoing_call_destroy()
+        self._built = False
+
+    @staticmethod
+    def _battery_percent(context: "AppContext | None") -> int:
+        if context is None:
+            return 100
+        return max(0, min(100, int(getattr(context, "battery_percent", 100))))
+
+    @staticmethod
+    def _voip_state(context: "AppContext | None") -> int:
+        if context is None or not getattr(context, "voip_configured", False):
+            return 0
+        return 1 if getattr(context, "voip_ready", False) else 2

--- a/yoyopy/ui/screens/voip/outgoing_call.py
+++ b/yoyopy/ui/screens/voip/outgoing_call.py
@@ -8,10 +8,12 @@ from loguru import logger
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.voip.lvgl import LvglOutgoingCallView
 from yoyopy.ui.screens.theme import INK, MUTED, TALK, draw_icon, render_footer, render_header, rounded_panel, text_fit, wrap_text
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens import ScreenView
 
 
 class OutgoingCallScreen(Screen):
@@ -30,9 +32,43 @@ class OutgoingCallScreen(Screen):
         self.callee_address = callee_address
         self.callee_name = callee_name
         self.ring_animation_frame = 0
+        self._lvgl_view: "ScreenView | None" = None
+
+    def enter(self) -> None:
+        """Create the LVGL view when the screen becomes active."""
+        super().enter()
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving outgoing call."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Create an LVGL view when the Whisplay renderer is active."""
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglOutgoingCallView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
 
     def render(self) -> None:
         """Render the outgoing-call screen."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
         callee_name = self.callee_name
         callee_address = self.callee_address
         if self.voip_manager:
@@ -79,7 +115,7 @@ class OutgoingCallScreen(Screen):
             self.display.text(line, (self.display.WIDTH - width) // 2, line_y, color=MUTED, font_size=11)
             line_y += 13
 
-        status_text = "Connecting..."
+        status_text = "Calling"
         status_width, _ = self.display.get_text_size(status_text, 13)
         self.display.text(status_text, (self.display.WIDTH - status_width) // 2, panel_bottom - 58, color=TALK.accent, font_size=13)
 


### PR DESCRIPTION
﻿## Summary
- migrate the remaining Whisplay-target screens to LVGL-backed views: Talk hub, contact list, outgoing call, in-call, Ask, and Setup
- extend the native LVGL shim and CPython binding with the new scene lifecycles while reusing the existing playlist scene for list-style Talk screens
- flip the Whisplay default renderer to `lvgl` and update the developer guide/config defaults to match the new cutover state
- add focused tests for the remaining LVGL delegations while preserving the current PIL fallback for non-Whisplay paths

## Verification
- `python -m compileall yoyopy tests`
- `uv run pytest -q`
- `uv run python scripts/pi_remote.py --host rpi-zero --branch codex/lvgl-remaining-cutover sync`
- `ssh rpi-zero` build of `scripts/lvgl_build.py`
- real Whisplay LVGL validation on `rpi-zero` for Call hub, Contacts, Outgoing Call, In Call, Ask, and Setup (`LVGL_CALL_HUB_OK`, `LVGL_CONTACTS_OK`, `LVGL_OUTGOING_CALL_OK`, `LVGL_IN_CALL_OK`, `LVGL_ASK_OK`, `LVGL_POWER_OK`)
- production service restart on `rpi-zero`, with journal confirmation of `Active UI backend: lvgl` and `Backend: lvgl`
