### PR TITLE
Slim README and archive stale docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,8 +372,9 @@ The current codebase is in a good place to focus on product behavior instead of 
 ## References
 
 - `README.md`
+- `docs/DEVELOPMENT_GUIDE.md`
 - `docs/SYSTEM_ARCHITECTURE.md`
-- `docs/INTEGRATION_PLAN.md`
 - `docs/RPI_SMOKE_VALIDATION.md`
 - `docs/PI_DEV_WORKFLOW.md`
+- `docs/archive/`
 - Project repository: `https://github.com/moustafattia/yoyo-py`

--- a/README.md
+++ b/README.md
@@ -1,294 +1,51 @@
 # YoyoPod
 
-YoyoPod is an iPod-inspired Raspberry Pi application that combines SIP calling and local-first mpv-based music playback behind a small-screen, button-driven UI.
+YoyoPod is an iPod-inspired Raspberry Pi application that combines SIP calling, local-first music playback, and a small-screen button UI.
 
-The current codebase supports three display/input modes:
+Current product surface:
+- `Listen` - local-only music with `Playlists`, `Recent`, and `Shuffle`
+- `Talk` - contact-first calls and voice notes
+- `Ask` - staged shell for future safe AI interactions
+- `Setup` - power, care, and device status
 
-- Pimoroni Display HAT Mini: 320x240 landscape display with four buttons
-- PiSugar Whisplay HAT: 240x280 portrait display with a single PTT-style button
-- Simulation mode: browser display plus keyboard and web-button input
+Supported display/input modes:
+- Pimoroni Display HAT Mini: `320x240` landscape with four buttons
+- PiSugar Whisplay HAT: `240x280` portrait with a single PTT-style button
+- Simulation mode: browser display with keyboard and web-button input
 
