### PR TITLE
Fix now playing track rendering and layout

### DIFF
--- a/tests/test_mopidy_client.py
+++ b/tests/test_mopidy_client.py
@@ -1,0 +1,76 @@
+"""Focused tests for Mopidy client local playback behavior."""
+
+from __future__ import annotations
+
+from yoyopy.audio.mopidy_client import MopidyClient
+
+
+class StubMopidyClient(MopidyClient):
+    """RPC-free Mopidy client stub for unit tests."""
+
+    def __init__(self, responses: dict[str, object]) -> None:
+        super().__init__(host="localhost", port=6680)
+        self._responses = responses
+
+    def _rpc_call(self, method: str, params=None):  # type: ignore[override]
+        return self._responses.get(method)
+
+
+def test_get_current_track_falls_back_to_tracklist_when_current_tl_track_is_missing() -> None:
+    """Queued local playback should still surface the first active track during handoff."""
+
+    client = StubMopidyClient(
+        {
+            "core.playback.get_current_tl_track": None,
+            "core.tracklist.index": 1,
+            "core.tracklist.get_tl_tracks": [
+                {
+                    "track": {
+                        "uri": "file:///music/intro.ogg",
+                        "name": "Intro.ogg",
+                        "artists": [],
+                    }
+                },
+                {
+                    "track": {
+                        "uri": "file:///music/main-theme.ogg",
+                        "name": "Main Theme.ogg",
+                        "artists": [{"name": "Open Orchestra"}],
+                        "length": 123000,
+                    }
+                },
+            ],
+        }
+    )
+
+    track = client.get_current_track()
+
+    assert track is not None
+    assert track.uri == "file:///music/main-theme.ogg"
+    assert track.name == "Main Theme.ogg"
+    assert track.get_artist_string() == "Open Orchestra"
+
+
+def test_get_current_track_uses_cached_track_when_rpc_and_tracklist_are_empty() -> None:
+    """A previously known track should survive one empty RPC cycle."""
+
+    client = StubMopidyClient(
+        {
+            "core.playback.get_current_tl_track": None,
+            "core.tracklist.index": None,
+            "core.tracklist.get_tl_tracks": [],
+        }
+    )
+    client.current_track = type(
+        "Track",
+        (),
+        {
+            "uri": "file:///music/cached.ogg",
+            "name": "Cached.ogg",
+            "get_artist_string": lambda self: "Unknown Artist",
+        },
+    )()
+
+    track = client.get_current_track()
+
+    assert track is client.current_track

--- a/tests/test_mopidy_client.py
+++ b/tests/test_mopidy_client.py
@@ -78,6 +78,31 @@ def test_get_current_track_skips_null_tracklist_entries() -> None:
     assert track.get_artist_string() == "Sampler"
 
 
+def test_get_current_track_ignores_null_track_payload_before_falling_back() -> None:
+    """A null current_tl_track payload should not raise or mask a valid fallback track."""
+
+    client = StubMopidyClient(
+        {
+            "core.playback.get_current_tl_track": {"track": None},
+            "core.tracklist.index": 0,
+            "core.tracklist.get_tl_tracks": [
+                {
+                    "track": {
+                        "uri": "file:///music/fallback.ogg",
+                        "name": "Fallback.ogg",
+                        "artists": [],
+                    }
+                }
+            ],
+        }
+    )
+
+    track = client.get_current_track()
+
+    assert track is not None
+    assert track.uri == "file:///music/fallback.ogg"
+
+
 def test_get_current_track_uses_cached_track_when_rpc_and_tracklist_are_empty() -> None:
     """A previously known track should survive one empty RPC cycle."""
 

--- a/tests/test_mopidy_client.py
+++ b/tests/test_mopidy_client.py
@@ -51,6 +51,33 @@ def test_get_current_track_falls_back_to_tracklist_when_current_tl_track_is_miss
     assert track.get_artist_string() == "Open Orchestra"
 
 
