### PR TITLE
[codex] Add first-class logging contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ On Whisplay, the one-button root hub currently exposes four cards:
 - `scripts/pisugar_power.py`: PiSugar battery, shutdown, and watchdog helper
 - `scripts/pisugar_rtc.py`: PiSugar RTC status, sync, and alarm helper
 - `deploy/systemd/yoyopod@.service`: production systemd unit for boot-time app supervision
+- `deploy/pi-deploy.yaml`: stable Pi log/PID contract for remote tooling and future automation
 - `yoyopy/fsm.py`: split `MusicFSM`, `CallFSM`, and call interruption policy
 - `yoyopy/coordinators/runtime.py`: derived `AppRuntimeState` over music, call, and UI state
 - `yoyopy/audio/mopidy_client.py`: Mopidy JSON-RPC client
@@ -96,6 +97,7 @@ Important settings:
 - `config/yoyopod_config.yaml`: `input.ptt_navigation=false` is reserved for future voice/PTT work and is currently experimental
 - `config/yoyopod_config.yaml`: `power.watchdog_*` controls the PiSugar app heartbeat watchdog
 - `config/yoyopod_config.yaml`: `power.*` also controls low-battery warning, graceful shutdown, and PiSugar polling
+- `config/yoyopod_config.yaml`: `logging.*` controls file rotation, retention, error-only logs, PID file location, and traceback detail
 - `config/voip_config.yaml`: SIP account, transport, STUN, `linphonec` path
 - `config/contacts.yaml`: contact list and speed dial entries
 
@@ -125,6 +127,8 @@ uv run python scripts/pi_remote.py smoke --with-mopidy --with-voip
 uv run python scripts/pi_remote.py power
 uv run python scripts/pi_remote.py rtc status
 uv run python scripts/pi_remote.py rtc sync-to-rtc
+uv run python scripts/pi_remote.py logs --lines 200
+uv run python scripts/pi_remote.py logs --errors --filter voip
 uv run python scripts/pi_remote.py service status
 uv run python scripts/pi_remote.py service install
 uv run python scripts/pi_remote.py whisplay --duration-seconds 45
@@ -150,6 +154,28 @@ PiSugar power diagnostics:
 ```bash
 uv run python scripts/pisugar_power.py
 uv run python scripts/pi_remote.py power
+```
+
+## Logging
+
+The production app now writes two rotating files in `logs/`:
+
+- `logs/yoyopod.log`: main structured log with timestamps, subsystem tag, module/function/line, and message
+- `logs/yoyopod_errors.log`: errors-only companion log
+
+On the Pi, the checked-in deploy contract at `deploy/pi-deploy.yaml` pins the default project-relative paths used by remote tooling:
+
+- `<project-dir>/logs/yoyopod.log`
+- `<project-dir>/logs/yoyopod_errors.log`
+- `/tmp/yoyopod.pid`
+
+Typical remote debugging flow:
+
+```bash
+uv run python scripts/pi_remote.py logs --lines 200
+uv run python scripts/pi_remote.py logs --errors
+uv run python scripts/pi_remote.py logs --filter voip
+uv run python scripts/pi_remote.py logs --follow --filter ERROR
 ```
 
 ## Running

--- a/config/yoyopod_config.yaml
+++ b/config/yoyopod_config.yaml
@@ -76,5 +76,14 @@ display:
 logging:
   level: "INFO"                   # DEBUG, INFO, WARNING, ERROR
   file: "logs/yoyopod.log"
-  max_size_mb: 10
-  backup_count: 3
+  error_file: "logs/yoyopod_errors.log"
+  pid_file: "/tmp/yoyopod.pid"
+  rotation: "5 MB"
+  retention: "3 days"
+  compression: "gz"
+  error_rotation: "2 MB"
+  error_retention: "7 days"
+  encoding: "utf-8"
+  enqueue: false                  # Write immediately for near-real-time tails
+  backtrace: true
+  diagnose: true

--- a/deploy/pi-deploy.yaml
+++ b/deploy/pi-deploy.yaml
@@ -1,0 +1,5 @@
+project_dir: ~/yoyo-py
+log_file: logs/yoyopod.log
+error_log_file: logs/yoyopod_errors.log
+pid_file: /tmp/yoyopod.pid
+startup_marker: "YoyoPod starting"

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -12,6 +12,7 @@ The repo now has a clear hardware smoke path, but developers still need a quick 
 - run the Pi smoke checks
 - launch the production app
 - install and inspect the production systemd unit
+- tail the structured file logs with subsystem/error filtering
 
 Use `scripts/pi_remote.py` for that loop.
 
@@ -55,6 +56,8 @@ Shows:
 - remote branch and commit
 - dirty working tree state
 - Mopidy user-service state
+- tracked PID file state
+- latest startup marker from the file log
 - top memory processes
 
 ### Sync branch to the Raspberry Pi
@@ -124,7 +127,25 @@ uv run python scripts/pi_remote.py service logs --lines 150
 
 This installs `deploy/systemd/yoyopod@.service` onto the Pi as
 `yoyopod@<remote-user>.service`, enables it at boot, and keeps the app paired
-with the PiSugar watchdog recovery loop.
+with the PiSugar watchdog recovery loop. `service install`, `start`, and
+`restart` now wait for the file-log startup marker and verify that it matches
+the PID file before returning success.
+
+### Structured file logs
+
+```bash
+uv run python scripts/pi_remote.py logs --lines 200
+uv run python scripts/pi_remote.py logs --errors
+uv run python scripts/pi_remote.py logs --filter voip
+uv run python scripts/pi_remote.py logs --follow --filter ERROR
+```
+
+This tails the file sinks declared in `deploy/pi-deploy.yaml`, which is the
+stable Pi contract for:
+
+- `<project-dir>/logs/yoyopod.log`
+- `<project-dir>/logs/yoyopod_errors.log`
+- `/tmp/yoyopod.pid`
 
 Use this during on-device tuning when the Whisplay button feels too eager or too sluggish. The helper runs interactively over SSH, prints every semantic gesture event, and accepts temporary timing overrides without modifying the tracked config file.
 

--- a/scripts/pi_remote.py
+++ b/scripts/pi_remote.py
@@ -9,7 +9,10 @@ import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Sequence
+
+import yaml
 
 
 @dataclass
@@ -19,6 +22,31 @@ class RemoteConfig:
     host: str
     project_dir: str
     branch: str