-On Whisplay, the one-button root hub currently exposes four cards:
-- `Listen`
-- `Talk`
-- `Ask`
-- `Setup`
-
-## Current Status
-
-- VoIP and music integration is implemented in the production app
-- The UI package has been refactored into display, input, and screen subpackages
-- Hardware abstraction layers exist for display and input
-- Demo scripts and tests have been migrated to the current UI/HAL APIs
-- Background VoIP and music-backend callbacks are coordinated through the app's main loop
-- The production UI now uses the Graffiti Buddy visual system with a fixed root IA:
-  - `Listen`
-  - `Talk`
-  - `Ask`
-  - `Setup`
-- `Listen` is now local-first and local-only with `Playlists`, `Recent`, and `Shuffle`
-- `Talk` now opens as a people-first contact deck: pick a person, then choose `Call` or `Voice Note`
-- `Voice Note` now supports hold-to-record, review, local preview playback, send, and sent/failed feedback in the Talk flow
-- `Ask` is now a staged shell with idle, listening, thinking, and response states
-- Whisplay production rendering now runs on the LVGL backend by default
-- Local music playback now runs through an app-managed mpv backend under `yoyopy/audio/music/`
-- GitHub Actions CI validates `uv sync --extra dev` and `uv run pytest -q`
-
-## Main Runtime Components
-
-- `yoyopod.py`: top-level launcher for local development
-- `yoyopy/main.py`: package entry point for installed console scripts
-- `yoyopy/app.py`: `YoyoPodApp` coordinator
-- `scripts/pi_smoke.py`: Raspberry Pi smoke validator for hardware and optional music, power, RTC, and VoIP checks
-- `scripts/pi_remote.py`: SSH helper for Raspberry Pi deploy, rsync, restart, logs, status, screenshots, smoke, and run loops
-- `scripts/lvgl_soak.py`: LVGL transition and sleep/wake soak helper for Whisplay
-- `scripts/pisugar_power.py`: PiSugar battery, shutdown, and watchdog helper
-- `scripts/pisugar_rtc.py`: PiSugar RTC status, sync, and alarm helper
-- `deploy/systemd/yoyopod@.service`: production systemd unit for boot-time app supervision
-- `deploy/pi-deploy.yaml`: shared source of truth for Raspberry Pi runtime, log, screenshot, and rsync settings
-- `deploy/pi-deploy.local.yaml`: optional gitignored override for machine-specific Pi host, SSH user, project dir, and branch defaults
-- `yoyopy/fsm.py`: split `MusicFSM`, `CallFSM`, and call interruption policy
-- `yoyopy/coordinators/runtime.py`: derived `AppRuntimeState` over music, call, and UI state
-- `yoyopy/audio/music/backend.py`: `MusicBackend`, `MpvBackend`, and `MockMusicBackend`
-- `yoyopy/audio/music/process.py`: `MpvProcess` lifecycle wrapper around the spawned mpv process
-- `yoyopy/audio/music/ipc.py`: low-level mpv JSON IPC client
-- `yoyopy/audio/local_service.py`: filesystem-backed local library, playlists, shuffle, and recent-track integration
-- `yoyopy/audio/volume.py`: shared output-volume control across ALSA and mpv
-- `yoyopy/voip/manager.py`: Liblinphone-backed call and message facade
-- `yoyopy/ui/display/`: display HAL, factory, and adapters
-- `yoyopy/ui/input/`: input HAL, manager, and adapters
-- `yoyopy/ui/screens/`: screen base class, navigation manager, and feature screens
-
-## Hardware Notes
-
-The current implementation assumes a Raspberry Pi environment, but the main hardware-specific paths and audio devices can now be overridden:
-
-- Whisplay driver discovery can be overridden with `YOYOPOD_WHISPLAY_DRIVER`
-- Liblinphone audio devices can be overridden with `YOYOPOD_PLAYBACK_DEVICE`, `YOYOPOD_RINGER_DEVICE`, `YOYOPOD_CAPTURE_DEVICE`, and `YOYOPOD_MEDIA_DEVICE`
-- Local music playback can be overridden with `YOYOPOD_MUSIC_DIR`, `YOYOPOD_MPV_SOCKET`, `YOYOPOD_MPV_BINARY`, `YOYOPOD_ALSA_DEVICE`, and `YOYOPOD_DEFAULT_VOLUME`
-- Ring tone output can be overridden with `YOYOPOD_RING_OUTPUT_DEVICE` or `config/yoyopod_config.yaml`
-- Simulation mode starts a Flask-SocketIO web server on `http://localhost:5000`
-
-## Installation
-
-### Python Environment
+## Quick Start
 
 ```bash
 uv sync --extra dev
-```
-
-### System Dependencies
-
-YoyoPod expects these external packages on Raspberry Pi OS:
-
-- `mpv`
-- `liblinphone-dev`
-- `pkg-config`
-- `cmake`
-- `alsa-utils` for `speaker-test`
-- `i2c-tools` for PiSugar watchdog control
-- `pisugar-server` for PiSugar power/RTC telemetry via PiSugar's official installer
-
-Example:
-
-```bash
-sudo apt install mpv liblinphone-dev pkg-config cmake alsa-utils i2c-tools
-uv run python scripts/liblinphone_build.py
-```
-
-### Configuration
-
-The repo already ships tracked config files in `config/`.
-Edit these in place for your environment:
-
-- `config/voip_config.yaml`
-- `config/liblinphone_factory.conf`
-- `config/contacts.yaml`
-- `config/yoyopod_config.yaml`
-
-Important settings:
-
-- `config/yoyopod_config.yaml`: display hardware selection, `audio.music_dir`, `audio.mpv_socket`, `audio.mpv_binary`, `audio.alsa_device`, `audio.default_volume`, and auto-resume behavior
-- `docs/LOCAL_FIRST_MUSIC_PLAN.md`: local-only music direction and implementation notes
-- `config/yoyopod_config.yaml`: Whisplay gesture tuning under `input.whisplay_*_ms`
-- `config/yoyopod_config.yaml`: `input.ptt_navigation=false` is reserved for future voice/PTT work and is currently experimental
-- `config/yoyopod_config.yaml`: `power.watchdog_*` controls the PiSugar app heartbeat watchdog
-- `config/yoyopod_config.yaml`: `power.*` also controls low-battery warning, graceful shutdown, and PiSugar polling
-- `config/yoyopod_config.yaml`: `logging.*` controls file rotation, retention, error-only logs, PID file location, and traceback detail
-- `config/voip_config.yaml`: SIP account, transport, STUN, Liblinphone messaging/file-transfer settings
-- `config/liblinphone_factory.conf`: repo-managed Liblinphone media, codec, and network defaults used for outbound-call parity on Raspberry Pi
-- `config/contacts.yaml`: contact list and speed dial entries
-
-### Verification
-
-CI-safe:
-
-```bash
+python yoyopod.py --simulate
 uv run pytest -q
 ```
 