+def test_get_current_track_skips_null_tracklist_entries() -> None:
+    """Sparse tracklists from Mopidy should still yield the first valid track."""
+
+    client = StubMopidyClient(
+        {
+            "core.playback.get_current_tl_track": None,
+            "core.tracklist.index": 0,
+            "core.tracklist.get_tl_tracks": [
+                None,
+                {
+                    "track": {
+                        "uri": "file:///music/recovered.ogg",
+                        "name": "Recovered.ogg",
+                        "artists": [{"name": "Sampler"}],
+                    }
+                },
+            ],
+        }
+    )
+
+    track = client.get_current_track()
+
+    assert track is not None
+    assert track.uri == "file:///music/recovered.ogg"
+    assert track.get_artist_string() == "Sampler"
+
+
 def test_get_current_track_uses_cached_track_when_rpc_and_tracklist_are_empty() -> None:
     """A previously known track should survive one empty RPC cycle."""
 

--- a/tests/test_mopidy_client.py
+++ b/tests/test_mopidy_client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from yoyopy.audio.mopidy_client import MopidyClient
+from yoyopy.audio.mopidy_client import MopidyClient, MopidyTrack
 
 
 class StubMopidyClient(MopidyClient):
@@ -47,7 +47,7 @@ def test_get_current_track_falls_back_to_tracklist_when_current_tl_track_is_miss
 
     assert track is not None
     assert track.uri == "file:///music/main-theme.ogg"
-    assert track.name == "Main Theme.ogg"
+    assert track.name == "Main Theme"
     assert track.get_artist_string() == "Open Orchestra"
 
 
@@ -126,3 +126,21 @@ def test_get_current_track_uses_cached_track_when_rpc_and_tracklist_are_empty() 
     track = client.get_current_track()
 
     assert track is client.current_track
+
+
+def test_mopidy_track_from_mopidy_handles_sparse_metadata_and_strips_file_extensions() -> None:
+    """Local file tracks should tolerate null metadata and present a cleaner title."""
+
+    track = MopidyTrack.from_mopidy(
+        {
+            "uri": "file:///music/OpenSampler/02-Moonlight-Sonata.ogg",
+            "name": "02-Moonlight-Sonata.ogg",
+            "artists": [None, {"name": "Sampler"}],
+            "album": None,
+            "length": 123456,
+        }
+    )
+
+    assert track.name == "02-Moonlight-Sonata"
+    assert track.artists == ["Sampler"]
+    assert track.album == ""

--- a/tests/test_now_playing_lvgl_view.py
+++ b/tests/test_now_playing_lvgl_view.py
@@ -110,6 +110,7 @@ def test_now_playing_screen_builds_syncs_and_destroys_lvgl_view() -> None:
     assert payload["title_text"] == "Adventure Song"
     assert payload["artist_text"] == "Kid Band"
     assert payload["state_text"] == "PLAYING"
+    assert payload["footer"] == "Tap skip / Double pause"
     assert payload["progress_permille"] == 250
     assert payload["voip_state"] == 1
     assert payload["battery_percent"] == 84
@@ -139,4 +140,5 @@ def test_now_playing_screen_syncs_offline_state_through_lvgl() -> None:
     assert payload["title_text"] == "Music Offline"
     assert payload["artist_text"] == "Trying to reconnect"
     assert payload["state_text"] == "OFFLINE"
+    assert payload["footer"] == "Tap skip / Double play"
     assert payload["progress_permille"] == 0

--- a/yoyopy/audio/mopidy_client.py
+++ b/yoyopy/audio/mopidy_client.py
@@ -303,9 +303,36 @@ class MopidyClient:
                 track = MopidyTrack.from_mopidy(tl_track["track"])
                 return track
 
+            queued_track = self._fallback_track_from_tracklist()
+            if queued_track is not None:
+                return queued_track
+
+            if self.current_track is not None:
+                return self.current_track
+
             return None
         except Exception as e:
             logger.error(f"Failed to get current track: {e}")
