### PR TITLE
Add Talk history, Ask shell, and LVGL soak diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # YoyoPod Current Status & Developer Guide
 
-**Last Updated:** 2026-04-05
+**Last Updated:** 2026-04-06
 **Target Hardware:** Raspberry Pi Zero 2W
 **Project:** iPod-inspired VoIP and Mopidy player with a small-screen, button-driven UI
 
@@ -24,7 +24,7 @@
   - RTC helpers
   - PiSugar software watchdog support
 - Production Raspberry Pi deployment now has a committed systemd unit template under `deploy/systemd/`.
-- Whisplay now has an in-progress LVGL rendering path under `yoyopy/ui/lvgl_binding/`, and the Whisplay renderer default is `lvgl`.
+- Whisplay now runs on the LVGL rendering path in production under `yoyopy/ui/lvgl_binding/`.
 - CI validates the Python test suite with `uv sync --extra dev` and `uv run pytest -q`.
 - Raspberry Pi validation has a defined path through `scripts/pi_smoke.py` and `scripts/pi_remote.py`.
 
@@ -32,14 +32,11 @@ This file should reflect the repo as it exists on `main`. Older milestone notes 
 
 ---
 
-## Active LVGL Migration
+## LVGL Status
 
-- Whisplay is beginning a rendering migration from PIL drawing to LVGL-backed widgets.
-- The migration plan lives in `docs/LVGL_MIGRATION_PLAN.md`.
-- Until cutover is complete:
-  - Whisplay defaults to `display.whisplay_renderer: pil`
-  - Pimoroni and simulation remain on the PIL path
-  - current screens, routes, coordinators, FSMs, and input grammar stay intact
+- Whisplay has completed its production cutover to LVGL-backed rendering.
+- The migration plan and backend notes live in `docs/LVGL_MIGRATION_PLAN.md`.
+- Pimoroni and simulation still use the PIL rendering path.
 - Raw LVGL usage should remain confined to `yoyopy/ui/lvgl_binding/` and related display-layer code.
 
 ---
@@ -129,6 +126,7 @@ Key design points:
 - `yoyopy/voip/manager.py` - app-facing VoIP facade
 - `yoyopy/voip/backend.py` - `VoIPBackend`, `LinphonecBackend`, `MockVoIPBackend`
 - `yoyopy/voip/models.py` - SIP config and typed backend events
+- `yoyopy/voip/history.py` - persistent recent/missed-call store for the Talk flow
 
 ### Power
 
@@ -149,9 +147,11 @@ Key design points:
 - `yoyopy/ui/screens/router.py` - declarative route resolution
 - `yoyopy/ui/screens/theme.py` - Graffiti Buddy shared chrome, colors, icons, and status-bar renderer
 - `yoyopy/ui/screens/navigation/listen.py` - source chooser for the `Listen` root mode
-- `yoyopy/ui/screens/navigation/ask.py` - future-safe `Ask` mode placeholder
+- `yoyopy/ui/screens/navigation/ask.py` - staged `Ask` shell with idle/listening/thinking/response states
 - `yoyopy/ui/screens/system/power.py` - `Setup` screen with power and care pages
-- `yoyopy/ui/screens/voip/quick_call.py` - `Talk` quick-call hub
+- `yoyopy/ui/screens/voip/quick_call.py` - `Talk` quick-call hub with favorites, recents, and voice-note entry
+- `yoyopy/ui/screens/voip/call_history.py` - Talk recents and missed-call screen
+- `yoyopy/ui/screens/voip/voice_note.py` - voice-note shell for the Talk flow
 
 ### Configuration
 
@@ -225,9 +225,10 @@ Preferred remote helper:
 
 ```bash
 uv run python scripts/pi_remote.py status --host rpi-zero
-uv run python scripts/pi_remote.py preflight --host rpi-zero --with-mopidy --with-voip
+uv run python scripts/pi_remote.py preflight --host rpi-zero --with-mopidy --with-voip --with-lvgl-soak
 uv run python scripts/pi_remote.py sync --host rpi-zero --branch main
-uv run python scripts/pi_remote.py smoke --host rpi-zero --with-mopidy --with-voip
+uv run python scripts/pi_remote.py smoke --host rpi-zero --with-mopidy --with-voip --with-lvgl-soak
+uv run python scripts/pi_remote.py lvgl-soak --host rpi-zero --cycles 2
 uv run python scripts/pi_remote.py power --host rpi-zero
 uv run python scripts/pi_remote.py service install --host rpi-zero
 ```
@@ -237,6 +238,7 @@ Direct smoke helper on the Pi:
 ```bash
 uv run python scripts/pi_smoke.py
 uv run python scripts/pi_smoke.py --with-mopidy --with-voip
+uv run python scripts/pi_smoke.py --with-lvgl-soak
 ```
 
 If the Pi seems to keep old Python state after a pull, restart the running app process before retesting.
@@ -312,7 +314,7 @@ If an old doc mentions combined VoIP/music states as the implementation model, t
 The architecture cleanup is largely done. The remaining work is more product-facing:
 
 - dial pad / manual SIP entry
-- call history and missed-call UX
+- voice-note recording/send implementation behind the new shell
 - fuller settings UI
 - additional hardware-in-the-loop validation on Raspberry Pi
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ The current codebase supports three display/input modes:
 - Simulation mode: browser display plus keyboard and web-button input
 
 On Whisplay, the one-button root hub currently exposes four cards:
-- `Now Playing`
-- `Playlists`
-- `Calls`
-- `Power`
+- `Listen`
+- `Talk`
+- `Ask`
+- `Setup`
 
 ## Current Status
 
@@ -26,6 +26,9 @@ On Whisplay, the one-button root hub currently exposes four cards:
   - `Talk`
   - `Ask`
   - `Setup`
+- `Talk` now includes quick-call favorites, recents/missed calls, and a voice-note recipient entry point
+- `Ask` is now a staged shell with idle, listening, thinking, and response states
+- Whisplay production rendering now runs on the LVGL backend by default
 - GitHub Actions CI validates `uv sync --extra dev` and `uv run pytest -q`
 
 ## Main Runtime Components
@@ -35,6 +38,7 @@ On Whisplay, the one-button root hub currently exposes four cards:
 - `yoyopy/app.py`: `YoyoPodApp` coordinator
 - `scripts/pi_smoke.py`: Raspberry Pi smoke validator for hardware and optional service checks
 - `scripts/pi_remote.py`: SSH helper for Raspberry Pi sync, smoke, status, and run loops
+- `scripts/lvgl_soak.py`: LVGL transition and sleep/wake soak helper for Whisplay
 - `scripts/pisugar_power.py`: PiSugar battery, shutdown, and watchdog helper
 - `scripts/pisugar_rtc.py`: PiSugar RTC status, sync, and alarm helper
 - `deploy/systemd/yoyopod@.service`: production systemd unit for boot-time app supervision
@@ -113,6 +117,7 @@ Raspberry Pi smoke:
 uv run python scripts/pi_smoke.py
 uv run python scripts/pi_smoke.py --with-power --with-rtc
 uv run python scripts/pi_smoke.py --with-mopidy --with-voip --with-rtc
+uv run python scripts/pi_smoke.py --with-lvgl-soak
 ```
 
 Remote Pi workflow:
@@ -125,6 +130,7 @@ uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip
 uv run python scripts/pi_remote.py power
 uv run python scripts/pi_remote.py rtc status
 uv run python scripts/pi_remote.py rtc sync-to-rtc
+uv run python scripts/pi_remote.py lvgl-soak --cycles 2
 uv run python scripts/pi_remote.py service status
 uv run python scripts/pi_remote.py service install
 uv run python scripts/pi_remote.py whisplay --duration-seconds 45
@@ -198,6 +204,7 @@ yoyopy/
     manager.py
   voip/
     backend.py
+    history.py
     manager.py
     models.py
   ui/
@@ -234,6 +241,7 @@ yoyopy/
 - `docs/DISPLAY_HAL_ARCHITECTURE.md`: current display HAL design
 - `docs/INPUT_HAL_ARCHITECTURE.md`: current input HAL design and compatibility notes
 - `docs/POWER_MODULE.md`: PiSugar power architecture, config, safety, RTC, watchdog, and diagnostics
+- `docs/LVGL_MIGRATION_PLAN.md`: Whisplay LVGL migration record and backend boundaries
 - `docs/RPI_SMOKE_VALIDATION.md`: Raspberry Pi smoke checklist and manual follow-up drills
 - `docs/PI_DEV_WORKFLOW.md`: SSH-based Raspberry Pi sync/run workflow and release checklist
 - `docs/UI_RESTRUCTURE_PROPOSAL.md`: refactor status and remaining cleanup

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -82,6 +82,7 @@ uv run python scripts/pi_remote.py sync --branch main --skip-uv-sync
 uv run python scripts/pi_remote.py smoke
 uv run python scripts/pi_remote.py smoke --with-power --with-rtc
 uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip --with-rtc
+uv run python scripts/pi_remote.py smoke --with-lvgl-soak
 ```
 
 Useful variations:
@@ -97,6 +98,19 @@ uv run python scripts/pi_remote.py smoke --with-voip --voip-timeout 15 --verbose
 uv run python scripts/pi_remote.py whisplay
 uv run python scripts/pi_remote.py whisplay --duration-seconds 45 --double-tap-ms 240 --long-hold-ms 900
 ```
+
+### Run the LVGL Whisplay soak remotely
+
+```bash
+uv run python scripts/pi_remote.py lvgl-soak
+uv run python scripts/pi_remote.py lvgl-soak --cycles 3 --hold-seconds 0.3
+```
+
+Use this when you want a focused hardware-in-the-loop pass for:
+
+- repeated LVGL screen transitions
+- sleep/wake recovery
+- Whisplay-only rendering regressions
 
 ### PiSugar RTC helpers
 
@@ -131,7 +145,7 @@ Use this during on-device tuning when the Whisplay button feels too eager or too
 ### Run the full preflight in one command
 
 ```bash
-uv run python scripts/pi_remote.py preflight --branch main --with-mopidy --with-voip
+uv run python scripts/pi_remote.py preflight --branch main --with-mopidy --with-voip --with-lvgl-soak
 ```
 
 What it does:
@@ -167,7 +181,7 @@ uv run python scripts/pi_remote.py run --app-arg=--your-extra-flag
 1. Run local checks: `uv run pytest -q`
 2. Push your branch
 3. Run the combined preflight:
-   `uv run python scripts/pi_remote.py preflight --branch <branch> --with-mopidy --with-voip`
+   `uv run python scripts/pi_remote.py preflight --branch <branch> --with-mopidy --with-voip --with-lvgl-soak`
 4. Launch the app:
    `uv run python scripts/pi_remote.py run`
 
@@ -181,7 +195,7 @@ run, use:
 
 - Local branch is green with `uv run pytest -q`
 - Branch is pushed and reviewed
-- `uv run python scripts/pi_remote.py preflight --branch <branch> --with-mopidy --with-voip` passes
+- `uv run python scripts/pi_remote.py preflight --branch <branch> --with-mopidy --with-voip --with-lvgl-soak` passes
 - `uv run python scripts/pi_remote.py run` starts cleanly
 - Manual sanity:
   - display renders correctly

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -22,6 +22,7 @@ Run this on the target Raspberry Pi after pulling the latest branch:
 ```bash
 uv run python scripts/pi_smoke.py
 uv run python scripts/pi_smoke.py --with-power --with-rtc
+uv run python scripts/pi_smoke.py --with-lvgl-soak
 ```
 
 What it checks:
@@ -29,6 +30,7 @@ What it checks:
 - target environment information
 - display initialization on real hardware
 - matching input adapter construction and start/stop
+- optional LVGL transition and sleep/wake soak when requested
 
 Expected result:
 
@@ -111,6 +113,19 @@ Useful flags:
 - `--long-hold-ms 900`
 - `--verbose`
 
+### LVGL Whisplay soak
+
+```bash
+uv run python scripts/lvgl_soak.py
+uv run python scripts/lvgl_soak.py --cycles 3 --hold-seconds 0.3
+```
+
+Use this when Whisplay rendering feels fast but you still want a hardware pass for:
+
+- repeated routed screen transitions
+- sleep/wake recovery
+- LVGL-only corruption or stuck redraw issues
+
 ### PiSugar RTC drill
 
 ```bash
@@ -134,7 +149,8 @@ Use this when you want a focused battery, charging, RTC, shutdown-threshold, and
 2. `uv run pytest -q`
 3. `uv run python scripts/pi_smoke.py`
 4. `uv run python scripts/pi_smoke.py --with-mopidy --with-voip`
-5. `uv run python yoyopod.py`
+5. `uv run python scripts/pi_smoke.py --with-lvgl-soak`
+6. `uv run python yoyopod.py`
 
 ## Failure Triage
 