-Raspberry Pi smoke:
-
-```bash
-uv run python scripts/pi_smoke.py
-uv run python scripts/pi_smoke.py --with-power --with-rtc
-uv run python scripts/pi_smoke.py --with-music --with-voip --with-rtc
-uv run python scripts/pi_smoke.py --with-lvgl-soak
-```
-
-Remote Pi workflow:
-
-```bash
-uv run python scripts/pi_remote.py config show
-uv run python scripts/pi_remote.py config edit
-uv run python scripts/pi_remote.py status
-uv run python scripts/pi_remote.py preflight --branch main --with-music --with-voip
-uv run python scripts/pi_remote.py sync --branch main
-uv run python scripts/pi_remote.py rsync
-uv run python scripts/pi_remote.py restart
-uv run python scripts/pi_remote.py smoke --with-music --with-voip
-uv run python scripts/pi_remote.py power
-uv run python scripts/pi_remote.py rtc status
-uv run python scripts/pi_remote.py rtc sync-to-rtc
-uv run python scripts/pi_remote.py logs --lines 200
-uv run python scripts/pi_remote.py logs --errors --filter voip
-uv run python scripts/pi_remote.py screenshot --output ./pi_screenshot.png
-uv run python scripts/pi_remote.py lvgl-soak --cycles 2
-uv run python scripts/pi_remote.py service status
-uv run python scripts/pi_remote.py service install
-uv run python scripts/pi_remote.py whisplay --duration-seconds 45
-```
-
-Production service install on the Pi:
-
-```bash
-uv run python scripts/pi_remote.py sync --branch main
-uv run python scripts/pi_remote.py service install
-uv run python scripts/pi_remote.py service status
-```
-
-Whisplay tuning on-device:
-
-```bash
-uv run python scripts/whisplay_tune.py
-uv run python scripts/whisplay_tune.py --double-tap-ms 240 --long-hold-ms 900
-```
-
-PiSugar power diagnostics:
-
-```bash
-uv run python scripts/pisugar_power.py
-uv run python scripts/pi_remote.py power
-```
-
-## Logging
-
-The production app writes two rotating files in `logs/`:
-
-- `logs/yoyopod.log`: main structured log with timestamps, subsystem tag, module/function/line, and message
-- `logs/yoyopod_errors.log`: errors-only companion log
-
-The checked-in deploy contract at `deploy/pi-deploy.yaml` defines the shared remote tooling defaults. `deploy/pi-deploy.local.yaml` is the gitignored machine-local override for host, SSH user, project directory, and branch. Manage them with:
-
-```bash
-uv run python scripts/pi_remote.py config show
-uv run python scripts/pi_remote.py config edit
-```
-
-The merged config controls process names, screenshot path, and these project-relative log paths:
-
-- `<project-dir>/logs/yoyopod.log`
-- `<project-dir>/logs/yoyopod_errors.log`
-- `/tmp/yoyopod.pid`
-
-Typical remote debugging flow:
-
-```bash
-uv run python scripts/pi_remote.py logs --lines 200
-uv run python scripts/pi_remote.py logs --errors
-uv run python scripts/pi_remote.py logs --filter voip
-uv run python scripts/pi_remote.py logs --follow --filter ERROR
-```
-
-## Running
-
-### Production App
+Run on hardware:
 
 ```bash
 python yoyopod.py
 ```
 
-### Simulation Mode
+## Docs
 
-```bash
-python yoyopod.py --simulate
-```
+- [Development Guide](docs/DEVELOPMENT_GUIDE.md)
+- [System Architecture](docs/SYSTEM_ARCHITECTURE.md)
+- [Pi Dev Workflow](docs/PI_DEV_WORKFLOW.md)
+- [Pi Smoke Validation](docs/RPI_SMOKE_VALIDATION.md)
+- [Power Module](docs/POWER_MODULE.md)
+- [Local-First Music Plan](docs/LOCAL_FIRST_MUSIC_PLAN.md)
+- [mpv Dependencies](docs/MPV_DEPENDENCIES.md)
+- [LVGL Migration Plan](docs/LVGL_MIGRATION_PLAN.md)
 
