### PR TITLE
Remove screenshot shadow sync from Whisplay LVGL hot path

### DIFF
--- a/docs/superpowers/specs/2026-04-06-rpi-deploy-plugin-design.md
+++ b/docs/superpowers/specs/2026-04-06-rpi-deploy-plugin-design.md
@@ -165,17 +165,15 @@ The skills depend on YoyoPod's loguru-based logging implementation providing:
 
 **Trigger phrases:** "take a screenshot", "show me the screen", `/screenshot`
 
-**Two capture modes:**
+**Default capture mode:**
 
-- **Shadow buffer (default):** Captures the PIL shadow buffer that mirrors what the app sent to the display via LVGL flush callbacks. This shows what the app *intended* to render.
-- **LVGL readback (`--readback`):** Captures directly from LVGL's internal object tree via `lv_snapshot_take()`. This shows what LVGL *actually has rendered*, which may differ from the shadow buffer if there are partial flush issues or stale content.
+- **LVGL readback first:** Captures directly from LVGL's internal object tree via `lv_snapshot_take()`. This shows what LVGL *actually rendered*.
+- **Fallback:** If readback is unavailable, the app falls back to the adapter's screenshot method.
 
 **Behavior:**
 
 1. Read `pi-deploy.yaml` for `host`, `user`, `pid_file`, and `screenshot_path`.
-2. Send the appropriate signal to the app process:
-   - Default (shadow buffer): `SIGUSR1`
-   - With `--readback` flag: `SIGUSR2`
+2. Send `SIGUSR1` to the app process.
 3. Wait 1 second for the screenshot to be written.
 4. SCP the screenshot PNG from the Pi to a local temp file.
 5. Read the local PNG file using the Read tool (Claude is multimodal — it can see images).
@@ -183,9 +181,8 @@ The skills depend on YoyoPod's loguru-based logging implementation providing:
 
 **App-side requirements (in YoyoPod):**
 
-- `SIGUSR1` handler: saves the PIL shadow buffer to `screenshot_path` as PNG.
-- `SIGUSR2` handler: triggers LVGL `lv_snapshot_take()` on the active screen, converts RGB565 to RGB888, saves to `screenshot_path` as PNG.
-- The Whisplay adapter's `draw_rgb565_region()` must dual-write: send to hardware AND update the PIL shadow buffer (removing the early `return` on hardware path).
+- `SIGUSR1` handler: uses LVGL readback first and falls back to the adapter screenshot method.
+- `SIGUSR2` handler: remains available as a legacy shadow-first debug path.
 - `lv_conf.h` must enable `LV_USE_SNAPSHOT 1`.
 - C shim must expose a `yoyopy_lvgl_snapshot()` function.
 

--- a/rules/lvgl.md
+++ b/rules/lvgl.md
@@ -51,6 +51,6 @@ Must rebuild on Pi after changing `lv_conf.h` or `lvgl_shim.c`.
 
 ## Screenshot Support
 
-Two modes for capturing display output:
-- **Shadow buffer** (SIGUSR1): PIL buffer kept in sync via dual-write in `draw_rgb565_region()`
-- **LVGL readback** (SIGUSR2): `lv_snapshot_take()` captures the LVGL object tree directly
+Default screenshot capture should use LVGL readback first via `SIGUSR1`.
+If readback is unavailable, it may fall back to the adapter screenshot path.
+`SIGUSR2` is reserved as a legacy shadow-first debug path only.

--- a/skills/screenshot.md
+++ b/skills/screenshot.md
@@ -1,7 +1,6 @@
 ---
 description: Capture a screenshot of the app's display from Raspberry Pi
 allowed-tools: Read, Bash(ssh:*), Bash(scp:*)
-argument-hint: "[--readback]"
 ---
 
 ## Config
@@ -16,12 +15,6 @@ Extract these values from the YAML:
 
 Construct the SSH target as: `user@host` if user is set, otherwise just `host`.
 
-## Argument Parsing
-
-Parse the arguments string provided after `/screenshot`:
-
-- **--readback flag:** If `--readback` is present, use SIGUSR2 (LVGL readback — captures what is actually rendered on screen). Otherwise use SIGUSR1 (shadow buffer — captures what the app intended to send to the display).
-
 ## Steps
 
 1. **Check the app is running.** Run:
