### PR TITLE
Fix LVGL Pi follow-up regressions

### DIFF
--- a/scripts/lvgl_soak.py
+++ b/scripts/lvgl_soak.py
@@ -53,7 +53,7 @@ def _exercise_sleep_wake(app: YoyoPodApp) -> tuple[bool, str]:
     if app.context is None or app.context.screen_awake:
         return False, "screen did not enter sleep during soak"
 
-    app.event_bus.publish(UserActivityEvent(source="lvgl_soak"))
+    app.event_bus.publish(UserActivityEvent(action_name="lvgl_soak"))
     _pump_app(app, 0.35)
     if app.context is None or not app.context.screen_awake:
         return False, "screen did not wake after simulated activity"

--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Callable
+
 import pytest
 
 from yoyopy.app_context import AppContext
@@ -177,3 +179,31 @@ def test_screen_manager_routes_whisplay_hub_cards_through_stack(display: Display
     hub.selected_index = 3
     input_manager.simulate_action(InputAction.SELECT)
     assert screen_manager.current_screen is power
+
+
+def test_screen_manager_can_schedule_actions_for_main_thread(display: Display) -> None:
+    """A scheduled ScreenManager should defer screen actions until the scheduler runs them."""
+
+    context = AppContext()
+    input_manager = InputManager()
+    scheduled_callbacks: list[Callable[[], None]] = []
+    screen_manager = ScreenManager(
+        display,
+        input_manager,
+        action_scheduler=scheduled_callbacks.append,
+    )
+
+    hub = HubScreen(display, context)
+    listen = RoutableStubScreen(display, context)
+
+    screen_manager.register_screen("hub", hub)
+    screen_manager.register_screen("listen", listen)
+
+    screen_manager.replace_screen("hub")
+    input_manager.simulate_action(InputAction.SELECT)
+
+    assert screen_manager.current_screen is hub
+    assert len(scheduled_callbacks) == 1
+
+    scheduled_callbacks.pop()()
+    assert screen_manager.current_screen is listen

--- a/tests/test_voip_backend.py
+++ b/tests/test_voip_backend.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 from yoyopy.voip import (
     BackendStopped,
@@ -151,3 +153,29 @@ def test_voip_manager_stop_can_suppress_teardown_callbacks() -> None:
     assert manager.call_state == CallState.RELEASED
     assert manager.call_start_time is None
     assert manager.get_caller_info()["display_name"] == "Unknown"
+
+
+def test_linphone_backend_stop_kills_process_after_terminate_timeout() -> None:
+    """Stopping linphonec should hard-kill the process if terminate still hangs."""
+
+    backend = LinphonecBackend(build_config())
+    process = SimpleNamespace()
+    process.stdin = Mock()
+    process.wait = Mock(
+        side_effect=[
+            subprocess.TimeoutExpired(cmd=["linphonec"], timeout=2),
+            subprocess.TimeoutExpired(cmd=["linphonec"], timeout=1),
+            None,
+        ]
+    )
+    process.terminate = Mock()
+    process.kill = Mock()
+    backend.process = process
+    backend.running = True
+
+    backend.stop()
+
+    process.terminate.assert_called_once()
+    process.kill.assert_called_once()
+    assert process.wait.call_count == 3
+    assert backend.process is None

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 import json
 import threading
 import time
+from queue import SimpleQueue
 from pathlib import Path
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from loguru import logger
 
@@ -160,6 +161,7 @@ class YoyoPodApp:
         # Main-thread event bus
         self._main_thread_id = threading.get_ident()
         self.event_bus = EventBus(main_thread_id=self._main_thread_id)
+        self._pending_main_thread_callbacks: SimpleQueue[Callable[[], None]] = SimpleQueue()
         self.event_bus.subscribe(ScreenChangedEvent, self._handle_screen_changed_event)
         self.event_bus.subscribe(UserActivityEvent, self._handle_user_activity_event)
         self.event_bus.subscribe(
@@ -422,7 +424,16 @@ class YoyoPodApp:
                 logger.info("    → No input hardware available")
 
             logger.info("  - ScreenManager")
-            self.screen_manager = ScreenManager(self.display, self.input_manager)
+            action_scheduler = (
+                self._queue_main_thread_callback
+                if getattr(self.display, "backend_kind", "pil") == "lvgl"
+                else None
+            )
+            self.screen_manager = ScreenManager(
+                self.display,
+                self.input_manager,
+                action_scheduler=action_scheduler,
+            )
             return True
         except Exception as exc:
             logger.error(f"Failed to initialize core components: {exc}")
@@ -678,7 +689,20 @@ class YoyoPodApp:
 
     def _process_pending_main_thread_actions(self, limit: Optional[int] = None) -> int:
         """Drain queued typed events scheduled by worker threads."""
-        return self.event_bus.drain(limit)
+        processed = 0
+        while not self._pending_main_thread_callbacks.empty():
+            callback = self._pending_main_thread_callbacks.get()
+            callback()
+            processed += 1
+            if limit is not None and processed >= limit:
+                return processed
+
+        remaining_limit = None if limit is None else max(0, limit - processed)
+        return processed + self.event_bus.drain(remaining_limit)
+
+    def _queue_main_thread_callback(self, callback: Callable[[], None]) -> None:
+        """Schedule a callback to run on the coordinator thread."""
+        self._pending_main_thread_callbacks.put(callback)
 
     def _queue_lvgl_input_action(self, action, _data: Optional[Any] = None) -> None:
         """Queue semantic actions for LVGL from input polling threads."""

--- a/yoyopy/ui/screens/manager.py
+++ b/yoyopy/ui/screens/manager.py
@@ -37,6 +37,7 @@ class ScreenManager:
         input_manager: Optional['InputManager'] = None,
         router: Optional[ScreenRouter] = None,
         on_screen_changed: Optional[Callable[[Optional[str]], None]] = None,
+        action_scheduler: Optional[Callable[[Callable[[], None]], None]] = None,
     ) -> None:
         """
         Initialize the screen manager.
@@ -52,6 +53,7 @@ class ScreenManager:
         self.screens: Dict[str, Screen] = {}
         self.router = router or ScreenRouter()
         self.on_screen_changed = on_screen_changed
+        self.action_scheduler = action_scheduler
 
         logger.info("ScreenManager initialized")
 
@@ -213,19 +215,25 @@ class ScreenManager:
             return
 
         # Helper function to dispatch an action and then refresh or route
+        def dispatch_action(action: "InputAction", data=None) -> None:
+            previous_screen = self.current_screen
+            if previous_screen is None:
+                return
+
+            previous_screen.handle_action(action, data)
+            navigation_request = previous_screen.consume_navigation_request()
+            if navigation_request is not None:
+                self.apply_navigation_request(navigation_request, source_screen=previous_screen)
+            if self.current_screen is previous_screen:
+                self.refresh_current_screen()
+
         def wrap_with_refresh(action: "InputAction"):
             """Wrap action handler to automatically refresh display after execution."""
             def wrapper(data=None):
-                previous_screen = self.current_screen
-                if previous_screen is None:
+                if self.action_scheduler is not None:
+                    self.action_scheduler(lambda: dispatch_action(action, data))
                     return
-
-                previous_screen.handle_action(action, data)
-                navigation_request = previous_screen.consume_navigation_request()
-                if navigation_request is not None:
-                    self.apply_navigation_request(navigation_request, source_screen=previous_screen)
-                if self.current_screen is previous_screen:
-                    self.refresh_current_screen()
+                dispatch_action(action, data)
             return wrapper
 
         for action in InputAction:

--- a/yoyopy/voip/backend.py
+++ b/yoyopy/voip/backend.py
@@ -124,7 +124,11 @@ class LinphonecBackend:
                 self.process.wait(timeout=2)
             except subprocess.TimeoutExpired:
                 self.process.terminate()
-                self.process.wait(timeout=1)
+                try:
+                    self.process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    self.process.kill()
+                    self.process.wait(timeout=1)
             except Exception as exc:
                 logger.error(f"Error stopping linphone backend: {exc}")
             finally:


### PR DESCRIPTION
## Summary
- fix the new LVGL soak helper and standalone VoIP smoke teardown so the final Pi smoke path passes cleanly
- queue LVGL screen navigation and refresh work onto the app main thread instead of running it from the Whisplay input polling thread
- harden the Whisplay follow-up path that showed up during hardware testing around Voice Notes and sleep/wake validation

## Verification
- `python -m compileall yoyopy tests scripts/lvgl_soak.py`
- `uv run pytest -q`
- `uv run python scripts/pi_remote.py --host rpi-zero --branch codex/final-check-followups sync`
- `uv run python scripts/pi_remote.py --host rpi-zero service restart`
- `uv run python scripts/pi_remote.py --host rpi-zero smoke --with-power --with-rtc --with-mopidy --with-voip --with-lvgl-soak`