-Simulation mode starts the browser UI at `http://localhost:5000`.
+Historical milestone notes are kept under [docs/archive](docs/archive).
 
-### Runtime Demos
+## Rules
 
-```bash
-python demos/demo_voip.py --simulate
-python demos/demo_playlists.py
-python demos/demo_runtime_state.py --simulate
-```
-
-### Installed Console Script
-
-If the package is installed from `pyproject.toml`, the same app is available as:
-
-```bash
-yoyopod
-```
-
-## Package Layout
-
-```text
-yoyopy/
-  app.py
-  main.py
-  fsm.py
-  app_context.py
-  coordinators/
-  audio/
-    history.py
-    local_service.py
-    volume.py
-    music/
-      backend.py
-      ipc.py
-      models.py
-      process.py
-  config/
-    manager.py
-    models.py
-  voip/
-    backend.py
-    history.py
-    manager.py
-    models.py
-  ui/
-    display/
-    input/
-    screens/
-    web_server.py
-```
-
-## Documentation
-
-- `docs/SYSTEM_ARCHITECTURE.md`: current runtime architecture
-- `docs/INTEGRATION_PLAN.md`: integration completion record and remaining cleanup
-- `docs/DISPLAY_HAL_ARCHITECTURE.md`: current display HAL design
-- `docs/INPUT_HAL_ARCHITECTURE.md`: current input HAL design and compatibility notes
-- `docs/POWER_MODULE.md`: PiSugar power architecture, config, safety, RTC, watchdog, and diagnostics
-- `docs/LVGL_MIGRATION_PLAN.md`: Whisplay LVGL migration record and backend boundaries
-- `docs/RPI_SMOKE_VALIDATION.md`: Raspberry Pi smoke checklist and manual follow-up drills
-- `docs/PI_DEV_WORKFLOW.md`: SSH-based Raspberry Pi sync/run workflow and release checklist
-- `docs/LOCAL_FIRST_MUSIC_PLAN.md`: current local-library product direction
-- `docs/MPV_DEPENDENCIES.md`: mpv runtime and validation reference
-
-## Current Gaps
-
-- Full end-to-end validation still requires Raspberry Pi hardware, `mpv`, and a reachable SIP service; see `docs/RPI_SMOKE_VALIDATION.md`
-- CI currently covers the Python test suite, not hardware-in-the-loop scenarios
+- [Project](rules/project.md)
+- [Architecture](rules/architecture.md)
+- [Deploy](rules/deploy.md)
+- [Logging](rules/logging.md)
+- [LVGL](rules/lvgl.md)
+- [VoIP](rules/voip.md)
+- [Code Style](rules/code-style.md)

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -1,0 +1,186 @@
+# Development Guide
+
+This guide holds the operational detail that does not belong on the repo landing page.
+
+## Python Environment
+
+```bash
+uv sync --extra dev
+```
+
+## System Dependencies
+
+Raspberry Pi OS packages expected by the current stack:
+
+- `mpv`
+- `liblinphone-dev`
+- `pkg-config`
+- `cmake`
+- `alsa-utils`
+- `i2c-tools`
+- `pisugar-server`
+
+Example:
+
+```bash
+sudo apt install mpv liblinphone-dev pkg-config cmake alsa-utils i2c-tools
+uv run python scripts/liblinphone_build.py
+uv run python scripts/lvgl_build.py
+```
+
+## Configuration
+
+Tracked config files live under `config/`:
+
+- `config/yoyopod_config.yaml`
+- `config/voip_config.yaml`
+- `config/liblinphone_factory.conf`
+- `config/contacts.yaml`
+
+Key settings:
+
+- `config/yoyopod_config.yaml`
+  - `display.*` hardware and renderer selection
+  - `audio.music_dir`
+  - `audio.mpv_socket`
+  - `audio.mpv_binary`
+  - `audio.alsa_device`
+  - `audio.default_volume`
+  - `input.whisplay_*_ms`
+  - `power.*`
+  - `logging.*`
+- `config/voip_config.yaml`
+  - SIP account, transport, STUN, Liblinphone messaging and media config
+- `config/contacts.yaml`
+  - contact list and speed-dial style entries
+
+## Running
+
+Production app:
+
+```bash
+python yoyopod.py
+```
+
+Simulation:
+
+```bash
+python yoyopod.py --simulate
+```
+
+Installed console entrypoint:
+
+```bash
+yoyopod
+```
+
+Useful demos:
+
+```bash
+python demos/demo_voip.py --simulate
+python demos/demo_playlists.py
+python demos/demo_runtime_state.py --simulate
+```
+
+## Validation
+
+Local validation:
+
+```bash
+python -m compileall yoyopy tests demos scripts
+uv run pytest -q
+```
+
+Pi smoke:
+
+```bash
+uv run python scripts/pi_smoke.py
+uv run python scripts/pi_smoke.py --with-music --with-voip
+uv run python scripts/pi_smoke.py --with-power --with-rtc
+uv run python scripts/pi_smoke.py --with-lvgl-soak
+```
+
+## Raspberry Pi Workflow
+
+Preferred remote helper:
+
+```bash
+uv run python scripts/pi_remote.py config show
+uv run python scripts/pi_remote.py status
+uv run python scripts/pi_remote.py preflight --branch main --with-music --with-voip --with-lvgl-soak
+uv run python scripts/pi_remote.py sync --branch main
+uv run python scripts/pi_remote.py smoke --with-music --with-voip
+uv run python scripts/pi_remote.py service status
+uv run python scripts/pi_remote.py logs --lines 200
+```
+
+The detailed deploy and validation flows live in:
+
+- `docs/PI_DEV_WORKFLOW.md`
+- `docs/RPI_SMOKE_VALIDATION.md`
+- `rules/deploy.md`
+
+## Logging
+
+The app writes:
+
+- `logs/yoyopod.log`
+- `logs/yoyopod_errors.log`
+
+Pi deploy defaults live in:
+
+- `deploy/pi-deploy.yaml`
+- `deploy/pi-deploy.local.yaml` for gitignored machine-local overrides
+
+Useful remote log commands:
+
+```bash
+uv run python scripts/pi_remote.py logs --lines 200
+uv run python scripts/pi_remote.py logs --errors
+uv run python scripts/pi_remote.py logs --filter voip
+uv run python scripts/pi_remote.py logs --follow --filter ERROR
+```
+
+## Package Layout
+
+```text
+yoyopy/
+  app.py
+  main.py
+  fsm.py
+  app_context.py
+  coordinators/
+  audio/
+    history.py
+    local_service.py
+    volume.py
+    music/
+      backend.py
+      ipc.py
+      models.py
+      process.py
+  config/
+    manager.py
+    models.py
+  voip/
+    backend.py
+    history.py
+    manager.py
+    models.py
+  ui/
+    display/
+    input/
+    lvgl_binding/
+    screens/
+    web_server.py
+```
+
+## Current Active Docs
+
+- `docs/SYSTEM_ARCHITECTURE.md`
+- `docs/POWER_MODULE.md`
+- `docs/LOCAL_FIRST_MUSIC_PLAN.md`
+- `docs/MPV_DEPENDENCIES.md`
+- `docs/LVGL_MIGRATION_PLAN.md`
+
+Historical milestone notes are archived under `docs/archive/`.

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -92,10 +92,11 @@ Use this when SIP registration works but incoming-call parsing or callback deliv
 ### Whisplay display-only debug
 
 ```bash
-uv run python test_hal_whisplay.py
+uv run python scripts/lvgl_build.py
+uv run python scripts/lvgl_probe.py --scene carousel --duration-seconds 10
 ```
 