@@ -30,16 +23,9 @@ Parse the arguments string provided after `/screenshot`:
    ```
    If DEAD, tell the user the app is not running and suggest `/restart`.
 
-2. **Trigger the screenshot.** Send the appropriate signal to the app process:
-
-   For shadow buffer (default, SIGUSR1):
+2. **Trigger the screenshot.** Send the default screenshot signal to the app process:
    ```
    ssh <target> "kill -USR1 \$(cat <pid_file>)"
-   ```
-
-   For LVGL readback (--readback, SIGUSR2):
-   ```
-   ssh <target> "kill -USR2 \$(cat <pid_file>)"
    ```
 
 3. **Wait for the screenshot to be written.** Sleep 1 second to allow the app to process the signal and write the PNG file.
@@ -59,8 +45,8 @@ Parse the arguments string provided after `/screenshot`:
 6. **Display the screenshot.** Use the Read tool to read the local PNG file. Claude is multimodal and can see images directly. Present the screenshot in the conversation.
 
 7. **Explain what was captured.** After showing the image:
-   - If default mode: "This is the **shadow buffer** — what the app sent to the display via LVGL flush callbacks."
-   - If `--readback`: "This is the **LVGL readback** — what LVGL actually rendered on screen."
+   - "This is the default screenshot capture. On LVGL/Whisplay it uses **readback first**, so it reflects what LVGL actually rendered on screen."
+   - "If readback is unavailable, the app falls back to the adapter screenshot method."
 
    Remind the user they can ask follow-up questions about what they see, such as "why is the status bar missing?" or "what screen is this?"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -43,3 +43,55 @@ def test_configure_logger_uses_shared_utility(monkeypatch) -> None:
             "announce": False,
         }
     ]
+
+
+def test_capture_screenshot_prefers_readback_and_falls_back_to_shadow() -> None:
+    """Default screenshot capture should try readback first, then shadow."""
+
+    calls: list[tuple[str, str]] = []
+
+    class Adapter:
+        def save_screenshot_readback(self, path: str) -> bool:
+            calls.append(("readback", path))
+            return False
+
+        def save_screenshot(self, path: str) -> bool:
+            calls.append(("shadow", path))
+            return True
+
+    logs: list[tuple[str, tuple[object, ...]]] = []
+    fake_log = SimpleNamespace(
+        info=lambda *args: logs.append(("info", args)),
+        warning=lambda *args: logs.append(("warning", args)),
+    )
+
+    result = main_module._capture_screenshot(
+        adapter=Adapter(),
+        screenshot_path="/tmp/test.png",
+        app_log=fake_log,
+        prefer_readback=True,
+    )
+
+    assert result is True
+    assert calls == [("readback", "/tmp/test.png"), ("shadow", "/tmp/test.png")]
+    assert logs[-1][0] == "info"
+
+
+def test_capture_screenshot_handles_missing_adapter() -> None:
+    """Missing adapters should return False without raising."""
+
+    logs: list[tuple[str, tuple[object, ...]]] = []
+    fake_log = SimpleNamespace(
+        info=lambda *args: logs.append(("info", args)),
+        warning=lambda *args: logs.append(("warning", args)),
+    )
+
+    result = main_module._capture_screenshot(
+        adapter=None,
+        screenshot_path="/tmp/test.png",
+        app_log=fake_log,
+        prefer_readback=True,
+    )
+
+    assert result is False
+    assert logs == [("warning", ("Screenshot not available — no active display adapter",))]

--- a/tests/test_whisplay_adapter.py
+++ b/tests/test_whisplay_adapter.py
@@ -1,0 +1,80 @@
+"""Focused tests for the Whisplay adapter hot paths."""
+
+from __future__ import annotations
+
+from yoyopy.ui.display.adapters.whisplay import WhisplayDisplayAdapter
+
+
+class FakeDevice:
+    """Small device double that records RGB565 writes."""
+
+    def __init__(self) -> None:
+        self.draw_calls: list[tuple[int, int, int, int, bytes]] = []
+
+    def draw_image(
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        pixel_data: bytes,
+    ) -> None:
+        self.draw_calls.append((x, y, width, height, pixel_data))
+
+
+def test_hardware_lvgl_flush_skips_shadow_buffer_sync(monkeypatch) -> None:
+    """Hardware LVGL flushes should not mirror every region into PIL."""
+
+    adapter = WhisplayDisplayAdapter(simulate=True, renderer="lvgl")
+    adapter.simulate = False
+    adapter.shadow_buffer_sync_enabled = False
+    adapter.device = FakeDevice()
+
+    mirrored: list[tuple[int, int, int, int, bytes]] = []
+    monkeypatch.setattr(
+        adapter,
+        "_paste_rgb565_region",
+        lambda x, y, width, height, pixel_data: mirrored.append((x, y, width, height, pixel_data)),
+    )
+
+    payload = b"\x12\x34" * 8
+    adapter.draw_rgb565_region(1, 2, 4, 2, payload)
+
+    assert adapter.device.draw_calls == [(1, 2, 4, 2, payload)]
+    assert mirrored == []
+
+
+def test_simulated_lvgl_flush_keeps_shadow_buffer_for_debug(monkeypatch) -> None:
+    """Simulation still needs the PIL shadow buffer for local inspection."""
+
+    adapter = WhisplayDisplayAdapter(simulate=True, renderer="lvgl")
+
+    mirrored: list[tuple[int, int, int, int, bytes]] = []
+    monkeypatch.setattr(
+        adapter,
+        "_paste_rgb565_region",
+        lambda x, y, width, height, pixel_data: mirrored.append((x, y, width, height, pixel_data)),
+    )
+
+    payload = b"\xAA\x55" * 8
+    adapter.draw_rgb565_region(0, 0, 4, 2, payload)
+
+    assert mirrored == [(0, 0, 4, 2, payload)]
+
+
+def test_shadow_screenshot_falls_back_to_lvgl_readback_when_shadow_sync_is_disabled(monkeypatch) -> None:
+    """Hardware LVGL screenshots should use readback instead of per-flush shadow sync."""
+
+    adapter = WhisplayDisplayAdapter(simulate=True, renderer="lvgl")
+    adapter.simulate = False
+    adapter.shadow_buffer_sync_enabled = False
+
+    readback_calls: list[str] = []
+    monkeypatch.setattr(
+        adapter,
+        "save_screenshot_readback",
+        lambda path: readback_calls.append(path) or True,
+    )
+
+    assert adapter.save_screenshot("/tmp/test.png") is True
+    assert readback_calls == ["/tmp/test.png"]

--- a/tests/test_whisplay_adapter.py
+++ b/tests/test_whisplay_adapter.py
@@ -27,7 +27,7 @@ def test_hardware_lvgl_flush_skips_shadow_buffer_sync(monkeypatch) -> None:
 
     adapter = WhisplayDisplayAdapter(simulate=True, renderer="lvgl")
     adapter.simulate = False
-    adapter.shadow_buffer_sync_enabled = False
+    adapter.ui_backend = type("Backend", (), {"available": True})()
     adapter.device = FakeDevice()
 
     mirrored: list[tuple[int, int, int, int, bytes]] = []
@@ -67,7 +67,7 @@ def test_shadow_screenshot_falls_back_to_lvgl_readback_when_shadow_sync_is_disab
 
     adapter = WhisplayDisplayAdapter(simulate=True, renderer="lvgl")
     adapter.simulate = False
-    adapter.shadow_buffer_sync_enabled = False
+    adapter.ui_backend = type("Backend", (), {"available": True})()
 
     readback_calls: list[str] = []
     monkeypatch.setattr(
@@ -78,3 +78,23 @@ def test_shadow_screenshot_falls_back_to_lvgl_readback_when_shadow_sync_is_disab
 
     assert adapter.save_screenshot("/tmp/test.png") is True
     assert readback_calls == ["/tmp/test.png"]
+
+
+def test_shadow_sync_mode_tracks_runtime_fallback_state_changes() -> None:
+    """The sync mode should follow later renderer/simulation fallback changes."""
+
+    adapter = WhisplayDisplayAdapter(simulate=True, renderer="lvgl")
+
+    assert adapter.shadow_buffer_sync_enabled is True
+
+    adapter.simulate = False
+    adapter.renderer = "lvgl"
+    adapter.ui_backend = type("Backend", (), {"available": True})()
+    assert adapter.shadow_buffer_sync_enabled is False
+
+    adapter.renderer = "pil"
+    assert adapter.shadow_buffer_sync_enabled is True
+
+    adapter.renderer = "lvgl"
+    adapter.ui_backend = type("Backend", (), {"available": False})()
+    assert adapter.shadow_buffer_sync_enabled is True

--- a/yoyopy/main.py
+++ b/yoyopy/main.py
@@ -27,6 +27,43 @@ from yoyopy.utils.logger import (
 )
 
 
+def _capture_screenshot(
+    *,
+    adapter: object | None,
+    screenshot_path: str,
+    app_log,
+    prefer_readback: bool,
+) -> bool:
+    """Capture a screenshot using readback-first or shadow-first fallback order."""
+
+    if adapter is None:
+        app_log.warning("Screenshot not available — no active display adapter")
+        return False
+
+    ordered_methods = (
+        ("save_screenshot_readback", "LVGL readback"),
+        ("save_screenshot", "shadow buffer"),
+    ) if prefer_readback else (
+        ("save_screenshot", "shadow buffer"),
+        ("save_screenshot_readback", "LVGL readback"),
+    )
+
+    for method_name, label in ordered_methods:
+        save_fn = getattr(adapter, method_name, None)
+        if not callable(save_fn):
+            continue
+        try:
+            if save_fn(screenshot_path):
+                app_log.info("Saved screenshot via {} -> {}", label, screenshot_path)
+                return True
+        except Exception:
+            logger.exception("Screenshot capture failed via {}", label)
+            return False
+
+    app_log.warning("Screenshot not available — adapter does not expose a usable capture method")
+    return False
+
+
 def load_app_settings(config_dir: str = "config") -> YoyoPodConfig:
     """Load app settings early enough to configure logging before app setup."""
 
@@ -126,30 +163,32 @@ def main() -> int:
         screenshot_path = "/tmp/yoyopod_screenshot.png"
         if hasattr(signal, "SIGUSR1"):
 
-            def handle_screenshot_shadow(_signum: int, _frame: object) -> None:
-                """SIGUSR1: save shadow buffer screenshot."""
+            def handle_screenshot_default(_signum: int, _frame: object) -> None:
+                """SIGUSR1: save a screenshot using readback-first capture."""
                 display = getattr(app, "display", None)
                 adapter = getattr(display, "_adapter", None) if display else None
-                save_fn = getattr(adapter, "save_screenshot", None)
-                if save_fn:
-                    save_fn(screenshot_path)
-                else:
-                    app_log.warning("Screenshot not available — no save_screenshot method")
+                _capture_screenshot(
+                    adapter=adapter,
+                    screenshot_path=screenshot_path,
+                    app_log=app_log,
+                    prefer_readback=True,
+                )
 
-            def handle_screenshot_readback(_signum: int, _frame: object) -> None:
-                """SIGUSR2: save LVGL readback screenshot."""
+            def handle_screenshot_legacy_shadow(_signum: int, _frame: object) -> None:
+                """SIGUSR2: save a screenshot using shadow-first capture for debugging."""
                 display = getattr(app, "display", None)
                 adapter = getattr(display, "_adapter", None) if display else None
-                save_fn = getattr(adapter, "save_screenshot_readback", None)
-                if save_fn:
-                    save_fn(screenshot_path)
-                else:
-                    app_log.warning("LVGL readback not available — no save_screenshot_readback method")
+                _capture_screenshot(
+                    adapter=adapter,
+                    screenshot_path=screenshot_path,
+                    app_log=app_log,
+                    prefer_readback=False,
+                )
 
-            signal.signal(signal.SIGUSR1, handle_screenshot_shadow)
-            signal.signal(signal.SIGUSR2, handle_screenshot_readback)
+            signal.signal(signal.SIGUSR1, handle_screenshot_default)
+            signal.signal(signal.SIGUSR2, handle_screenshot_legacy_shadow)
             app_log.info(
-                "Screenshot handlers installed (SIGUSR1=shadow, SIGUSR2=readback) -> {}",
+                "Screenshot handlers installed (SIGUSR1=default/readback-first, SIGUSR2=legacy shadow-first) -> {}",
                 screenshot_path,
             )
 

--- a/yoyopy/ui/display/adapters/whisplay.py
+++ b/yoyopy/ui/display/adapters/whisplay.py
@@ -80,6 +80,7 @@ class WhisplayDisplayAdapter(DisplayHAL):
         self.renderer = renderer.lower().strip() or "pil"
         self.lvgl_buffer_lines = max(1, int(lvgl_buffer_lines))
         self.ui_backend = None
+        self.shadow_buffer_sync_enabled = self.simulate or self.renderer != "lvgl"
 
         # Create PIL drawing buffer
         self._create_buffer()
@@ -184,13 +185,15 @@ class WhisplayDisplayAdapter(DisplayHAL):
         height: int,
         pixel_data: bytes,
     ) -> None:
-        """Write an RGB565 region to hardware and the PIL shadow buffer."""
+        """Write an RGB565 region to hardware and optionally the PIL shadow buffer."""
 
         if not self.simulate and self.device:
             self.device.draw_image(x, y, width, height, pixel_data)
 
-        # Always keep PIL shadow buffer in sync for screenshots.
-        self._paste_rgb565_region(x, y, width, height, pixel_data)
+        # Keep the PIL buffer in sync only when it is the active renderer or simulation target.
+        # Doing this for every LVGL partial flush on hardware is too expensive on the Pi.
+        if self.shadow_buffer_sync_enabled:
+            self._paste_rgb565_region(x, y, width, height, pixel_data)
 
     def clear(self, color: Optional[Tuple[int, int, int]] = None) -> None:
         """Clear the display with specified color."""
@@ -418,6 +421,12 @@ class WhisplayDisplayAdapter(DisplayHAL):
         Returns:
             True if the screenshot was saved, False if no buffer exists.
         """
+        if not self.shadow_buffer_sync_enabled:
+            logger.info(
+                "Shadow-buffer screenshots are disabled for hardware LVGL; using LVGL readback instead"
+            )
+            return self.save_screenshot_readback(path)
+
         if self.buffer is None:
             logger.warning("No buffer available for screenshot")
             return False

--- a/yoyopy/ui/display/adapters/whisplay.py
+++ b/yoyopy/ui/display/adapters/whisplay.py
@@ -80,7 +80,6 @@ class WhisplayDisplayAdapter(DisplayHAL):
         self.renderer = renderer.lower().strip() or "pil"
         self.lvgl_buffer_lines = max(1, int(lvgl_buffer_lines))
         self.ui_backend = None
-        self.shadow_buffer_sync_enabled = self.simulate or self.renderer != "lvgl"
 
         # Create PIL drawing buffer
         self._create_buffer()
@@ -115,6 +114,21 @@ class WhisplayDisplayAdapter(DisplayHAL):
                 logger.warning(f"Failed to prepare LVGL backend: {e}")
                 self.ui_backend = None
                 self.renderer = "pil"
+
+    @property
+    def shadow_buffer_sync_enabled(self) -> bool:
+        """Return True when screenshots should rely on the PIL shadow buffer.
+
+        This must follow the adapter's effective runtime mode instead of the
+        initial constructor arguments, because hardware/LVGL setup can fall
+        back to simulation or PIL later in __init__.
+        """
+
+        if self.simulate or self.renderer != "lvgl":
+            return True
+        if self.ui_backend is None:
+            return True
+        return not bool(getattr(self.ui_backend, "available", False))
 
     def _create_buffer(self) -> None:
         """Create a new PIL drawing buffer."""


### PR DESCRIPTION
## Summary
- remove per-flush PIL shadow-buffer syncing from the Whisplay LVGL hardware render path
- keep simulation and PIL behavior unchanged while making `save_screenshot()` fall back to LVGL readback on hardware LVGL
- add focused tests covering the no-shadow hardware path and screenshot fallback behavior

## Verification
- python -m compileall yoyopy tests
- uv run pytest -q
- Pi benchmark before: `240x40` shadow paste averaged about `62 ms` and spiked above `137 ms`
- Pi benchmark after: `240x40` hardware LVGL flush path averaged about `0.004 ms`