--- a/scripts/lvgl_soak.py
+++ b/scripts/lvgl_soak.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Run a small hardware-in-the-loop LVGL soak pass on the Whisplay path."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+from loguru import logger
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from yoyopy.app import YoyoPodApp
+from yoyopy.events import UserActivityEvent
+
+
+def configure_logging(verbose: bool) -> None:
+    """Configure human-readable logging."""
+
+    logger.remove()
+    logger.add(
+        sys.stderr,
+        format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <level>{message}</level>",
+        level="DEBUG" if verbose else "INFO",
+    )
+
+
+def _pump_app(app: YoyoPodApp, duration_seconds: float) -> None:
+    """Pump the coordinator-thread services without entering the full app run loop."""
+
+    deadline = time.monotonic() + max(0.0, duration_seconds)
+    while time.monotonic() < deadline:
+        app._process_pending_main_thread_actions()
+        now = time.monotonic()
+        app._attempt_manager_recovery()
+        app._poll_power_status(now=now)
+        app._pump_lvgl_backend(now)
+        app._feed_watchdog_if_due(now)
+        app._update_screen_power(now)
+        time.sleep(0.05)
+
+
+def _exercise_sleep_wake(app: YoyoPodApp) -> tuple[bool, str]:
+    """Force one sleep/wake cycle against the current app."""
+
+    timeout_seconds = max(1.0, float(app._screen_timeout_seconds or 0.0))
+    app._last_user_activity_at = time.monotonic() - timeout_seconds - 1.0
+    _pump_app(app, 0.35)
+    if app.context is None or app.context.screen_awake:
+        return False, "screen did not enter sleep during soak"
+
+    app.event_bus.publish(UserActivityEvent(source="lvgl_soak"))
+    _pump_app(app, 0.35)
+    if app.context is None or not app.context.screen_awake:
+        return False, "screen did not wake after simulated activity"
+
+    return True, "sleep/wake ok"
+
+
+def run_lvgl_soak(
+    *,
+    config_dir: str = "config",
+    simulate: bool = False,
+    cycles: int = 2,
+    hold_seconds: float = 0.2,
+    exercise_sleep: bool = True,
+) -> tuple[bool, str]:
+    """Run a deterministic screen-transition soak and return success/details."""
+
+    app = YoyoPodApp(config_dir=config_dir, simulate=simulate)
+    if not app.setup():
+        return False, "app setup failed"
+
+    try:
+        if app.display is None or app.screen_manager is None:
+            return False, "display or screen manager not initialized"
+
+        if app.display.backend_kind != "lvgl":
+            return False, f"backend is {app.display.backend_kind}, expected lvgl"
+
+        screens = [
+            "hub",
+            "listen",
+            "playlists",
+            "now_playing",
+            "call",
+            "call_history",
+            "contacts",
+            "voice_note_contacts",
+            "voice_note",
+            "ask",
+            "power",
+        ]
+
+        transitions = 0
+        for _cycle in range(max(1, cycles)):
+            for screen_name in screens:
+                if screen_name not in app.screen_manager.screens:
+                    continue
+                app.screen_manager.replace_screen(screen_name)
+                _pump_app(app, hold_seconds)
+                transitions += 1
+
+        sleep_details = "sleep/wake skipped"
+        if exercise_sleep:
+            sleep_ok, sleep_details = _exercise_sleep_wake(app)
+            if not sleep_ok:
+                return False, sleep_details
+
+        return True, f"backend=lvgl, transitions={transitions}, {sleep_details}"
+    finally:
+        app.stop()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+
+    parser = argparse.ArgumentParser(
+        description="Run a small LVGL screen-transition soak pass against YoyoPod."
+    )
+    parser.add_argument(
+        "--config-dir",
+        default="config",
+        help="Configuration directory to use (default: config)",
+    )
+    parser.add_argument(
+        "--simulate",
+        action="store_true",
+        help="Run against simulation instead of hardware",
+    )
+    parser.add_argument(
+        "--cycles",
+        type=int,
+        default=2,
+        help="How many full transition cycles to run (default: 2)",
+    )
+    parser.add_argument(
+        "--hold-seconds",
+        type=float,
+        default=0.2,
+        help="How long to keep each screen active during the soak (default: 0.2)",
+    )
+    parser.add_argument(
+        "--skip-sleep",
+        action="store_true",
+        help="Skip the sleep/wake exercise",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG logging",
+    )
+    return parser
+
+
+def main() -> int:
+    """CLI entry point."""
+
+    parser = build_parser()
+    args = parser.parse_args()
+    configure_logging(args.verbose)
+
+    ok, details = run_lvgl_soak(
+        config_dir=args.config_dir,
+        simulate=args.simulate,
+        cycles=args.cycles,
+        hold_seconds=args.hold_seconds,
+        exercise_sleep=not args.skip_sleep,
+    )
+    if ok:
+        logger.info(f"LVGL soak passed: {details}")
+        return 0
+
+    logger.error(f"LVGL soak failed: {details}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pi_remote.py
+++ b/scripts/pi_remote.py
@@ -88,6 +88,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Include SIP registration checks",
     )
     smoke_parser.add_argument(
+        "--with-lvgl-soak",
+        action="store_true",
+        help="Include a short LVGL transition and sleep/wake soak",
+    )
+    smoke_parser.add_argument(
         "--verbose",
         action="store_true",
         help="Enable verbose smoke-script logging",
@@ -139,6 +144,33 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-display",
         action="store_true",
         help="Log events only without drawing tuner hints on the display",
+    )
+
+    lvgl_soak_parser = subparsers.add_parser(
+        "lvgl-soak",
+        help="Run the LVGL Whisplay soak helper remotely",
+    )
+    lvgl_soak_parser.add_argument(
+        "--cycles",
+        type=int,
+        default=2,
+        help="How many full transition cycles to run (default: 2)",
+    )
+    lvgl_soak_parser.add_argument(
+        "--hold-seconds",
+        type=float,
+        default=0.2,
+        help="How long to keep each screen active (default: 0.2)",
+    )
+    lvgl_soak_parser.add_argument(
+        "--skip-sleep",
+        action="store_true",
+        help="Skip the sleep/wake exercise",
+    )
+    lvgl_soak_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose soak logging",
     )
 
     rtc_parser = subparsers.add_parser(
@@ -234,6 +266,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--with-voip",
         action="store_true",
         help="Include SIP registration checks in the remote smoke pass",
+    )
+    preflight_parser.add_argument(
+        "--with-lvgl-soak",
+        action="store_true",
+        help="Include the LVGL soak helper in the remote smoke pass",
     )
     preflight_parser.add_argument(
         "--verbose",
@@ -362,20 +399,37 @@ def build_sync_command(config: RemoteConfig, skip_uv_sync: bool) -> str:
 def build_smoke_command(args: argparse.Namespace) -> str:
     """Create the remote smoke-validation command."""
     parts = ["uv run python scripts/pi_smoke.py"]
-    if args.with_power:
+    if getattr(args, "with_power", False):
         parts.append("--with-power")
-    if args.with_rtc:
+    if getattr(args, "with_rtc", False):
         parts.append("--with-rtc")
-    if args.with_mopidy:
+    if getattr(args, "with_mopidy", False):
         parts.append("--with-mopidy")
-    if args.with_voip:
+    if getattr(args, "with_voip", False):
         parts.append("--with-voip")
+    if getattr(args, "with_lvgl_soak", False):
+        parts.append("--with-lvgl-soak")
+    if getattr(args, "verbose", False):
+        parts.append("--verbose")
+    if getattr(args, "mopidy_timeout", 5) != 5:
+        parts.extend(["--mopidy-timeout", str(args.mopidy_timeout)])
+    if getattr(args, "voip_timeout", 10.0) != 10.0:
+        parts.extend(["--voip-timeout", str(args.voip_timeout)])
+    return " ".join(parts)
+
+
+def build_lvgl_soak_command(args: argparse.Namespace) -> str:
+    """Create the remote LVGL soak command."""
+
+    parts = ["uv run python scripts/lvgl_soak.py"]
     if args.verbose:
         parts.append("--verbose")
-    if args.mopidy_timeout != 5:
-        parts.extend(["--mopidy-timeout", str(args.mopidy_timeout)])
-    if args.voip_timeout != 10.0:
-        parts.extend(["--voip-timeout", str(args.voip_timeout)])
+    if args.cycles != 2:
+        parts.extend(["--cycles", str(args.cycles)])
+    if args.hold_seconds != 0.2:
+        parts.extend(["--hold-seconds", str(args.hold_seconds)])
+    if args.skip_sleep:
+        parts.append("--skip-sleep")
     return " ".join(parts)
 
 
@@ -479,6 +533,7 @@ def build_local_preflight_commands() -> list[tuple[str, list[str]]]:
                 "scripts/pisugar_rtc.py",
                 "scripts/pisugar_power.py",
                 "scripts/whisplay_tune.py",
+                "scripts/lvgl_soak.py",
             ],
         ),
         (
@@ -530,6 +585,9 @@ def main() -> int:
 
     if args.command == "whisplay":
         return run_remote(config, build_whisplay_command(args), tty=True)
+
+    if args.command == "lvgl-soak":
+        return run_remote(config, build_lvgl_soak_command(args), tty=True)
 
     if args.command == "rtc":
         return run_remote(config, build_rtc_command(args))

--- a/scripts/pi_smoke.py
+++ b/scripts/pi_smoke.py
@@ -23,6 +23,7 @@ from yoyopy.power import PowerManager
 from yoyopy.voip import VoIPConfig, VoIPManager
 from yoyopy.ui.display import Display, detect_hardware
 from yoyopy.ui.input import get_input_manager
+from scripts.lvgl_soak import run_lvgl_soak
 
 
 @dataclass
@@ -338,6 +339,23 @@ def voip_check(config_dir: Path, registration_timeout: float) -> CheckResult:
         manager.stop()
 
 
+def lvgl_soak_check(config_dir: Path) -> CheckResult:
+    """Run a small LVGL transition and sleep/wake soak on the active app path."""
+
+    ok, details = run_lvgl_soak(
+        config_dir=str(config_dir),
+        simulate=False,
+        cycles=1,
+        hold_seconds=0.15,
+        exercise_sleep=True,
+    )
+    return CheckResult(
+        name="lvgl_soak",
+        status="pass" if ok else "fail",
+        details=details,
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Create the command-line parser."""
     parser = argparse.ArgumentParser(
@@ -370,6 +388,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--with-voip",
         action="store_true",
         help="Also validate linphone startup and SIP registration",
+    )
+    parser.add_argument(
+        "--with-lvgl-soak",
+        action="store_true",
+        help="Also run a short LVGL transition and sleep/wake soak",
     )
     parser.add_argument(
         "--mopidy-timeout",
@@ -441,6 +464,9 @@ def main() -> int:
 
         if args.with_voip:
             results.append(voip_check(config_dir, args.voip_timeout))
+
+        if args.with_lvgl_soak:
+            results.append(lvgl_soak_check(config_dir))
     finally:
         if display is not None:
             try:

--- a/tests/test_call_history.py
+++ b/tests/test_call_history.py
@@ -1,0 +1,51 @@
+"""Focused tests for the Talk call-history persistence layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from yoyopy.voip.history import CallHistoryEntry, CallHistoryStore
+
+
+def test_call_history_store_persists_and_restores_entries(tmp_path: Path) -> None:
+    """Call history should survive a save/load round-trip."""
+
+    history_file = tmp_path / "call_history.json"
+    store = CallHistoryStore(history_file)
+    store.add_entry(
+        CallHistoryEntry.create(
+            direction="incoming",
+            display_name="Hagar",
+            sip_address="sip:hagar@example.com",
+            outcome="missed",
+        )
+    )
+
+    reloaded = CallHistoryStore(history_file)
+    recent = reloaded.list_recent()
+
+    assert len(recent) == 1
+    assert recent[0].display_name == "Hagar"
+    assert recent[0].outcome == "missed"
+    assert reloaded.missed_count() == 1
+
+
+def test_call_history_store_marks_missed_calls_seen(tmp_path: Path) -> None:
+    """Opening recents should clear the unseen missed-call badge count."""
+
+    history_file = tmp_path / "call_history.json"
+    store = CallHistoryStore(history_file)
+    store.add_entry(
+        CallHistoryEntry.create(
+            direction="incoming",
+            display_name="Mama",
+            sip_address="sip:mama@example.com",
+            outcome="missed",
+        )
+    )
+
+    assert store.missed_count() == 1
+    store.mark_all_seen()
+
+    assert store.missed_count() == 0
+    assert store.list_recent()[0].seen is True

--- a/tests/test_call_screen.py
+++ b/tests/test_call_screen.py
@@ -89,6 +89,7 @@ def test_call_screen_prefers_favorites_and_adds_contacts_shortcut(display: Displ
     assert [target.title for target in screen.quick_targets] == [
         "Alice",
         "Carol",
+        "Voice Note",
         "All Contacts",
     ]
 
@@ -108,7 +109,12 @@ def test_call_screen_falls_back_to_all_contacts_when_no_favorites(display: Displ
 
     screen.enter()
 
-    assert [target.title for target in screen.quick_targets] == ["Alice", "Bob"]
+    assert [target.title for target in screen.quick_targets] == [
+        "Alice",
+        "Bob",
+        "Voice Note",
+        "All Contacts",
+    ]
 
 
 def test_call_screen_select_calls_selected_quick_contact(display: Display) -> None:
@@ -172,6 +178,27 @@ def test_call_screen_browse_target_routes_to_full_contacts(display: Display) -> 
     assert screen.consume_navigation_request() == NavigationRequest.route("browse_contacts")
 
 
+def test_call_screen_voice_note_target_routes_to_voice_note_contacts(display: Display) -> None:
+    """Selecting the Voice Note action should open the recipient picker."""
+
+    contacts = [
+        Contact(name="Alice", sip_address="sip:alice@example.com", favorite=True),
+    ]
+    screen = CallScreen(
+        display,
+        AppContext(),
+        voip_manager=FakeVoIPManager(),
+        config_manager=FakeConfigManager(contacts),
+    )
+
+    screen.enter()
+    screen.selected_index = 1
+    screen.on_select()
+
+    assert screen.quick_targets[1].title == "Voice Note"
+    assert screen.consume_navigation_request() == NavigationRequest.route("voice_notes")
+
+
 def test_call_screen_render_smoke_includes_active_call_context(display: Display) -> None:
     """Rendering should stay stable when the VoIP hub reflects an active call state."""
     contacts = [
@@ -194,10 +221,7 @@ def test_call_screen_render_smoke_includes_active_call_context(display: Display)
     screen.enter()
     screen.render()
 
-    assert screen._call_context_lines(voip_manager.get_status()) == (
-        "Call connected",
-        "Alice",
-    )
+    assert screen._call_context_lines(voip_manager.get_status()) == ("In call", "Alice")
 
 
 def test_call_screen_hides_released_call_context(display: Display) -> None:

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -3,6 +3,7 @@
 from scripts.pi_remote import (
     RemoteConfig,
     build_local_preflight_commands,
+    build_lvgl_soak_command,
     build_power_command,
     build_rtc_command,
     build_service_command,
@@ -45,6 +46,7 @@ def test_build_smoke_command_adds_optional_checks() -> None:
         with_rtc=True,
         with_mopidy=True,
         with_voip=True,
+        with_lvgl_soak=True,
         verbose=True,
         mopidy_timeout=10,
         voip_timeout=15.0,
@@ -57,6 +59,7 @@ def test_build_smoke_command_adds_optional_checks() -> None:
     assert "--with-rtc" in command
     assert "--with-mopidy" in command
     assert "--with-voip" in command
+    assert "--with-lvgl-soak" in command
     assert "--verbose" in command
     assert "--mopidy-timeout 10" in command
     assert "--voip-timeout 15.0" in command
@@ -71,6 +74,7 @@ def test_build_local_preflight_commands_cover_compile_and_pytest() -> None:
     assert "scripts/pisugar_rtc.py" in commands[0][1]
     assert "scripts/pisugar_power.py" in commands[0][1]
     assert "scripts/whisplay_tune.py" in commands[0][1]
+    assert "scripts/lvgl_soak.py" in commands[0][1]
     assert commands[1] == ("pytest", ["uv", "run", "pytest", "-q"])
 
 
@@ -126,6 +130,25 @@ def test_build_power_command_supports_verbose_status() -> None:
     command = build_power_command(Namespace(verbose=True))
 
     assert command == "uv run python scripts/pisugar_power.py --verbose"
+
+
+def test_build_lvgl_soak_command_supports_cycles_and_sleep_toggle() -> None:
+    """LVGL soak helper should forward the relevant duration flags."""
+
+    command = build_lvgl_soak_command(
+        Namespace(
+            verbose=True,
+            cycles=3,
+            hold_seconds=0.35,
+            skip_sleep=True,
+        )
+    )
+
+    assert command.startswith("uv run python scripts/lvgl_soak.py")
+    assert "--verbose" in command
+    assert "--cycles 3" in command
+    assert "--hold-seconds 0.35" in command
+    assert "--skip-sleep" in command
 
 
 def test_build_status_command_reports_yoyopod_service_and_pisugar_server() -> None:

--- a/tests/test_remaining_lvgl_views.py
+++ b/tests/test_remaining_lvgl_views.py
@@ -189,8 +189,8 @@ def test_call_screen_builds_syncs_and_destroys_lvgl_view() -> None:
     assert payload["page_text"] is None
     assert payload["status_chip_text"] == "Ready"
     assert payload["status_chip_kind"] == 1
-    assert payload["items"] == ["Hagar", "Mama"]
-    assert payload["badges"] == ["", ""]
+    assert payload["items"] == ["Hagar", "Mama", "Voice Note"]
+    assert payload["badges"] == ["", "", ""]
     assert payload["selected_visible_index"] == 0
 
     screen.on_advance()
@@ -260,7 +260,7 @@ def test_contact_list_screen_syncs_sorted_contacts_through_lvgl() -> None:
     assert payload["title_text"] == "Contacts"
     assert payload["page_text"] is None
     assert payload["items"] == ["Amy", "Mona", "Zed"]
-    assert payload["badges"] == ["FAV", "", ""]
+    assert payload["badges"] == ["", "", ""]
 
     screen.exit()
     assert binding.playlist_destroy_calls == 1
@@ -323,8 +323,8 @@ def test_in_call_screen_syncs_duration_and_mute_state_through_lvgl() -> None:
     assert binding.in_call_destroy_calls == 1
 
 
-def test_ask_screen_syncs_minimal_placeholder_through_lvgl() -> None:
-    """AskScreen should keep its LVGL payload intentionally minimal."""
+def test_ask_screen_syncs_staged_shell_through_lvgl() -> None:
+    """AskScreen should expose the staged Ask shell through LVGL."""
 
     binding = FakeLvglBinding()
     screen = AskScreen(FakeLvglDisplay(binding), make_one_button_context())
@@ -334,12 +334,35 @@ def test_ask_screen_syncs_minimal_placeholder_through_lvgl() -> None:
 
     assert binding.ask_build_calls == 1
     payload = binding.ask_sync_payloads[-1]
-    assert payload["title_text"] == "Coming soon"
-    assert payload["subtitle_text"] == "Safe AI later."
-    assert payload["footer"] == "Hold back"
+    assert payload["icon_key"] == "ask"
+    assert payload["title_text"] == "Ask AI"
+    assert payload["subtitle_text"] == "Tell me a fun fact"
+    assert payload["footer"] == "Tap idea / Double start / Hold back"
 
     screen.exit()
     assert binding.ask_destroy_calls == 1
+
+
+def test_voice_note_screen_reuses_lvgl_card_scene_with_talk_copy() -> None:
+    """VoiceNoteScreen should reuse the compact LVGL card scene with Talk copy."""
+
+    from yoyopy.ui.screens.voip.voice_note import VoiceNoteScreen
+
+    binding = FakeLvglBinding()
+    context = make_one_button_context()
+    context.set_voice_note_recipient(name="Hagar", sip_address="sip:hagar@example.com")
+    screen = VoiceNoteScreen(FakeLvglDisplay(binding), context)
+
+    screen.enter()
+    screen.render()
+
+    payload = binding.ask_sync_payloads[-1]
+    assert payload["icon_key"] == "voice_note"
+    assert payload["title_text"] == "Voice note"
+    assert payload["subtitle_text"] == "Ready for Hagar."
+    assert payload["footer"] == "Double record / Hold back"
+
+    screen.exit()
 
 
 def test_power_screen_cycles_three_lvgl_pages() -> None:

--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -72,6 +72,8 @@ def test_screen_router_covers_call_hub_routes() -> None:
     router = ScreenRouter()
 
     assert router.resolve("call", "browse_contacts") == NavigationRequest.push("contacts")
+    assert router.resolve("call", "browse_history") == NavigationRequest.push("call_history")
+    assert router.resolve("call", "voice_notes") == NavigationRequest.push("voice_note_contacts")
     assert router.resolve("call", "call_started") == NavigationRequest.push("outgoing_call")
 
 

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -45,6 +45,7 @@ from yoyopy.ui.lvgl_binding import LvglDisplayBackend, LvglInputBridge
 from yoyopy.ui.screens import (
     AskScreen,
     CallScreen,
+    CallHistoryScreen,
     ContactListScreen,
     HubScreen,
     HomeScreen,
@@ -57,8 +58,9 @@ from yoyopy.ui.screens import (
     PlaylistScreen,
     PowerScreen,
     ScreenManager,
+    VoiceNoteScreen,
 )
-from yoyopy.voip import VoIPConfig, VoIPManager
+from yoyopy.voip import CallHistoryStore, VoIPConfig, VoIPManager
 
 
 @dataclass(slots=True)
@@ -122,6 +124,7 @@ class YoyoPodApp:
         self.voip_manager: Optional[VoIPManager] = None
         self.mopidy_client: Optional[MopidyClient] = None
         self.power_manager: Optional[PowerManager] = None
+        self.call_history_store: Optional[CallHistoryStore] = None
 
         # Screen instances
         self.hub_screen: Optional[HubScreen] = None
@@ -133,7 +136,10 @@ class YoyoPodApp:
         self.now_playing_screen: Optional[NowPlayingScreen] = None
         self.playlist_screen: Optional[PlaylistScreen] = None
         self.call_screen: Optional[CallScreen] = None
+        self.call_history_screen: Optional[CallHistoryScreen] = None
         self.contact_list_screen: Optional[ContactListScreen] = None
+        self.voice_note_contacts_screen: Optional[ContactListScreen] = None
+        self.voice_note_screen: Optional[VoiceNoteScreen] = None
         self.incoming_call_screen: Optional[IncomingCallScreen] = None
         self.outgoing_call_screen: Optional[OutgoingCallScreen] = None
         self.in_call_screen: Optional[InCallScreen] = None
@@ -269,6 +275,9 @@ class YoyoPodApp:
             self.config_manager = ConfigManager(config_dir=self.config_dir)
             self.app_settings = self.config_manager.get_app_settings()
             self.config = self.config_manager.get_app_config_dict()
+            self.call_history_store = CallHistoryStore(
+                self.config_manager.config_dir / "call_history.json"
+            )
 
             if self.config_manager.app_config_loaded:
                 logger.info(f"Loaded configuration from {self.config_manager.app_config_file}")
@@ -318,6 +327,17 @@ class YoyoPodApp:
             self.display.set_backlight(self._active_brightness)
 
         self._update_screen_runtime_metrics(now)
+
+    def _refresh_talk_summary(self) -> None:
+        """Refresh Talk summary data exposed through the shared app context."""
+
+        if self.context is None or self.call_history_store is None:
+            return
+
+        self.context.update_call_summary(
+            missed_calls=self.call_history_store.missed_count(),
+            recent_calls=self.call_history_store.recent_preview(),
+        )
 
     def _init_core_components(self) -> bool:
         """Initialize display, context, orchestration models, input, and screen manager."""
@@ -376,6 +396,7 @@ class YoyoPodApp:
                     ),
                     ready=False,
                 )
+                self._refresh_talk_summary()
             self._update_screen_runtime_metrics(time.monotonic())
 
             logger.info("  - Orchestration Models")
@@ -512,12 +533,30 @@ class YoyoPodApp:
                 self.context,
                 voip_manager=self.voip_manager,
                 config_manager=self.config_manager,
+                call_history_store=self.call_history_store,
+            )
+            self.call_history_screen = CallHistoryScreen(
+                self.display,
+                self.context,
+                voip_manager=self.voip_manager,
+                call_history_store=self.call_history_store,
             )
             self.contact_list_screen = ContactListScreen(
                 self.display,
                 self.context,
                 voip_manager=self.voip_manager,
                 config_manager=self.config_manager,
+            )
+            self.voice_note_contacts_screen = ContactListScreen(
+                self.display,
+                self.context,
+                voip_manager=self.voip_manager,
+                config_manager=self.config_manager,
+                action_mode="voice_note",
+            )
+            self.voice_note_screen = VoiceNoteScreen(
+                self.display,
+                self.context,
             )
             self.incoming_call_screen = IncomingCallScreen(
                 self.display,
@@ -548,7 +587,10 @@ class YoyoPodApp:
             self.screen_manager.register_screen("now_playing", self.now_playing_screen)
             self.screen_manager.register_screen("playlists", self.playlist_screen)
             self.screen_manager.register_screen("call", self.call_screen)
+            self.screen_manager.register_screen("call_history", self.call_history_screen)
             self.screen_manager.register_screen("contacts", self.contact_list_screen)
+            self.screen_manager.register_screen("voice_note_contacts", self.voice_note_contacts_screen)
+            self.screen_manager.register_screen("voice_note", self.voice_note_screen)
             self.screen_manager.register_screen("incoming_call", self.incoming_call_screen)
             self.screen_manager.register_screen("outgoing_call", self.outgoing_call_screen)
             self.screen_manager.register_screen("in_call", self.in_call_screen)
@@ -558,7 +600,7 @@ class YoyoPodApp:
             logger.info("    - Listen flow: listen, playlists, now_playing")
             logger.info("    - Ask flow: ask")
             logger.info("    - Power screen: power")
-            logger.info("    - VoIP screens: call, contacts, incoming_call, outgoing_call, in_call")
+            logger.info("    - VoIP screens: call, call_history, contacts, voice_note_contacts, voice_note, incoming_call, outgoing_call, in_call")
             logger.info("    - Navigation: home, menu")
 
             initial_screen = self._get_initial_screen_name()
@@ -840,6 +882,7 @@ class YoyoPodApp:
             runtime=self.coordinator_runtime,
             screen_coordinator=self.screen_coordinator,
             auto_resume_after_call=self.auto_resume_after_call,
+            call_history_store=self.call_history_store,
             initial_voip_registered=self._voip_registered,
         )
         self.playback_coordinator = PlaybackCoordinator(
@@ -1440,6 +1483,8 @@ class YoyoPodApp:
             "battery_percent": self.context.battery_percent if self.context else None,
             "battery_charging": self.context.battery_charging if self.context else None,
             "external_power": self.context.external_power if self.context else None,
+            "missed_calls": self.context.missed_calls if self.context else 0,
+            "recent_calls": self.context.recent_calls if self.context else [],
             "screen_awake": self.context.screen_awake if self.context else self._screen_awake,
             "screen_idle_seconds": self.context.screen_idle_seconds if self.context else None,
             "screen_on_seconds": self.context.screen_on_seconds if self.context else None,

--- a/yoyopy/app_context.py
+++ b/yoyopy/app_context.py
@@ -134,6 +134,10 @@ class AppContext:
         self.is_connected: bool = False
         self.connection_type: str = "none"  # wifi, 4g, none
         self.current_audio_source: str = "local"
+        self.missed_calls: int = 0
+        self.recent_calls: List[str] = []
+        self.voice_note_recipient_name: str = ""
+        self.voice_note_recipient_address: str = ""
 
         # Navigation history for back button
         self.navigation_history: List[str] = []
@@ -377,3 +381,15 @@ class AppContext:
         self.app_uptime_seconds = max(0, int(app_uptime_seconds))
         self.screen_on_seconds = max(0, int(screen_on_seconds))
         self.screen_idle_seconds = max(0, int(idle_seconds))
+
+    def update_call_summary(self, *, missed_calls: int, recent_calls: list[str]) -> None:
+        """Update Talk summary state used by the hub and call-related screens."""
+
+        self.missed_calls = max(0, int(missed_calls))
+        self.recent_calls = list(recent_calls)
+
+    def set_voice_note_recipient(self, *, name: str, sip_address: str) -> None:
+        """Store the currently selected voice-note recipient."""
+
+        self.voice_note_recipient_name = name
+        self.voice_note_recipient_address = sip_address

--- a/yoyopy/coordinators/call.py
+++ b/yoyopy/coordinators/call.py
@@ -5,6 +5,8 @@ Call-event coordination for YoyoPod.
 from __future__ import annotations
 
 import subprocess
+import time
+from dataclasses import dataclass, field
 from typing import Optional
 
 from loguru import logger
@@ -19,7 +21,18 @@ from yoyopy.events import (
     RegistrationChangedEvent,
     VoIPAvailabilityChangedEvent,
 )
-from yoyopy.voip import CallState, RegistrationState
+from yoyopy.voip import CallHistoryEntry, CallHistoryStore, CallState, RegistrationState
+
+
+@dataclass(slots=True)
+class _CallSessionDraft:
+    """One in-progress call, tracked until the final release event."""
+
+    direction: str
+    display_name: str
+    sip_address: str
+    started_at: float = field(default_factory=time.time)
+    answered: bool = False
 
 
 class CallCoordinator:
@@ -30,16 +43,19 @@ class CallCoordinator:
         runtime: CoordinatorRuntime,
         screen_coordinator: ScreenCoordinator,
         auto_resume_after_call: bool,
+        call_history_store: CallHistoryStore | None = None,
         initial_voip_registered: bool = False,
     ) -> None:
         self.runtime = runtime
         self.screen_coordinator = screen_coordinator
         self.auto_resume_after_call = auto_resume_after_call
+        self.call_history_store = call_history_store
         self.voip_registered = initial_voip_registered
         self.handling_incoming_call = False
         self.ringing_process: Optional[subprocess.Popen] = None
         self._event_bus: Optional[EventBus] = None
         self._bound = False
+        self._active_call_session: _CallSessionDraft | None = None
 
     def bind(self, event_bus: EventBus) -> None:
         """Bind typed event subscriptions once."""
@@ -110,7 +126,7 @@ class CallCoordinator:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
-            logger.debug("🔔 Ring tone started")
+            logger.debug("Ring tone started")
         except Exception as exc:
             logger.warning(f"Failed to start ring tone: {exc}")
 
@@ -120,7 +136,7 @@ class CallCoordinator:
             try:
                 self.ringing_process.terminate()
                 self.ringing_process.wait(timeout=1.0)
-                logger.debug("🔕 Ring tone stopped")
+                logger.debug("Ring tone stopped")
             except Exception as exc:
                 logger.warning(f"Failed to stop ring tone: {exc}")
             finally:
@@ -132,7 +148,7 @@ class CallCoordinator:
 
     def on_enter_call_active_music_paused(self) -> None:
         """Log entry into the active-call-with-paused-music state."""
-        logger.info("🎞 → In call (music paused in background)")
+        logger.info("In call (music paused in background)")
 
     def _on_incoming_call_event(self, event: IncomingCallEvent) -> None:
         self.handle_incoming_call(event.caller_address, event.caller_name)
@@ -152,11 +168,16 @@ class CallCoordinator:
     def handle_incoming_call(self, caller_address: str, caller_name: str) -> None:
         """Coordinate music pause and UI transitions for an incoming call."""
         if self.handling_incoming_call:
-            logger.debug(f"  (Already handling call from {caller_name})")
+            logger.debug(f"Already handling call from {caller_name}")
             return
 
         self.handling_incoming_call = True
-        logger.info(f"📞 INCOMING CALL: {caller_name} ({caller_address})")
+        logger.info(f"Incoming call: {caller_name} ({caller_address})")
+        self._active_call_session = _CallSessionDraft(
+            direction="incoming",
+            display_name=caller_name or "Unknown",
+            sip_address=caller_address,
+        )
 
         playback_state = (
             self.runtime.mopidy_client.get_playback_state()
@@ -165,7 +186,7 @@ class CallCoordinator:
         )
 
         if playback_state == "playing":
-            logger.info("  🎵 Auto-pausing music for incoming call")
+            logger.info("Auto-pausing music for incoming call")
             self.runtime.call_interruption_policy.pause_for_call(self.runtime.music_fsm)
             if self.runtime.mopidy_client:
                 self.runtime.mopidy_client.pause()
@@ -178,7 +199,7 @@ class CallCoordinator:
 
     def handle_call_state_change(self, state: CallState) -> None:
         """Coordinate high-level call state updates."""
-        logger.info(f"📞 Call state changed: {state.value}")
+        logger.info(f"Call state changed: {state.value}")
 
         if state in (
             CallState.OUTGOING,
@@ -186,6 +207,7 @@ class CallCoordinator:
             CallState.OUTGOING_RINGING,
             CallState.OUTGOING_EARLY_MEDIA,
         ):
+            self._ensure_outgoing_call_session()
             self.runtime.call_fsm.transition("dial")
             self.runtime.sync_app_state("call_outgoing")
             return
@@ -196,6 +218,9 @@ class CallCoordinator:
             return
 
         if state in (CallState.CONNECTED, CallState.STREAMS_RUNNING):
+            if self._active_call_session is not None:
+                self._active_call_session.answered = True
+
             self.runtime.call_fsm.transition("connect")
             state_change = self.runtime.sync_app_state("call_connected")
             if state_change.entered(AppRuntimeState.CALL_ACTIVE_MUSIC_PAUSED):
@@ -205,10 +230,11 @@ class CallCoordinator:
 
     def handle_call_ended(self) -> None:
         """Coordinate call cleanup and possible music resume."""
-        logger.info("📞 Call ended")
+        logger.info("Call ended")
 
         self.stop_ringing()
         self.handling_incoming_call = False
+        self._finalize_call_history()
         self.screen_coordinator.pop_call_screens()
 
         should_resume = self.runtime.call_interruption_policy.should_auto_resume(
@@ -217,23 +243,23 @@ class CallCoordinator:
         self.runtime.call_fsm.transition("end")
 
         if should_resume:
-            logger.info("  🎵 Auto-resuming music after call")
+            logger.info("Auto-resuming music after call")
             if self.runtime.mopidy_client:
                 self.runtime.mopidy_client.play()
             self.runtime.music_fsm.transition("play")
             self.screen_coordinator.refresh_now_playing_screen()
         elif self.runtime.call_interruption_policy.music_interrupted_by_call:
-            logger.info("  🎵 Music stays paused (auto-resume disabled)")
+            logger.info("Music stays paused (auto-resume disabled)")
             self.runtime.music_fsm.transition("pause")
         else:
-            logger.info("  No music to resume")
+            logger.info("No music to resume")
 
         self.runtime.call_interruption_policy.clear()
         self.runtime.sync_app_state("call_ended")
 
     def handle_registration_change(self, state: RegistrationState) -> None:
         """Coordinate registration updates and VoIP availability state."""
-        logger.info(f"📞 VoIP registration: {state.value}")
+        logger.info(f"VoIP registration: {state.value}")
 
         self.voip_registered = state == RegistrationState.OK
         self.runtime.set_voip_ready(self.voip_registered)
@@ -244,9 +270,9 @@ class CallCoordinator:
             )
 
         if state == RegistrationState.OK:
-            logger.info("  ✓ VoIP ready to receive calls")
+            logger.info("VoIP ready to receive calls")
         elif state == RegistrationState.FAILED:
-            logger.warning("  ⚠ VoIP registration failed")
+            logger.warning("VoIP registration failed")
 
         self.screen_coordinator.refresh_call_screen_if_visible()
 
@@ -287,3 +313,76 @@ class CallCoordinator:
 
         config_file = self.runtime.config.get("voip", {}).get("config_file")
         return bool(config_file)
+
+    def _ensure_outgoing_call_session(self) -> None:
+        """Capture callee metadata for an outgoing call once it starts."""
+
+        if self._active_call_session is not None:
+            return
+
+        caller_info = self._current_caller_info()
+        self._active_call_session = _CallSessionDraft(
+            direction="outgoing",
+            display_name=str(caller_info.get("display_name") or caller_info.get("name") or "Unknown"),
+            sip_address=str(caller_info.get("address") or ""),
+        )
+
+    def _current_caller_info(self) -> dict[str, str]:
+        """Return the current caller/callee metadata from the VoIP manager."""
+
+        call_voip_manager = getattr(self.runtime.call_screen, "voip_manager", None)
+        if call_voip_manager is not None:
+            return dict(call_voip_manager.get_caller_info())
+
+        in_call_voip_manager = getattr(self.runtime.in_call_screen, "voip_manager", None)
+        if in_call_voip_manager is not None:
+            return dict(in_call_voip_manager.get_caller_info())
+
+        return {}
+
+    def _finalize_call_history(self) -> None:
+        """Persist the just-finished call into the Talk history store."""
+
+        if self.call_history_store is None:
+            self._active_call_session = None
+            return
+
+        if self._active_call_session is None:
+            self._publish_call_summary_to_context()
+            return
+
+        draft = self._active_call_session
+        call_duration = 0
+        call_voip_manager = getattr(self.runtime.call_screen, "voip_manager", None)
+        if call_voip_manager is not None:
+            call_duration = int(call_voip_manager.get_call_duration())
+
+        if draft.direction == "incoming" and not draft.answered:
+            outcome = "missed"
+        elif draft.answered:
+            outcome = "completed"
+        else:
+            outcome = "cancelled"
+
+        self.call_history_store.add_entry(
+            CallHistoryEntry.create(
+                direction=draft.direction,  # type: ignore[arg-type]
+                display_name=draft.display_name,
+                sip_address=draft.sip_address,
+                outcome=outcome,  # type: ignore[arg-type]
+                duration_seconds=call_duration,
+            )
+        )
+        self._active_call_session = None
+        self._publish_call_summary_to_context()
+
+    def _publish_call_summary_to_context(self) -> None:
+        """Refresh Talk summary data stored in the shared app context."""
+
+        if self.runtime.context is None or self.call_history_store is None:
+            return
+
+        self.runtime.context.update_call_summary(
+            missed_calls=self.call_history_store.missed_count(),
+            recent_calls=self.call_history_store.recent_preview(),
+        )

--- a/yoyopy/ui/lvgl_binding/binding.py
+++ b/yoyopy/ui/lvgl_binding/binding.py
@@ -149,6 +149,7 @@ int yoyopy_lvgl_in_call_sync(
 void yoyopy_lvgl_in_call_destroy(void);
 int yoyopy_lvgl_ask_build(void);
 int yoyopy_lvgl_ask_sync(
+    const char * icon_key,
     const char * title_text,
     const char * subtitle_text,
     const char * footer,
@@ -644,6 +645,7 @@ class LvglBinding:
     def ask_sync(
         self,
         *,
+        icon_key: str,
         title_text: str,
         subtitle_text: str,
         footer: str,
@@ -653,10 +655,12 @@ class LvglBinding:
         power_available: bool,
         accent: tuple[int, int, int],
     ) -> None:
+        icon_raw = self.ffi.new("char[]", icon_key.encode("utf-8"))
         title_raw = self.ffi.new("char[]", title_text.encode("utf-8"))
         subtitle_raw = self.ffi.new("char[]", subtitle_text.encode("utf-8"))
         footer_raw = self.ffi.new("char[]", footer.encode("utf-8"))
         result = self.lib.yoyopy_lvgl_ask_sync(
+            icon_raw,
             title_raw,
             subtitle_raw,
             footer_raw,

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
@@ -537,6 +537,9 @@ static const char * yoyopy_symbol_for_empty_icon(const char * icon_key) {
     if(strcmp(icon_key, "ask") == 0) {
         return "AI";
     }
+    if(strcmp(icon_key, "voice_note") == 0) {
+        return LV_SYMBOL_AUDIO;
+    }
     if(strcmp(icon_key, "setup") == 0 || strcmp(icon_key, "power") == 0) {
         return LV_SYMBOL_SETTINGS;
     }
@@ -2039,6 +2042,7 @@ int yoyopy_lvgl_ask_build(void) {
 }
 
 int yoyopy_lvgl_ask_sync(
+    const char * icon_key,
     const char * title_text,
     const char * subtitle_text,
     const char * footer,
@@ -2080,6 +2084,7 @@ int yoyopy_lvgl_ask_sync(
     lv_obj_set_style_bg_color(g_ask_scene.icon_halo, halo_fill, 0);
     lv_obj_set_style_bg_opa(g_ask_scene.icon_halo, LV_OPA_COVER, 0);
     lv_obj_set_style_border_color(g_ask_scene.icon_halo, halo_border, 0);
+    lv_label_set_text(g_ask_scene.icon_label, yoyopy_symbol_for_empty_icon(icon_key));
     lv_obj_set_style_text_color(g_ask_scene.icon_label, accent, 0);
     lv_obj_center(g_ask_scene.icon_label);
 

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.h
@@ -161,6 +161,7 @@ int yoyopy_lvgl_in_call_sync(
 void yoyopy_lvgl_in_call_destroy(void);
 int yoyopy_lvgl_ask_build(void);
 int yoyopy_lvgl_ask_sync(
+    const char * icon_key,
     const char * title_text,
     const char * subtitle_text,
     const char * footer,

--- a/yoyopy/ui/screens/__init__.py
+++ b/yoyopy/ui/screens/__init__.py
@@ -28,10 +28,12 @@ from yoyopy.ui.screens.music import NowPlayingScreen, PlaylistScreen
 # VoIP screens
 from yoyopy.ui.screens.voip import (
     CallScreen,
+    CallHistoryScreen,
     IncomingCallScreen,
     OutgoingCallScreen,
     InCallScreen,
     ContactListScreen,
+    VoiceNoteScreen,
 )
 
 __all__ = [
@@ -53,8 +55,10 @@ __all__ = [
     'PlaylistScreen',
     # VoIP
     'CallScreen',
+    'CallHistoryScreen',
     'IncomingCallScreen',
     'OutgoingCallScreen',
     'InCallScreen',
     'ContactListScreen',
+    'VoiceNoteScreen',
 ]

--- a/yoyopy/ui/screens/navigation/ask.py
+++ b/yoyopy/ui/screens/navigation/ask.py
@@ -1,4 +1,4 @@
-"""Future-safe Ask screen placeholder for the Graffiti Buddy redesign."""
+"""Future-safe Ask mode shell."""
 
 from __future__ import annotations
 
@@ -7,7 +7,16 @@ from typing import TYPE_CHECKING, Optional
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
 from yoyopy.ui.screens.navigation.lvgl import LvglAskView
-from yoyopy.ui.screens.theme import ASK, INK, MUTED, draw_icon, render_footer, render_header, rounded_panel, wrap_text
+from yoyopy.ui.screens.theme import (
+    ASK,
+    INK,
+    MUTED,
+    draw_icon,
+    render_footer,
+    render_header,
+    rounded_panel,
+    wrap_text,
+)
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
@@ -15,15 +24,31 @@ if TYPE_CHECKING:
 
 
 class AskScreen(Screen):
-    """Placeholder surface for the future safe-AI ask mode."""
+    """Small staged shell for the future Ask experience."""
+
+    _PROMPTS = [
+        "Tell me a fun fact",
+        "Help me calm down",
+        "Tell me a short story",
+        "What can you do?",
+    ]
+    _RESPONSES = [
+        "Safe answers will land here soon.",
+        "This mode will answer with kid-safe help.",
+        "We are building Ask carefully, not quickly.",
+    ]
 
     def __init__(self, display: Display, context: Optional["AppContext"] = None) -> None:
         super().__init__(display, context, "Ask")
+        self._state = "idle"
+        self._prompt_index = 0
+        self._response_index = 0
         self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
-        """Create the LVGL view when the screen becomes active."""
+        """Reset Ask to its calm idle shell when the screen becomes active."""
         super().enter()
+        self._state = "idle"
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
@@ -49,13 +74,49 @@ class AskScreen(Screen):
         self._lvgl_view.build()
         return self._lvgl_view
 
+    def current_view_model(self) -> tuple[str, str, str, str]:
+        """Return title, subtitle, footer, and icon for the current Ask state."""
+
+        prompt = self._PROMPTS[self._prompt_index]
+        response = self._RESPONSES[self._response_index]
+
+        if self._state == "listening":
+            return (
+                "Listening",
+                "Say your question now.",
+                "Double done / Hold back" if self.is_one_button_mode() else "A done | B back",
+                "ask",
+            )
+        if self._state == "thinking":
+            return (
+                "Thinking",
+                "Preparing a safe reply.",
+                "Double finish / Hold back" if self.is_one_button_mode() else "A finish | B back",
+                "ask",
+            )
+        if self._state == "response":
+            return (
+                "Safe reply",
+                response,
+                "Tap next / Double again / Hold back" if self.is_one_button_mode() else "A again | B back | X/Y cycle",
+                "ask",
+            )
+
+        return (
+            "Ask AI",
+            prompt,
+            "Tap idea / Double start / Hold back" if self.is_one_button_mode() else "A start | B back | X/Y idea",
+            "ask",
+        )
+
     def render(self) -> None:
-        """Render the future Ask mode preview."""
+        """Render the current Ask shell state."""
         lvgl_view = self._ensure_lvgl_view()
         if lvgl_view is not None:
             lvgl_view.sync()
             return
 
+        title_text, subtitle_text, footer_text, icon_key = self.current_view_model()
         content_top = render_header(
             self.display,
             self.context,
@@ -78,32 +139,59 @@ class AskScreen(Screen):
             radius=24,
         )
 
-        draw_icon(self.display, "ask", (self.display.WIDTH // 2) - 24, panel_top + 18, 48, ASK.accent)
+        draw_icon(self.display, icon_key, (self.display.WIDTH // 2) - 24, panel_top + 18, 48, ASK.accent)
 
-        headline = "Coming soon"
-        headline_width, _ = self.display.get_text_size(headline, 18)
-        self.display.text(headline, (self.display.WIDTH - headline_width) // 2, panel_top + 78, color=ASK.accent, font_size=18)
+        headline_width, headline_height = self.display.get_text_size(title_text, 18)
+        self.display.text(
+            title_text,
+            (self.display.WIDTH - headline_width) // 2,
+            panel_top + 78,
+            color=ASK.accent,
+            font_size=18,
+        )
 
         copy_lines = wrap_text(
             self.display,
-            "Safe questions will live here soon.",
+            subtitle_text,
             self.display.WIDTH - 52,
             12,
-            max_lines=1,
+            max_lines=2,
         )
         line_y = panel_top + 108
         for line in copy_lines:
             line_width, _ = self.display.get_text_size(line, 12)
-            self.display.text(line, (self.display.WIDTH - line_width) // 2, line_y, color=INK, font_size=12)
+            self.display.text(
+                line,
+                (self.display.WIDTH - line_width) // 2,
+                line_y,
+                color=INK if self._state != "response" else MUTED,
+                font_size=12,
+            )
             line_y += 15
 
-        help_text = "Hold back" if self.is_one_button_mode() else "B back"
-        render_footer(self.display, help_text, mode="ask")
+        render_footer(self.display, footer_text, mode="ask")
         self.display.update()
 
+    def on_advance(self, data=None) -> None:
+        """Cycle prompt ideas or response cards in one-button mode."""
+        if self._state == "response":
+            self._response_index = (self._response_index + 1) % len(self._RESPONSES)
+            return
+        if self._state == "idle":
+            self._prompt_index = (self._prompt_index + 1) % len(self._PROMPTS)
+
     def on_select(self, data=None) -> None:
-        """Ask is intentionally passive until the future feature lands."""
-        return
+        """Move through the staged Ask shell without requiring a real AI backend yet."""
+        if self._state == "idle":
+            self._state = "listening"
+            return
+        if self._state == "listening":
+            self._state = "thinking"
+            return
+        if self._state == "thinking":
+            self._state = "response"
+            return
+        self._state = "listening"
 
     def on_back(self, data=None) -> None:
         """Return to the previous screen."""

--- a/yoyopy/ui/screens/navigation/hub.py
+++ b/yoyopy/ui/screens/navigation/hub.py
@@ -89,7 +89,7 @@ class HubScreen(Screen):
         return [
             HubCard("Listen", self._listen_subtitle(), "listen", "listen"),
             HubCard("Talk", self._talk_subtitle(), "talk", "talk"),
-            HubCard("Ask", "Coming soon", "ask", "ask"),
+            HubCard("Ask", "Safe questions", "ask", "ask"),
             HubCard("Setup", self._setup_subtitle(), "setup", "setup"),
         ]
 
@@ -126,6 +126,11 @@ class HubScreen(Screen):
 
     def _talk_subtitle(self) -> str:
         """Return the compact Talk card subtitle."""
+        if self.context is not None and getattr(self.context, "missed_calls", 0) > 0:
+            missed_calls = int(self.context.missed_calls)
+            label = "call" if missed_calls == 1 else "calls"
+            return f"{missed_calls} missed {label}"
+
         if self.voip_manager is None:
             return "Unavailable"
 

--- a/yoyopy/ui/screens/router.py
+++ b/yoyopy/ui/screens/router.py
@@ -121,11 +121,24 @@ class ScreenRouter:
             "call": {
                 "back": NavigationRequest.pop(),
                 "browse_contacts": NavigationRequest.push("contacts"),
+                "browse_history": NavigationRequest.push("call_history"),
+                "voice_notes": NavigationRequest.push("voice_note_contacts"),
                 "call_started": NavigationRequest.push("outgoing_call"),
             },
             "contacts": {
                 "back": NavigationRequest.pop(),
                 "call_started": NavigationRequest.push("outgoing_call"),
+            },
+            "voice_note_contacts": {
+                "back": NavigationRequest.pop(),
+                "voice_note_selected": NavigationRequest.push("voice_note"),
+            },
+            "call_history": {
+                "back": NavigationRequest.pop(),
+                "call_started": NavigationRequest.push("outgoing_call"),
+            },
+            "voice_note": {
+                "back": NavigationRequest.pop(),
             },
             "incoming_call": {
                 "call_answered": NavigationRequest.push("in_call"),

--- a/yoyopy/ui/screens/theme.py
+++ b/yoyopy/ui/screens/theme.py
@@ -96,6 +96,7 @@ PHOSPHOR_ICON_FILES = {
     "listen": "headphones.png",
     "talk": "phone-call.png",
     "ask": "microphone.png",
+    "voice_note": "microphone.png",
     "setup": "gear-six.png",
     "power": "gear-six.png",
 }

--- a/yoyopy/ui/screens/voip/__init__.py
+++ b/yoyopy/ui/screens/voip/__init__.py
@@ -1,15 +1,19 @@
 """VoIP screens for YoyoPod."""
 
 from yoyopy.ui.screens.voip.quick_call import CallScreen
+from yoyopy.ui.screens.voip.call_history import CallHistoryScreen
 from yoyopy.ui.screens.voip.incoming_call import IncomingCallScreen
 from yoyopy.ui.screens.voip.outgoing_call import OutgoingCallScreen
 from yoyopy.ui.screens.voip.in_call import InCallScreen
 from yoyopy.ui.screens.voip.contact_list import ContactListScreen
+from yoyopy.ui.screens.voip.voice_note import VoiceNoteScreen
 
 __all__ = [
     'CallScreen',
+    'CallHistoryScreen',
     'IncomingCallScreen',
     'OutgoingCallScreen',
     'InCallScreen',
     'ContactListScreen',
+    'VoiceNoteScreen',
 ]

--- a/yoyopy/ui/screens/voip/call_history.py
+++ b/yoyopy/ui/screens/voip/call_history.py
@@ -1,0 +1,242 @@
+"""Recent-call history screen for the Talk flow."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from loguru import logger
+
+from yoyopy.ui.display import Display
+from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.theme import (
+    SURFACE,
+    draw_empty_state,
+    draw_list_item,
+    render_footer,
+    render_header,
+    rounded_panel,
+    text_fit,
+)
+from yoyopy.ui.screens.voip.lvgl.call_history_view import LvglCallHistoryView
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens import ScreenView
+    from yoyopy.voip import CallHistoryEntry, CallHistoryStore
+
+
+class CallHistoryScreen(Screen):
+    """Show recent and missed calls, with quick redial when possible."""
+
+    def __init__(
+        self,
+        display: Display,
+        context: Optional["AppContext"] = None,
+        voip_manager=None,
+        call_history_store: Optional["CallHistoryStore"] = None,
+    ) -> None:
+        super().__init__(display, context, "CallHistory")
+        self.voip_manager = voip_manager
+        self.call_history_store = call_history_store
+        self.entries: list["CallHistoryEntry"] = []
+        self.selected_index = 0
+        self.scroll_offset = 0
+        self.max_visible_items = 4 if display.is_portrait() else 5
+        self._lvgl_view: "ScreenView | None" = None
+
+    def enter(self) -> None:
+        """Refresh call history and clear the unseen-missed badge count."""
+        super().enter()
+        self._load_entries()
+        if self.call_history_store is not None:
+            self.call_history_store.mark_all_seen()
+            self._sync_context_summary()
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving recents."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglCallHistoryView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
+
+    def _load_entries(self) -> None:
+        """Load the recent calls from persistent storage."""
+        if self.call_history_store is None:
+            self.entries = []
+        else:
+            self.entries = self.call_history_store.list_recent()
+        if self.entries:
+            self.selected_index = min(self.selected_index, len(self.entries) - 1)
+        else:
+            self.selected_index = 0
+            self.scroll_offset = 0
+
+    def _sync_context_summary(self) -> None:
+        """Refresh the shared Talk summary after opening recents."""
+        if self.context is None or self.call_history_store is None:
+            return
+
+        self.context.update_call_summary(
+            missed_calls=self.call_history_store.missed_count(),
+            recent_calls=self.call_history_store.recent_preview(),
+        )
+
+    def _is_ready_to_call(self) -> bool:
+        """Return whether VoIP is ready to redial from recents."""
+        if self.voip_manager is None:
+            return False
+        status = self.voip_manager.get_status()
+        return bool(status.get("running")) and bool(status.get("registered"))
+
+    def _selected_entry(self) -> "CallHistoryEntry | None":
+        if not self.entries:
+            return None
+        return self.entries[self.selected_index]
+
+    def _instruction_text(self) -> str:
+        """Return compact footer hints for recents."""
+        if not self.entries:
+            return "Hold back" if self.is_one_button_mode() else "B back"
+        if self._is_ready_to_call():
+            return "Tap next / Double call" if self.is_one_button_mode() else "A call | B back | X/Y move"
+        return "Tap next / Hold back" if self.is_one_button_mode() else "B back | X/Y move"
+
+    def render(self) -> None:
+        """Render the recent-calls list."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
+        content_top = render_header(
+            self.display,
+            self.context,
+            mode="talk",
+            title="Recents",
+            page_text=None,
+            show_time=False,
+            show_mode_chip=False,
+        )
+
+        if not self.entries:
+            draw_empty_state(
+                self.display,
+                mode="talk",
+                title="No recent calls",
+                subtitle="Calls will show up here after the first one.",
+                icon="talk",
+                top=content_top,
+            )
+            render_footer(self.display, "Hold back", mode="talk")
+            self.display.update()
+            return
+
+        if self.selected_index < self.scroll_offset:
+            self.scroll_offset = self.selected_index
+        elif self.selected_index >= self.scroll_offset + self.max_visible_items:
+            self.scroll_offset = self.selected_index - self.max_visible_items + 1
+
+        panel_top = content_top + 6
+        panel_bottom = self.display.HEIGHT - 28
+        rounded_panel(
+            self.display,
+            12,
+            panel_top,
+            self.display.WIDTH - 12,
+            panel_bottom,
+            fill=SURFACE,
+            outline=None,
+            radius=24,
+        )
+
+        item_height = 46
+        for row in range(self.max_visible_items):
+            entry_index = self.scroll_offset + row
+            if entry_index >= len(self.entries):
+                break
+
+            entry = self.entries[entry_index]
+            y1 = panel_top + 10 + (row * item_height)
+            y2 = y1 + 38
+            draw_list_item(
+                self.display,
+                x1=20,
+                y1=y1,
+                x2=self.display.WIDTH - 20,
+                y2=y2,
+                title=text_fit(self.display, entry.title, self.display.WIDTH - 90, 15),
+                subtitle="",
+                mode="talk",
+                selected=entry_index == self.selected_index,
+                badge=None,
+            )
+
+        render_footer(self.display, self._instruction_text(), mode="talk")
+        self.display.update()
+
+    def get_visible_window(self) -> tuple[list[str], list[str], int]:
+        """Return the visible recent-call titles for the shared LVGL list scene."""
+        if not self.entries:
+            return [], [], 0
+
+        if self.selected_index < self.scroll_offset:
+            self.scroll_offset = self.selected_index
+        elif self.selected_index >= self.scroll_offset + self.max_visible_items:
+            self.scroll_offset = self.selected_index - self.max_visible_items + 1
+
+        visible_titles: list[str] = []
+        visible_badges: list[str] = []
+        selected_visible_index = 0
+        for row in range(self.max_visible_items):
+            entry_index = self.scroll_offset + row
+            if entry_index >= len(self.entries):
+                break
+
+            entry = self.entries[entry_index]
+            visible_titles.append(entry.title)
+            visible_badges.append("")
+            if entry_index == self.selected_index:
+                selected_visible_index = row
+
+        return visible_titles, visible_badges, selected_visible_index
+
+    def on_select(self, data=None) -> None:
+        """Redial the selected recent call when VoIP is ready."""
+        selected = self._selected_entry()
+        if (
+            selected is None
+            or not selected.sip_address
+            or not self._is_ready_to_call()
+            or self.voip_manager is None
+        ):
+            return
+
+        logger.info(f"Redialing recent contact: {selected.title} ({selected.sip_address})")
+        if self.voip_manager.make_call(selected.sip_address, contact_name=selected.display_name):
+            self.request_route("call_started")
+
+    def on_back(self, data=None) -> None:
+        """Return to the previous screen."""
+        self.request_route("back")
+
+    def on_advance(self, data=None) -> None:
+        """Move through recents with wraparound."""
+        if not self.entries:
+            return
+        self.selected_index = (self.selected_index + 1) % len(self.entries)

--- a/yoyopy/ui/screens/voip/contact_list.py
+++ b/yoyopy/ui/screens/voip/contact_list.py
@@ -1,15 +1,23 @@
-"""Talk contact list screen."""
+"""Talk contact picker screen."""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 from loguru import logger
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.theme import (
+    SURFACE,
+    draw_empty_state,
+    draw_list_item,
+    render_footer,
+    render_header,
+    rounded_panel,
+    text_fit,
+)
 from yoyopy.ui.screens.voip.lvgl import LvglContactListView
-from yoyopy.ui.screens.theme import SURFACE, draw_empty_state, draw_list_item, render_footer, render_header, rounded_panel, text_fit
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
@@ -17,7 +25,7 @@ if TYPE_CHECKING:
 
 
 class ContactListScreen(Screen):
-    """Full contact list for the Talk flow."""
+    """Full contact list for calling or picking a voice-note recipient."""
 
     def __init__(
         self,
@@ -25,15 +33,37 @@ class ContactListScreen(Screen):
         context: Optional["AppContext"] = None,
         voip_manager=None,
         config_manager=None,
+        action_mode: Literal["call", "voice_note"] = "call",
     ) -> None:
         super().__init__(display, context, "ContactList")
         self.voip_manager = voip_manager
         self.config_manager = config_manager
+        self.action_mode = action_mode
         self.contacts = []
         self.selected_index = 0
         self.scroll_offset = 0
         self.max_visible_items = 4 if display.is_portrait() else 5
         self._lvgl_view: "ScreenView | None" = None
+
+    @property
+    def title_text(self) -> str:
+        """Return the screen title for the current Talk subflow."""
+
+        return "Voice Note" if self.action_mode == "voice_note" else "Contacts"
+
+    @property
+    def empty_title(self) -> str:
+        """Return the empty-state title."""
+
+        return "No contacts"
+
+    @property
+    def empty_subtitle(self) -> str:
+        """Return the empty-state subtitle."""
+
+        if self.action_mode == "voice_note":
+            return "Add a contact before sending a note."
+        return "Add contacts to call them here."
 
     def enter(self) -> None:
         """Load contacts when the screen becomes active."""
@@ -81,16 +111,12 @@ class ContactListScreen(Screen):
             lvgl_view.sync()
             return
 
-        page_text = None
-        if self.contacts:
-            page_text = f"{self.selected_index + 1}/{len(self.contacts)}"
-
         content_top = render_header(
             self.display,
             self.context,
             mode="talk",
-            title="Contacts",
-            page_text=page_text,
+            title=self.title_text,
+            page_text=None,
             show_time=False,
             show_mode_chip=False,
         )
@@ -99,8 +125,8 @@ class ContactListScreen(Screen):
             draw_empty_state(
                 self.display,
                 mode="talk",
-                title="No contacts",
-                subtitle="Add people in contacts config to call them here.",
+                title=self.empty_title,
+                subtitle=self.empty_subtitle,
                 icon="talk",
                 top=content_top,
             )
@@ -135,7 +161,6 @@ class ContactListScreen(Screen):
             contact = self.contacts[contact_index]
             y1 = panel_top + 10 + (row * item_height)
             y2 = y1 + 38
-            badge = "FAV" if contact.favorite else None
             draw_list_item(
                 self.display,
                 x1=20,
@@ -146,18 +171,15 @@ class ContactListScreen(Screen):
                 subtitle="",
                 mode="talk",
                 selected=contact_index == self.selected_index,
-                badge=badge,
+                badge=None,
             )
 
-        help_text = "Tap next / Call / Hold back" if self.is_one_button_mode() else "A call | B back | X/Y move"
-        render_footer(self.display, help_text, mode="talk")
+        render_footer(self.display, self._instruction_text(), mode="talk")
         self.display.update()
 
     def get_page_text(self) -> str | None:
-        """Return the compact page indicator for the current contact selection."""
-        if not self.contacts:
-            return None
-        return f"{self.selected_index + 1}/{len(self.contacts)}"
+        """Contact lists now intentionally omit page counters."""
+        return None
 
     def get_visible_window(self) -> tuple[list[str], list[str], int]:
         """Return the visible contact titles, badges, and selected row index."""
@@ -179,11 +201,18 @@ class ContactListScreen(Screen):
 
             contact = self.contacts[contact_index]
             visible_titles.append(contact.name)
-            visible_badges.append("FAV" if contact.favorite else "")
+            visible_badges.append("")
             if contact_index == self.selected_index:
                 selected_visible_index = row
 
         return visible_titles, visible_badges, selected_visible_index
+
+    def _instruction_text(self) -> str:
+        """Return footer hints for the current action mode."""
+
+        if self.action_mode == "voice_note":
+            return "Tap next / Double choose" if self.is_one_button_mode() else "A choose | B back | X/Y move"
+        return "Tap next / Double call" if self.is_one_button_mode() else "A call | B back | X/Y move"
 
     def select_next(self) -> None:
         """Move selection to next contact."""
@@ -218,8 +247,25 @@ class ContactListScreen(Screen):
         else:
             logger.error(f"Failed to initiate call to {contact.name}")
 
+    def choose_voice_note_recipient(self) -> None:
+        """Store the chosen recipient and move into the voice-note shell."""
+        if not self.contacts or self.selected_index >= len(self.contacts):
+            logger.warning("No contact selected for voice note")
+            return
+
+        contact = self.contacts[self.selected_index]
+        if self.context is not None:
+            self.context.set_voice_note_recipient(
+                name=contact.name,
+                sip_address=contact.sip_address,
+            )
+        self.request_route("voice_note_selected")
+
     def on_select(self, data=None) -> None:
-        """Call the selected contact."""
+        """Call or choose the selected contact depending on the mode."""
+        if self.action_mode == "voice_note":
+            self.choose_voice_note_recipient()
+            return
         self.call_selected_contact()
 
     def on_back(self, data=None) -> None:

--- a/yoyopy/ui/screens/voip/lvgl/__init__.py
+++ b/yoyopy/ui/screens/voip/lvgl/__init__.py
@@ -1,15 +1,19 @@
 """LVGL-backed VoIP screen views."""
 
 from yoyopy.ui.screens.voip.lvgl.call_view import LvglCallView
+from yoyopy.ui.screens.voip.lvgl.call_history_view import LvglCallHistoryView
 from yoyopy.ui.screens.voip.lvgl.contact_list_view import LvglContactListView
 from yoyopy.ui.screens.voip.lvgl.in_call_view import LvglInCallView
 from yoyopy.ui.screens.voip.lvgl.incoming_call_view import LvglIncomingCallView
 from yoyopy.ui.screens.voip.lvgl.outgoing_call_view import LvglOutgoingCallView
+from yoyopy.ui.screens.voip.lvgl.voice_note_view import LvglVoiceNoteView
 
 __all__ = [
     "LvglCallView",
+    "LvglCallHistoryView",
     "LvglContactListView",
     "LvglInCallView",
     "LvglIncomingCallView",
     "LvglOutgoingCallView",
+    "LvglVoiceNoteView",
 ]

--- a/yoyopy/ui/screens/voip/lvgl/call_history_view.py
+++ b/yoyopy/ui/screens/voip/lvgl/call_history_view.py
@@ -1,4 +1,4 @@
-"""LVGL-backed view for the Ask placeholder screen."""
+"""LVGL-backed view for the recent-calls screen."""
 
 from __future__ import annotations
 
@@ -6,49 +6,55 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopy.ui.lvgl_binding import LvglDisplayBackend
-from yoyopy.ui.screens.theme import ASK
+from yoyopy.ui.screens.theme import TALK
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
-    from yoyopy.ui.screens.navigation.ask import AskScreen
+    from yoyopy.ui.screens.voip.call_history import CallHistoryScreen
 
 
 @dataclass(slots=True)
-class LvglAskView:
-    """Own the LVGL object lifecycle for AskScreen."""
+class LvglCallHistoryView:
+    """Own the LVGL object lifecycle for CallHistoryScreen."""
 
-    screen: "AskScreen"
+    screen: "CallHistoryScreen"
     backend: LvglDisplayBackend
     _built: bool = False
 
     def build(self) -> None:
         if self._built or self.backend.binding is None:
             return
-        self.backend.binding.ask_build()
+        self.backend.binding.playlist_build()
         self._built = True
 
     def sync(self) -> None:
         if not self._built or self.backend.binding is None:
             return
 
+        visible_items, visible_badges, selected_visible_index = self.screen.get_visible_window()
         context = self.screen.context
-        title_text, subtitle_text, footer_text, icon_key = self.screen.current_view_model()
-        self.backend.binding.ask_sync(
-            icon_key=icon_key,
-            title_text=title_text,
-            subtitle_text=subtitle_text,
-            footer=footer_text,
+
+        self.backend.binding.playlist_sync(
+            title_text="Recents",
+            page_text=None,
+            footer=self.screen._instruction_text(),
+            items=visible_items,
+            badges=visible_badges,
+            selected_visible_index=selected_visible_index,
             voip_state=self._voip_state(context),
             battery_percent=self._battery_percent(context),
             charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
             power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
-            accent=ASK.accent,
+            accent=TALK.accent,
+            empty_title="No recent calls",
+            empty_subtitle="Calls will appear here.",
+            empty_icon_key="talk",
         )
 
     def destroy(self) -> None:
         if not self._built or self.backend.binding is None:
             return
-        self.backend.binding.ask_destroy()
+        self.backend.binding.playlist_destroy()
         self._built = False
 
     @staticmethod
@@ -62,3 +68,4 @@ class LvglAskView:
         if context is None or not getattr(context, "voip_configured", False):
             return 0
         return 1 if getattr(context, "voip_ready", False) else 2
+

--- a/yoyopy/ui/screens/voip/lvgl/contact_list_view.py
+++ b/yoyopy/ui/screens/voip/lvgl/contact_list_view.py
@@ -35,9 +35,9 @@ class LvglContactListView:
         context = self.screen.context
 
         self.backend.binding.playlist_sync(
-            title_text="Contacts",
+            title_text=self.screen.title_text,
             page_text=None,
-            footer="Tap next / Call" if self.screen.is_one_button_mode() else "A call | B back | X/Y move",
+            footer=self.screen._instruction_text(),
             items=visible_items,
             badges=visible_badges,
             selected_visible_index=selected_visible_index,
@@ -46,8 +46,8 @@ class LvglContactListView:
             charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
             power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
             accent=TALK.accent,
-            empty_title="No contacts",
-            empty_subtitle="Add contacts to call them here.",
+            empty_title=self.screen.empty_title,
+            empty_subtitle=self.screen.empty_subtitle,
             empty_icon_key="talk",
         )
 

--- a/yoyopy/ui/screens/voip/lvgl/voice_note_view.py
+++ b/yoyopy/ui/screens/voip/lvgl/voice_note_view.py
@@ -1,4 +1,4 @@
-"""LVGL-backed view for the Ask placeholder screen."""
+"""LVGL-backed view for the voice-note shell."""
 
 from __future__ import annotations
 
@@ -6,18 +6,18 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopy.ui.lvgl_binding import LvglDisplayBackend
-from yoyopy.ui.screens.theme import ASK
+from yoyopy.ui.screens.theme import TALK
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
-    from yoyopy.ui.screens.navigation.ask import AskScreen
+    from yoyopy.ui.screens.voip.voice_note import VoiceNoteScreen
 
 
 @dataclass(slots=True)
-class LvglAskView:
-    """Own the LVGL object lifecycle for AskScreen."""
+class LvglVoiceNoteView:
+    """Own the LVGL object lifecycle for VoiceNoteScreen."""
 
-    screen: "AskScreen"
+    screen: "VoiceNoteScreen"
     backend: LvglDisplayBackend
     _built: bool = False
 
@@ -42,7 +42,7 @@ class LvglAskView:
             battery_percent=self._battery_percent(context),
             charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
             power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
-            accent=ASK.accent,
+            accent=TALK.accent,
         )
 
     def destroy(self) -> None:

--- a/yoyopy/ui/screens/voip/quick_call.py
+++ b/yoyopy/ui/screens/voip/quick_call.py
@@ -9,31 +9,40 @@ from loguru import logger
 
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.theme import (
+    INK,
+    MUTED,
+    SURFACE,
+    TALK,
+    draw_empty_state,
+    draw_list_item,
+    render_footer,
+    render_header,
+    rounded_panel,
+)
 from yoyopy.ui.screens.voip.lvgl import LvglCallView
-from yoyopy.ui.screens.theme import INK, MUTED, SURFACE, TALK, draw_empty_state, draw_list_item, render_footer, render_header, rounded_panel, text_fit
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
     from yoyopy.config import ConfigManager, Contact
     from yoyopy.ui.screens import ScreenView
-    from yoyopy.voip import VoIPManager
+    from yoyopy.voip import CallHistoryStore, VoIPManager
 
 
 @dataclass(slots=True)
 class QuickCallTarget:
     """Represents one selectable quick action on the Talk screen."""
 
-    kind: Literal["contact", "browse_contacts"]
+    kind: Literal["contact", "browse_contacts", "history", "voice_notes"]
     title: str
     subtitle: str
     sip_address: str = ""
-    favorite: bool = False
 
 
 class CallScreen(Screen):
-    """Talk screen showing call readiness and favorite contacts."""
+    """Talk screen showing readiness, favorites, recents, and voice notes."""
 
-    _MAX_QUICK_CONTACTS = 6
+    _MAX_QUICK_CONTACTS = 4
 
     def __init__(
         self,
@@ -41,10 +50,12 @@ class CallScreen(Screen):
         context: Optional["AppContext"] = None,
         voip_manager: Optional["VoIPManager"] = None,
         config_manager: Optional["ConfigManager"] = None,
+        call_history_store: Optional["CallHistoryStore"] = None,
     ) -> None:
         super().__init__(display, context, "Call")
         self.voip_manager = voip_manager
         self.config_manager = config_manager
+        self.call_history_store = call_history_store
         self.quick_targets: list[QuickCallTarget] = []
         self.selected_index = 0
         self.scroll_offset = 0
@@ -81,7 +92,7 @@ class CallScreen(Screen):
         return self._lvgl_view
 
     def _load_quick_targets(self) -> None:
-        """Load favorite or regular contacts for quick calling."""
+        """Load quick-call contacts plus product actions like recents and voice notes."""
         contacts: list["Contact"] = []
         if self.config_manager is not None:
             contacts = sorted(
@@ -93,30 +104,48 @@ class CallScreen(Screen):
         quick_contacts = favorites or contacts
         visible_contacts = quick_contacts[: self._MAX_QUICK_CONTACTS]
 
-        self.quick_targets = [
+        targets = [
             QuickCallTarget(
                 kind="contact",
                 title=contact.name,
                 subtitle=contact.sip_address,
                 sip_address=contact.sip_address,
-                favorite=contact.favorite,
             )
             for contact in visible_contacts
         ]
+
+        if self.call_history_store is not None:
+            targets.append(
+                QuickCallTarget(
+                    kind="history",
+                    title="Recents",
+                    subtitle=self._history_subtitle(),
+                )
+            )
+
+        if contacts:
+            targets.append(
+                QuickCallTarget(
+                    kind="voice_notes",
+                    title="Voice Note",
+                    subtitle="Pick who gets your note",
+                )
+            )
 
         has_more_contacts = bool(contacts) and (
             len(contacts) > len(visible_contacts)
             or (bool(favorites) and len(favorites) < len(contacts))
         )
-        if has_more_contacts:
-            self.quick_targets.append(
+        if has_more_contacts or contacts:
+            targets.append(
                 QuickCallTarget(
                     kind="browse_contacts",
                     title="All Contacts",
-                    subtitle="See the full list",
+                    subtitle="See everyone",
                 )
             )
 
+        self.quick_targets = targets
         if not self.quick_targets:
             self.selected_index = 0
             self.scroll_offset = 0
@@ -124,6 +153,21 @@ class CallScreen(Screen):
 
         self.selected_index = min(self.selected_index, len(self.quick_targets) - 1)
         self._ensure_selection_visible()
+
+    def _history_subtitle(self) -> str:
+        """Return the compact subtitle for the Recents quick target."""
+        if self.call_history_store is None:
+            return "Recent calls"
+
+        missed_count = self.call_history_store.missed_count()
+        if missed_count > 0:
+            label = "call" if missed_count == 1 else "calls"
+            return f"{missed_count} missed {label}"
+
+        recent_entries = self.call_history_store.list_recent(limit=1)
+        if recent_entries:
+            return f"Last: {recent_entries[0].title}"
+        return "Recent calls"
 
     def render(self) -> None:
         """Render the Talk hub with status and quick-call cards."""
@@ -135,16 +179,13 @@ class CallScreen(Screen):
         status = self._get_status_snapshot()
         status_text, _status_color, _detail_text = self._status_lines(status)
         call_state_text, caller_text = self._call_context_lines(status)
-        position_text = None
-        if self.quick_targets:
-            position_text = f"{self.selected_index + 1}/{len(self.quick_targets)}"
 
         content_top = render_header(
             self.display,
             self.context,
             mode="talk",
             title="Talk",
-            page_text=position_text,
+            page_text=None,
             show_time=False,
             show_mode_chip=False,
         )
@@ -162,20 +203,20 @@ class CallScreen(Screen):
             radius=24,
         )
 
-        header_text = call_state_text or status_text or "Quick calls"
+        header_text = call_state_text or "Calls"
         self.display.text(header_text, 22, panel_top + 10, color=TALK.accent, font_size=13)
-        if caller_text:
-            caller_text = text_fit(self.display, caller_text, self.display.WIDTH - 120, 10)
+
+        if call_state_text and caller_text:
             self.display.text(caller_text, 22, panel_top + 28, color=INK, font_size=10)
         else:
-            self.display.text("Favorites", 22, panel_top + 28, color=MUTED, font_size=10)
+            self.display.text(status_text, 22, panel_top + 28, color=MUTED, font_size=10)
 
         if not self.quick_targets:
             draw_empty_state(
                 self.display,
                 mode="talk",
                 title="No contacts",
-                subtitle="Add favorite people to make Talk feel instant.",
+                subtitle="Add people to make Talk feel instant.",
                 icon="talk",
                 top=content_top + 12,
             )
@@ -196,7 +237,6 @@ class CallScreen(Screen):
             target = self.quick_targets[target_index]
             y1 = list_top + (row * item_height)
             y2 = y1 + 42
-            badge = "ALL" if target.kind == "browse_contacts" else None
             draw_list_item(
                 self.display,
                 x1=20,
@@ -207,17 +247,15 @@ class CallScreen(Screen):
                 subtitle="",
                 mode="talk",
                 selected=target_index == self.selected_index,
-                badge=badge,
+                badge=None,
             )
 
         render_footer(self.display, self._instruction_text(), mode="talk")
         self.display.update()
 
     def get_page_text(self) -> str | None:
-        """Return the compact page indicator for the current quick target."""
-        if not self.quick_targets:
-            return None
-        return f"{self.selected_index + 1}/{len(self.quick_targets)}"
+        """Talk now intentionally omits page counts to keep the chrome calmer."""
+        return None
 
     def get_visible_window(self) -> tuple[list[str], list[str], int]:
         """Return the visible quick-target titles, badges, and selected row index."""
@@ -238,7 +276,7 @@ class CallScreen(Screen):
 
             target = self.quick_targets[target_index]
             visible_titles.append(target.title)
-            visible_badges.append("ALL" if target.kind == "browse_contacts" else "")
+            visible_badges.append("")
             if target_index == self.selected_index:
                 selected_visible_index = row
 
@@ -281,13 +319,13 @@ class CallScreen(Screen):
             return ("", "")
 
         state_labels = {
-            "incoming": "Incoming call",
-            "outgoing": "Calling...",
-            "outgoing_progress": "Calling...",
-            "outgoing_ringing": "Ringing...",
-            "outgoing_early_media": "Connecting audio",
-            "connected": "Call connected",
-            "streams_running": "Call connected",
+            "incoming": "Incoming",
+            "outgoing": "Calling",
+            "outgoing_progress": "Calling",
+            "outgoing_ringing": "Ringing",
+            "outgoing_early_media": "Connecting",
+            "connected": "In call",
+            "streams_running": "In call",
         }
         caller_info = self.voip_manager.get_caller_info()
         caller_text = caller_info.get("display_name") or caller_info.get("address") or ""
@@ -306,27 +344,21 @@ class CallScreen(Screen):
 
     def _instruction_text(self) -> str:
         """Return footer hints for the current selection and state."""
-        if self.is_one_button_mode():
-            if not self.quick_targets:
-                return "Hold back"
-
-            selected_target = self._selected_target()
-            if selected_target is None:
-                return "Hold back"
-
-            if selected_target.kind == "browse_contacts" or not self._is_ready_to_call():
-                return "Tap next / Double open"
-            return "Tap next / Double call"
-
         if not self.quick_targets:
-            return "B back"
+            return "Hold back" if self.is_one_button_mode() else "B back"
 
         selected_target = self._selected_target()
         if selected_target is None:
-            return "B back"
+            return "Hold back" if self.is_one_button_mode() else "B back"
 
-        primary_text = "A open" if selected_target.kind == "browse_contacts" or not self._is_ready_to_call() else "A call"
-        return f"{primary_text} | B back | X/Y move"
+        if self.is_one_button_mode():
+            if selected_target.kind == "contact" and self._is_ready_to_call():
+                return "Tap next / Double call"
+            return "Tap next / Double open"
+
+        if selected_target.kind == "contact" and self._is_ready_to_call():
+            return "A call | B back | X/Y move"
+        return "A open | B back | X/Y move"
 
     def _ensure_selection_visible(self, visible_items: Optional[int] = None) -> None:
         """Adjust scroll offset to keep the selected target on screen."""
@@ -345,14 +377,36 @@ class CallScreen(Screen):
         logger.info("Opening full contact list from Talk")
         self.request_route("browse_contacts")
 
+    def _open_history(self) -> None:
+        """Open the recent-calls history screen."""
+        logger.info("Opening Talk recents")
+        self.request_route("browse_history")
+
+    def _open_voice_notes(self) -> None:
+        """Open the voice-note recipient picker."""
+        logger.info("Opening Talk voice-note recipients")
+        self.request_route("voice_notes")
+
     def _call_selected_target(self) -> None:
-        """Place a call to the currently selected contact."""
+        """Place a call to the currently selected contact or open the chosen action."""
         selected_target = self._selected_target()
         if selected_target is None:
             logger.debug("No Talk target selected")
             return
 
-        if selected_target.kind == "browse_contacts" or not self._is_ready_to_call():
+        if selected_target.kind == "browse_contacts":
+            self._browse_contacts()
+            return
+
+        if selected_target.kind == "history":
+            self._open_history()
+            return
+
+        if selected_target.kind == "voice_notes":
+            self._open_voice_notes()
+            return
+
+        if not self._is_ready_to_call():
             self._browse_contacts()
             return
 
@@ -368,7 +422,7 @@ class CallScreen(Screen):
         logger.error(f"Failed to initiate quick call to {selected_target.title}")
 
     def on_select(self, data=None) -> None:
-        """Call the selected person or open contacts."""
+        """Call the selected person or open the selected Talk action."""
         self._call_selected_target()
 
     def on_back(self, data=None) -> None:

--- a/yoyopy/ui/screens/voip/voice_note.py
+++ b/yoyopy/ui/screens/voip/voice_note.py
@@ -1,0 +1,152 @@
+"""Voice-note foundation screen for the Talk flow."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from yoyopy.ui.display import Display
+from yoyopy.ui.screens.base import Screen
+from yoyopy.ui.screens.theme import TALK, INK, draw_icon, render_footer, render_header, rounded_panel, wrap_text
+from yoyopy.ui.screens.voip.lvgl.voice_note_view import LvglVoiceNoteView
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.ui.screens import ScreenView
+
+
+class VoiceNoteScreen(Screen):
+    """Small shell for future Talk voice-note recording."""
+
+    def __init__(self, display: Display, context: Optional["AppContext"] = None) -> None:
+        super().__init__(display, context, "VoiceNote")
+        self._state = "ready"
+        self._lvgl_view: "ScreenView | None" = None
+
+    def enter(self) -> None:
+        """Reset the voice-note shell when opened."""
+        super().enter()
+        self._state = "ready"
+        self._ensure_lvgl_view()
+
+    def exit(self) -> None:
+        """Tear down any active LVGL view when leaving voice notes."""
+        if self._lvgl_view is not None:
+            self._lvgl_view.destroy()
+            self._lvgl_view = None
+        super().exit()
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            return None
+
+        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            return None
+
+        self._lvgl_view = LvglVoiceNoteView(self, ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
+
+    def recipient_name(self) -> str:
+        """Return the current selected recipient name."""
+        if self.context is None:
+            return "Friend"
+        return self.context.voice_note_recipient_name or "Friend"
+
+    def current_view_model(self) -> tuple[str, str, str, str]:
+        """Return title, subtitle, footer, and icon for the current voice-note state."""
+        recipient = self.recipient_name()
+        if self._state == "recording":
+            return (
+                "Recording",
+                f"Saving a note for {recipient}.",
+                "Double save / Hold back" if self.is_one_button_mode() else "A save | B back",
+                "voice_note",
+            )
+        if self._state == "saved":
+            return (
+                "Saved",
+                f"Your next voice note will go to {recipient}.",
+                "Double again / Hold back" if self.is_one_button_mode() else "A again | B back",
+                "voice_note",
+            )
+        return (
+            "Voice note",
+            f"Ready for {recipient}.",
+            "Double record / Hold back" if self.is_one_button_mode() else "A record | B back",
+            "voice_note",
+        )
+
+    def render(self) -> None:
+        """Render the current voice-note shell state."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is not None:
+            lvgl_view.sync()
+            return
+
+        title_text, subtitle_text, footer_text, icon_key = self.current_view_model()
+        content_top = render_header(
+            self.display,
+            self.context,
+            mode="talk",
+            title="Voice Note",
+            show_time=False,
+            show_mode_chip=False,
+        )
+
+        panel_top = content_top + 8
+        panel_bottom = self.display.HEIGHT - 28
+        rounded_panel(
+            self.display,
+            16,
+            panel_top,
+            self.display.WIDTH - 16,
+            panel_bottom,
+            fill=(31, 34, 40),
+            outline=TALK.accent_dim,
+            radius=24,
+        )
+
+        draw_icon(self.display, icon_key, (self.display.WIDTH // 2) - 24, panel_top + 18, 48, TALK.accent)
+
+        headline_width, headline_height = self.display.get_text_size(title_text, 18)
+        self.display.text(
+            title_text,
+            (self.display.WIDTH - headline_width) // 2,
+            panel_top + 78,
+            color=TALK.accent,
+            font_size=18,
+        )
+
+        copy_lines = wrap_text(
+            self.display,
+            subtitle_text,
+            self.display.WIDTH - 52,
+            12,
+            max_lines=2,
+        )
+        line_y = panel_top + 108
+        for line in copy_lines:
+            line_width, _ = self.display.get_text_size(line, 12)
+            self.display.text(line, (self.display.WIDTH - line_width) // 2, line_y, color=INK, font_size=12)
+            line_y += 15
+
+        render_footer(self.display, footer_text, mode="talk")
+        self.display.update()
+
+    def on_select(self, data=None) -> None:
+        """Cycle the voice-note shell through record/save/ready states."""
+        if self._state == "ready":
+            self._state = "recording"
+            return
+        if self._state == "recording":
+            self._state = "saved"
+            return
+        self._state = "recording"
+
+    def on_back(self, data=None) -> None:
+        """Return to the previous screen."""
+        self.request_route("back")

--- a/yoyopy/voip/__init__.py
+++ b/yoyopy/voip/__init__.py
@@ -11,6 +11,7 @@ from yoyopy.voip.backend import (
     VoIPBackend,
 )
 from yoyopy.voip.manager import VoIPManager
+from yoyopy.voip.history import CallHistoryEntry, CallHistoryStore
 from yoyopy.voip.models import (
     BackendStopped,
     CallState,
@@ -24,6 +25,8 @@ from yoyopy.voip.models import (
 
 __all__ = [
     "VoIPManager",
+    "CallHistoryEntry",
+    "CallHistoryStore",
     "VoIPBackend",
     "LinphonecBackend",
     "MockVoIPBackend",

--- a/yoyopy/voip/history.py
+++ b/yoyopy/voip/history.py
@@ -1,0 +1,182 @@
+"""Persistent call history for the Talk flow."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+from uuid import uuid4
+
+from loguru import logger
+
+CallDirection = Literal["incoming", "outgoing"]
+CallOutcome = Literal["missed", "completed", "cancelled", "rejected", "failed"]
+
+
+def _utc_now_iso() -> str:
+    """Return the current UTC timestamp as an ISO8601 string."""
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(slots=True)
+class CallHistoryEntry:
+    """One persisted Talk call history entry."""
+
+    direction: CallDirection
+    display_name: str
+    sip_address: str
+    outcome: CallOutcome
+    started_at: str
+    ended_at: str
+    duration_seconds: int = 0
+    seen: bool = False
+    id: str = field(default_factory=lambda: uuid4().hex)
+
+    @property
+    def is_unseen_missed(self) -> bool:
+        """Return True when this entry is a missed call the child has not opened yet."""
+
+        return self.outcome == "missed" and not self.seen
+
+    @property
+    def title(self) -> str:
+        """Return the main list title for this entry."""
+
+        return self.display_name or self.sip_address or "Unknown"
+
+    @property
+    def subtitle(self) -> str:
+        """Return a compact human-readable outcome summary."""
+
+        if self.outcome == "missed":
+            return "Missed call"
+        if self.outcome == "completed":
+            if self.duration_seconds > 0:
+                minutes, seconds = divmod(max(0, self.duration_seconds), 60)
+                return f"Call {minutes}:{seconds:02d}"
+            return "Call done"
+        if self.outcome == "rejected":
+            return "Rejected"
+        if self.outcome == "failed":
+            return "Failed"
+        return "Cancelled"
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        direction: CallDirection,
+        display_name: str,
+        sip_address: str,
+        outcome: CallOutcome,
+        duration_seconds: int = 0,
+    ) -> "CallHistoryEntry":
+        """Create a new entry using the current time for start/end."""
+
+        now = _utc_now_iso()
+        return cls(
+            direction=direction,
+            display_name=display_name,
+            sip_address=sip_address,
+            outcome=outcome,
+            started_at=now,
+            ended_at=now,
+            duration_seconds=max(0, int(duration_seconds)),
+            seen=outcome != "missed",
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "CallHistoryEntry":
+        """Build an entry from persisted JSON data."""
+
+        return cls(
+            direction=str(data.get("direction", "incoming")),  # type: ignore[arg-type]
+            display_name=str(data.get("display_name", "")),
+            sip_address=str(data.get("sip_address", "")),
+            outcome=str(data.get("outcome", "failed")),  # type: ignore[arg-type]
+            started_at=str(data.get("started_at", _utc_now_iso())),
+            ended_at=str(data.get("ended_at", _utc_now_iso())),
+            duration_seconds=max(0, int(data.get("duration_seconds", 0) or 0)),
+            seen=bool(data.get("seen", False)),
+            id=str(data.get("id", uuid4().hex)),
+        )
+
+
+class CallHistoryStore:
+    """Persist and query Talk call history for the kid-facing UI."""
+
+    def __init__(self, history_file: str | Path, max_entries: int = 50) -> None:
+        self.history_file = Path(history_file)
+        self.max_entries = max(1, int(max_entries))
+        self._entries: list[CallHistoryEntry] = []
+        self.load()
+
+    def load(self) -> None:
+        """Load history from disk if present."""
+
+        if not self.history_file.exists():
+            self._entries = []
+            return
+
+        try:
+            with open(self.history_file, "r", encoding="utf-8") as handle:
+                payload = json.load(handle) or {}
+            items = payload.get("entries", [])
+            self._entries = [CallHistoryEntry.from_dict(item) for item in items]
+            self._entries = self._entries[: self.max_entries]
+        except Exception as exc:
+            logger.warning(f"Failed to load call history from {self.history_file}: {exc}")
+            self._entries = []
+
+    def save(self) -> None:
+        """Persist the current history state to disk."""
+
+        try:
+            self.history_file.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.history_file, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {"entries": [asdict(entry) for entry in self._entries[: self.max_entries]]},
+                    handle,
+                    indent=2,
+                )
+        except Exception as exc:
+            logger.warning(f"Failed to save call history to {self.history_file}: {exc}")
+
+    def add_entry(self, entry: CallHistoryEntry) -> None:
+        """Append a new call history entry and persist it."""
+
+        self._entries.insert(0, entry)
+        self._entries = self._entries[: self.max_entries]
+        self.save()
+
+    def list_recent(self, limit: int | None = None) -> list[CallHistoryEntry]:
+        """Return recent history entries, newest first."""
+
+        if limit is None:
+            return list(self._entries)
+        return list(self._entries[: max(0, limit)])
+
+    def recent_preview(self, limit: int = 3) -> list[str]:
+        """Return a short preview list suitable for the root hub and context."""
+
+        return [entry.title for entry in self.list_recent(limit)]
+
+    def missed_count(self) -> int:
+        """Return the number of unseen missed calls."""
+
+        return sum(1 for entry in self._entries if entry.is_unseen_missed)
+
+    def mark_all_seen(self) -> None:
+        """Mark missed calls as seen once the child opens recents/history."""
+
+        changed = False
+        for entry in self._entries:
+            if entry.is_unseen_missed:
+                entry.seen = True
+                changed = True
+        if changed:
+            self.save()
+


### PR DESCRIPTION
## Summary
- add a persistent Talk call-history layer with missed-call tracking, a Recents screen, and a voice-note entry flow
- turn Ask from a static placeholder into a staged shell with idle, listening, thinking, and response states while keeping the existing controller architecture
- add Whisplay/LVGL soak diagnostics and wire them into the Raspberry Pi smoke and remote-helper workflows
- update the hub/Talk summaries and docs so the new Talk/Ask behavior and Pi workflow are discoverable

## Verification
- python -m compileall yoyopy tests demos scripts
- uv run pytest -q
- uv run python scripts/lvgl_soak.py --help
- uv run python scripts/pi_remote.py lvgl-soak --help