-Use this only on a Pi with the Whisplay hardware attached. It is a manual hardware smoke script, not part of CI.
+Use this only on a Pi with the Whisplay hardware attached. It validates the display/LVGL path without starting the full app and is not part of CI.
 
 ### Whisplay gesture tuning
 

--- a/docs/archive/INTEGRATION_PLAN.md
+++ b/docs/archive/INTEGRATION_PLAN.md
@@ -1,0 +1,119 @@
+# YoyoPod VoIP + Local Music Integration Record
+
+**Last updated:** 2026-04-07
+**Status:** Implemented
+
+This document started as a plan and now serves as the completion record for the VoIP + local music integration that ships on `main`.
+
+## What Is Implemented
+
+- unified `YoyoPodApp` coordinator in `yoyopy/app.py`
+- split orchestration models in `yoyopy/fsm.py`
+- derived app runtime state in `yoyopy/coordinators/runtime.py`
+- music auto-pause on incoming call
+- optional music auto-resume after call end
+- screen stack transitions for incoming, outgoing, and active calls
+- periodic now-playing refresh for progress updates
+- simulation mode using the web server and keyboard input
+
+## Current Implementation Map
+
+### Coordinator
+
+- `yoyopy/app.py`
+
+Responsibilities:
+
+- load config
+- initialize display/input/screen infrastructure
+- start VoIP and music backends
+- register callbacks
+- coordinate call interruption and resume behavior
+
+### Music Layer
+
+- `yoyopy/audio/music/backend.py`
+- `yoyopy/audio/local_service.py`
+
+Responsibilities:
+
+- app-managed mpv lifecycle and JSON IPC
+- playback control and property-event handling
+- local playlist discovery, shuffle input, and recent-track integration
+
+### VoIP Layer
+
+- `yoyopy/voip/manager.py`
+
+Responsibilities:
+
+- Liblinphone lifecycle and iterate loop
+- registration state tracking
+- typed call/message event translation
+- caller lookup and callback dispatch
+
+### UI Layer
+
+- `yoyopy/ui/display/`
+- `yoyopy/ui/input/`
+- `yoyopy/ui/screens/`
+
+The older `display.py`, `screens.py`, `screen_manager.py`, and `input_handler.py` layout is no longer current.
+
+## Integrated States
+
+Key states used by the running app:
+
+- `PLAYING`
+- `PAUSED`
+- `CALL_IDLE`
+- `CALL_INCOMING`
+- `CALL_OUTGOING`
+- `CALL_ACTIVE`
+- `PLAYING_WITH_VOIP`
+- `PAUSED_BY_CALL`
+- `CALL_ACTIVE_MUSIC_PAUSED`
+
+See `yoyopy/fsm.py` for the music/call transitions and `yoyopy/coordinators/runtime.py` for the derived application state mapping.
+
+## Incoming Call Flow
+
+1. `VoIPManager` receives an incoming call event from the Liblinphone backend
+2. `YoyoPodApp` pauses music if playback is active
+3. state changes to `CALL_INCOMING`
+4. `IncomingCallScreen` is pushed
+5. answer/reject actions route back through `VoIPManager`
+6. call end clears call screens and optionally resumes music
+
+## Outgoing Call Flow
+
+1. user navigates to contacts
+2. `VoIPManager.make_call()` issues the SIP call through Liblinphone
+3. outgoing and in-call screens are pushed as typed call state changes arrive
+4. call end pops call screens and returns the app to the prior playback state
+
+## Music Playback Flow
+
+1. screen action triggers a music-backend command
+2. `MpvBackend` receives push events from mpv over JSON IPC
+3. `LocalMusicService` handles local playlist and filesystem browse concerns
+4. callbacks refresh `NowPlayingScreen`
+5. derived runtime state stays synchronized with actual playback state
+
+## What Changed After The Original Plan
+
+The original integration work predated later backend and UI refactors. The current code now uses:
+
+- `InputManager` instead of `InputHandler`
+- `Display` HAL instead of a single hardcoded display module
+- split screen modules instead of one `screens.py`
+- `MpvBackend` instead of the removed JSON-RPC music client
+
+## Remaining Cleanup Outside Integration
+
+The integration itself is done. Remaining repository work is separate:
+
+- continue reducing stale historical docs
+- migrate older demos and tests to current names and entry points
+- finish semantic input migration inside screen implementations
+- reduce hardcoded hardware assumptions