+            return None
+
+    def _fallback_track_from_tracklist(self) -> Optional[MopidyTrack]:
+        """Return the current queued track when Mopidy lags on current_tl_track."""
+
+        try:
+            tl_tracks = self._rpc_call("core.tracklist.get_tl_tracks")
+            if not tl_tracks:
+                return None
+
+            index = self._rpc_call("core.tracklist.index")
+            if not isinstance(index, int) or index < 0 or index >= len(tl_tracks):
+                index = 0
+
+            track_data = tl_tracks[index].get("track") if isinstance(tl_tracks[index], dict) else None
+            if not track_data:
+                return None
+            return MopidyTrack.from_mopidy(track_data)
+        except Exception as e:
+            logger.debug(f"Failed to derive current track from tracklist: {e}")
             return None
 
     def get_playback_state(self) -> str:

--- a/yoyopy/audio/mopidy_client.py
+++ b/yoyopy/audio/mopidy_client.py
@@ -320,17 +320,27 @@ class MopidyClient:
 
         try:
             tl_tracks = self._rpc_call("core.tracklist.get_tl_tracks")
-            if not tl_tracks:
+            if not isinstance(tl_tracks, list) or not tl_tracks:
                 return None
 
             index = self._rpc_call("core.tracklist.index")
             if not isinstance(index, int) or index < 0 or index >= len(tl_tracks):
                 index = 0
 
-            track_data = tl_tracks[index].get("track") if isinstance(tl_tracks[index], dict) else None
+            selected_track = tl_tracks[index]
+            track_data = selected_track.get("track") if isinstance(selected_track, dict) else None
+            if track_data:
+                return MopidyTrack.from_mopidy(track_data)
+
+            for tl_track in tl_tracks:
+                if not isinstance(tl_track, dict):
+                    continue
+                track_data = tl_track.get("track")
+                if track_data:
+                    return MopidyTrack.from_mopidy(track_data)
+
             if not track_data:
                 return None
-            return MopidyTrack.from_mopidy(track_data)
         except Exception as e:
             logger.debug(f"Failed to derive current track from tracklist: {e}")
             return None

--- a/yoyopy/audio/mopidy_client.py
+++ b/yoyopy/audio/mopidy_client.py
@@ -7,6 +7,7 @@ and playlist management via HTTP JSON-RPC API.
 
 import requests
 import time
+from pathlib import Path
 from typing import Optional, List, Dict, Any, Callable
 from dataclasses import dataclass
 from threading import Thread, Event