+
+
+@dataclass(frozen=True)
+class PiDeployConfig:
+    """Stable runtime paths used by the Pi deploy/debugging workflow."""
+
+    log_file: str
+    error_log_file: str
+    pid_file: str
+    startup_marker: str
+
+
+def load_pi_deploy_config() -> PiDeployConfig:
+    """Load the checked-in Raspberry Pi deploy contract."""
+
+    config_path = Path(__file__).resolve().parent.parent / "deploy" / "pi-deploy.yaml"
+    with open(config_path, "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+
+    return PiDeployConfig(
+        log_file=data["log_file"],
+        error_log_file=data["error_log_file"],
+        pid_file=data["pid_file"],
+        startup_marker=data["startup_marker"],
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -178,6 +206,31 @@ def build_parser() -> argparse.ArgumentParser:
         help="Enable verbose power helper logging",
     )
 
+    logs_parser = subparsers.add_parser(
+        "logs",
+        help="Tail the file-based YoyoPod logs on the Raspberry Pi",
+    )
+    logs_parser.add_argument(
+        "--errors",
+        action="store_true",
+        help="Read the errors-only log file instead of the main log",
+    )
+    logs_parser.add_argument(
+        "--follow",
+        action="store_true",
+        help="Follow the log output until interrupted",
+    )
+    logs_parser.add_argument(
+        "--filter",
+        help="Case-insensitive grep filter for subsystem, module, level, or text",
+    )
+    logs_parser.add_argument(
+        "--lines",
+        type=int,
+        default=100,
+        help="How many lines to show before following (default: 100)",
+    )
+
     service_parser = subparsers.add_parser(
         "service",
         help="Install or inspect the production YoyoPod systemd service",
@@ -323,8 +376,15 @@ def run_local(command: Sequence[str], label: str) -> int:
     return completed.returncode
 
 
-def build_status_command() -> str:
+def shell_quote(value: str) -> str:
+    """Shell-escape one literal value for the remote command string."""
+
+    return shlex.quote(value)
+
+
+def build_status_command(deploy_config: PiDeployConfig | None = None) -> str:
     """Create the remote status command."""
+    deploy = deploy_config or load_pi_deploy_config()
     return " && ".join(
         [
             "echo '== Git ==' ",
@@ -340,6 +400,20 @@ def build_status_command() -> str:
             "echo",
             "echo '== PiSugar Server ==' ",
             "systemctl is-active pisugar-server || true",
+            "echo",
+            "echo '== PID File ==' ",
+            (
+                f"if test -f {shell_quote(deploy.pid_file)}; "
+                f"then cat {shell_quote(deploy.pid_file)}; "
+                "else echo 'missing'; fi"
+            ),
+            "echo",
+            "echo '== Latest Startup Marker ==' ",
+            (
+                f"if test -f {shell_quote(deploy.log_file)}; "
+                f"then grep -F {shell_quote(deploy.startup_marker)} {shell_quote(deploy.log_file)} | tail -n 1 || true; "
+                "else echo 'missing'; fi"
+            ),
             "echo",
             "echo '== Top Processes ==' ",
             "ps -eo pid,comm,%mem,%cpu --sort=-%mem | head -15",
@@ -420,9 +494,71 @@ def build_power_command(args: argparse.Namespace) -> str:
     return " ".join(parts)
 
 
-def build_service_command(args: argparse.Namespace) -> str:
+def build_logs_command(
+    args: argparse.Namespace,
+    deploy_config: PiDeployConfig | None = None,
+) -> str:
+    """Create the remote file-log inspection command."""
+
+    deploy = deploy_config or load_pi_deploy_config()
+    target_log = deploy.error_log_file if args.errors else deploy.log_file
+    tail_mode = "-F" if args.follow else ""
+    base_tail = f"tail -n {args.lines} {tail_mode} {shell_quote(target_log)}".strip()
+
+    if args.filter:
+        return (
+            f"test -f {shell_quote(target_log)} && "
+            f"{base_tail} | grep --line-buffered -i -- {shell_quote(args.filter)}"
+        )
+
+    return f"test -f {shell_quote(target_log)} && {base_tail}"
+
+
+def build_startup_verification_command(
+    deploy_config: PiDeployConfig | None = None,
+    *,
+    attempts: int = 20,
+) -> str:
+    """Create a remote command that waits for the startup marker and matching PID."""
+
+    deploy = deploy_config or load_pi_deploy_config()
+    pid_file = shell_quote(deploy.pid_file)
+    log_file = shell_quote(deploy.log_file)
+    startup_marker = shell_quote(deploy.startup_marker)
+    return " && ".join(
+        [
+            (
+                f"for _ in $(seq 1 {attempts}); do "
+                f"test -f {pid_file} && break; "
+                "sleep 1; "
+                "done"
+            ),
+            f"test -f {pid_file}",
+            f'pid="$(tr -d \'\\n\' < {pid_file})"',
+            'test -n "$pid"',
+            'kill -0 "$pid"',
+            (
+                f"for _ in $(seq 1 {attempts}); do "
+                f"if test -f {log_file} && "
+                f"grep -F {startup_marker} {log_file} | tail -n 1 | grep -F \"pid=$pid\" >/dev/null; then "
+                "break; "
+                "fi; "
+                "sleep 1; "
+                "done"
+            ),
+            f"grep -F {startup_marker} {log_file} | tail -n 1 | grep -F \"pid=$pid\"",
+        ]
+    )
+
+
+def build_service_command(
+    args: argparse.Namespace,
+    deploy_config: PiDeployConfig | None = None,
+) -> str:
     """Create the remote systemd service command."""
+    deploy = deploy_config or load_pi_deploy_config()
     service_name = 'yoyopod@"$(id -un)".service'
+    verify_startup = build_startup_verification_command(deploy)
 
     if args.service_action == "status":
         return f"sudo systemctl status {service_name} --no-pager || true"
@@ -434,18 +570,27 @@ def build_service_command(args: argparse.Namespace) -> str:
                 "sudo cp deploy/systemd/yoyopod@.service /etc/systemd/system/yoyopod@.service",
                 "sudo systemctl daemon-reload",
                 f"sudo systemctl enable --now {service_name}",
+                verify_startup,
                 f"sudo systemctl status {service_name} --no-pager",
             ]
         )
 
     if args.service_action == "start":
-        return f"sudo systemctl start {service_name} && sudo systemctl status {service_name} --no-pager"
+        return (
+            f"sudo systemctl start {service_name} && "
+            f"{verify_startup} && "
+            f"sudo systemctl status {service_name} --no-pager"
+        )
 
     if args.service_action == "stop":
         return f"sudo systemctl stop {service_name} && sudo systemctl status {service_name} --no-pager || true"
 
     if args.service_action == "restart":
-        return f"sudo systemctl restart {service_name} && sudo systemctl status {service_name} --no-pager"
+        return (
+            f"sudo systemctl restart {service_name} && "
+            f"{verify_startup} && "
+            f"sudo systemctl status {service_name} --no-pager"
+        )
 
     if args.service_action == "logs":
         return f"sudo journalctl -u {service_name} -n {args.lines} --no-pager"
@@ -511,6 +656,7 @@ def main() -> int:
     """Program entry point."""
     parser = build_parser()
     args = parser.parse_args()
+    deploy_config = load_pi_deploy_config()
 
     config = RemoteConfig(
         host=args.host,
@@ -520,7 +666,7 @@ def main() -> int:
     validate_config(config)
 
     if args.command == "status":
-        return run_remote(config, build_status_command())
+        return run_remote(config, build_status_command(deploy_config))
 
     if args.command == "sync":
         return run_remote(config, build_sync_command(config, args.skip_uv_sync))
@@ -537,8 +683,11 @@ def main() -> int:
     if args.command == "power":
         return run_remote(config, build_power_command(args))
 
+    if args.command == "logs":
+        return run_remote(config, build_logs_command(args, deploy_config), tty=args.follow)
+
     if args.command == "service":
-        return run_remote(config, build_service_command(args))
+        return run_remote(config, build_service_command(args, deploy_config))
 
     if args.command == "preflight":
         return run_preflight(config, args)

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -50,6 +50,16 @@ def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> Non
     assert settings.display.hardware == "auto"
     assert settings.display.whisplay_renderer == "lvgl"
     assert settings.display.lvgl_buffer_lines == 40
+    assert settings.logging.file == "logs/yoyopod.log"
+    assert settings.logging.error_file == "logs/yoyopod_errors.log"
+    assert settings.logging.pid_file == "/tmp/yoyopod.pid"
+    assert settings.logging.rotation == "5 MB"
+    assert settings.logging.retention == "3 days"
+    assert settings.logging.error_rotation == "2 MB"
+    assert settings.logging.error_retention == "7 days"
+    assert settings.logging.enqueue is False
+    assert settings.logging.backtrace is True
+    assert settings.logging.diagnose is True
 
 
 def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) -> None:
@@ -94,6 +104,10 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     monkeypatch.setenv("YOYOPOD_DISPLAY", "whisplay")
     monkeypatch.setenv("YOYOPOD_WHISPLAY_RENDERER", "lvgl")
     monkeypatch.setenv("YOYOPOD_LVGL_BUFFER_LINES", "24")
+    monkeypatch.setenv("YOYOPOD_LOG_FILE", "/var/log/yoyopod.log")
+    monkeypatch.setenv("YOYOPOD_ERROR_LOG_FILE", "/var/log/yoyopod_errors.log")
+    monkeypatch.setenv("YOYOPOD_PID_FILE", "/run/yoyopod.pid")
+    monkeypatch.setenv("YOYOPOD_LOG_ENQUEUE", "true")
 
     config_manager = ConfigManager(config_dir=str(tmp_path))
     settings = config_manager.get_app_settings()
@@ -120,10 +134,15 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     assert settings.display.whisplay_renderer == "lvgl"
     assert settings.display.lvgl_buffer_lines == 24
     assert settings.logging.level == "DEBUG"
+    assert settings.logging.file == "/var/log/yoyopod.log"
+    assert settings.logging.error_file == "/var/log/yoyopod_errors.log"
+    assert settings.logging.pid_file == "/run/yoyopod.pid"
+    assert settings.logging.enqueue is True
     assert config_dict["audio"]["mopidy_port"] == 7788
     assert config_dict["display"]["hardware"] == "whisplay"
     assert config_dict["display"]["whisplay_renderer"] == "lvgl"
     assert config_dict["display"]["lvgl_buffer_lines"] == 24
+    assert config_dict["logging"]["file"] == "/var/log/yoyopod.log"
 
 
 def test_config_manager_keeps_typed_voip_audio_settings(tmp_path, monkeypatch) -> None:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,82 @@
+"""Tests for the centralized YoyoPod logging helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+
+from yoyopy.config.models import AppLoggingConfig
+from yoyopy.utils.logger import (
+    LoggingRuntimeConfig,
+    build_logging_runtime_config,
+    get_subsystem_logger,
+    infer_subsystem,
+    init_logger,
+    remove_pid_file,
+    write_pid_file,
+)
+
+
+def test_build_logging_runtime_config_resolves_relative_paths(tmp_path: Path) -> None:
+    """Relative logging paths should resolve against the project root."""
+
+    config = AppLoggingConfig(
+        file="logs/main.log",
+        error_file="logs/errors.log",
+        pid_file="run/yoyopod.pid",
+    )
+
+    runtime = build_logging_runtime_config(config, base_dir=tmp_path)
+
+    assert runtime.log_file == (tmp_path / "logs" / "main.log").resolve()
+    assert runtime.error_log_file == (tmp_path / "logs" / "errors.log").resolve()
+    assert runtime.pid_file == (tmp_path / "run" / "yoyopod.pid").resolve()
+
+
+def test_init_logger_writes_structured_main_and_error_logs(tmp_path: Path) -> None:
+    """Main and error log sinks should receive immediate structured output."""
+
+    runtime = LoggingRuntimeConfig(
+        level="DEBUG",
+        log_file=tmp_path / "yoyopod.log",
+        error_log_file=tmp_path / "yoyopod_errors.log",
+        pid_file=tmp_path / "yoyopod.pid",
+        diagnose=False,
+    )
+
+    init_logger(config=runtime, console=False, file_logging=True, announce=False)
+
+    get_subsystem_logger("voip").info("Placed test call")
+    logger.error("Simulated failure")
+
+    main_log = runtime.log_file.read_text(encoding="utf-8")
+    error_log = runtime.error_log_file.read_text(encoding="utf-8")
+
+    assert "voip" in main_log
+    assert "Placed test call" in main_log
+    assert "ERROR" in main_log
+    assert "Simulated failure" in error_log
+
+
+def test_pid_file_helpers_create_and_cleanup_file(tmp_path: Path) -> None:
+    """PID helpers should support deterministic process bookkeeping."""
+
+    pid_file = tmp_path / "yoyopod.pid"
+
+    write_pid_file(pid_file, pid=4242)
+
+    assert pid_file.read_text(encoding="utf-8").strip() == "4242"
+
+    remove_pid_file(pid_file)
+
+    assert not pid_file.exists()
+
+
+def test_infer_subsystem_maps_core_packages() -> None:
+    """Subsystem inference should keep logs grep-friendly by package area."""
+
+    assert infer_subsystem("yoyopy.voip.manager") == "voip"
+    assert infer_subsystem("yoyopy.ui.screens.manager") == "ui"
+    assert infer_subsystem("yoyopy.event_bus") == "core"
+    assert infer_subsystem("yoyopy.main") == "app"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,24 +1,44 @@
 import sys
+from types import SimpleNamespace
 
 import yoyopy.main as main_module
 
 
 def test_configure_logger_uses_shared_utility(monkeypatch) -> None:
     """Keep the app entrypoint aligned with the shared logging helper."""
+    fake_settings = SimpleNamespace(logging=object())
+    fake_runtime = object()
     calls = []
+
+    def fake_load_app_settings(config_dir: str) -> object:
+        assert config_dir == "config"
+        return fake_settings
+
+    def fake_build_logging_runtime_config(settings, *, base_dir):
+        assert settings is fake_settings.logging
+        assert str(base_dir).endswith("yoyo-py")
+        return fake_runtime
 
     def fake_init_logger(**kwargs) -> None:
         calls.append(kwargs)
+        return fake_runtime
 
+    monkeypatch.setattr(main_module, "load_app_settings", fake_load_app_settings)
+    monkeypatch.setattr(
+        main_module,
+        "build_logging_runtime_config",
+        fake_build_logging_runtime_config,
+    )
     monkeypatch.setattr(main_module, "init_logger", fake_init_logger)
 
-    main_module.configure_logger()
+    runtime = main_module.configure_logger()
 
+    assert runtime is fake_runtime
     assert calls == [
         {
-            "level": "INFO",
+            "config": fake_runtime,
             "console": True,
-            "file_logging": False,
+            "file_logging": True,
             "console_stream": sys.stderr,
             "announce": False,
         }

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -1,18 +1,28 @@
 """Tests for Raspberry Pi remote workflow helpers."""
 
 from scripts.pi_remote import (
+    PiDeployConfig,
     RemoteConfig,
     build_local_preflight_commands,
+    build_logs_command,
     build_power_command,
     build_rtc_command,
     build_service_command,
     build_smoke_command,
+    build_startup_verification_command,
     build_status_command,
     build_sync_command,
     build_whisplay_command,
     quote_remote_project_dir,
 )
 from argparse import Namespace
+
+DEPLOY_CONFIG = PiDeployConfig(
+    log_file="logs/yoyopod.log",
+    error_log_file="logs/yoyopod_errors.log",
+    pid_file="/tmp/yoyopod.pid",
+    startup_marker="YoyoPod starting",
+)
 
 
 def test_quote_remote_project_dir_preserves_home_expansion() -> None:
@@ -131,10 +141,12 @@ def test_build_power_command_supports_verbose_status() -> None:
 def test_build_status_command_reports_yoyopod_service_and_pisugar_server() -> None:
     """Status output should include the production YoyoPod service and PiSugar daemon."""
 
-    command = build_status_command()
+    command = build_status_command(DEPLOY_CONFIG)
 
     assert 'systemctl is-active "yoyopod@$(id -un).service" || true' in command
     assert "systemctl is-active pisugar-server || true" in command
+    assert "/tmp/yoyopod.pid" in command
+    assert "YoyoPod starting" in command
 
 
 def test_build_service_command_supports_install_and_logs() -> None:
@@ -143,9 +155,33 @@ def test_build_service_command_supports_install_and_logs() -> None:
     install_args = Namespace(service_action="install", lines=100)
     logs_args = Namespace(service_action="logs", lines=25)
 
-    install_command = build_service_command(install_args)
-    logs_command = build_service_command(logs_args)
+    install_command = build_service_command(install_args, DEPLOY_CONFIG)
+    logs_command = build_service_command(logs_args, DEPLOY_CONFIG)
 
     assert "deploy/systemd/yoyopod@.service" in install_command
     assert 'sudo systemctl enable --now yoyopod@"$(id -un)".service' in install_command
+    assert "/tmp/yoyopod.pid" in install_command
+    assert "YoyoPod starting" in install_command
     assert logs_command == 'sudo journalctl -u yoyopod@"$(id -un)".service -n 25 --no-pager'
+
+
+def test_build_logs_command_supports_error_filtering_and_follow() -> None:
+    """File log tails should support error-only, grep filters, and follow mode."""
+
+    args = Namespace(errors=True, follow=True, filter="voip", lines=50)
+
+    command = build_logs_command(args, DEPLOY_CONFIG)
+
+    assert "tail -n 50 -F logs/yoyopod_errors.log" in command
+    assert "grep --line-buffered -i -- voip" in command
+
+
+def test_build_startup_verification_command_checks_pid_and_marker() -> None:
+    """Startup verification should cross-check the PID file against the startup log line."""
+
+    command = build_startup_verification_command(DEPLOY_CONFIG, attempts=3)
+
+    assert "test -f /tmp/yoyopod.pid" in command
+    assert "kill -0 \"$pid\"" in command
+    assert "grep -F 'YoyoPod starting' logs/yoyopod.log" in command
+    assert "grep -F \"pid=$pid\"" in command

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -257,8 +257,8 @@ class YoyoPodApp:
 
             logger.info("YoyoPod setup complete")
             return True
-        except Exception as exc:
-            logger.error(f"Setup failed: {exc}")
+        except Exception:
+            logger.exception("Setup failed")
             return False
 
     def _load_configuration(self) -> bool:
@@ -282,8 +282,8 @@ class YoyoPodApp:
             logger.info(f"  Screen timeout: {self._screen_timeout_seconds:.1f}s")
             logger.info(f"  Active brightness: {self._active_brightness:.2f}")
             return True
-        except Exception as exc:
-            logger.error(f"Failed to load configuration: {exc}")
+        except Exception:
+            logger.exception("Failed to load configuration")
             return False
 
     def _resolve_screen_timeout_seconds(self) -> float:
@@ -403,8 +403,8 @@ class YoyoPodApp:
             logger.info("  - ScreenManager")
             self.screen_manager = ScreenManager(self.display, self.input_manager)
             return True
-        except Exception as exc:
-            logger.error(f"Failed to initialize core components: {exc}")
+        except Exception:
+            logger.exception("Failed to initialize core components")
             return False
 
     def _init_managers(self) -> bool:
@@ -462,8 +462,8 @@ class YoyoPodApp:
                 logger.info("    Power backend disabled in config")
 
             return True
-        except Exception as exc:
-            logger.error(f"Failed to initialize managers: {exc}")
+        except Exception:
+            logger.exception("Failed to initialize managers")
             return False
 
     def _setup_screens(self) -> bool:
@@ -568,8 +568,8 @@ class YoyoPodApp:
             logger.info(f"  Initial screen confirmed as {initial_screen}")
             logger.info("  ✓ Initial screen set to menu")
             return True
-        except Exception as exc:
-            logger.error(f"Failed to setup screens: {exc}")
+        except Exception:
+            logger.exception("Failed to setup screens")
             return False
 
     def _get_interaction_profile(self) -> InteractionProfile:

--- a/yoyopy/config/manager.py
+++ b/yoyopy/config/manager.py
@@ -86,8 +86,8 @@ class ConfigManager:
             logger.debug(f"Mopidy host: {self.app_settings.audio.mopidy_host}")
             logger.debug(f"Display hardware: {self.app_settings.display.hardware}")
             return self.app_config_loaded
-        except Exception as exc:
-            logger.error(f"Error loading app config: {exc}")
+        except Exception:
+            logger.exception("Error loading app config")
             self.app_settings = YoyoPodConfig()
             self.app_config = config_to_dict(self.app_settings)
             self.app_config_loaded = False
@@ -114,8 +114,8 @@ class ConfigManager:
             logger.debug(f"SIP Server: {self.get_sip_server()}")
             logger.debug(f"SIP Identity: {self.get_sip_identity()}")
             return self.voip_config_loaded
-        except Exception as exc:
-            logger.error(f"Error loading VoIP config: {exc}")
+        except Exception:
+            logger.exception("Error loading VoIP config")
             self.voip_settings = VoIPFileConfig()
             self.voip_config = config_to_dict(self.voip_settings)
             return False
@@ -151,8 +151,8 @@ class ConfigManager:
 
             logger.info(f"Loaded {len(self.contacts)} contacts")
             return True
-        except Exception as exc:
-            logger.error(f"Error loading contacts: {exc}")
+        except Exception:
+            logger.exception("Error loading contacts")
             return False
 
     def save_contacts(self) -> bool:
@@ -182,8 +182,8 @@ class ConfigManager:
 
             logger.info("Contacts saved successfully")
             return True
-        except Exception as exc:
-            logger.error(f"Error saving contacts: {exc}")
+        except Exception:
+            logger.exception("Error saving contacts")
             return False
 
     def _create_default_voip_config(self) -> None:

--- a/yoyopy/config/models.py
+++ b/yoyopy/config/models.py
@@ -295,9 +295,21 @@ class AppLoggingConfig:
     """Logging configuration."""
 
     level: str = config_value(default="INFO", env="YOYOPOD_LOG_LEVEL")
-    file: str = "logs/yoyopod.log"
-    max_size_mb: int = 10
-    backup_count: int = 3
+    file: str = config_value(default="logs/yoyopod.log", env="YOYOPOD_LOG_FILE")
+    error_file: str = config_value(
+        default="logs/yoyopod_errors.log",
+        env="YOYOPOD_ERROR_LOG_FILE",
+    )
+    pid_file: str = config_value(default="/tmp/yoyopod.pid", env="YOYOPOD_PID_FILE")
+    rotation: str = config_value(default="5 MB", env="YOYOPOD_LOG_ROTATION")
+    retention: str = config_value(default="3 days", env="YOYOPOD_LOG_RETENTION")
+    compression: str = config_value(default="gz", env="YOYOPOD_LOG_COMPRESSION")
+    error_rotation: str = config_value(default="2 MB", env="YOYOPOD_ERROR_LOG_ROTATION")
+    error_retention: str = config_value(default="7 days", env="YOYOPOD_ERROR_LOG_RETENTION")
+    encoding: str = config_value(default="utf-8", env="YOYOPOD_LOG_ENCODING")
+    enqueue: bool = config_value(default=False, env="YOYOPOD_LOG_ENQUEUE")
+    backtrace: bool = config_value(default=True, env="YOYOPOD_LOG_BACKTRACE")
+    diagnose: bool = config_value(default=True, env="YOYOPOD_LOG_DIAGNOSE")
 
 
 @dataclass(slots=True)

--- a/yoyopy/main.py
+++ b/yoyopy/main.py
@@ -5,21 +5,50 @@ This module provides the console-script target used by `pyproject.toml`
 and keeps the installed entry point aligned with the top-level launcher.
 """
 
+import os
 import sys
 import signal
+from pathlib import Path
 
 from loguru import logger
 
+from yoyopy import __version__
 from yoyopy.app import YoyoPodApp
-from yoyopy.utils.logger import init_logger
+from yoyopy.config.models import YoyoPodConfig, load_config_model_from_yaml
+from yoyopy.utils.logger import (
+    LoggingRuntimeConfig,
+    build_logging_runtime_config,
+    get_subsystem_logger,
+    init_logger,
+    log_shutdown,
+    log_startup,
+    remove_pid_file,
+    write_pid_file,
+)
 
 
-def configure_logger() -> None:
-    """Configure the default console logger for the app."""
-    init_logger(
-        level="INFO",
+def load_app_settings(config_dir: str = "config") -> YoyoPodConfig:
+    """Load app settings early enough to configure logging before app setup."""
+
+    config_path = Path(config_dir) / "yoyopod_config.yaml"
+    try:
+        return load_config_model_from_yaml(YoyoPodConfig, config_path)
+    except Exception:
+        return YoyoPodConfig()
+
+
+def configure_logger(config_dir: str = "config") -> LoggingRuntimeConfig:
+    """Configure the shared logger using typed logging settings."""
+
+    settings = load_app_settings(config_dir)
+    logging_config = build_logging_runtime_config(
+        settings.logging,
+        base_dir=Path.cwd(),
+    )
+    return init_logger(
+        config=logging_config,
         console=True,
-        file_logging=False,
+        file_logging=True,
         console_stream=sys.stderr,
         announce=False,
     )
@@ -27,71 +56,86 @@ def configure_logger() -> None:
 
 def main() -> int:
     """Run the integrated YoyoPod application."""
-    configure_logger()
+    logging_config = configure_logger()
+    app_log = get_subsystem_logger("app")
 
     simulate = "--simulate" in sys.argv
+    pid = os.getpid()
+    startup_logged = False
 
-    if simulate:
-        logger.info("=" * 60)
-        logger.info("SIMULATION MODE")
-        logger.info("Running without physical hardware")
-        logger.info("Web server will start on http://localhost:5000")
-        logger.info("Open the URL in your browser to view the display")
-        logger.info("Use keyboard (Arrow keys, Enter, Esc) or web buttons for input")
-        logger.info("=" * 60)
-
-    logger.info("Initializing YoyoPod...")
-    app = YoyoPodApp(config_dir="config", simulate=simulate)
-
-    if not app.setup():
-        logger.error("Failed to setup application!")
-        logger.error("Check that:")
-        logger.error("  - config/voip_config.yaml exists")
-        logger.error("  - config/contacts.yaml exists")
-        logger.error("  - linphonec is installed")
-        logger.error("  - Mopidy is running on localhost:6680")
-        return 1
-
-    logger.info("")
-    logger.info("=" * 60)
-    logger.info("YoyoPod Ready!")
-    logger.info("=" * 60)
-    logger.info("")
-    logger.info("Available Features:")
-    logger.info("  - Music streaming (Mopidy/Spotify)")
-    logger.info("  - VoIP calling (linphonec)")
-    logger.info("  - Auto-pause music on calls")
-    logger.info("  - Auto-resume after calls")
-    logger.info("  - Full UI navigation")
-    logger.info("")
-    logger.info("Current Configuration:")
-    status = app.get_status()
-    logger.info(f"  Auto-resume: {status['auto_resume']}")
-    logger.info(f"  VoIP available: {status['voip_available']}")
-    logger.info(f"  Music available: {status['music_available']}")
-    logger.info("")
-    logger.info("Press Ctrl+C to exit")
-    logger.info("=" * 60)
-    logger.info("")
-
-    def handle_shutdown_signal(signum, _frame) -> None:
-        signal_name = signal.Signals(signum).name
-        logger.info(f"Received {signal_name}, shutting down...")
-        raise KeyboardInterrupt
-
-    previous_sigterm = signal.getsignal(signal.SIGTERM)
-    signal.signal(signal.SIGTERM, handle_shutdown_signal)
+    write_pid_file(logging_config.pid_file, pid)
 
     try:
-        app.run()
-    except KeyboardInterrupt:
-        logger.info("")
-        logger.info("=" * 60)
-        logger.info("Shutting down...")
-    finally:
-        signal.signal(signal.SIGTERM, previous_sigterm)
-        app.stop()
+        log_startup(version=__version__, pid=pid, runtime=logging_config)
+        startup_logged = True
 
-    logger.info("")
-    logger.info("Goodbye!")
-    return 0
+        if simulate:
+            app_log.info("=" * 60)
+            app_log.info("SIMULATION MODE")
+            app_log.info("Running without physical hardware")
+            app_log.info("Web server will start on http://localhost:5000")
+            app_log.info("Open the URL in your browser to view the display")
+            app_log.info("Use keyboard (Arrow keys, Enter, Esc) or web buttons for input")
+            app_log.info("=" * 60)
+
+        app_log.info("Initializing YoyoPod...")
+        app = YoyoPodApp(config_dir="config", simulate=simulate)
+
+        if not app.setup():
+            app_log.error("Failed to setup application")
+            app_log.error("Check that:")
+            app_log.error("  - config/voip_config.yaml exists")
+            app_log.error("  - config/contacts.yaml exists")
+            app_log.error("  - linphonec is installed")
+            app_log.error("  - Mopidy is running on localhost:6680")
+            app.stop()
+            return 1
+
+        app_log.info("")
+        app_log.info("=" * 60)
+        app_log.info("YoyoPod Ready!")
+        app_log.info("=" * 60)
+        app_log.info("")
+        app_log.info("Available Features:")
+        app_log.info("  - Music streaming (Mopidy/Spotify)")
+        app_log.info("  - VoIP calling (linphonec)")
+        app_log.info("  - Auto-pause music on calls")
+        app_log.info("  - Auto-resume after calls")
+        app_log.info("  - Full UI navigation")
+        app_log.info("")
+        app_log.info("Current Configuration:")
+        status = app.get_status()
+        app_log.info(f"  Auto-resume: {status['auto_resume']}")
+        app_log.info(f"  VoIP available: {status['voip_available']}")
+        app_log.info(f"  Music available: {status['music_available']}")
+        app_log.info("")
+        app_log.info("Press Ctrl+C to exit")
+        app_log.info("=" * 60)
+        app_log.info("")
+
+        def handle_shutdown_signal(signum, _frame) -> None:
+            signal_name = signal.Signals(signum).name
+            app_log.info(f"Received {signal_name}, shutting down...")
+            raise KeyboardInterrupt
+
+        previous_sigterm = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGTERM, handle_shutdown_signal)
+
+        exit_code = 0
+        try:
+            app.run()
+        except KeyboardInterrupt:
+            app_log.info("Shutdown requested by signal or keyboard interrupt")
+        except Exception:
+            logger.exception("Unhandled exception escaped the YoyoPod main loop")
+            exit_code = 1
+        finally:
+            signal.signal(signal.SIGTERM, previous_sigterm)
+            app.stop()
+
+        app_log.info("Goodbye!")
+        return exit_code
+    finally:
+        if startup_logged:
+            log_shutdown(pid=pid)
+        remove_pid_file(logging_config.pid_file)

--- a/yoyopy/utils/logger.py
+++ b/yoyopy/utils/logger.py
@@ -1,82 +1,310 @@
-"""
-Logging utility for YoyoPod using Loguru.
+"""Centralized Loguru configuration and runtime logging helpers for YoyoPod."""
 
-Provides structured logging with both file and console output,
-colorized messages, and automatic rotation.
-"""
+from __future__ import annotations
 
+import atexit
+import logging
+import os
 import sys
+import threading
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, TextIO
+from typing import TYPE_CHECKING, Any, Optional, TextIO
+
 from loguru import logger
+
+if TYPE_CHECKING:
+    from yoyopy.config.models import AppLoggingConfig
+
+
+DEFAULT_SUBSYSTEM = "app"
+STARTUP_MARKER = "YoyoPod starting"
+SHUTDOWN_MARKER = "YoyoPod shutting down"
+CONSOLE_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
+    "<level>{level:<8}</level> | "
+    "<cyan>{extra[subsystem]:<6}</cyan> | "
+    "<level>{name}:{function}:{line}</level> | "
+    "<level>{message}</level>"
+)
+FILE_FORMAT = (
+    "{time:YYYY-MM-DD HH:mm:ss.SSS} | "
+    "{level:<8} | "
+    "{extra[subsystem]:<6} | "
+    "{name}:{function}:{line} | "
+    "{message}"
+)
+_SUBSYSTEM_OVERRIDES = {
+    "yoyopy.voip": "voip",
+    "yoyopy.audio": "music",
+    "yoyopy.coordinators": "coord",
+    "yoyopy.ui": "ui",
+    "yoyopy.power": "power",
+    "yoyopy.config": "config",
+}
+
+
+@dataclass(slots=True)
+class LoggingRuntimeConfig:
+    """Resolved runtime logging settings used by the entrypoint."""
+
+    level: str = "INFO"
+    log_file: Path = Path("logs/yoyopod.log")
+    error_log_file: Path = Path("logs/yoyopod_errors.log")
+    pid_file: Path = Path("/tmp/yoyopod.pid")
+    rotation: str = "5 MB"
+    retention: str = "3 days"
+    compression: str = "gz"
+    error_rotation: str = "2 MB"
+    error_retention: str = "7 days"
+    encoding: str = "utf-8"
+    enqueue: bool = False
+    backtrace: bool = True
+    diagnose: bool = True
+
+
+class InterceptHandler(logging.Handler):
+    """Route stdlib logging records into Loguru."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            level: str | int = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        frame = logging.currentframe()
+        depth = 2
+        while frame is not None and frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+
+        logger.bind(subsystem=infer_subsystem(record.name)).opt(
+            depth=depth,
+            exception=record.exc_info,
+        ).log(level, record.getMessage())
+
+
+def infer_subsystem(module_name: str | None) -> str:
+    """Infer a stable subsystem tag from the module/logger name."""
+
+    if not module_name:
+        return DEFAULT_SUBSYSTEM
+
+    for prefix, subsystem in _SUBSYSTEM_OVERRIDES.items():
+        if module_name.startswith(prefix):
+            return subsystem
+
+    if module_name in {"yoyopy.app", "yoyopy.main"}:
+        return "app"
+    if module_name in {"yoyopy.event_bus", "yoyopy.events", "yoyopy.fsm"}:
+        return "core"
+    return DEFAULT_SUBSYSTEM
+
+
+def get_subsystem_logger(subsystem: str) -> Any:
+    """Return a logger bound to the provided subsystem."""
+
+    return logger.bind(subsystem=subsystem)
+
+
+def build_logging_runtime_config(
+    app_logging_config: "AppLoggingConfig | None" = None,
+    *,
+    base_dir: Path | None = None,
+) -> LoggingRuntimeConfig:
+    """Resolve typed logging settings into concrete runtime paths."""
+
+    root_dir = (base_dir or Path.cwd()).resolve()
+
+    if app_logging_config is None:
+        return LoggingRuntimeConfig(
+            log_file=root_dir / "logs" / "yoyopod.log",
+            error_log_file=root_dir / "logs" / "yoyopod_errors.log",
+            pid_file=Path("/tmp/yoyopod.pid"),
+        )
+
+    return LoggingRuntimeConfig(
+        level=app_logging_config.level,
+        log_file=_resolve_log_path(app_logging_config.file, root_dir),
+        error_log_file=_resolve_log_path(app_logging_config.error_file, root_dir),
+        pid_file=_resolve_log_path(app_logging_config.pid_file, root_dir),
+        rotation=app_logging_config.rotation,
+        retention=app_logging_config.retention,
+        compression=app_logging_config.compression,
+        error_rotation=app_logging_config.error_rotation,
+        error_retention=app_logging_config.error_retention,
+        encoding=app_logging_config.encoding,
+        enqueue=app_logging_config.enqueue,
+        backtrace=app_logging_config.backtrace,
+        diagnose=app_logging_config.diagnose,
+    )
 
 
 def init_logger(
+    *,
+    config: LoggingRuntimeConfig | None = None,
     level: str = "INFO",
-    log_dir: Optional[Path] = None,
     console: bool = True,
     file_logging: bool = True,
     console_stream: Optional[TextIO] = None,
-    rotation: str = "100 MB",
-    retention: str = "10 days",
     announce: bool = True,
-) -> None:
+) -> LoggingRuntimeConfig:
     """
-    Initialize the loguru logger with custom settings.
+    Initialize Loguru for the YoyoPod application.
 
     Args:
-        level: Logging level (TRACE, DEBUG, INFO, SUCCESS, WARNING, ERROR, CRITICAL)
-        log_dir: Directory for log files (defaults to ./logs)
-        console: Enable console output
-        file_logging: Enable file output
-        console_stream: Stream for console output (defaults to sys.stdout)
-        rotation: When to rotate log files (size or time-based)
-        retention: How long to keep old log files
-        announce: Log a one-line initialization message after setup
+        config: Fully resolved runtime logging configuration.
+        level: Console/file threshold used when `config` is omitted.
+        console: Enable console output.
+        file_logging: Enable file sinks.
+        console_stream: Stream for console output.
+        announce: Emit a one-line logger readiness message.
     """
-    # Remove default handler
+
+    runtime = config or LoggingRuntimeConfig(level=level)
+    runtime.level = level if config is None else runtime.level
+
     logger.remove()
+    logger.configure(
+        extra={"subsystem": DEFAULT_SUBSYSTEM},
+        patcher=_patch_record,
+    )
 
-    # Set up log directory
-    if log_dir is None:
-        log_dir = Path.cwd() / "logs"
-
-    if file_logging:
-        log_dir.mkdir(parents=True, exist_ok=True)
-
-    # Console handler with colors
     if console:
         if console_stream is None:
-            console_stream = sys.stdout
+            console_stream = sys.stderr
         logger.add(
             console_stream,
-            format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <level>{message}</level>",
-            level=level,
+            format=CONSOLE_FORMAT,
+            level=runtime.level,
             colorize=True,
+            backtrace=runtime.backtrace,
+            diagnose=runtime.diagnose,
+            enqueue=False,
         )
 
-    # File handler with detailed format and rotation
     if file_logging:
-        log_file = log_dir / "yoyopy_{time:YYYY-MM-DD}.log"
+        runtime.log_file.parent.mkdir(parents=True, exist_ok=True)
+        runtime.error_log_file.parent.mkdir(parents=True, exist_ok=True)
         logger.add(
-            log_file,
-            format="{time:YYYY-MM-DD HH:mm:ss} | {level: <8} | {name}:{function}:{line} | {message}",
-            level="DEBUG",  # Always capture all logs to file
-            rotation=rotation,
-            retention=retention,
-            compression="zip",  # Compress old logs
-            enqueue=True,  # Thread-safe logging
+            runtime.log_file,
+            format=FILE_FORMAT,
+            level=runtime.level,
+            rotation=runtime.rotation,
+            retention=runtime.retention,
+            compression=runtime.compression,
+            encoding=runtime.encoding,
+            enqueue=runtime.enqueue,
+            backtrace=runtime.backtrace,
+            diagnose=runtime.diagnose,
         )
+        logger.add(
+            runtime.error_log_file,
+            format=FILE_FORMAT,
+            level="ERROR",
+            rotation=runtime.error_rotation,
+            retention=runtime.error_retention,
+            compression=runtime.compression,
+            encoding=runtime.encoding,
+            enqueue=runtime.enqueue,
+            backtrace=runtime.backtrace,
+            diagnose=runtime.diagnose,
+        )
+
+    _install_stdlib_logging_intercept()
+    _install_exception_hooks()
 
     if announce:
-        logger.info(f"Logger initialized with level: {level}")
+        get_subsystem_logger("app").info(
+            "Logger ready (level={}, main_log={}, error_log={})",
+            runtime.level,
+            runtime.log_file,
+            runtime.error_log_file,
+        )
+
+    return runtime
 
 
-def get_logger():
-    """
-    Get the loguru logger instance.
+def write_pid_file(pid_file: Path, pid: int | None = None) -> None:
+    """Persist the current process ID to the configured PID file."""
 
-    Returns:
-        The loguru logger instance
-    """
+    resolved_pid_file = pid_file.expanduser()
+    resolved_pid_file.parent.mkdir(parents=True, exist_ok=True)
+    resolved_pid_file.write_text(f"{pid or os.getpid()}\n", encoding="utf-8")
+    atexit.register(remove_pid_file, resolved_pid_file)
+
+
+def remove_pid_file(pid_file: Path) -> None:
+    """Best-effort cleanup of the PID file on shutdown."""
+
+    pid_file.expanduser().unlink(missing_ok=True)
+
+
+def log_startup(*, version: str, pid: int, runtime: LoggingRuntimeConfig) -> None:
+    """Emit the canonical application startup marker."""
+
+    app_log = get_subsystem_logger("app")
+    app_log.info("===== {} (version={}, pid={}) =====", STARTUP_MARKER, version, pid)
+    app_log.info(
+        "Logging contract active (main_log={}, error_log={}, pid_file={})",
+        runtime.log_file,
+        runtime.error_log_file,
+        runtime.pid_file,
+    )
+
+
+def log_shutdown(*, pid: int) -> None:
+    """Emit the canonical application shutdown marker."""
+
+    get_subsystem_logger("app").info("===== {} (pid={}) =====", SHUTDOWN_MARKER, pid)
+
+
+def get_logger() -> Any:
+    """Return the configured Loguru logger instance."""
+
     return logger
+
+
+def _resolve_log_path(path_value: str, base_dir: Path) -> Path:
+    """Resolve config paths relative to the working tree when needed."""
+
+    candidate = Path(path_value).expanduser()
+    if candidate.is_absolute():
+        return candidate
+    return (base_dir / candidate).resolve()
+
+
+def _patch_record(record: dict) -> None:
+    """Attach derived context to every emitted log record."""
+
+    extra = record["extra"]
+    if not extra.get("subsystem"):
+        extra["subsystem"] = infer_subsystem(record["name"])
+
+
+def _install_stdlib_logging_intercept() -> None:
+    """Forward stdlib logging into Loguru's configured sinks."""
+
+    logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
+
+
+def _install_exception_hooks() -> None:
+    """Ensure uncaught exceptions are logged with a full traceback."""
+
+    def handle_exception(exc_type, exc_value, exc_traceback) -> None:
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_traceback)
+            return
+        get_subsystem_logger("app").opt(
+            exception=(exc_type, exc_value, exc_traceback)
+        ).critical("Unhandled exception reached sys.excepthook")
+
+    def handle_thread_exception(args: threading.ExceptHookArgs) -> None:
+        if args.exc_type is KeyboardInterrupt:
+            return
+        get_subsystem_logger("app").bind(thread=args.thread.name if args.thread else "unknown").opt(
+            exception=(args.exc_type, args.exc_value, args.exc_traceback)
+        ).critical("Unhandled exception reached threading.excepthook")
+
+    sys.excepthook = handle_exception
+    threading.excepthook = handle_thread_exception