--- a/docs/archive/PHASE2_SUMMARY.md
+++ b/docs/archive/PHASE2_SUMMARY.md
@@ -1,0 +1,43 @@
+# Phase 2 Summary: Screen Integration
+
+**Last updated:** 2026-04-02
+**Status:** Historical summary, corrected to current file paths
+
+Phase 2 was the point where the integrated application stopped being a set of separate demos and became one navigable app.
+
+## What Phase 2 Added
+
+- screen instance setup inside `YoyoPodApp`
+- screen registration with `ScreenManager`
+- callback-driven transitions for call and music events
+- stack cleanup for call-related screens
+- production entrypoint via `yoyopod.py`
+
+## Correct Current File References
+
+The integration work lives in:
+
+- `yoyopy/app.py`
+- `yoyopod.py`
+
+The older reference to `yoyopy/yoyopod_app.py` is no longer correct.
+
+## Screen Set Registered By The App
+
+- navigation: `home`, `menu`
+- music: `now_playing`, `playlists`
+- VoIP: `call`, `contacts`, `incoming_call`, `outgoing_call`, `in_call`
+
+## Important Helper
+
+`YoyoPodApp._pop_call_screens()` remains the key guard against call-screen stack buildup. That logic still exists in `yoyopy/app.py`.
+
+## Later Refactor Note
+
+After Phase 2, the UI package was refactored:
+
+- `screens.py` was split into `yoyopy/ui/screens/`
+- `screen_manager.py` moved to `yoyopy/ui/screens/manager.py`
+- input and display were moved behind HAL packages
+
+So the Phase 2 behavior is still relevant, but the old module layout is not.

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,5 @@
+# Historical Notes
+
+Files in this directory are archived milestone plans and completion summaries.
+
+They are kept for historical context only. They are not the source of truth for the current runtime, repo layout, or product surface.