@@ -34,12 +35,23 @@ class MopidyTrack:
         Returns:
             MopidyTrack instance
         """
-        artists = [artist.get('name', 'Unknown') for artist in track_data.get('artists', [])]
-        album = track_data.get('album', {}).get('name', '')
+        raw_artists = track_data.get('artists') or []
+        artists = [
+            str(artist.get('name') or 'Unknown')
+            for artist in raw_artists
+            if isinstance(artist, dict)
+        ]
+
+        raw_album = track_data.get('album')
+        album = raw_album.get('name', '') if isinstance(raw_album, dict) else ''
+        uri = track_data.get('uri', '')
+        name = track_data.get('name') or 'Unknown Track'
+        if isinstance(name, str) and uri.startswith('file://'):
+            name = Path(name).stem or name
 
         return cls(
-            uri=track_data.get('uri', ''),
-            name=track_data.get('name', 'Unknown Track'),
+            uri=uri,
+            name=name,
             artists=artists,
             album=album,
             length=track_data.get('length', 0),

--- a/yoyopy/audio/mopidy_client.py
+++ b/yoyopy/audio/mopidy_client.py
@@ -299,8 +299,9 @@ class MopidyClient:
         try:
             tl_track = self._rpc_call("core.playback.get_current_tl_track")
 
-            if tl_track and "track" in tl_track:
-                track = MopidyTrack.from_mopidy(tl_track["track"])
+            track_data = tl_track.get("track") if isinstance(tl_track, dict) else None
+            if track_data:
+                track = MopidyTrack.from_mopidy(track_data)
                 return track
 
             queued_track = self._fallback_track_from_tracklist()

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
@@ -1395,7 +1395,7 @@ int yoyopy_lvgl_now_playing_build(void) {
 
     g_now_playing_scene.icon_label = lv_label_create(g_now_playing_scene.icon_halo);
     lv_label_set_text(g_now_playing_scene.icon_label, LV_SYMBOL_AUDIO);
-    lv_obj_set_style_text_font(g_now_playing_scene.icon_label, &lv_font_montserrat_22, 0);
+    lv_obj_set_style_text_font(g_now_playing_scene.icon_label, &lv_font_montserrat_24, 0);
     lv_obj_center(g_now_playing_scene.icon_label);
 
     g_now_playing_scene.state_chip = lv_obj_create(g_now_playing_scene.panel);
@@ -1416,7 +1416,7 @@ int yoyopy_lvgl_now_playing_build(void) {
     lv_obj_set_size(g_now_playing_scene.title_label, 176, 44);
     lv_obj_set_pos(g_now_playing_scene.title_label, 16, 106);
     lv_label_set_long_mode(g_now_playing_scene.title_label, LV_LABEL_LONG_MODE_DOTS);
-    lv_obj_set_style_text_font(g_now_playing_scene.title_label, &lv_font_montserrat_20, 0);
+    lv_obj_set_style_text_font(g_now_playing_scene.title_label, &lv_font_montserrat_18, 0);
     lv_obj_set_style_text_align(g_now_playing_scene.title_label, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_set_style_text_line_space(g_now_playing_scene.title_label, -2, 0);
 

--- a/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
+++ b/yoyopy/ui/lvgl_binding/native/lvgl_shim.c
@@ -1385,8 +1385,8 @@ int yoyopy_lvgl_now_playing_build(void) {
     lv_obj_set_scrollbar_mode(g_now_playing_scene.panel, LV_SCROLLBAR_MODE_OFF);
 
     g_now_playing_scene.icon_halo = lv_obj_create(g_now_playing_scene.panel);
-    lv_obj_set_size(g_now_playing_scene.icon_halo, 76, 58);
-    lv_obj_set_pos(g_now_playing_scene.icon_halo, 66, 16);
+    lv_obj_set_size(g_now_playing_scene.icon_halo, 76, 54);
+    lv_obj_set_pos(g_now_playing_scene.icon_halo, 66, 14);
     lv_obj_set_style_radius(g_now_playing_scene.icon_halo, 20, 0);
     lv_obj_set_style_border_width(g_now_playing_scene.icon_halo, 2, 0);
     lv_obj_set_style_shadow_width(g_now_playing_scene.icon_halo, 0, 0);
@@ -1395,12 +1395,12 @@ int yoyopy_lvgl_now_playing_build(void) {
 
     g_now_playing_scene.icon_label = lv_label_create(g_now_playing_scene.icon_halo);
     lv_label_set_text(g_now_playing_scene.icon_label, LV_SYMBOL_AUDIO);
-    lv_obj_set_style_text_font(g_now_playing_scene.icon_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_font(g_now_playing_scene.icon_label, &lv_font_montserrat_22, 0);
     lv_obj_center(g_now_playing_scene.icon_label);
 
     g_now_playing_scene.state_chip = lv_obj_create(g_now_playing_scene.panel);
     lv_obj_set_size(g_now_playing_scene.state_chip, 92, 24);
-    lv_obj_set_pos(g_now_playing_scene.state_chip, 58, 84);
+    lv_obj_set_pos(g_now_playing_scene.state_chip, 58, 74);
     lv_obj_set_style_radius(g_now_playing_scene.state_chip, 12, 0);
     lv_obj_set_style_border_width(g_now_playing_scene.state_chip, 0, 0);
     lv_obj_set_style_pad_all(g_now_playing_scene.state_chip, 0, 0);
@@ -1413,17 +1413,18 @@ int yoyopy_lvgl_now_playing_build(void) {
     lv_obj_center(g_now_playing_scene.state_label);
 
     g_now_playing_scene.title_label = lv_label_create(g_now_playing_scene.panel);
-    lv_obj_set_width(g_now_playing_scene.title_label, 176);
-    lv_obj_set_pos(g_now_playing_scene.title_label, 16, 118);
+    lv_obj_set_size(g_now_playing_scene.title_label, 176, 44);
+    lv_obj_set_pos(g_now_playing_scene.title_label, 16, 106);
     lv_label_set_long_mode(g_now_playing_scene.title_label, LV_LABEL_LONG_MODE_DOTS);
-    lv_obj_set_style_text_font(g_now_playing_scene.title_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_font(g_now_playing_scene.title_label, &lv_font_montserrat_20, 0);
     lv_obj_set_style_text_align(g_now_playing_scene.title_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_style_text_line_space(g_now_playing_scene.title_label, -2, 0);
 
     g_now_playing_scene.artist_label = lv_label_create(g_now_playing_scene.panel);
-    lv_obj_set_width(g_now_playing_scene.artist_label, 176);
-    lv_obj_set_pos(g_now_playing_scene.artist_label, 16, 148);
+    lv_obj_set_size(g_now_playing_scene.artist_label, 176, 16);
+    lv_obj_set_pos(g_now_playing_scene.artist_label, 16, 154);
     lv_label_set_long_mode(g_now_playing_scene.artist_label, LV_LABEL_LONG_MODE_DOTS);
-    lv_obj_set_style_text_font(g_now_playing_scene.artist_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_font(g_now_playing_scene.artist_label, &lv_font_montserrat_12, 0);
     lv_obj_set_style_text_align(g_now_playing_scene.artist_label, LV_TEXT_ALIGN_CENTER, 0);
 
     g_now_playing_scene.progress_track = lv_obj_create(g_now_playing_scene.panel);

--- a/yoyopy/ui/screens/music/lvgl/now_playing_view.py
+++ b/yoyopy/ui/screens/music/lvgl/now_playing_view.py
@@ -35,8 +35,8 @@ class LvglNowPlayingView:
         if not self._built or self.backend.binding is None:
             return
 
-        track_title, artist, progress, state_label, _is_playing = self.screen._track_snapshot()
-        footer = "Tap skip / Play" if self.screen.is_one_button_mode() else "A play | B back | X/Y tracks"
+        track_title, artist, progress, state_label, is_playing = self.screen._track_snapshot()
+        footer = self.screen.get_footer_text(is_playing=is_playing)
         context = self.screen.context
 
         self.backend.binding.now_playing_sync(

--- a/yoyopy/ui/screens/music/now_playing.py
+++ b/yoyopy/ui/screens/music/now_playing.py
@@ -62,7 +62,7 @@ class NowPlayingScreen(Screen):
             lvgl_view.sync()
             return
 
-        track_title, artist, progress, state_label, _is_playing = self._track_snapshot()
+        track_title, artist, progress, state_label, is_playing = self._track_snapshot()
 
         content_top = render_header(
             self.display,
@@ -119,9 +119,16 @@ class NowPlayingScreen(Screen):
         if fill_width > 0:
             self.display.rectangle(progress_x, progress_y, progress_x + fill_width, progress_y + 8, fill=LISTEN.accent)
 
-        hint = "Tap skip / Play / Hold back" if self.is_one_button_mode() else "A play | B back | X/Y tracks"
+        hint = self.get_footer_text(is_playing=is_playing)
         render_footer(self.display, hint, mode="listen")
         self.display.update()
+
+    def get_footer_text(self, *, is_playing: bool) -> str:
+        """Return the gesture hint for the active playback state."""
+
+        if self.is_one_button_mode():
+            return "Tap skip / Double pause" if is_playing else "Tap skip / Double play"
+        return "A play | B back | X/Y tracks"
 
     def _track_snapshot(self) -> tuple[str, str, float, str, bool]:
         """Return current track, artist, progress and state label."""

--- a/yoyopy/ui/screens/music/now_playing.py
+++ b/yoyopy/ui/screens/music/now_playing.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
 from yoyopy.ui.screens.music.lvgl import LvglNowPlayingView
-from yoyopy.ui.screens.theme import INK, LISTEN, MUTED, SURFACE, draw_icon, render_footer, render_header, rounded_panel, text_fit
+from yoyopy.ui.screens.theme import INK, LISTEN, MUTED, SURFACE, draw_icon, render_footer, render_header, rounded_panel, text_fit, wrap_text
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
@@ -87,32 +87,47 @@ class NowPlayingScreen(Screen):
             shadow=True,
         )
 
-        draw_icon(self.display, "listen", (self.display.WIDTH // 2) - 24, panel_top + 16, 48, LISTEN.accent)
+        draw_icon(self.display, "listen", (self.display.WIDTH // 2) - 22, panel_top + 14, 44, LISTEN.accent)
 
         state_width, _ = self.display.get_text_size(state_label, 10)
         rounded_panel(
             self.display,
             (self.display.WIDTH - state_width - 22) // 2,
-            panel_top + 68,
+            panel_top + 64,
             (self.display.WIDTH + state_width + 22) // 2,
-            panel_top + 90,
+            panel_top + 86,
             fill=LISTEN.accent_dim,
             outline=None,
             radius=12,
         )
-        self.display.text(state_label, (self.display.WIDTH - state_width) // 2, panel_top + 74, color=LISTEN.accent, font_size=10)
+        self.display.text(state_label, (self.display.WIDTH - state_width) // 2, panel_top + 70, color=LISTEN.accent, font_size=10)
 
-        title_y = panel_top + 112
-        display_title = text_fit(self.display, track_title, self.display.WIDTH - 56, 20)
-        title_width, title_height = self.display.get_text_size(display_title, 20)
-        self.display.text(display_title, (self.display.WIDTH - title_width) // 2, title_y, color=INK, font_size=20)
+        title_y = panel_top + 102
+        title_lines = wrap_text(
+            self.display,
+            track_title,
+            self.display.WIDTH - 64,
+            18,
+            max_lines=2,
+        ) or [text_fit(self.display, track_title, self.display.WIDTH - 64, 18)]
+        title_line_height = self.display.get_text_size("Ag", 18)[1]
+        for index, line in enumerate(title_lines):
+            title_width, _ = self.display.get_text_size(line, 18)
+            self.display.text(
+                line,
+                (self.display.WIDTH - title_width) // 2,
+                title_y + (index * title_line_height),
+                color=INK,
+                font_size=18,
+            )
 
-        artist_text = text_fit(self.display, artist, self.display.WIDTH - 64, 12)
-        artist_width, _ = self.display.get_text_size(artist_text, 12)
-        self.display.text(artist_text, (self.display.WIDTH - artist_width) // 2, title_y + title_height + 10, color=MUTED, font_size=12)
+        artist_y = title_y + (len(title_lines) * title_line_height) + 4
+        artist_text = text_fit(self.display, artist, self.display.WIDTH - 64, 11)
+        artist_width, _ = self.display.get_text_size(artist_text, 11)
+        self.display.text(artist_text, (self.display.WIDTH - artist_width) // 2, artist_y, color=MUTED, font_size=11)
 
         progress_x = 28
-        progress_y = panel_bottom - 44
+        progress_y = panel_bottom - 40
         progress_width = self.display.WIDTH - 56
         self.display.rectangle(progress_x, progress_y, progress_x + progress_width, progress_y + 8, fill=(22, 25, 32))
         fill_width = max(0, min(progress_width, int(progress_width * progress)))


### PR DESCRIPTION
## Summary
- harden Mopidy current-track parsing so local playback titles keep rendering even with sparse/null Mopidy payloads
- fix Whisplay Now Playing footer hints for one-button playback actions
- tighten the Now Playing layout so long track names no longer overlap the artist line on PIL or LVGL

## Verification
- python -m compileall yoyopy tests
- uv run pytest -q
- rebuilt the LVGL shim on pi-zero
- restarted yoyopod@tifo.service and verified the updated Now Playing layout on hardware