### PR DESCRIPTION
## What changed

This PR adds a first-class logging contract for YoyoPod across the runtime, config model, and Raspberry Pi workflow.

It introduces:
- structured rotating main and error log files
- immediate writes suitable for tail-based debugging on-device
- subsystem tagging for grep-friendly filtering
- PID file lifecycle and startup/shutdown sentinels
- uncaught exception capture with full tracebacks
- Pi remote helper support for file-log inspection and startup verification

## Why

YoyoPod needs a stable debugging surface that works on the device, not just in local development. The previous logger wrapper was too thin for production debugging and did not provide a reliable contract for remote status, restart validation, or targeted log inspection.

During Pi validation, this also exposed a deploy-path issue: the first pass assumed `/home/pi/...`, but the actual service on the device runs as `tifo`. The deploy contract was corrected to use project-relative log paths with a fixed PID file so the systemd `%i` user model stays valid.

## Impact

Developers can now:
- inspect `logs/yoyopod.log` and `logs/yoyopod_errors.log`
- verify restarts against a PID file plus startup marker
- filter file logs by subsystem or level using `pi_remote.py logs --filter ...`
- rely on typed logging config rather than ad hoc logger setup

## Validation

Local:
- `uv run pytest -q`
- `python -m compileall yoyopy tests demos scripts`

Raspberry Pi (`rpi-zero`):
- `uv run python scripts/pi_remote.py --host rpi-zero smoke --with-mopidy --with-voip`
- `uv run python scripts/pi_remote.py --host rpi-zero service restart`
- `uv run python scripts/pi_remote.py --host rpi-zero status`
- `uv run python scripts/pi_remote.py --host rpi-zero logs --lines 20`
- `ssh rpi-zero "bash -lc 'cd ~/yoyo-py && uv run pytest -q tests/test_logger.py tests/test_main.py tests/test_config_models.py tests/test_pi_remote.py'"`