--- a/docs/archive/UI_RESTRUCTURE_PROPOSAL.md
+++ b/docs/archive/UI_RESTRUCTURE_PROPOSAL.md
@@ -1,0 +1,91 @@
+# YoyoPod UI Refactor Status
+
+**Last updated:** 2026-04-02
+**Status:** Mostly implemented
+
+This document replaces the old proposal-only version and records what the refactor actually accomplished.
+
+## Refactor Goals
+
+- split the monolithic UI package into focused modules
+- introduce display and input HALs
+- move screen navigation logic into the screens package
+- reduce the cost of working on one screen or adapter at a time
+
+## Current Structure
+
+```text
+yoyopy/ui/
+  __init__.py
+  web_server.py
+  display/
+    __init__.py
+    hal.py
+    factory.py
+    manager.py
+    adapters/
+      pimoroni.py
+      simulation.py
+      whisplay.py
+  input/
+    __init__.py
+    hal.py
+    factory.py
+    manager.py
+    adapters/
+      four_button.py
+      keyboard.py
+      ptt_button.py
+  screens/
+    __init__.py
+    base.py
+    manager.py
+    navigation/
+    music/
+    voip/
+```
+
+## Phase Status
+
+### Phase 1: Display module restructure
+
+Status: done
+
+- display code moved under `yoyopy/ui/display/`
+- facade, factory, and adapters are separate files
+
+### Phase 2: Screen split
+
+Status: done
+
+- `screens.py` was split by feature area
+- `screen_manager.py` became `yoyopy/ui/screens/manager.py`
+
+### Phase 3: Semantic input migration
+
+Status: partial
+
+- semantic input infrastructure exists
+- `ScreenManager` dispatches semantic actions
+- concrete screens still mostly implement legacy `on_button_*()` methods
+
+### Phase 4: Cleanup and documentation
+
+Status: partial
+
+- obsolete core files were removed
+- docs, demos, and tests were not fully updated at the same time
+
+## What Still Needs Cleanup
+
+- migrate concrete screens from `on_button_*()` to semantic handlers
+- update demos to use `yoyopy.ui.input` and `yoyopy.ui.screens.manager`
+- update tests that still target removed modules
+- remove small compatibility leftovers after migration is complete
+
+## Why The Refactor Was Worth It
+
+- display and input are no longer hardwired into the rest of the app
+- screens are easier to navigate and maintain
+- simulation mode can share the same screen code and action model
+- adding a new adapter no longer requires editing a monolithic UI file


### PR DESCRIPTION
## Summary
- slim the README down to product overview, quick start, and a clean docs/rules map
- move the detailed setup, config, logging, Pi workflow, and package layout material into a new docs/DEVELOPMENT_GUIDE.md
- archive historical milestone docs and replace the stale 	est_hal_whisplay.py reference with the current LVGL probe path

## Verification
- repo consistency check via git grep for stale references to 	est_hal_whisplay.py, INTEGRATION_PLAN.md, UI_RESTRUCTURE_PROPOSAL.md, and PHASE2_SUMMARY.md
- no tests run; docs/layout-only change