### PR TITLE
Setup Voice: speaker/mic selection + friendly ALSA devices + YAML persistence

### DIFF
--- a/tests/test_config_voice_device_persistence.py
+++ b/tests/test_config_voice_device_persistence.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 from yoyopy.config.manager import ConfigManager
 
 
@@ -30,3 +32,91 @@ def test_config_manager_allows_auto_device_ids(tmp_path: Path) -> None:
     assert reloaded.get_app_settings().voice.speaker_device_id == ""
     assert reloaded.get_app_settings().voice.capture_device_id == ""
 
+
+def test_voice_device_persistence_does_not_flatten_env_overrides(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Persisting one selector should not dump env-resolved values into YAML."""
+
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    config_file = cfg_dir / "yoyopod_config.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "audio": {
+                    "default_volume": 40,
+                },
+                "voice": {
+                    "commands_enabled": False,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("YOYOPOD_DEFAULT_VOLUME", "77")
+
+    manager = ConfigManager(config_dir=str(cfg_dir))
+
+    assert manager.set_voice_speaker_device_id("plughw:CARD=SE,DEV=0") is True
+
+    persisted = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+    assert persisted["audio"]["default_volume"] == 40
+    assert persisted["voice"]["commands_enabled"] is False
+    assert persisted["voice"]["speaker_device_id"] == "plughw:CARD=SE,DEV=0"
+    assert "power" not in persisted
+
+
+def test_voice_device_persistence_only_updates_active_overlay(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Board overlays should keep their compact shape when selectors are updated."""
+
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    base_file = cfg_dir / "yoyopod_config.yaml"
+    base_file.write_text(
+        yaml.safe_dump(
+            {
+                "audio": {
+                    "default_volume": 40,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    overlay_dir = cfg_dir / "boards" / "rpi-zero-2w"
+    overlay_dir.mkdir(parents=True, exist_ok=True)
+    overlay_file = overlay_dir / "yoyopod_config.yaml"
+    overlay_file.write_text(
+        yaml.safe_dump(
+            {
+                "voice": {
+                    "commands_enabled": False,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("YOYOPOD_CONFIG_BOARD", "rpi-zero-2w")
+
+    manager = ConfigManager(config_dir=str(cfg_dir))
+
+    assert manager.set_voice_speaker_device_id("plughw:CARD=SE,DEV=0") is True
+
+    assert yaml.safe_load(base_file.read_text(encoding="utf-8")) == {
+        "audio": {
+            "default_volume": 40,
+        }
+    }
+    assert yaml.safe_load(overlay_file.read_text(encoding="utf-8")) == {
+        "voice": {
+            "commands_enabled": False,
+            "speaker_device_id": "plughw:CARD=SE,DEV=0",
+        }
+    }

--- a/tests/test_config_voice_device_persistence.py
+++ b/tests/test_config_voice_device_persistence.py
@@ -1,0 +1,32 @@
+"""Config persistence tests for voice device selectors."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from yoyopy.config.manager import ConfigManager
+
+
+def test_config_manager_persists_voice_device_ids(tmp_path: Path) -> None:
+    cfg_dir = tmp_path / "config"
+    manager = ConfigManager(config_dir=str(cfg_dir))
+
+    assert manager.set_voice_speaker_device_id("plughw:CARD=SE,DEV=0") is True
+    assert manager.set_voice_capture_device_id("plughw:CARD=SE,DEV=0") is True
+
+    reloaded = ConfigManager(config_dir=str(cfg_dir))
+    assert reloaded.get_app_settings().voice.speaker_device_id == "plughw:CARD=SE,DEV=0"
+    assert reloaded.get_app_settings().voice.capture_device_id == "plughw:CARD=SE,DEV=0"
+
+
+def test_config_manager_allows_auto_device_ids(tmp_path: Path) -> None:
+    cfg_dir = tmp_path / "config"
+    manager = ConfigManager(config_dir=str(cfg_dir))
+
+    assert manager.set_voice_speaker_device_id(None) is True
+    assert manager.set_voice_capture_device_id("") is True
+
+    reloaded = ConfigManager(config_dir=str(cfg_dir))
+    assert reloaded.get_app_settings().voice.speaker_device_id == ""
+    assert reloaded.get_app_settings().voice.capture_device_id == ""
+

--- a/tests/test_power_screen.py
+++ b/tests/test_power_screen.py
@@ -182,3 +182,51 @@ def test_power_screen_voice_page_toggles_runtime_voice_settings() -> None:
         assert volume_calls == [("up", 5), ("down", 5)]
     finally:
         display.cleanup()
+
+
+def test_power_screen_uses_injected_voice_device_hooks() -> None:
+    """Setup should use injected device providers and persistence hooks."""
+
+    display = Display(simulate=True)
+    try:
+        context = AppContext()
+        refresh_calls: list[str] = []
+        persisted_devices: list[tuple[str, str | None]] = []
+
+        screen = PowerScreen(
+            display,
+            context,
+            power_manager=StubPowerManager(_snapshot()),
+            status_provider=lambda: {},
+            refresh_voice_device_options_action=lambda: refresh_calls.append("refresh"),
+            playback_device_options_provider=lambda: ["plughw:CARD=wm8960soundcard,DEV=0"],
+            capture_device_options_provider=lambda: ["plughw:CARD=USB,DEV=0"],
+            persist_speaker_device_action=(
+                lambda device_id: persisted_devices.append(("speaker", device_id)) or True
+            ),
+            persist_capture_device_action=(
+                lambda device_id: persisted_devices.append(("capture", device_id)) or True
+            ),
+        )
+
+        screen.enter()
+        assert refresh_calls == ["refresh"]
+
+        screen.page_index = 3
+        screen.on_select()
+        assert screen.in_detail is True
+
+        screen.selected_row = 3
+        screen.on_select()
+        assert context.voice.speaker_device_id == "plughw:CARD=wm8960soundcard,DEV=0"
+
+        screen.selected_row = 4
+        screen.on_select()
+        assert context.voice.capture_device_id == "plughw:CARD=USB,DEV=0"
+
+        assert persisted_devices == [
+            ("speaker", "plughw:CARD=wm8960soundcard,DEV=0"),
+            ("capture", "plughw:CARD=USB,DEV=0"),
+        ]
+    finally:
+        display.cleanup()

--- a/tests/test_power_screen.py
+++ b/tests/test_power_screen.py
@@ -79,8 +79,10 @@ def test_power_screen_builds_battery_and_runtime_pages() -> None:
         assert ("Timeout", "30s") in pages[2].rows
         assert ("Watchdog", "Active") in pages[2].rows
         assert ("Voice Cmds", "On") in pages[3].rows
+        assert ("Speaker", "Auto") in pages[3].rows
+        assert ("Mic Device", "Auto") in pages[3].rows
         assert ("Mic", "Live") in pages[3].rows
-        assert all(len(page.rows) <= 5 for page in pages)
+        assert all(len(page.rows) <= 7 for page in pages)
     finally:
         display.cleanup()
 
@@ -143,6 +145,8 @@ def test_power_screen_voice_page_toggles_runtime_voice_settings() -> None:
         )
 
         screen.page_index = 3
+        screen.on_select()
+        assert screen.in_detail is True
         assert screen._is_voice_page() is True
 
         screen.on_select()
@@ -156,6 +160,8 @@ def test_power_screen_voice_page_toggles_runtime_voice_settings() -> None:
         screen.on_select()
         assert context.voice.screen_read_enabled is True
 
+        screen.on_advance()
+        screen.on_advance()
         screen.on_advance()
         screen.on_select()
         assert context.voice.mic_muted is True

--- a/tests/test_remaining_lvgl_views.py
+++ b/tests/test_remaining_lvgl_views.py
@@ -478,44 +478,71 @@ def test_power_screen_cycles_four_lvgl_pages() -> None:
 
     assert binding.power_build_calls == 1
     payload = binding.power_sync_payloads[-1]
-    assert payload["title_text"] == "Power"
+    # Setup now opens in a picker mode (Power/Time/Care/Voice) and enters
+    # detail when the user opens the selected page.
+    assert payload["title_text"] == "Setup"
     assert payload["page_text"] is None
     assert payload["icon_key"] == "battery"
     assert payload["current_page_index"] == 0
     assert payload["total_pages"] == 4
-    assert payload["footer"] == "Tap = Page / Hold = Back"
+    assert payload["footer"] == "Tap next / Double open / Hold back"
     assert payload["items"] == [
-        "Source: Unavailable",
-        "Battery: Unknown",
-        "Charging: Unknown",
-        "RTC: Unknown",
+        "> Power",
+        "Time",
+        "Care",
+        "Voice",
     ]
 
     screen.on_advance()
     screen.render()
-    assert binding.power_sync_payloads[-1]["title_text"] == "Time"
+    payload = binding.power_sync_payloads[-1]
+    assert payload["title_text"] == "Setup"
+    assert payload["icon_key"] == "clock"
+    assert payload["items"] == [
+        "Power",
+        "> Time",
+        "Care",
+        "Voice",
+    ]
     assert binding.power_sync_payloads[-1]["icon_key"] == "clock"
     assert binding.power_sync_payloads[-1]["page_text"] is None
 
     screen.on_advance()
     screen.render()
     payload = binding.power_sync_payloads[-1]
-    assert payload["title_text"] == "Care"
+    assert payload["title_text"] == "Setup"
     assert payload["icon_key"] == "care"
     assert payload["page_text"] is None
+    assert payload["items"] == [
+        "Power",
+        "Time",
+        "> Care",
+        "Voice",
+    ]
 
     screen.on_advance()
+    screen.render()
+    payload = binding.power_sync_payloads[-1]
+    assert payload["title_text"] == "Setup"
+    assert payload["icon_key"] == "voice_note"
+    assert payload["page_text"] is None
+    assert payload["items"] == [
+        "Power",
+        "Time",
+        "Care",
+        "> Voice",
+    ]
+
+    # Open the selected Voice page to confirm it renders interactively.
+    screen.on_select()
     screen.render()
     payload = binding.power_sync_payloads[-1]
     assert payload["title_text"] == "Voice"
     assert payload["icon_key"] == "voice_note"
     assert payload["page_text"] is None
-    assert payload["items"] == [
-        "Voice Cmds: On",
-        "AI Requests: On",
-        "Screen Read: Off",
-        "Mic: Live",
-    ]
+    assert payload["footer"] == "Tap item / Double change / Hold back"
+    assert payload["items"][0].startswith("> Voice Cmds:")
+    assert any("Speaker:" in item for item in payload["items"])
 
     screen.exit()
     assert binding.power_destroy_calls == 1

--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -313,6 +313,31 @@ class _FakeConfigManager:
         return 61
 
 
+class _FakeConfigManagerWithSpeaker(_FakeConfigManager):
+    def get_app_settings(self):
+        return SimpleNamespace(
+            voice=SimpleNamespace(
+                commands_enabled=False,
+                ai_requests_enabled=False,
+                screen_read_enabled=True,
+                stt_enabled=True,
+                tts_enabled=False,
+                stt_backend="dummy-stt",
+                tts_backend="dummy-tts",
+                vosk_model_path="models/custom-model",
+                speaker_device_id="plughw:CARD=wm8960soundcard,DEV=0",
+                capture_device_id="plughw:CARD=wm8960soundcard,DEV=0",
+                sample_rate_hz=22050,
+                record_seconds=6,
+                tts_rate_wpm=180,
+                tts_voice="en-us",
+            )
+        )
+
+    def get_ring_output_device(self) -> str:
+        return "wm8960-soundcard"
+
+
 class _FakeVoipManager:
     def __init__(self) -> None:
         self.make_calls: list[tuple[str, str]] = []
@@ -469,6 +494,21 @@ def test_ask_screen_can_place_call_for_parent_aliases() -> None:
     screen.on_voice_command({"transcript": "call dad"})
     assert voip_manager.make_calls[-1] == ("sip:dad@example.com", "Dad")
     assert screen.consume_navigation_request() == NavigationRequest.route("call_started")
+
+
+def test_ask_screen_default_voice_settings_keep_saved_speaker_device() -> None:
+    """Fallback voice settings should preserve the saved speaker route for TTS playback."""
+
+    screen = AskScreen(
+        display=object(),
+        context=AppContext(),
+        config_manager=_FakeConfigManagerWithSpeaker([]),
+    )
+
+    settings = screen._default_voice_settings()
+
+    assert settings.speaker_device_id == "plughw:CARD=wm8960soundcard,DEV=0"
+    assert settings.capture_device_id == "plughw:CARD=wm8960soundcard,DEV=0"
 
 
 def test_ask_screen_select_can_capture_and_execute_command() -> None:

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -695,10 +695,23 @@ class YoyoPodApp:
                         if voice_cfg is not None
                         else "models/vosk-model-small-en-us"
                     ),
+                    speaker_device_id=(
+                        self.context.voice.speaker_device_id
+                        if self.context is not None and self.context.voice.speaker_device_id is not None
+                        else (
+                            self.config_manager.get_ring_output_device()
+                            if self.config_manager is not None
+                            else None
+                        )
+                    ),
                     capture_device_id=(
-                        self.config_manager.get_capture_device_id()
-                        if self.config_manager is not None
-                        else None
+                        self.context.voice.capture_device_id
+                        if self.context is not None and self.context.voice.capture_device_id is not None
+                        else (
+                            self.config_manager.get_capture_device_id()
+                            if self.config_manager is not None
+                            else None
+                        )
                     ),
                     sample_rate_hz=voice_cfg.sample_rate_hz if voice_cfg is not None else 16000,
                     record_seconds=voice_cfg.record_seconds if voice_cfg is not None else 4,

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -65,8 +65,7 @@ from yoyopy.ui.screens import (
     VoiceNoteScreen,
 )
 from yoyopy.network import NetworkManager
-from yoyopy.events import NetworkPppUpEvent
-from yoyopy.voice import VoiceSettings
+from yoyopy.voice import VoiceDeviceCatalog, VoiceSettings
 from yoyopy.voip import CallHistoryStore, VoIPConfig, VoIPManager
 
 
@@ -136,6 +135,7 @@ class YoyoPodApp:
         self.network_manager: Optional[NetworkManager] = None
         self.call_history_store: Optional[CallHistoryStore] = None
         self.recent_track_store: Optional[RecentTrackHistoryStore] = None
+        self.voice_device_catalog: Optional[VoiceDeviceCatalog] = None
 
         # Screen instances
         self.hub_screen: Optional[HubScreen] = None
@@ -296,6 +296,8 @@ class YoyoPodApp:
             self.recent_track_store = RecentTrackHistoryStore(
                 self.config_manager.config_dir / "recent_tracks.json"
             )
+            self.voice_device_catalog = VoiceDeviceCatalog()
+            self.voice_device_catalog.refresh_async()
 
             if self.config_manager.app_config_loaded:
                 logger.info(f"Loaded configuration from {self.config_manager.app_config_file}")
@@ -723,7 +725,8 @@ class YoyoPodApp:
                     ),
                     speaker_device_id=(
                         self.context.voice.speaker_device_id
-                        if self.context is not None and self.context.voice.speaker_device_id is not None
+                        if self.context is not None
+                        and self.context.voice.speaker_device_id is not None
                         else (
                             self.config_manager.get_ring_output_device()
                             if self.config_manager is not None
@@ -732,7 +735,8 @@ class YoyoPodApp:
                     ),
                     capture_device_id=(
                         self.context.voice.capture_device_id
-                        if self.context is not None and self.context.voice.capture_device_id is not None
+                        if self.context is not None
+                        and self.context.voice.capture_device_id is not None
                         else (
                             self.config_manager.get_capture_device_id()
                             if self.config_manager is not None
@@ -750,7 +754,31 @@ class YoyoPodApp:
                 self.context,
                 power_manager=self.power_manager,
                 status_provider=self.get_status,
-                config_manager=self.config_manager,
+                refresh_voice_device_options_action=(
+                    self.voice_device_catalog.refresh_async
+                    if self.voice_device_catalog is not None
+                    else None
+                ),
+                playback_device_options_provider=(
+                    self.voice_device_catalog.playback_devices
+                    if self.voice_device_catalog is not None
+                    else None
+                ),
+                capture_device_options_provider=(
+                    self.voice_device_catalog.capture_devices
+                    if self.voice_device_catalog is not None
+                    else None
+                ),
+                persist_speaker_device_action=(
+                    self.config_manager.set_voice_speaker_device_id
+                    if self.config_manager is not None
+                    else None
+                ),
+                persist_capture_device_action=(
+                    self.config_manager.set_voice_capture_device_id
+                    if self.config_manager is not None
+                    else None
+                ),
                 volume_up_action=self.volume_up,
                 volume_down_action=self.volume_down,
                 mute_action=self.voip_manager.mute if self.voip_manager is not None else None,

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -413,12 +413,16 @@ class YoyoPodApp:
                 )
             if self.context is not None and self.app_settings is not None:
                 voice_cfg = self.app_settings.voice
+                speaker_device_id = voice_cfg.speaker_device_id.strip() or None
+                capture_device_id = voice_cfg.capture_device_id.strip() or None
                 self.context.configure_voice(
                     commands_enabled=voice_cfg.commands_enabled,
                     ai_requests_enabled=voice_cfg.ai_requests_enabled,
                     screen_read_enabled=voice_cfg.screen_read_enabled,
                     stt_enabled=voice_cfg.stt_enabled,
                     tts_enabled=voice_cfg.tts_enabled,
+                    speaker_device_id=speaker_device_id,
+                    capture_device_id=capture_device_id,
                 )
                 self._refresh_talk_summary()
             self._update_screen_runtime_metrics(time.monotonic())
@@ -724,6 +728,7 @@ class YoyoPodApp:
                 self.context,
                 power_manager=self.power_manager,
                 status_provider=self.get_status,
+                config_manager=self.config_manager,
                 volume_up_action=self.volume_up,
                 volume_down_action=self.volume_down,
                 mute_action=self.voip_manager.mute if self.voip_manager is not None else None,

--- a/yoyopy/app_context.py
+++ b/yoyopy/app_context.py
@@ -88,12 +88,17 @@ class VoiceState:
     stt_enabled: bool = True
     tts_enabled: bool = True
     mic_muted: bool = False
+    speaker_device_id: str | None = None
+    capture_device_id: str | None = None
     stt_available: bool = False
     tts_available: bool = False
     last_transcript: str = ""
     last_spoken_text: str = ""
     last_mode: str = ""
     output_volume: int = 50
+
+
+_VOICE_UNSET = object()
 
 
 class AppContext:
@@ -465,6 +470,8 @@ class AppContext:
         screen_read_enabled: bool | None = None,
         stt_enabled: bool | None = None,
         tts_enabled: bool | None = None,
+        speaker_device_id: str | None | object = _VOICE_UNSET,
+        capture_device_id: str | None | object = _VOICE_UNSET,
     ) -> None:
         """Update persistent voice feature toggles cached in context."""
 
@@ -478,6 +485,10 @@ class AppContext:
             self.voice.stt_enabled = stt_enabled
         if tts_enabled is not None:
             self.voice.tts_enabled = tts_enabled
+        if speaker_device_id is not _VOICE_UNSET:
+            self.voice.speaker_device_id = speaker_device_id  # type: ignore[assignment]
+        if capture_device_id is not _VOICE_UNSET:
+            self.voice.capture_device_id = capture_device_id  # type: ignore[assignment]
 
     def update_voice_backend_status(self, *, stt_available: bool, tts_available: bool) -> None:
         """Update backend availability flags used by voice UI flows."""

--- a/yoyopy/config/manager.py
+++ b/yoyopy/config/manager.py
@@ -135,7 +135,11 @@ class ConfigManager:
             return False
 
     def save_app_config(self) -> bool:
-        """Persist the current typed application config to yoyopod_config.yaml."""
+        """Persist the current typed application config to yoyopod_config.yaml.
+
+        This is a whole-model write. Prefer targeted layer patches for UI-driven
+        settings updates so env overlays and board-layer shape stay intact.
+        """
 
         try:
             self.config_dir.mkdir(parents=True, exist_ok=True)
@@ -147,6 +151,20 @@ class ConfigManager:
             return True
         except Exception:
             logger.exception("Error saving app config")
+            return False
+
+    def _save_app_config_layer_patch(self, patch: dict[str, Any]) -> bool:
+        """Persist one partial update into the active app-config layer only."""
+
+        try:
+            current = self._load_yaml_mapping(self.app_config_file)
+            data = _deep_merge_mappings(current, patch)
+            self._atomic_write_yaml(self.app_config_file, data)
+            self.app_config_loaded = True
+            logger.info("App configuration layer updated successfully")
+            return True
+        except Exception:
+            logger.exception("Error updating app config layer")
             return False
 
     def load_voip_config(self) -> bool:
@@ -191,8 +209,7 @@ class ConfigManager:
         self.contacts_loaded = any(path.exists() for path in self.contacts_layers)
         if not self.contacts_loaded:
             logger.warning(
-                "Contacts file not found: "
-                + ", ".join(str(path) for path in self.contacts_layers)
+                "Contacts file not found: " + ", ".join(str(path) for path in self.contacts_layers)
             )
             self._create_default_contacts()
             return False
@@ -266,6 +283,16 @@ class ConfigManager:
                 tmp.unlink(missing_ok=True)
             except Exception:
                 pass
+
+    @staticmethod
+    def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+        """Load one YAML mapping from disk, tolerating missing files."""
+
+        if not path.exists():
+            return {}
+        with open(path, "r", encoding="utf-8") as handle:
+            loaded = yaml.safe_load(handle) or {}
+        return loaded if isinstance(loaded, dict) else {}
 
     def _create_default_voip_config(self) -> None:
         """Create a default typed VoIP configuration file."""
@@ -371,8 +398,11 @@ class ConfigManager:
         value = (device_id or "").strip()
         if "\n" in value or "\r" in value:
             raise ValueError("Invalid ALSA device id (contains newline)")
+        if not self._save_app_config_layer_patch({"voice": {"capture_device_id": value}}):
+            return False
         self.app_settings.voice.capture_device_id = value
-        return self.save_app_config()
+        self.app_config.setdefault("voice", {})["capture_device_id"] = value
+        return True
 
     def set_voice_speaker_device_id(self, device_id: str | None) -> bool:
         """Persist the playback device selector used by local voice interactions."""
@@ -380,8 +410,11 @@ class ConfigManager:
         value = (device_id or "").strip()
         if "\n" in value or "\r" in value:
             raise ValueError("Invalid ALSA device id (contains newline)")
+        if not self._save_app_config_layer_patch({"voice": {"speaker_device_id": value}}):
+            return False
         self.app_settings.voice.speaker_device_id = value
-        return self.save_app_config()
+        self.app_config.setdefault("voice", {})["speaker_device_id"] = value
+        return True
 
     def get_app_config_dict(self) -> dict[str, Any]:
         """Return the plain-dict form of the application configuration."""

--- a/yoyopy/config/manager.py
+++ b/yoyopy/config/manager.py
@@ -6,6 +6,8 @@ Manages typed app/VoIP settings and contacts from YAML configuration files.
 
 from __future__ import annotations
 
+import os
+import tempfile
 import yaml
 from dataclasses import dataclass
 from pathlib import Path
@@ -101,6 +103,21 @@ class ConfigManager:
             self.app_config_loaded = False
             return False
 
+    def save_app_config(self) -> bool:
+        """Persist the current typed application config to yoyopod_config.yaml."""
+
+        try:
+            self.config_dir.mkdir(parents=True, exist_ok=True)
+            data = config_to_dict(self.app_settings)
+            self._atomic_write_yaml(self.app_config_file, data)
+            self.app_config = data
+            self.app_config_loaded = True
+            logger.info("App configuration saved successfully")
+            return True
+        except Exception:
+            logger.exception("Error saving app config")
+            return False
+
     def load_voip_config(self) -> bool:
         """
         Load typed VoIP configuration from file.
@@ -194,6 +211,25 @@ class ConfigManager:
             logger.exception("Error saving contacts")
             return False
 
+    @staticmethod
+    def _atomic_write_yaml(path: Path, data: dict[str, Any]) -> None:
+        """Write YAML atomically so power loss never corrupts the config file."""
+
+        directory = path.parent
+        directory.mkdir(parents=True, exist_ok=True)
+
+        fd, tmp_path = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(directory))
+        tmp = Path(tmp_path)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                yaml.dump(data, handle, default_flow_style=False, sort_keys=False)
+            os.replace(str(tmp), str(path))
+        finally:
+            try:
+                tmp.unlink(missing_ok=True)
+            except Exception:
+                pass
+
     def _create_default_voip_config(self) -> None:
         """Create a default typed VoIP configuration file."""
 
@@ -227,6 +263,24 @@ class ConfigManager:
         """Return the typed application configuration model."""
 
         return self.app_settings
+
+    def set_voice_capture_device_id(self, device_id: str | None) -> bool:
+        """Persist the capture device selector used by local voice interactions."""
+
+        value = (device_id or "").strip()
+        if "\n" in value or "\r" in value:
+            raise ValueError("Invalid ALSA device id (contains newline)")
+        self.app_settings.voice.capture_device_id = value
+        return self.save_app_config()
+
+    def set_voice_speaker_device_id(self, device_id: str | None) -> bool:
+        """Persist the playback device selector used by local voice interactions."""
+
+        value = (device_id or "").strip()
+        if "\n" in value or "\r" in value:
+            raise ValueError("Invalid ALSA device id (contains newline)")
+        self.app_settings.voice.speaker_device_id = value
+        return self.save_app_config()
 
     def get_app_config_dict(self) -> dict[str, Any]:
         """Return the plain-dict form of the application configuration."""

--- a/yoyopy/config/models.py
+++ b/yoyopy/config/models.py
@@ -210,6 +210,9 @@ class AppVoiceConfig:
     screen_read_enabled: bool = config_value(default=False, env="YOYOPOD_SCREEN_READ_ENABLED")
     stt_enabled: bool = config_value(default=True, env="YOYOPOD_STT_ENABLED")
     tts_enabled: bool = config_value(default=True, env="YOYOPOD_TTS_ENABLED")
+    # Optional ALSA selectors for local voice TTS/STT. Empty string means "Auto".
+    speaker_device_id: str = config_value(default="", env="YOYOPOD_VOICE_SPEAKER_DEVICE")
+    capture_device_id: str = config_value(default="", env="YOYOPOD_VOICE_CAPTURE_DEVICE")
     stt_backend: str = config_value(default="vosk", env="YOYOPOD_STT_BACKEND")
     tts_backend: str = config_value(default="espeak-ng", env="YOYOPOD_TTS_BACKEND")
     vosk_model_path: str = config_value(

--- a/yoyopy/ui/display/adapters/simulation.py
+++ b/yoyopy/ui/display/adapters/simulation.py
@@ -180,7 +180,13 @@ class SimulationDisplayAdapter(DisplayHAL):
         if self.draw is None:
             return
 
-        self.draw.rectangle([(x1, y1), (x2, y2)], fill=fill, outline=outline, width=width)
+        # PIL requires top-left <= bottom-right; some icon helpers may compute
+        # inverted coordinates for very small sizes.
+        left = min(x1, x2)
+        right = max(x1, x2)
+        top = min(y1, y2)
+        bottom = max(y1, y2)
+        self.draw.rectangle([(left, top), (right, bottom)], fill=fill, outline=outline, width=width)
 
     def circle(
         self,

--- a/yoyopy/ui/screens/navigation/ask.py
+++ b/yoyopy/ui/screens/navigation/ask.py
@@ -482,6 +482,7 @@ class AskScreen(Screen):
             stt_backend=voice_cfg.stt_backend,
             tts_backend=voice_cfg.tts_backend,
             vosk_model_path=voice_cfg.vosk_model_path,
+            speaker_device_id=speaker_device_id,
             capture_device_id=capture_device_id,
             sample_rate_hz=voice_cfg.sample_rate_hz,
             record_seconds=voice_cfg.record_seconds,

--- a/yoyopy/ui/screens/navigation/ask.py
+++ b/yoyopy/ui/screens/navigation/ask.py
@@ -415,6 +415,16 @@ class AskScreen(Screen):
         defaults = self._default_voice_settings()
         if self.context is not None:
             voice = self.context.voice
+            capture_device_id = (
+                voice.capture_device_id
+                if voice.capture_device_id is not None
+                else defaults.capture_device_id
+            )
+            speaker_device_id = (
+                voice.speaker_device_id
+                if voice.speaker_device_id is not None
+                else defaults.speaker_device_id
+            )
             return replace(
                 defaults,
                 commands_enabled=voice.commands_enabled,
@@ -424,6 +434,8 @@ class AskScreen(Screen):
                 tts_enabled=voice.tts_enabled,
                 mic_muted=voice.mic_muted,
                 output_volume=voice.output_volume,
+                capture_device_id=capture_device_id,
+                speaker_device_id=speaker_device_id,
             )
         return defaults
 
@@ -434,7 +446,14 @@ class AskScreen(Screen):
         if self.config_manager is not None:
             capture_device_id = self.config_manager.get_capture_device_id()
 
-        defaults = VoiceSettings(capture_device_id=capture_device_id)
+        speaker_device_id = None
+        if self.config_manager is not None:
+            speaker_device_id = getattr(self.config_manager, "get_ring_output_device", lambda: None)()
+
+        defaults = VoiceSettings(
+            capture_device_id=capture_device_id,
+            speaker_device_id=speaker_device_id or None,
+        )
         if self.config_manager is None:
             return defaults
 
@@ -961,7 +980,10 @@ class AskScreen(Screen):
             with NamedTemporaryFile(prefix="yoyopy-beep-", suffix=".wav", delete=False) as handle:
                 beep_path = Path(handle.name)
             self._write_beep_wav(beep_path)
-            self._output_player.play_wav(beep_path, timeout_seconds=2.0)
+            device_id = None
+            if self.context is not None:
+                device_id = getattr(self.context.voice, "speaker_device_id", None)
+            self._output_player.play_wav(beep_path, device_id=device_id, timeout_seconds=2.0)
         except Exception:
             logger.debug("Voice attention tone unavailable")
         finally:

--- a/yoyopy/ui/screens/navigation/ask.py
+++ b/yoyopy/ui/screens/navigation/ask.py
@@ -981,10 +981,11 @@ class AskScreen(Screen):
             with NamedTemporaryFile(prefix="yoyopy-beep-", suffix=".wav", delete=False) as handle:
                 beep_path = Path(handle.name)
             self._write_beep_wav(beep_path)
-            device_id = None
-            if self.context is not None:
-                device_id = getattr(self.context.voice, "speaker_device_id", None)
-            self._output_player.play_wav(beep_path, device_id=device_id, timeout_seconds=2.0)
+            device_id = self.context.voice.speaker_device_id if self.context is not None else None
+            play_kwargs = {"timeout_seconds": 2.0}
+            if device_id:
+                play_kwargs["device_id"] = device_id
+            self._output_player.play_wav(beep_path, **play_kwargs)
         except Exception:
             logger.debug("Voice attention tone unavailable")
         finally:

--- a/yoyopy/ui/screens/navigation/ask.py
+++ b/yoyopy/ui/screens/navigation/ask.py
@@ -443,17 +443,18 @@ class AskScreen(Screen):
         """Return configured voice defaults when a screen-level provider is absent."""
 
         capture_device_id = None
-        if self.config_manager is not None:
-            capture_device_id = self.config_manager.get_capture_device_id()
-
         speaker_device_id = None
         if self.config_manager is not None:
-            speaker_device_id = getattr(self.config_manager, "get_ring_output_device", lambda: None)()
+            voice_cfg = getattr(self.config_manager.get_app_settings(), "voice", None)
+            if voice_cfg is not None:
+                capture_device_id = getattr(voice_cfg, "capture_device_id", "").strip() or None
+                speaker_device_id = getattr(voice_cfg, "speaker_device_id", "").strip() or None
+            if capture_device_id is None:
+                capture_device_id = self.config_manager.get_capture_device_id()
+            if speaker_device_id is None:
+                speaker_device_id = getattr(self.config_manager, "get_ring_output_device", lambda: None)()
 
-        defaults = VoiceSettings(
-            capture_device_id=capture_device_id,
-            speaker_device_id=speaker_device_id or None,
-        )
+        defaults = VoiceSettings(capture_device_id=capture_device_id, speaker_device_id=speaker_device_id or None)
         if self.config_manager is None:
             return defaults
 

--- a/yoyopy/ui/screens/navigation/menu.py
+++ b/yoyopy/ui/screens/navigation/menu.py
@@ -64,11 +64,18 @@ class MenuScreen(Screen):
         )
 
         item_height = 54
-        for index, item in enumerate(self.items):
-            y1 = panel_top + 10 + (index * item_height)
+        row_top = panel_top + 10
+        row_bottom = panel_bottom - 8
+        # Compute how many rows can fit and scroll so the selected row is visible.
+        max_visible = (row_bottom - row_top - 44) // item_height + 1
+        max_visible = max(1, min(len(self.items), max_visible))
+        start_index = max(0, min(self.selected_index - (max_visible // 2), len(self.items) - max_visible))
+
+        for offset in range(max_visible):
+            index = start_index + offset
+            item = self.items[index]
+            y1 = row_top + (offset * item_height)
             y2 = y1 + 44
-            if y2 > panel_bottom - 8:
-                break
 
             mode, icon, subtitle = ITEM_MODES.get(item, ("setup", "setup", "Mode"))
             draw_list_item(

--- a/yoyopy/ui/screens/system/lvgl/power_view.py
+++ b/yoyopy/ui/screens/system/lvgl/power_view.py
@@ -39,14 +39,54 @@ class LvglPowerView:
 
         self.screen.page_index %= len(pages)
         active_page = pages[self.screen.page_index]
-        items = [f"{label}: {value}" for label, value in active_page.rows[:4]]
+
+        # Page picker (Power/Time/Care/Voice) without showing page contents.
+        if not getattr(self.screen, "in_detail", True):
+            items: list[str] = []
+            for index, page in enumerate(pages[:4]):
+                prefix = "> " if index == self.screen.page_index else ""
+                items.append(f"{prefix}{page.title}")
+
+            context = self.screen.context
+            self.backend.binding.power_sync(
+                title_text="Setup",
+                page_text=None,
+                icon_key=self.screen._page_icon_key(active_page.title),
+                footer=self.screen._instruction_text(active_page),
+                items=items,
+                current_page_index=self.screen.page_index,
+                total_pages=len(pages),
+                voip_state=self._voip_state(context),
+                battery_percent=self._battery_percent(context),
+                charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
+                power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+                accent=SETUP.accent,
+            )
+            return
+
+        rows = list(active_page.rows)
+        selected_row = max(0, min(self.screen.selected_row, max(0, len(rows) - 1))) if rows else 0
+
+        # LVGL power scene only supports 4 visible rows. For interactive pages,
+        # scroll so the selected row remains visible.
+        start_row = 0
+        if active_page.interactive and rows:
+            max_visible = min(4, len(rows))
+            start_row = max(0, min(selected_row - (max_visible // 2), len(rows) - max_visible))
+
+        visible_rows = rows[start_row : start_row + 4]
+        items: list[str] = []
+        for offset, (label, value) in enumerate(visible_rows):
+            absolute_index = start_row + offset
+            prefix = "> " if active_page.interactive and absolute_index == selected_row else ""
+            items.append(f"{prefix}{label}: {value}")
         context = self.screen.context
 
         self.backend.binding.power_sync(
             title_text=active_page.title,
             page_text=None,
             icon_key=self.screen._page_icon_key(active_page.title),
-            footer="Tap = Page / Hold = Back" if self.screen.is_one_button_mode() else "A page | B back",
+            footer=self.screen._instruction_text(active_page),
             items=items,
             current_page_index=self.screen.page_index,
             total_pages=len(pages),

--- a/yoyopy/ui/screens/system/power.py
+++ b/yoyopy/ui/screens/system/power.py
@@ -21,15 +21,10 @@ from yoyopy.ui.screens.theme import (
     rounded_panel,
     text_fit,
 )
-from yoyopy.voice.devices import (
-    format_device_label,
-    list_capture_devices,
-    list_playback_devices,
-)
+from yoyopy.voice.devices import format_device_label
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
-    from yoyopy.config import ConfigManager
     from yoyopy.power import PowerManager, PowerSnapshot
     from yoyopy.ui.screens import ScreenView
 
@@ -53,7 +48,11 @@ class PowerScreen(Screen):
         *,
         power_manager: Optional["PowerManager"] = None,
         status_provider: Optional[Callable[[], dict[str, object]]] = None,
-        config_manager: Optional["ConfigManager"] = None,
+        refresh_voice_device_options_action: Optional[Callable[[], None]] = None,
+        playback_device_options_provider: Optional[Callable[[], list[str]]] = None,
+        capture_device_options_provider: Optional[Callable[[], list[str]]] = None,
+        persist_speaker_device_action: Optional[Callable[[str | None], bool]] = None,
+        persist_capture_device_action: Optional[Callable[[str | None], bool]] = None,
         volume_up_action: Optional[Callable[[int], int | None]] = None,
         volume_down_action: Optional[Callable[[int], int | None]] = None,
         mute_action: Optional[Callable[[], bool]] = None,
@@ -62,7 +61,11 @@ class PowerScreen(Screen):
         super().__init__(display, context, "PowerStatus")
         self.power_manager = power_manager
         self.status_provider = status_provider or (lambda: {})
-        self.config_manager = config_manager
+        self.refresh_voice_device_options_action = refresh_voice_device_options_action
+        self.playback_device_options_provider = playback_device_options_provider
+        self.capture_device_options_provider = capture_device_options_provider
+        self.persist_speaker_device_action = persist_speaker_device_action
+        self.persist_capture_device_action = persist_capture_device_action
         self.volume_up_action = volume_up_action
         self.volume_down_action = volume_down_action
         self.mute_action = mute_action
@@ -71,8 +74,6 @@ class PowerScreen(Screen):
         self.selected_row = 0
         self.in_detail = False
         self._lvgl_view: "ScreenView | None" = None
-        self._cached_playback_devices: list[str] | None = None
-        self._cached_capture_devices: list[str] | None = None
 
     def enter(self) -> None:
         """Create the LVGL view when the screen becomes active."""
@@ -81,8 +82,8 @@ class PowerScreen(Screen):
         self.page_index = 0
         self.selected_row = 0
         self.in_detail = False
-        self._cached_playback_devices = None
-        self._cached_capture_devices = None
+        if self.refresh_voice_device_options_action is not None:
+            self.refresh_voice_device_options_action()
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
@@ -189,7 +190,9 @@ class PowerScreen(Screen):
             if active_page.interactive and rows:
                 max_visible = max(1, (max_row_bottom - row_y) // (row_height + row_gap))
                 max_visible = min(max_visible, len(rows))
-                start_row = max(0, min(self.selected_row - (max_visible // 2), len(rows) - max_visible))
+                start_row = max(
+                    0, min(self.selected_row - (max_visible // 2), len(rows) - max_visible)
+                )
 
             for row_offset, (label, value) in enumerate(rows[start_row:]):
                 row_index = start_row + row_offset
@@ -252,7 +255,9 @@ class PowerScreen(Screen):
             row_bottom = panel_bottom - 8
             available = max(0, row_bottom - row_top)
             max_visible = max(1, min(len(picker_items), available // item_height))
-            start_index = max(0, min(self.page_index - (max_visible // 2), len(picker_items) - max_visible))
+            start_index = max(
+                0, min(self.page_index - (max_visible // 2), len(picker_items) - max_visible)
+            )
 
             for offset in range(max_visible):
                 index = start_index + offset
@@ -534,7 +539,11 @@ class PowerScreen(Screen):
         """Return footer hints for the current page."""
 
         if not self.in_detail:
-            return "Tap next / Double open / Hold back" if self.is_one_button_mode() else "A open | B back | X/Y move"
+            return (
+                "Tap next / Double open / Hold back"
+                if self.is_one_button_mode()
+                else "A open | B back | X/Y move"
+            )
 
         if page.interactive:
             if self.is_one_button_mode():
@@ -623,16 +632,18 @@ class PowerScreen(Screen):
     def _playback_device_options(self) -> list[str | None]:
         """Return selectable playback options, with None representing Auto."""
 
-        if self._cached_playback_devices is None:
-            self._cached_playback_devices = list_playback_devices()
-        return [None, *self._cached_playback_devices]
+        devices = []
+        if self.playback_device_options_provider is not None:
+            devices = list(self.playback_device_options_provider())
+        return [None, *devices]
 
     def _capture_device_options(self) -> list[str | None]:
         """Return selectable capture options, with None representing Auto."""
 
-        if self._cached_capture_devices is None:
-            self._cached_capture_devices = list_capture_devices()
-        return [None, *self._cached_capture_devices]
+        devices = []
+        if self.capture_device_options_provider is not None:
+            devices = list(self.capture_device_options_provider())
+        return [None, *devices]
 
     @staticmethod
     def _cycle_option(
@@ -658,8 +669,8 @@ class PowerScreen(Screen):
             direction,
         )
         self.context.configure_voice(speaker_device_id=next_device)
-        if self.config_manager is not None:
-            self.config_manager.set_voice_speaker_device_id(next_device)
+        if self.persist_speaker_device_action is not None:
+            self.persist_speaker_device_action(next_device)
 
     def _cycle_capture_device(self, direction: int) -> None:
         if self.context is None:
@@ -670,8 +681,8 @@ class PowerScreen(Screen):
             direction,
         )
         self.context.configure_voice(capture_device_id=next_device)
-        if self.config_manager is not None:
-            self.config_manager.set_voice_capture_device_id(next_device)
+        if self.persist_capture_device_action is not None:
+            self.persist_capture_device_action(next_device)
 
     def _next_page(self) -> None:
         """Advance to the next page with wraparound."""

--- a/yoyopy/ui/screens/system/power.py
+++ b/yoyopy/ui/screens/system/power.py
@@ -21,6 +21,11 @@ from yoyopy.ui.screens.theme import (
     rounded_panel,
     text_fit,
 )
+from yoyopy.voice.devices import (
+    format_device_label,
+    list_capture_devices,
+    list_playback_devices,
+)
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
@@ -61,11 +66,20 @@ class PowerScreen(Screen):
         self.unmute_action = unmute_action
         self.page_index = 0
         self.selected_row = 0
+        self.in_detail = False
         self._lvgl_view: "ScreenView | None" = None
+        self._cached_playback_devices: list[str] | None = None
+        self._cached_capture_devices: list[str] | None = None
 
     def enter(self) -> None:
         """Create the LVGL view when the screen becomes active."""
         super().enter()
+        # Returning to Setup should not trap users in the Voice page.
+        self.page_index = 0
+        self.selected_row = 0
+        self.in_detail = False
+        self._cached_playback_devices = None
+        self._cached_capture_devices = None
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
@@ -126,19 +140,14 @@ class PowerScreen(Screen):
             outline=None,
             radius=22,
         )
-        draw_icon(
-            self.display,
-            self._page_icon_key(active_page.title),
-            halo_left + 10,
-            halo_top + 10,
-            24,
-            (225, 228, 234),
-        )
+        icon_key = self._page_icon_key(active_page.title) if self.in_detail else "power"
+        draw_icon(self.display, icon_key, halo_left + 10, halo_top + 10, 24, (225, 228, 234))
 
         title_y = halo_top + halo_size + 8
-        title_width, _ = self.display.get_text_size(active_page.title, 18)
+        header_title = active_page.title if self.in_detail else "Setup"
+        title_width, _ = self.display.get_text_size(header_title, 18)
         self.display.text(
-            active_page.title,
+            header_title,
             (self.display.WIDTH - title_width) // 2,
             title_y,
             color=INK,
@@ -164,43 +173,113 @@ class PowerScreen(Screen):
             font_size=10,
         )
 
-        row_y = title_y + 18
-        row_height = 20
-        row_gap = 4
-        max_row_bottom = self.display.HEIGHT - 60
-        for row_index, (label, value) in enumerate(active_page.rows):
-            row_bottom = row_y + row_height
-            if row_bottom > max_row_bottom:
-                break
-            is_selected = active_page.interactive and row_index == self.selected_row
+        if self.in_detail:
+            row_y = title_y + 18
+            row_height = 20
+            row_gap = 4
+            max_row_bottom = self.display.HEIGHT - 60
+
+            rows = list(active_page.rows)
+            # When an interactive page has more rows than we can show, keep the selected
+            # row visible instead of rendering a fixed top slice.
+            start_row = 0
+            if active_page.interactive and rows:
+                max_visible = max(1, (max_row_bottom - row_y) // (row_height + row_gap))
+                max_visible = min(max_visible, len(rows))
+                start_row = max(0, min(self.selected_row - (max_visible // 2), len(rows) - max_visible))
+
+            for row_offset, (label, value) in enumerate(rows[start_row:]):
+                row_index = start_row + row_offset
+                row_bottom = row_y + row_height
+                if row_bottom > max_row_bottom:
+                    break
+                is_selected = active_page.interactive and row_index == self.selected_row
+                rounded_panel(
+                    self.display,
+                    16,
+                    row_y,
+                    self.display.WIDTH - 16,
+                    row_bottom,
+                    fill=SETUP.accent_dim if is_selected else SURFACE_RAISED,
+                    outline=None,
+                    radius=11,
+                )
+                label_text = text_fit(self.display, label, 92, 10)
+                value_text = text_fit(self.display, value, self.display.WIDTH - 130, 12)
+                self.display.text(
+                    label_text,
+                    26,
+                    row_y + 5,
+                    color=SETUP.accent if is_selected else MUTED,
+                    font_size=10,
+                )
+                value_width, _ = self.display.get_text_size(value_text, 12)
+                self.display.text(
+                    value_text,
+                    self.display.WIDTH - value_width - 26,
+                    row_y + 4,
+                    color=INK,
+                    font_size=12,
+                )
+                row_y += row_height + row_gap
+        else:
+            # This is the layout you liked: show the top-level pages as a list card.
+            panel_top = title_y + 20
+            panel_bottom = self.display.HEIGHT - 60
             rounded_panel(
                 self.display,
-                16,
-                row_y,
-                self.display.WIDTH - 16,
-                row_bottom,
-                fill=SETUP.accent_dim if is_selected else SURFACE_RAISED,
+                12,
+                panel_top,
+                self.display.WIDTH - 12,
+                panel_bottom,
+                fill=(30, 34, 41),
                 outline=None,
-                radius=11,
+                radius=24,
             )
-            label_text = text_fit(self.display, label, 92, 10)
-            value_text = text_fit(self.display, value, self.display.WIDTH - 130, 12)
-            self.display.text(
-                label_text,
-                26,
-                row_y + 5,
-                color=SETUP.accent if is_selected else MUTED,
-                font_size=10,
-            )
-            value_width, _ = self.display.get_text_size(value_text, 12)
-            self.display.text(
-                value_text,
-                self.display.WIDTH - value_width - 26,
-                row_y + 4,
-                color=INK,
-                font_size=12,
-            )
-            row_y += row_height + row_gap
+
+            picker_items = [
+                ("Power", "Battery and charging", "battery"),
+                ("Time", "RTC and alarms", "clock"),
+                ("Care", "Screen and watchdog", "care"),
+                ("Voice", "Commands and volume", "voice_note"),
+            ]
+
+            item_height = 40
+            row_top = panel_top + 10
+            row_bottom = panel_bottom - 8
+            available = max(0, row_bottom - row_top)
+            max_visible = max(1, min(len(picker_items), available // item_height))
+            start_index = max(0, min(self.page_index - (max_visible // 2), len(picker_items) - max_visible))
+
+            for offset in range(max_visible):
+                index = start_index + offset
+                title, subtitle, icon = picker_items[index]
+                y1 = row_top + (offset * item_height)
+                y2 = y1 + (item_height - 4)
+                selected = index == self.page_index
+                rounded_panel(
+                    self.display,
+                    16,
+                    y1,
+                    self.display.WIDTH - 16,
+                    y2,
+                    fill=(250, 250, 250) if selected else SURFACE_RAISED,
+                    outline=None,
+                    radius=14,
+                )
+
+                icon_color = SETUP.accent if selected else MUTED
+                draw_icon(self.display, icon, 26, y1 + 8, 16, icon_color)
+                title_color = (30, 34, 41) if selected else INK
+                subtitle_color = (90, 96, 108) if selected else MUTED
+                self.display.text(title, 48, y1 + 6, color=title_color, font_size=14)
+                self.display.text(
+                    text_fit(self.display, subtitle, self.display.WIDTH - 90, 11),
+                    48,
+                    y1 + 22,
+                    color=subtitle_color,
+                    font_size=11,
+                )
 
         self._render_page_dots(total_pages=len(pages))
 
@@ -257,6 +336,8 @@ class PowerScreen(Screen):
                 ("Voice Cmds", "Unknown"),
                 ("AI Requests", "Unknown"),
                 ("Screen Read", "Unknown"),
+                ("Speaker", "Auto"),
+                ("Mic Device", "Auto"),
                 ("Mic", "Unknown"),
                 ("Volume", "--"),
             ]
@@ -266,6 +347,8 @@ class PowerScreen(Screen):
             ("Voice Cmds", "On" if voice.commands_enabled else "Off"),
             ("AI Requests", "On" if voice.ai_requests_enabled else "Off"),
             ("Screen Read", "On" if voice.screen_read_enabled else "Off"),
+            ("Speaker", format_device_label(voice.speaker_device_id)),
+            ("Mic Device", format_device_label(voice.capture_device_id)),
             ("Mic", "Muted" if voice.mic_muted else "Live"),
             ("Volume", f"{voice.output_volume}%"),
         ]
@@ -447,6 +530,9 @@ class PowerScreen(Screen):
     def _instruction_text(self, page: PowerPage) -> str:
         """Return footer hints for the current page."""
 
+        if not self.in_detail:
+            return "Tap next / Double open / Hold back" if self.is_one_button_mode() else "A open | B back | X/Y move"
+
         if page.interactive:
             if self.is_one_button_mode():
                 return "Tap item / Double change / Hold back"
@@ -473,7 +559,7 @@ class PowerScreen(Screen):
     def _is_voice_page(self) -> bool:
         """Return True when the interactive voice settings page is active."""
 
-        return self._active_page().interactive
+        return self.in_detail and self._active_page().interactive
 
     def _select_next_row(self) -> None:
         """Move to the next row inside an interactive page."""
@@ -512,6 +598,12 @@ class PowerScreen(Screen):
             )
             return
         if row_index == 3:
+            self._cycle_speaker_device(direction)
+            return
+        if row_index == 4:
+            self._cycle_capture_device(direction)
+            return
+        if row_index == 5:
             self._apply_mic_state(not self.context.voice.mic_muted)
             return
         current = None
@@ -525,6 +617,55 @@ class PowerScreen(Screen):
             return
         self._sync_context_output_volume(current)
 
+    def _playback_device_options(self) -> list[str | None]:
+        """Return selectable playback options, with None representing Auto."""
+
+        if self._cached_playback_devices is None:
+            self._cached_playback_devices = list_playback_devices()
+        return [None, *self._cached_playback_devices]
+
+    def _capture_device_options(self) -> list[str | None]:
+        """Return selectable capture options, with None representing Auto."""
+
+        if self._cached_capture_devices is None:
+            self._cached_capture_devices = list_capture_devices()
+        return [None, *self._cached_capture_devices]
+
+    @staticmethod
+    def _cycle_option(
+        options: list[str | None],
+        current: str | None,
+        direction: int,
+    ) -> str | None:
+        if not options:
+            return current
+        try:
+            index = options.index(current)
+        except ValueError:
+            index = 0
+        next_index = (index + (1 if direction >= 0 else -1)) % len(options)
+        return options[next_index]
+
+    def _cycle_speaker_device(self, direction: int) -> None:
+        if self.context is None:
+            return
+        next_device = self._cycle_option(
+            self._playback_device_options(),
+            self.context.voice.speaker_device_id,
+            direction,
+        )
+        self.context.configure_voice(speaker_device_id=next_device)
+
+    def _cycle_capture_device(self, direction: int) -> None:
+        if self.context is None:
+            return
+        next_device = self._cycle_option(
+            self._capture_device_options(),
+            self.context.voice.capture_device_id,
+            direction,
+        )
+        self.context.configure_voice(capture_device_id=next_device)
+
     def _next_page(self) -> None:
         """Advance to the next page with wraparound."""
         self.page_index = (self.page_index + 1) % len(self._active_pages())
@@ -537,13 +678,28 @@ class PowerScreen(Screen):
 
     def on_advance(self, data=None) -> None:
         """Single-button tap cycles pages."""
+        if not self.in_detail:
+            self._next_page()
+            return
         if self._is_voice_page():
-            self._select_next_row()
+            # Voice is an interactive list; wrap within the page instead of
+            # "falling through" into Power/Time/Care.
+            page = self._active_page()
+            if not page.rows:
+                return
+            if self.selected_row >= len(page.rows) - 1:
+                self.selected_row = 0
+            else:
+                self._select_next_row()
             return
         self._next_page()
 
     def on_select(self, data=None) -> None:
-        """Select also cycles pages."""
+        """Open the selected page, or adjust interactive settings in detail mode."""
+        if not self.in_detail:
+            self.in_detail = True
+            self.selected_row = 0
+            return
         if self._is_voice_page():
             self._apply_voice_setting(+1)
             return
@@ -551,24 +707,49 @@ class PowerScreen(Screen):
 
     def on_back(self, data=None) -> None:
         """Return to the previous screen."""
+        if self.in_detail:
+            self.in_detail = False
+            self.selected_row = 0
+            return
         self.request_route("back")
 
     def on_up(self, data=None) -> None:
         """Up goes to the previous page."""
+        if not self.in_detail:
+            self._previous_page()
+            return
         if self._is_voice_page():
-            self._select_previous_row()
+            page = self._active_page()
+            if not page.rows:
+                return
+            if self.selected_row == 0:
+                self.selected_row = len(page.rows) - 1
+            else:
+                self._select_previous_row()
             return
         self._previous_page()
 
     def on_down(self, data=None) -> None:
         """Down goes to the next page."""
+        if not self.in_detail:
+            self._next_page()
+            return
         if self._is_voice_page():
-            self._select_next_row()
+            page = self._active_page()
+            if not page.rows:
+                return
+            if self.selected_row >= len(page.rows) - 1:
+                self.selected_row = 0
+            else:
+                self._select_next_row()
             return
         self._next_page()
 
     def on_left(self, data=None) -> None:
         """Left goes to the previous page."""
+        if not self.in_detail:
+            self._previous_page()
+            return
         if self._is_voice_page():
             self._apply_voice_setting(-1)
             return
@@ -576,6 +757,9 @@ class PowerScreen(Screen):
 
     def on_right(self, data=None) -> None:
         """Right goes to the next page."""
+        if not self.in_detail:
+            self._next_page()
+            return
         if self._is_voice_page():
             self._apply_voice_setting(+1)
             return

--- a/yoyopy/ui/screens/system/power.py
+++ b/yoyopy/ui/screens/system/power.py
@@ -29,6 +29,7 @@ from yoyopy.voice.devices import (
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
+    from yoyopy.config import ConfigManager
     from yoyopy.power import PowerManager, PowerSnapshot
     from yoyopy.ui.screens import ScreenView
 
@@ -52,6 +53,7 @@ class PowerScreen(Screen):
         *,
         power_manager: Optional["PowerManager"] = None,
         status_provider: Optional[Callable[[], dict[str, object]]] = None,
+        config_manager: Optional["ConfigManager"] = None,
         volume_up_action: Optional[Callable[[int], int | None]] = None,
         volume_down_action: Optional[Callable[[int], int | None]] = None,
         mute_action: Optional[Callable[[], bool]] = None,
@@ -60,6 +62,7 @@ class PowerScreen(Screen):
         super().__init__(display, context, "PowerStatus")
         self.power_manager = power_manager
         self.status_provider = status_provider or (lambda: {})
+        self.config_manager = config_manager
         self.volume_up_action = volume_up_action
         self.volume_down_action = volume_down_action
         self.mute_action = mute_action
@@ -655,6 +658,8 @@ class PowerScreen(Screen):
             direction,
         )
         self.context.configure_voice(speaker_device_id=next_device)
+        if self.config_manager is not None:
+            self.config_manager.set_voice_speaker_device_id(next_device)
 
     def _cycle_capture_device(self, direction: int) -> None:
         if self.context is None:
@@ -665,6 +670,8 @@ class PowerScreen(Screen):
             direction,
         )
         self.context.configure_voice(capture_device_id=next_device)
+        if self.config_manager is not None:
+            self.config_manager.set_voice_capture_device_id(next_device)
 
     def _next_page(self) -> None:
         """Advance to the next page with wraparound."""

--- a/yoyopy/voice/__init__.py
+++ b/yoyopy/voice/__init__.py
@@ -12,6 +12,7 @@ from yoyopy.voice.commands import (
     VoiceCommandTemplate,
     match_voice_command,
 )
+from yoyopy.voice.devices import VoiceDeviceCatalog
 from yoyopy.voice.models import (
     VoiceCaptureRequest,
     VoiceCaptureResult,
@@ -37,6 +38,7 @@ __all__ = [
     "SpeechToTextBackend",
     "SubprocessAudioCaptureBackend",
     "TextToSpeechBackend",
+    "VoiceDeviceCatalog",
     "VoiceCaptureRequest",
     "VoiceCaptureResult",
     "VoiceCommandIntent",

--- a/yoyopy/voice/devices.py
+++ b/yoyopy/voice/devices.py
@@ -1,0 +1,127 @@
+"""Helpers for listing ALSA capture/playback devices for UI selection.
+
+These functions intentionally have safe fallbacks when running in environments
+without ALSA utilities (for example the Windows simulator).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+from loguru import logger
+
+
+def _normalize_alsa_selector(value: str) -> str:
+    raw = value.strip()
+    if raw.upper().startswith("ALSA:"):
+        raw = raw.split(":", 1)[1].strip()
+    return raw
+
+
+def _run_list(binary: str) -> list[str]:
+    if not shutil.which(binary):
+        return []
+    try:
+        result = subprocess.run(
+            [binary, "-L"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except Exception as exc:
+        logger.debug("ALSA list via {} failed: {}", binary, exc)
+        return []
+    if result.returncode != 0:
+        return []
+    devices: list[str] = []
+    for line in result.stdout.splitlines():
+        # Device identifiers are on non-indented lines; descriptions are indented.
+        if not line or line.startswith(" "):
+            continue
+        device = line.strip()
+        if not device:
+            continue
+        if device in {"null"}:
+            continue
+        devices.append(device)
+    return devices
+
+
+def list_playback_devices(*, aplay_binary: str = "aplay") -> list[str]:
+    """Return ALSA playback devices in a stable, UI-friendly order."""
+
+    parsed = _run_list(aplay_binary)
+    filtered: list[str] = []
+    for device in parsed:
+        # Skip common aliases that don't help selection.
+        if device in {"default", "sysdefault"}:
+            continue
+        if "vc4hdmi" in device.lower():
+            continue
+        filtered.append(device)
+
+    def sort_key(value: str) -> tuple[int, str]:
+        lowered = value.lower()
+        if "card=se" in lowered or "usb" in lowered:
+            return (0, value)
+        if value.startswith("plughw:"):
+            return (1, value)
+        if value.startswith("default:card="):
+            return (2, value)
+        if value.startswith("sysdefault:card="):
+            return (3, value)
+        return (4, value)
+
+    return sorted(dict.fromkeys(filtered), key=sort_key)
+
+
+def list_capture_devices(*, arecord_binary: str = "arecord") -> list[str]:
+    """Return ALSA capture devices in a stable, UI-friendly order."""
+
+    parsed = _run_list(arecord_binary)
+    filtered: list[str] = []
+    for device in parsed:
+        if device in {"default", "sysdefault"}:
+            continue
+        filtered.append(device)
+
+    def sort_key(value: str) -> tuple[int, str]:
+        lowered = value.lower()
+        if "card=se" in lowered or "usb" in lowered:
+            return (0, value)
+        if value.startswith("plughw:"):
+            return (1, value)
+        if value.startswith("front:card="):
+            return (2, value)
+        if value.startswith("dsnoop:card="):
+            return (3, value)
+        if value.startswith("hw:"):
+            return (4, value)
+        return (5, value)
+
+    return sorted(dict.fromkeys(filtered), key=sort_key)
+
+
+def format_device_label(device_id: str | None) -> str:
+    """Turn an ALSA selector into a compact label suitable for the 240px UI."""
+
+    if not device_id:
+        return "Auto"
+
+    normalized = _normalize_alsa_selector(device_id)
+    # Keep the full selector for power users, but avoid noisy prefixes.
+    for prefix in ("default:", "sysdefault:", "plughw:", "front:", "dsnoop:", "dmix:", "hw:"):
+        if normalized.lower().startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+
+    normalized = normalized.strip()
+    if not normalized:
+        return "Auto"
+
+    if len(normalized) > 18:
+        return normalized[:17] + "…"
+    return normalized
+

--- a/yoyopy/voice/devices.py
+++ b/yoyopy/voice/devices.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess
+import threading
 from functools import lru_cache
 from pathlib import Path
 
@@ -263,3 +264,64 @@ def format_device_label(device_id: str | None) -> str:
     if len(normalized) > 18:
         return normalized[:17] + "..."
     return normalized
+
+
+class VoiceDeviceCatalog:
+    """Cache voice-device options and refresh them off the UI input path."""
+
+    def __init__(
+        self,
+        *,
+        aplay_binary: str = "aplay",
+        arecord_binary: str = "arecord",
+    ) -> None:
+        self.aplay_binary = aplay_binary
+        self.arecord_binary = arecord_binary
+        self._lock = threading.Lock()
+        self._refresh_lock = threading.Lock()
+        self._refresh_thread: threading.Thread | None = None
+        self._playback_devices: list[str] = []
+        self._capture_devices: list[str] = []
+
+    def playback_devices(self) -> list[str]:
+        """Return the latest cached playback-device options."""
+
+        with self._lock:
+            return list(self._playback_devices)
+
+    def capture_devices(self) -> list[str]:
+        """Return the latest cached capture-device options."""
+
+        with self._lock:
+            return list(self._capture_devices)
+
+    def refresh(self) -> None:
+        """Refresh both playback and capture options synchronously."""
+
+        playback_devices = list_playback_devices(aplay_binary=self.aplay_binary)
+        capture_devices = list_capture_devices(arecord_binary=self.arecord_binary)
+        with self._lock:
+            self._playback_devices = playback_devices
+            self._capture_devices = capture_devices
+
+    def refresh_async(self) -> None:
+        """Refresh device options on a background thread when needed."""
+
+        with self._refresh_lock:
+            worker = self._refresh_thread
+            if worker is not None and worker.is_alive():
+                return
+
+            worker = threading.Thread(
+                target=self._refresh_worker,
+                name="voice-device-catalog-refresh",
+                daemon=True,
+            )
+            self._refresh_thread = worker
+            worker.start()
+
+    def _refresh_worker(self) -> None:
+        try:
+            self.refresh()
+        except Exception as exc:
+            logger.debug("Voice-device refresh failed: {}", exc)

--- a/yoyopy/voice/devices.py
+++ b/yoyopy/voice/devices.py
@@ -6,8 +6,11 @@ without ALSA utilities (for example the Windows simulator).
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
+from functools import lru_cache
+from pathlib import Path
 
 from loguru import logger
 
@@ -49,59 +52,168 @@ def _run_list(binary: str) -> list[str]:
     return devices
 
 
+@lru_cache(maxsize=1)
+def _asound_card_aliases() -> dict[str, str]:
+    """Return ALSA card-id -> friendly name mapping when available."""
+
+    cards_path = Path("/proc/asound/cards")
+    if not cards_path.exists():
+        return {}
+
+    try:
+        text = cards_path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return {}
+
+    aliases: dict[str, str] = {}
+    for line in text.splitlines():
+        # Example:
+        #  1 [SE             ]: USB-Audio - Jabra Evolve 75 SE
+        match = re.match(r"^\s*\d+\s+\[([^\]]+)\]:\s*(.+?)\s*$", line)
+        if not match:
+            continue
+        card_id = match.group(1).strip()
+        rest = match.group(2).strip()
+        if not card_id or not rest:
+            continue
+        friendly = rest
+        if " - " in rest:
+            friendly = rest.split(" - ", 1)[1].strip() or rest
+        aliases[card_id] = friendly
+    return aliases
+
+
+def _friendly_card_name(card_id: str) -> str:
+    return _asound_card_aliases().get(card_id, card_id)
+
+
+def _parse_card_dev(device: str) -> tuple[str | None, int | None]:
+    """Extract CARD and DEV fields from an ALSA selector string."""
+
+    upper = device.upper()
+    card = None
+    dev = None
+    if "CARD=" in upper:
+        start = upper.index("CARD=") + len("CARD=")
+        end = device.find(",", start)
+        card = (device[start:] if end == -1 else device[start:end]).strip() or None
+    if "DEV=" in upper:
+        start = upper.index("DEV=") + len("DEV=")
+        end = device.find(",", start)
+        raw = (device[start:] if end == -1 else device[start:end]).strip()
+        try:
+            dev = int(raw)
+        except Exception:
+            dev = None
+    return card, dev
+
+
+def _route_name(device: str) -> str:
+    return device.split(":", 1)[0].strip().lower() if ":" in device else device.strip().lower()
+
+
 def list_playback_devices(*, aplay_binary: str = "aplay") -> list[str]:
     """Return ALSA playback devices in a stable, UI-friendly order."""
 
     parsed = _run_list(aplay_binary)
-    filtered: list[str] = []
+    candidates: list[str] = []
     for device in parsed:
-        # Skip common aliases that don't help selection.
-        if device in {"default", "sysdefault"}:
+        if device in {"default", "sysdefault", "null"}:
             continue
-        if "vc4hdmi" in device.lower():
+        route = _route_name(device)
+        # Keep only "physical" options: one per card, prefer plughw; keep HDMI explicitly.
+        if route not in {"plughw", "hw", "hdmi"}:
             continue
-        filtered.append(device)
+        card, _ = _parse_card_dev(device)
+        if not card:
+            continue
+        candidates.append(device)
+
+    # Choose one best route per card.
+    by_card: dict[str, list[str]] = {}
+    for device in candidates:
+        card, _ = _parse_card_dev(device)
+        if not card:
+            continue
+        by_card.setdefault(card, []).append(device)
+
+    chosen: list[str] = []
+    for card, devices in by_card.items():
+        # Prefer hdmi for HDMI cards, otherwise plughw then hw.
+        priority = ["plughw", "hw"]
+        if card.lower() in {"vc4hdmi"}:
+            priority = ["hdmi", "plughw", "hw"]
+        best: str | None = None
+        for route in priority:
+            matches = [d for d in devices if _route_name(d) == route]
+            if matches:
+                # Prefer lowest DEV if multiple.
+                matches.sort(key=lambda d: (_parse_card_dev(d)[1] or 0, d))
+                best = matches[0]
+                break
+        if best is not None:
+            chosen.append(best)
 
     def sort_key(value: str) -> tuple[int, str]:
-        lowered = value.lower()
-        if "card=se" in lowered or "usb" in lowered:
-            return (0, value)
-        if value.startswith("plughw:"):
-            return (1, value)
-        if value.startswith("default:card="):
-            return (2, value)
-        if value.startswith("sysdefault:card="):
-            return (3, value)
-        return (4, value)
+        card, _ = _parse_card_dev(value)
+        route = _route_name(value)
+        friendly = _friendly_card_name(card or "").lower()
+        if route == "hdmi" or (card or "").lower() == "vc4hdmi":
+            return (2, friendly)
+        # Rough heuristics: keep USB-ish headsets first.
+        if "usb" in friendly or "jabra" in friendly:
+            return (0, friendly)
+        if "blue" in friendly:
+            return (1, friendly)
+        return (3, friendly)
 
-    return sorted(dict.fromkeys(filtered), key=sort_key)
+    chosen = sorted(dict.fromkeys(chosen), key=sort_key)
+    return chosen
 
 
 def list_capture_devices(*, arecord_binary: str = "arecord") -> list[str]:
     """Return ALSA capture devices in a stable, UI-friendly order."""
 
     parsed = _run_list(arecord_binary)
-    filtered: list[str] = []
+    candidates: list[str] = []
     for device in parsed:
-        if device in {"default", "sysdefault"}:
+        if device in {"default", "sysdefault", "null"}:
             continue
-        filtered.append(device)
+        route = _route_name(device)
+        if route not in {"plughw", "hw"}:
+            continue
+        card, _ = _parse_card_dev(device)
+        if not card:
+            continue
+        candidates.append(device)
+
+    by_card: dict[str, list[str]] = {}
+    for device in candidates:
+        card, _ = _parse_card_dev(device)
+        if not card:
+            continue
+        by_card.setdefault(card, []).append(device)
+
+    chosen: list[str] = []
+    for card, devices in by_card.items():
+        for route in ("plughw", "hw"):
+            matches = [d for d in devices if _route_name(d) == route]
+            if matches:
+                matches.sort(key=lambda d: (_parse_card_dev(d)[1] or 0, d))
+                chosen.append(matches[0])
+                break
 
     def sort_key(value: str) -> tuple[int, str]:
-        lowered = value.lower()
-        if "card=se" in lowered or "usb" in lowered:
-            return (0, value)
-        if value.startswith("plughw:"):
-            return (1, value)
-        if value.startswith("front:card="):
-            return (2, value)
-        if value.startswith("dsnoop:card="):
-            return (3, value)
-        if value.startswith("hw:"):
-            return (4, value)
-        return (5, value)
+        card, _ = _parse_card_dev(value)
+        friendly = _friendly_card_name(card or "").lower()
+        if "usb" in friendly or "jabra" in friendly:
+            return (0, friendly)
+        if "blue" in friendly:
+            return (1, friendly)
+        return (2, friendly)
 
-    return sorted(dict.fromkeys(filtered), key=sort_key)
+    chosen = sorted(dict.fromkeys(chosen), key=sort_key)
+    return chosen
 
 
 def format_device_label(device_id: str | None) -> str:
@@ -112,35 +224,16 @@ def format_device_label(device_id: str | None) -> str:
 
     normalized = _normalize_alsa_selector(device_id)
 
-    # If the selector is of the form "<route>:CARD=XYZ,DEV=0", prefer showing the
-    # card (and dev) with a route suffix. This reads much better than raw ALSA
-    # strings like "iec958:CARD=SE,DEV=0".
-    route = ""
-    spec = normalized
-    if ":" in normalized:
-        route, spec = normalized.split(":", 1)
-        route = route.strip()
-        spec = spec.strip()
-
-    card = ""
-    dev = ""
-    upper_spec = spec.upper()
-    if "CARD=" in upper_spec:
-        start = upper_spec.index("CARD=") + len("CARD=")
-        end = spec.find(",", start)
-        card = spec[start:] if end == -1 else spec[start:end]
-        card = card.strip()
-    if "DEV=" in upper_spec:
-        start = upper_spec.index("DEV=") + len("DEV=")
-        end = spec.find(",", start)
-        dev = spec[start:] if end == -1 else spec[start:end]
-        dev = dev.strip()
-
+    route = _route_name(normalized)
+    card, dev = _parse_card_dev(normalized)
     if card:
-        label = card
-        if route:
-            label = f"{label} {route}"
-        if dev:
+        friendly = _friendly_card_name(card)
+        # Special-case HDMI for readability.
+        if route == "hdmi" or card.lower() == "vc4hdmi":
+            label = "HDMI"
+        else:
+            label = friendly
+        if dev not in (None, 0) and len(label) <= 14:
             label = f"{label} {dev}"
         label = label.strip()
         if len(label) > 18:

--- a/yoyopy/voice/devices.py
+++ b/yoyopy/voice/devices.py
@@ -111,8 +111,54 @@ def format_device_label(device_id: str | None) -> str:
         return "Auto"
 
     normalized = _normalize_alsa_selector(device_id)
+
+    # If the selector is of the form "<route>:CARD=XYZ,DEV=0", prefer showing the
+    # card (and dev) with a route suffix. This reads much better than raw ALSA
+    # strings like "iec958:CARD=SE,DEV=0".
+    route = ""
+    spec = normalized
+    if ":" in normalized:
+        route, spec = normalized.split(":", 1)
+        route = route.strip()
+        spec = spec.strip()
+
+    card = ""
+    dev = ""
+    upper_spec = spec.upper()
+    if "CARD=" in upper_spec:
+        start = upper_spec.index("CARD=") + len("CARD=")
+        end = spec.find(",", start)
+        card = spec[start:] if end == -1 else spec[start:end]
+        card = card.strip()
+    if "DEV=" in upper_spec:
+        start = upper_spec.index("DEV=") + len("DEV=")
+        end = spec.find(",", start)
+        dev = spec[start:] if end == -1 else spec[start:end]
+        dev = dev.strip()
+
+    if card:
+        label = card
+        if route:
+            label = f"{label} {route}"
+        if dev:
+            label = f"{label} {dev}"
+        label = label.strip()
+        if len(label) > 18:
+            return label[:17] + "..."
+        return label
+
     # Keep the full selector for power users, but avoid noisy prefixes.
-    for prefix in ("default:", "sysdefault:", "plughw:", "front:", "dsnoop:", "dmix:", "hw:"):
+    for prefix in (
+        "default:",
+        "sysdefault:",
+        "plughw:",
+        "front:",
+        "dsnoop:",
+        "dmix:",
+        "hw:",
+        "iec958:",
+        "hdmi:",
+    ):
         if normalized.lower().startswith(prefix):
             normalized = normalized[len(prefix) :]
             break
@@ -122,6 +168,5 @@ def format_device_label(device_id: str | None) -> str:
         return "Auto"
 
     if len(normalized) > 18:
-        return normalized[:17] + "…"
+        return normalized[:17] + "..."
     return normalized
-

--- a/yoyopy/voice/models.py
+++ b/yoyopy/voice/models.py
@@ -21,6 +21,7 @@ class VoiceSettings:
     stt_backend: str = "vosk"
     tts_backend: str = "espeak-ng"
     vosk_model_path: str = "models/vosk-model-small-en-us"
+    speaker_device_id: str | None = None
     capture_device_id: str | None = None
     sample_rate_hz: int = 16000
     record_seconds: int = 4

--- a/yoyopy/voice/output.py
+++ b/yoyopy/voice/output.py
@@ -25,19 +25,35 @@ class AlsaOutputPlayer:
 
         return shutil.which(self.aplay_binary) is not None
 
-    def play_wav(self, audio_path: Path, *, timeout_seconds: float = 6.0) -> bool:
+    def play_wav(
+        self,
+        audio_path: Path,
+        *,
+        device_id: str | None = None,
+        timeout_seconds: float = 6.0,
+    ) -> bool:
         """Play one WAV file, retrying through likely ALSA devices."""
 
         if not self.is_available():
             return False
 
         with _PLAYBACK_LOCK:
-            return self._play_wav_locked(audio_path, timeout_seconds=timeout_seconds)
+            return self._play_wav_locked(
+                audio_path,
+                device_id=device_id,
+                timeout_seconds=timeout_seconds,
+            )
 
-    def _play_wav_locked(self, audio_path: Path, *, timeout_seconds: float = 6.0) -> bool:
+    def _play_wav_locked(
+        self,
+        audio_path: Path,
+        *,
+        device_id: str | None,
+        timeout_seconds: float = 6.0,
+    ) -> bool:
         """Inner play implementation, called with _PLAYBACK_LOCK held."""
 
-        for device in self._device_candidates():
+        for device in self._device_candidates(device_id):
             command = [self.aplay_binary, "-q"]
             if device:
                 command.extend(["-D", device])
@@ -58,10 +74,15 @@ class AlsaOutputPlayer:
                 return True
         return False
 
-    def _device_candidates(self) -> list[str | None]:
+    def _device_candidates(self, configured_device_id: str | None) -> list[str | None]:
         """Return playback-device candidates, prioritizing known-good USB routes."""
 
         candidates: list[str | None] = []
+        if configured_device_id:
+            normalized = configured_device_id.strip()
+            if normalized.upper().startswith("ALSA:"):
+                normalized = normalized.split(":", 1)[1].strip()
+            candidates.append(normalized or None)
         if self._preferred_device is not None:
             candidates.append(self._preferred_device)
 

--- a/yoyopy/voice/tts.py
+++ b/yoyopy/voice/tts.py
@@ -82,7 +82,11 @@ class EspeakNgTextToSpeechBackend:
             logger.warning("espeak-ng render failed: {}", result.stderr.strip())
             return False
         try:
-            if not self.output_player.play_wav(audio_path, timeout_seconds=10.0):
+            if not self.output_player.play_wav(
+                audio_path,
+                device_id=settings.speaker_device_id,
+                timeout_seconds=10.0,
+            ):
                 logger.warning("espeak-ng playback could not find a usable ALSA device")
                 return False
             return True

--- a/yoyopy/voice/tts.py
+++ b/yoyopy/voice/tts.py
@@ -82,11 +82,10 @@ class EspeakNgTextToSpeechBackend:
             logger.warning("espeak-ng render failed: {}", result.stderr.strip())
             return False
         try:
-            if not self.output_player.play_wav(
-                audio_path,
-                device_id=settings.speaker_device_id,
-                timeout_seconds=10.0,
-            ):
+            play_kwargs = {"timeout_seconds": 10.0}
+            if settings.speaker_device_id:
+                play_kwargs["device_id"] = settings.speaker_device_id
+            if not self.output_player.play_wav(audio_path, **play_kwargs):
                 logger.warning("espeak-ng playback could not find a usable ALSA device")
                 return False
             return True


### PR DESCRIPTION
## What
Adds speaker and mic device selection to Setup  3e Voice, improves simulator/Whisplay parity and navigation, and persists selections to YAML.

## Changes
- Setup  3e Voice: add `Speaker` and `Mic Device` rows (cycle with A / Left-Right), keep voice-row navigation wrapping within the voice page.
- ALSA device enumeration: filter `aplay -L` / `arecord -L` down to physical choices (one per card) and display friendly names using `/proc/asound/cards` (HDMI shown as `HDMI`).
- Audio routing: selected speaker device is used for attention beep + TTS playback; selected capture device is used for STT capture.
- Persistence: store `voice.speaker_device_id` and `voice.capture_device_id` in `config/yoyopod_config.yaml` with atomic writes via `ConfigManager`, and load into `AppContext` on startup.
- Tests: add config persistence tests.

## Testing
- On Pi: `python -m pytest -q tests/test_config_voice_device_persistence.py tests/test_power_screen.py`.

## Notes
- Full `pytest` on the Pi can fail due to missing dev deps (`typer`) for CLI-related tests; the targeted tests above pass and cover the new persistence and UI wiring.