### PR TITLE
[codex] Add board-aware config overlays

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.c text eol=lf
+*.h text eol=lf
+CMakeLists.txt text eol=lf

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Run on hardware:
 python yoyopod.py
 ```
 
+Board-specific hardware defaults can live in `config/boards/<board>/`.
+Known boards currently include `rpi-zero-2w` and `radxa-cubie-a7z`, and
+the app auto-selects those on matching hardware. You can also force one:
+
+```bash
+YOYOPOD_CONFIG_BOARD=radxa-cubie-a7z python yoyopod.py
+YOYOPOD_CONFIG_BOARD=rpi-zero-2w python yoyopod.py
+```
+
 ## Docs
 
 - [Development Guide](docs/DEVELOPMENT_GUIDE.md)

--- a/config/boards/radxa-cubie-a7z/yoyopod_config.yaml
+++ b/config/boards/radxa-cubie-a7z/yoyopod_config.yaml
@@ -1,0 +1,10 @@
+# Radxa Cubie A7Z board overrides.
+#
+# This board is auto-selected on known Cubie A7Z hardware, or can be forced with:
+#   YOYOPOD_CONFIG_BOARD=radxa-cubie-a7z
+
+audio:
+  music_dir: "/home/radxa/Music"
+
+power:
+  watchdog_i2c_bus: 7

--- a/config/boards/rpi-zero-2w/yoyopod_config.yaml
+++ b/config/boards/rpi-zero-2w/yoyopod_config.yaml
@@ -1,0 +1,10 @@
+# Raspberry Pi Zero 2W board overrides.
+#
+# This board is auto-selected on known Pi Zero 2W hardware, or can be forced with:
+#   YOYOPOD_CONFIG_BOARD=rpi-zero-2w
+
+audio:
+  music_dir: "/home/pi/Music"
+
+power:
+  watchdog_i2c_bus: 1

--- a/config/yoyopod_config.yaml
+++ b/config/yoyopod_config.yaml
@@ -1,5 +1,8 @@
 # YoyoPod Unified Configuration
 # Phase 5: VoIP + Music Integration
+# Known board configs live under `config/boards/<board>/yoyopod_config.yaml`.
+# `YOYOPOD_CONFIG_BOARD` can force a board, and known hardware such as
+# Raspberry Pi Zero 2W and Radxa Cubie A7Z is auto-detected.
 
 app:
   name: "YoyoPod"

--- a/docs/CUBIE_A7Z_BRINGUP.md
+++ b/docs/CUBIE_A7Z_BRINGUP.md
@@ -1,0 +1,338 @@
+# Radxa Cubie A7Z Bringup
+
+This note records the current YoyoPod bringup path for the Radxa Cubie A7Z and the main findings from hardware validation.
+
+It is intentionally practical:
+
+- what was required to make the board usable as a YoyoPod target
+- what was verified on-device
+- what is still risky, unsupported, or unresolved
+
+## Scope
+
+This bringup was done on:
+
+- board: `Radxa Cubie A7Z`
+- OS: `Debian Bullseye`
+- kernel family: Radxa vendor BSP `5.15.147-18-a733`
+- user: `radxa`
+- project dir: `~/yoyo-py`
+
+The Cubie A7Z is now a usable YoyoPod development target, but it is not yet a drop-in replacement for the Raspberry Pi Zero 2W. The major caveat is the Whisplay physical button behavior on this board.
+
+## Bringup Summary
+
+### 1. Base system packages
+
+Install the general build and runtime dependencies:
+
+```bash
+sudo apt update
+sudo apt upgrade -y
+sudo apt install -y \
+  build-essential git curl wget cmake pkg-config \
+  i2c-tools spi-tools \
+  libffi-dev libssl-dev python3-dev \
+  libasound2-dev libopus-dev libspeexdsp-dev \
+  libdrm-dev libinput-dev libevdev-dev libxkbcommon-dev
+```
+
+Additional runtime packages used later during validation:
+
+```bash
+sudo apt install -y mpv espeak-ng unzip
+```
+
+## 2. Python and project environment
+
+Install `uv` and Python `3.12`:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source ~/.bashrc
+uv python install 3.12
+```
+
+Important note:
+
+- Debian system `python3` remains `3.9.2`
+- YoyoPod should use `uv` / `.venv`, not replace `/usr/bin/python3`
+
+Project setup on the board:
+
+```bash
+cd ~/yoyo-py
+~/.local/bin/uv venv --python 3.12 .venv
+~/.local/bin/uv sync --extra dev
+```
+
+## 3. Hostname and timezone
+
+```bash
+sudo timedatectl set-timezone Europe/Berlin
+sudo hostnamectl set-hostname cubie-a7z
+```
+
+## 4. SPI for Whisplay display
+
+Enable the Cubie SPI1 spidev overlay.
+
+On this image, the Radxa tooling expected overlays to be managed through `rsetup`.
+
+Verified result:
+
+- `/dev/spidev1.0` present
+
+## 5. TWI7 / I2C for PiSugar 3 and WM8960
+
+For Whisplay audio and PiSugar 3 on Cubie A7Z:
+
+- enable `twi7`
+- adjust the TWI7 clock to `100 kHz` per PiSugar guidance
+
+Verified result:
+
+- `/dev/i2c-7` present
+- active TWI7 clock set to `100000`
+
+Other board I2C buses visible during bringup:
+
+- `/dev/i2c-13`
+- `/dev/i2c-14`
+- `/dev/i2c-20`
+
+## 6. Whisplay driver and WM8960 audio
+
+Use the Cubie A7Z-specific Whisplay install flow from the PiSugar repo.
+
+Expected outcome:
+
+- SPI display path working
+- WM8960 codec on I2C bus `7`
+- `wm8960-soundcard` available for playback and capture
+
+Observed validation:
+
+- Whisplay display worked
+- WM8960 audio worked
+- `aplay -L` and `arecord -L` exposed `wm8960-soundcard`
+
+## 7. PiSugar 3
+
+Install and configure `pisugar-server` on bus `7`.
+
+Expected configuration:
+
+- socket path: `/tmp/pisugar-server.sock`
+- I2C bus: `7`
+
+Verified behavior when PiSugar was attached and powered correctly:
+
+- battery telemetry available
+- charging state visible
+- external power visible
+- RTC accessible and syncable
+
+RTC status was checked and synchronized to the NTP-synced system clock.
+
+## 8. Board-specific YoyoPod config
+
+Cubie A7Z support is configured through a tracked board override:
+
+- `config/boards/radxa-cubie-a7z/yoyopod_config.yaml`
+
+Current Cubie override:
+
+- `audio.music_dir: /home/radxa/Music`
+- `power.watchdog_i2c_bus: 7`
+
+Board selection uses:
+
+- `YOYOPOD_CONFIG_BOARD=radxa-cubie-a7z`
+
+Known boards can also auto-detect through `ConfigManager`.
+
+## 9. Voice / media runtime
+
+The Cubie board was validated with:
+
+- `mpv`
+- `liblinphone-dev`
+- `linphone-common`
+- `espeak-ng`
+- Vosk Python package from the project environment
+- local Vosk model installed at:
+  - `~/yoyo-py/models/vosk-model-small-en-us`
+
+Verified state on the board:
+
+- `capture_available = True`
+- `stt_available = True`
+- `tts_available = True`
+
+## 10. Test music content
+
+For local-first music validation, sample tracks were placed under:
+
+- `/home/radxa/Music/Test Samples`
+
+And a simple playlist was created:
+
+- `/home/radxa/Music/YoyoPod Test Playlist.m3u`
+
+## Current Verified State
+
+The Cubie A7Z is currently able to run YoyoPod with:
+
+- Python `3.12` in the project `.venv`
+- working SPI display path
+- working Whisplay display
+- working WM8960 playback/capture path
+- working local music playback path
+- working Liblinphone backend on Bullseye
+- working local voice-command asset install
+
+## Findings And Known Issues
+
+### 1. Whisplay physical button is not safe on Cubie A7Z
+
+This is the most important finding.
+
+The Whisplay repository explicitly warns for Radxa Cubie A7Z:
+
+- the physical button on Whisplay HAT is not safe to use on this board
+- pressing it may shut the board down or make it lose power immediately
+
+That matched live behavior during testing.
+
+What was observed:
+
+- with Whisplay attached, display and audio worked
+- with Whisplay and PiSugar stacked together, pressing the Whisplay button reliably took the Cubie down immediately
+- the same shutdown happened even after stopping:
+  - `yoyopod`
+  - `pisugar-server`
+
+So this is not a YoyoPod application bug and not a PiSugar watchdog/software action issue.
+
+### 2. PiSugar software tap actions were not the cause
+
+PiSugar button actions were checked live and were disabled:
+
+- single tap disabled
+- double tap disabled
+- long tap disabled
+- soft poweroff disabled
+
+That rules out PiSugar button software behavior as the root cause of the immediate shutdown when pressing the Whisplay button.
+
+### 3. The PiSugar board makes the Whisplay button failure more reproducible
+
+One interesting observation:
+
+- Whisplay alone could appear to work
+- Whisplay + PiSugar made the shutdown behavior reproducible
+
+Current interpretation:
+
+- the Whisplay button path is fundamentally unsafe on Cubie A7Z
+- PiSugar likely amplifies the failure through stack mechanics, shared power behavior, grounding, or electrical margin
+
+This does not make the Whisplay button safe without PiSugar. It only means the failure threshold becomes easier to hit when PiSugar is attached.
+
+### 4. Recommended temporary hardware setup
+
+For now, the safest practical setup is:
+
+- remove PiSugar 3 from the Cubie stack
+- power the Cubie directly from USB
+- do not use the Whisplay physical button
+
+If one-button input is needed later, preferred next options are:
+
+- use the PiSugar custom function button as a semantic input source
+- or add an external button wired to a known-safe `3.3V` GPIO path
+
+### 5. System Python should not be replaced
+
+The Cubie image still uses Debian Bullseye system Python:
+
+- `python3 = 3.9.2`
+
+YoyoPod uses:
+
+- `uv`
+- Python `3.12`
+- project `.venv`
+
+Do not change `/usr/bin/python3` on this image.
+
+### 6. ALSA card index ordering is not stable
+
+ALSA card numbering can vary after reboot.
+
+Recommendation:
+
+- target playback/capture devices by device name
+- avoid assuming a fixed card index for `wm8960-soundcard`
+
+### 7. Avoid casual kernel upgrades
+
+The current working state depends on the Radxa vendor BSP kernel and overlays.
+
+At the time of bringup, this kernel line provided the needed behavior for:
+
+- Wi-Fi
+- SPI overlays
+- TWI overlays
+- Whisplay display
+- WM8960 audio
+- Radxa overlay tooling
+
+Do not upgrade or replace the kernel casually unless there is a specific hardware issue that requires it.
+
+## Open Points
+
+### 1. Final one-button UX on Cubie A7Z
+
+Because the Whisplay physical button is unsafe on this board, Cubie A7Z needs a different one-button input strategy.
+
+Open options:
+
+- PiSugar custom button as app input
+- external safe GPIO button
+- no one-button mode on Cubie for now
+
+### 2. Exact electrical root cause of the Whisplay button failure
+
+The behavior is confirmed, but the exact electrical mechanism is still not fully characterized.
+
+Open questions:
+
+- whether the failure is caused by the Whisplay `KEY` signal level on Cubie A7Z
+- whether the stack introduces a power/ground/mechanical interaction when PiSugar is attached
+- whether there is a safe hardware workaround
+
+This was important enough to justify contacting PiSugar support for clarification.
+
+### 3. Cubie-specific docs and validation flow
+
+Most tracked project docs still assume Raspberry Pi Zero 2W as the main target.
+
+The Cubie A7Z is now usable enough that follow-up docs may be worth adding later for:
+
+- Cubie-specific deploy workflow
+- Cubie-specific smoke checklist
+- Cubie-safe one-button input recommendations
+
+## Recommended Working Mode Right Now
+
+For immediate development:
+
+1. use Cubie A7Z powered directly by USB
+2. keep PiSugar detached unless specifically testing PiSugar features
+3. do not press the Whisplay physical button on Cubie A7Z
+4. use SSH plus service restarts for app validation
+5. use the Cubie board config override and the project `.venv`
+
+This is the safest current path while keeping the board productive for display, audio, VoIP, music, and local voice-command development.

--- a/docs/POWER_MODULE.md
+++ b/docs/POWER_MODULE.md
@@ -6,6 +6,11 @@ Current target hardware:
 - Raspberry Pi Zero 2W
 - PiSugar 3 battery HAT
 
+Board-specific overrides can now live under `config/boards/<board>/`.
+Known hardware boards:
+- `rpi-zero-2w` -> PiSugar watchdog on `i2c-1`
+- `radxa-cubie-a7z` -> PiSugar watchdog on `i2c-7`
+
 This module is responsible for:
 - UPS-style telemetry
 - low-battery warning
@@ -321,7 +326,8 @@ If power telemetry fails:
 - check `pisugar-server` is running
 - check `/tmp/pisugar-server.sock` exists or TCP `8423` is listening
 - run `yoyoctl pi power battery`
-- run `i2cdetect -y 1` on the Pi
+- run `i2cdetect -y 1` on Raspberry Pi Zero 2W hardware
+- run `i2cdetect -y 7` on Radxa Cubie A7Z hardware
 
 Expected PiSugar 3 visibility usually includes:
 - `0x57`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pygame>=2.5.0",
     "requests>=2.31.0",
     "loguru>=0.7.0",
+    "gpiod<2; platform_system == 'Linux'",
     "displayhatmini>=0.0.1; platform_system == 'Linux'",
     "pyyaml>=6.0.3",
     "vosk>=0.3.45",

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -866,6 +866,32 @@ def test_user_activity_event_wakes_screen_and_refreshes_current_screen() -> None
     assert app.menu_screen.render_calls == render_calls_before + 1
 
 
+def test_raw_user_activity_wakes_screen_without_rerendering_current_pil_screen() -> None:
+    """Raw button activity should wake the screen without flashing the current view."""
+
+    app, _, _ = _build_app(playback_state="stopped")
+    app.display = FakeDisplay()
+    app.app_settings = SimpleNamespace(
+        ui=SimpleNamespace(screen_timeout_seconds=300),
+        display=SimpleNamespace(brightness=75, backlight_timeout_seconds=30),
+    )
+
+    app._screen_timeout_seconds = app._resolve_screen_timeout_seconds()
+    app._active_brightness = app._resolve_active_brightness()
+    app._configure_screen_power(initial_now=0.0)
+    app._sleep_screen(31.0)
+
+    assert app.context.screen_awake is False
+    render_calls_before = app.menu_screen.render_calls
+
+    _publish_from_worker(app, UserActivityEvent(action_name=None))
+
+    assert app.event_bus.drain() == 1
+    assert app.display.set_backlight_calls[-1] == 0.75
+    assert app.context.screen_awake is True
+    assert app.menu_screen.render_calls == render_calls_before
+
+
 def test_user_activity_event_wakes_sleeping_lvgl_screen_with_forced_refresh() -> None:
     """LVGL wake should explicitly refresh the active scene after backlight sleep."""
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Tests for portable audio/device configuration helpers."""
 
+import yaml
+
 from yoyopy.config.manager import ConfigManager
 from yoyopy.ui.display.adapters.whisplay_paths import find_whisplay_driver
 
@@ -49,3 +51,78 @@ def test_whisplay_driver_path_can_come_from_env(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("YOYOPOD_WHISPLAY_DRIVER", str(driver_dir))
 
     assert find_whisplay_driver() == driver_file
+
+
+def test_board_config_overlays_base_config(tmp_path, monkeypatch) -> None:
+    """Board overlays should override only the settings they redefine."""
+
+    (tmp_path / "yoyopod_config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "audio": {
+                    "music_dir": "/srv/common-music",
+                    "default_volume": 72,
+                },
+                "power": {
+                    "watchdog_i2c_bus": 1,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    board_dir = tmp_path / "boards" / "radxa-cubie-a7z"
+    board_dir.mkdir(parents=True)
+    (board_dir / "yoyopod_config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "audio": {
+                    "music_dir": "/home/radxa/Music",
+                },
+                "power": {
+                    "watchdog_i2c_bus": 7,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("YOYOPOD_CONFIG_BOARD", "radxa-cubie-a7z")
+
+    config_manager = ConfigManager(config_dir=str(tmp_path))
+
+    assert config_manager.config_board == "radxa-cubie-a7z"
+    assert config_manager.app_config_file == board_dir / "yoyopod_config.yaml"
+    assert config_manager.app_settings.audio.music_dir == "/home/radxa/Music"
+    assert config_manager.app_settings.audio.default_volume == 72
+    assert config_manager.app_settings.power.watchdog_i2c_bus == 7
+
+
+def test_missing_board_overlay_falls_back_to_base_config(tmp_path, monkeypatch) -> None:
+    """Unknown or missing board overlays should leave the base config in place."""
+
+    base_file = tmp_path / "yoyopod_config.yaml"
+    base_file.write_text(
+        yaml.safe_dump(
+            {
+                "audio": {
+                    "music_dir": "/srv/base-music",
+                },
+                "power": {
+                    "watchdog_i2c_bus": 1,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("YOYOPOD_CONFIG_BOARD", "radxa-cubie-a7z")
+
+    config_manager = ConfigManager(config_dir=str(tmp_path))
+
+    assert config_manager.app_config_file == base_file
+    assert config_manager.app_settings.audio.music_dir == "/srv/base-music"
+    assert config_manager.app_settings.power.watchdog_i2c_bus == 1

--- a/tests/test_whisplay_adapter.py
+++ b/tests/test_whisplay_adapter.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from PIL import Image
 
-from yoyopy.ui.display.adapters.whisplay import WhisplayDisplayAdapter
+from yoyopy.ui.display.adapters.whisplay import (
+    WhisplayDisplayAdapter,
+    _patch_vendor_gpiod_compat,
+)
 
 
 class FakeDevice:
@@ -22,6 +27,78 @@ class FakeDevice:
         pixel_data: bytes,
     ) -> None:
         self.draw_calls.append((x, y, width, height, pixel_data))
+
+
+def test_vendor_gpiod_compat_aliases_pypi_module_shapes() -> None:
+    """PyPI gpiod layouts should be normalized for the vendor driver."""
+
+    chip_calls: list[object] = []
+    request_calls: list[tuple[object, object]] = []
+
+    class FakeLineRequest:
+        DIRECTION_OUTPUT = 3
+        DIRECTION_INPUT = 2
+        FLAG_BIAS_DISABLE = 8
+
+        def __init__(self) -> None:
+            self.consumer = None
+            self.request_type = None
+            self.flags = None
+
+    class FakeLine:
+        def request(self, config: object, default_val: object = None) -> dict[str, object]:
+            request_calls.append((config, default_val))
+            return {"config": config, "default_val": default_val}
+
+    class FakeChip:
+        def get_line(self, offset: int) -> FakeLine:
+            assert offset == 7
+            return FakeLine()
+
+    fake_gpiod = SimpleNamespace(
+        chip=lambda path: chip_calls.append(path) or FakeChip(),
+        line_request=FakeLineRequest,
+    )
+    fake_module = SimpleNamespace(gpiod=fake_gpiod)
+
+    _patch_vendor_gpiod_compat(fake_module)
+
+    assert fake_gpiod.LINE_REQ_DIR_OUT == FakeLineRequest.DIRECTION_OUTPUT
+    assert fake_gpiod.LINE_REQ_DIR_IN == FakeLineRequest.DIRECTION_INPUT
+    assert fake_gpiod.LINE_REQ_FLAG_BIAS_DISABLE == FakeLineRequest.FLAG_BIAS_DISABLE
+    chip = fake_gpiod.Chip("gpiochip0")
+    result = chip.get_line(7).request(
+        consumer="whisplay",
+        type=fake_gpiod.LINE_REQ_DIR_OUT,
+        flags=fake_gpiod.LINE_REQ_FLAG_BIAS_DISABLE,
+        default_val=1,
+    )
+
+    assert result["default_val"] == 1
+    assert request_calls[0][0].consumer == "whisplay"
+    assert request_calls[0][0].request_type == FakeLineRequest.DIRECTION_OUTPUT
+    assert request_calls[0][0].flags == FakeLineRequest.FLAG_BIAS_DISABLE
+    assert chip_calls == ["/dev/gpiochip0"]
+
+
+def test_vendor_gpiod_compat_retries_existing_chip_with_dev_prefix() -> None:
+    """Legacy ``gpiod.Chip`` call sites should retry with ``/dev`` when needed."""
+
+    chip_calls: list[object] = []
+
+    def fake_chip(path: object) -> dict[str, object]:
+        chip_calls.append(path)
+        if path == "gpiochip1":
+            raise FileNotFoundError(path)
+        return {"path": path}
+
+    fake_gpiod = SimpleNamespace(Chip=fake_chip)
+    fake_module = SimpleNamespace(gpiod=fake_gpiod)
+
+    _patch_vendor_gpiod_compat(fake_module)
+
+    assert fake_gpiod.Chip("gpiochip1") == {"path": "/dev/gpiochip1"}
+    assert chip_calls == ["gpiochip1", "/dev/gpiochip1"]
 
 
 def test_hardware_lvgl_flush_skips_shadow_buffer_sync(monkeypatch) -> None:

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -1018,7 +1018,14 @@ class YoyoPodApp:
     def _handle_user_activity_event(self, event: UserActivityEvent) -> None:
         """Wake the display and reset the inactivity timer on user activity."""
         logger.debug(f"User activity received: {event.action_name or 'unknown'}")
-        self._mark_user_activity(now=time.monotonic(), render_on_wake=True)
+        # Raw physical activity (for example the first Whisplay button press before
+        # one-button gesture resolution) should wake the backlight without forcing
+        # an immediate redraw of the current screen. The semantic action render that
+        # follows should own the visible transition.
+        self._mark_user_activity(
+            now=time.monotonic(),
+            render_on_wake=event.action_name is not None,
+        )
 
     def _handle_recovery_attempt_completed_event(
         self,

--- a/yoyopy/config/manager.py
+++ b/yoyopy/config/manager.py
@@ -6,6 +6,7 @@ Manages typed app/VoIP settings and contacts from YAML configuration files.
 
 from __future__ import annotations
 
+import os
 import yaml
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,9 +17,21 @@ from loguru import logger
 from yoyopy.config.models import (
     VoIPFileConfig,
     YoyoPodConfig,
+    build_config_model,
     config_to_dict,
-    load_config_model_from_yaml,
 )
+
+
+def _deep_merge_mappings(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge one config mapping into another."""
+
+    merged = dict(base)
+    for key, value in overlay.items():
+        if isinstance(merged.get(key), dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_mappings(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
 
 
 @dataclass
@@ -48,11 +61,20 @@ class ConfigManager:
     Loads typed application and VoIP settings plus contacts from YAML files.
     """
 
-    def __init__(self, config_dir: str = "config") -> None:
+    def __init__(
+        self,
+        config_dir: str = "config",
+        config_board: str | None = None,
+    ) -> None:
         self.config_dir = Path(config_dir)
-        self.app_config_file = self.config_dir / "yoyopod_config.yaml"
-        self.voip_config_file = self.config_dir / "voip_config.yaml"
-        self.contacts_file = self.config_dir / "contacts.yaml"
+        self.config_board = self._resolve_config_board(explicit_board=config_board)
+        self.app_config_layers = self._resolve_config_layers("yoyopod_config.yaml")
+        self.voip_config_layers = self._resolve_config_layers("voip_config.yaml")
+        self.contacts_layers = self._resolve_config_layers("contacts.yaml")
+
+        self.app_config_file = self.app_config_layers[-1]
+        self.voip_config_file = self.voip_config_layers[-1]
+        self.contacts_file = self.contacts_layers[-1]
 
         self.app_settings = YoyoPodConfig()
         self.voip_settings = VoIPFileConfig()
@@ -65,7 +87,10 @@ class ConfigManager:
         self.voip_config_loaded = False
         self.contacts_loaded = False
 
-        logger.info(f"ConfigManager initialized (config_dir: {config_dir})")
+        logger.info(
+            "ConfigManager initialized "
+            f"(config_dir: {config_dir}, config_board: {self.config_board or 'default'})"
+        )
 
         self.load_app_config()
         self.load_voip_config()
@@ -79,15 +104,22 @@ class ConfigManager:
             True if loaded from file, False if defaults were used.
         """
 
-        self.app_config_loaded = self.app_config_file.exists()
+        self.app_config_loaded = any(path.exists() for path in self.app_config_layers)
         try:
-            self.app_settings = load_config_model_from_yaml(YoyoPodConfig, self.app_config_file)
+            data = self._load_yaml_layers(self.app_config_layers)
+            self.app_settings = build_config_model(YoyoPodConfig, data)
             self.app_config = config_to_dict(self.app_settings)
 
             if self.app_config_loaded:
-                logger.info("App configuration loaded successfully")
+                logger.info(
+                    "App configuration loaded successfully from "
+                    + ", ".join(str(path) for path in self.app_config_layers if path.exists())
+                )
             else:
-                logger.warning(f"App config file not found: {self.app_config_file}")
+                logger.warning(
+                    "App config file not found: "
+                    + ", ".join(str(path) for path in self.app_config_layers)
+                )
                 logger.info("Using default app configuration")
 
             logger.debug(f"Music directory: {self.app_settings.audio.music_dir}")
@@ -109,13 +141,17 @@ class ConfigManager:
             True if loaded from file, False if a default file was created.
         """
 
-        self.voip_config_loaded = self.voip_config_file.exists()
+        self.voip_config_loaded = any(path.exists() for path in self.voip_config_layers)
         if not self.voip_config_loaded:
-            logger.warning(f"VoIP config file not found: {self.voip_config_file}")
+            logger.warning(
+                "VoIP config file not found: "
+                + ", ".join(str(path) for path in self.voip_config_layers)
+            )
             self._create_default_voip_config()
 
         try:
-            self.voip_settings = load_config_model_from_yaml(VoIPFileConfig, self.voip_config_file)
+            data = self._load_yaml_layers(self.voip_config_layers)
+            self.voip_settings = build_config_model(VoIPFileConfig, data)
             self.voip_config = config_to_dict(self.voip_settings)
 
             logger.info("VoIP configuration loaded successfully")
@@ -136,15 +172,17 @@ class ConfigManager:
             True if loaded successfully, False otherwise.
         """
 
-        self.contacts_loaded = self.contacts_file.exists()
+        self.contacts_loaded = any(path.exists() for path in self.contacts_layers)
         if not self.contacts_loaded:
-            logger.warning(f"Contacts file not found: {self.contacts_file}")
+            logger.warning(
+                "Contacts file not found: "
+                + ", ".join(str(path) for path in self.contacts_layers)
+            )
             self._create_default_contacts()
             return False
 
         try:
-            with open(self.contacts_file, "r", encoding="utf-8") as handle:
-                data = yaml.safe_load(handle) or {}
+            data = self._load_yaml_layers(self.contacts_layers)
 
             self.contacts = [
                 Contact(
@@ -201,6 +239,7 @@ class ConfigManager:
         self.config_dir.mkdir(parents=True, exist_ok=True)
 
         default_config = config_to_dict(VoIPFileConfig())
+        self.voip_config_file.parent.mkdir(parents=True, exist_ok=True)
         with open(self.voip_config_file, "w", encoding="utf-8") as handle:
             yaml.dump(default_config, handle, default_flow_style=False, sort_keys=False)
 
@@ -218,10 +257,73 @@ class ConfigManager:
             "speed_dial": {},
         }
 
+        self.contacts_file.parent.mkdir(parents=True, exist_ok=True)
         with open(self.contacts_file, "w", encoding="utf-8") as handle:
             yaml.dump(default_contacts, handle, default_flow_style=False, sort_keys=False)
 
         self.load_contacts()
+
+    @classmethod
+    def _detect_config_board(cls) -> str | None:
+        """Return the known board config that matches the current hardware."""
+
+        model = cls._read_device_tree_text(Path("/proc/device-tree/model")).lower()
+        compatible = cls._read_device_tree_text(Path("/proc/device-tree/compatible")).lower()
+
+        if "cubie a7z" in model or "radxa,cubie-a7z" in compatible:
+            return "radxa-cubie-a7z"
+        if "raspberry pi zero 2" in model:
+            return "rpi-zero-2w"
+
+        return None
+
+    @staticmethod
+    def _read_device_tree_text(path: Path) -> str:
+        """Read one device-tree text node, tolerating missing files off-device."""
+
+        try:
+            return path.read_bytes().replace(b"\x00", b"\n").decode("utf-8", errors="ignore")
+        except OSError:
+            return ""
+
+    def _resolve_config_board(
+        self,
+        *,
+        explicit_board: str | None,
+    ) -> str | None:
+        """Resolve the active board config from args, env, or hardware detection."""
+
+        if explicit_board:
+            return explicit_board
+
+        env_board = os.getenv("YOYOPOD_CONFIG_BOARD", "").strip()
+        if env_board:
+            return env_board
+
+        return self._detect_config_board()
+
+    def _resolve_config_layers(self, filename: str) -> tuple[Path, ...]:
+        """Return the base config file plus any matching board overlay."""
+
+        layers = [self.config_dir / filename]
+        if self.config_board:
+            board_file = self.config_dir / "boards" / self.config_board / filename
+            if board_file.exists():
+                layers.append(board_file)
+        return tuple(layers)
+
+    def _load_yaml_layers(self, paths: tuple[Path, ...]) -> dict[str, Any]:
+        """Load and merge YAML mappings from lowest to highest precedence."""
+
+        merged: dict[str, Any] = {}
+        for path in paths:
+            if not path.exists():
+                continue
+            with open(path, "r", encoding="utf-8") as handle:
+                loaded = yaml.safe_load(handle) or {}
+            if isinstance(loaded, dict):
+                merged = _deep_merge_mappings(merged, loaded)
+        return merged
 
     def get_app_settings(self) -> YoyoPodConfig:
         """Return the typed application configuration model."""

--- a/yoyopy/ui/display/adapters/whisplay.py
+++ b/yoyopy/ui/display/adapters/whisplay.py
@@ -16,7 +16,9 @@ Author: YoyoPod Team
 Date: 2025-11-30
 """
 
+from importlib import import_module
 from pathlib import Path
+from types import ModuleType
 from typing import Optional, Tuple
 
 from loguru import logger
@@ -27,8 +29,90 @@ from yoyopy.ui.display.hal import DisplayHAL
 
 DRIVER_PATH = ensure_whisplay_driver_on_path()
 
+
+def _normalize_gpiochip_path(candidate: object) -> object:
+    """Normalize bare ``gpiochipN`` names to ``/dev/gpiochipN`` when needed."""
+
+    if isinstance(candidate, str) and candidate.startswith("gpiochip"):
+        return f"/dev/{candidate}"
+    return candidate
+
+
+def _patch_vendor_gpiod_compat(whisplay_module: ModuleType) -> None:
+    """Normalize the WhisPlay driver's expected gpiod API for Python 3.12 envs."""
+
+    gpiod = getattr(whisplay_module, "gpiod", None)
+    if gpiod is None or getattr(gpiod, "_yoyopod_whisplay_compat", False):
+        return
+
+    line_request = getattr(gpiod, "line_request", None)
+    if line_request is not None:
+        aliases = {
+            "LINE_REQ_DIR_OUT": "DIRECTION_OUTPUT",
+            "LINE_REQ_DIR_IN": "DIRECTION_INPUT",
+            "LINE_REQ_FLAG_BIAS_DISABLE": "FLAG_BIAS_DISABLE",
+        }
+        for alias, source_name in aliases.items():
+            if not hasattr(gpiod, alias) and hasattr(line_request, source_name):
+                setattr(gpiod, alias, getattr(line_request, source_name))
+
+    if hasattr(gpiod, "chip") and not hasattr(gpiod, "Chip"):
+
+        class _CompatLine:
+            def __init__(self, line: object) -> None:
+                self._line = line
+
+            def request(self, *args, **kwargs):
+                if kwargs:
+                    request_config = line_request()
+                    request_config.consumer = kwargs.pop("consumer", "")
+                    request_config.request_type = kwargs.pop("type")
+                    request_config.flags = kwargs.pop("flags", 0)
+                    default_val = kwargs.pop("default_val", 0)
+                    if kwargs:
+                        unexpected = ", ".join(sorted(kwargs))
+                        raise TypeError(f"Unexpected line.request kwargs: {unexpected}")
+                    return self._line.request(request_config, default_val)
+                return self._line.request(*args)
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self._line, name)
+
+        class _CompatChip:
+            def __init__(self, chip: object) -> None:
+                self._chip = chip
+
+            def get_line(self, offset: int) -> _CompatLine:
+                return _CompatLine(self._chip.get_line(offset))
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self._chip, name)
+
+        def _compat_chip(name: object):
+            return _CompatChip(gpiod.chip(_normalize_gpiochip_path(name)))
+
+        gpiod.Chip = _compat_chip
+    elif hasattr(gpiod, "Chip"):
+        original_chip = gpiod.Chip
+
+        def _compat_chip(name: object):
+            try:
+                return original_chip(name)
+            except FileNotFoundError:
+                normalized = _normalize_gpiochip_path(name)
+                if normalized == name:
+                    raise
+                return original_chip(normalized)
+
+        gpiod.Chip = _compat_chip
+
+    gpiod._yoyopod_whisplay_compat = True
+
+
 try:
-    from WhisPlay import WhisPlayBoard
+    _whisplay_driver = import_module("WhisPlay")
+    _patch_vendor_gpiod_compat(_whisplay_driver)
+    WhisPlayBoard = _whisplay_driver.WhisPlayBoard
 
     HAS_HARDWARE = True
 except ImportError:

--- a/yoyopy/voip/liblinphone_binding/native/liblinphone_shim.c
+++ b/yoyopy/voip/liblinphone_binding/native/liblinphone_shim.c
@@ -13,9 +13,31 @@
 #include <time.h>
 #include <unistd.h>
 
+#if defined(__has_include)
+#if __has_include(<linphone/api/c-account.h>)
+#define YOYOPY_HAS_LINPHONE_ACCOUNT_API 1
+#else
+#define YOYOPY_HAS_LINPHONE_ACCOUNT_API 0
+#endif
+#if __has_include(<linphone/api/c-recorder.h>)
+#define YOYOPY_HAS_LINPHONE_RECORDER_API 1
+#else
+#define YOYOPY_HAS_LINPHONE_RECORDER_API 0
+#endif
+#else
+#define YOYOPY_HAS_LINPHONE_ACCOUNT_API 1
+#define YOYOPY_HAS_LINPHONE_RECORDER_API 1
+#endif
+
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
 #include <linphone/api/c-account-cbs.h>
 #include <linphone/api/c-account-params.h>
 #include <linphone/api/c-account.h>
+#else
+#include <linphone/callbacks.h>
+#include <linphone/sipsetup.h>
+#include <linphone/proxy_config.h>
+#endif
 #include <linphone/api/c-address.h>
 #include <linphone/api/c-auth-info.h>
 #include <linphone/api/c-call.h>
@@ -25,11 +47,25 @@
 #include <linphone/api/c-chat-room-cbs.h>
 #include <linphone/api/c-chat-room-params.h>
 #include <linphone/api/c-content.h>
+#if defined(__has_include) && __has_include(<linphone/api/c-event.h>)
 #include <linphone/api/c-event.h>
+#else
+#include <linphone/event.h>
+#endif
 #include <linphone/api/c-event-log.h>
+#if defined(__has_include) && __has_include(<linphone/api/c-factory.h>)
 #include <linphone/api/c-factory.h>
+#else
+#include <linphone/factory.h>
+#endif
+#if defined(__has_include) && __has_include(<linphone/api/c-nat-policy.h>)
 #include <linphone/api/c-nat-policy.h>
+#else
+#include <linphone/nat_policy.h>
+#endif
+#if YOYOPY_HAS_LINPHONE_RECORDER_API
 #include <linphone/api/c-recorder.h>
+#endif
 #include <bctoolbox/list.h>
 #include <linphone/buffer.h>
 #include <linphone/core.h>
@@ -94,22 +130,39 @@ enum {
     YOYOPY_MESSAGE_DELIVERY_FAILED = 5
 };
 
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+typedef LinphoneAccount yoyopy_linphone_account_t;
+typedef LinphoneAccountCbs yoyopy_linphone_account_cbs_t;
+#else
+typedef LinphoneProxyConfig yoyopy_linphone_account_t;
+typedef void yoyopy_linphone_account_cbs_t;
+#endif
+
+#if YOYOPY_HAS_LINPHONE_RECORDER_API
+typedef LinphoneRecorder yoyopy_linphone_recorder_t;
+#else
+typedef void yoyopy_linphone_recorder_t;
+#endif
+
 typedef struct {
     bool initialized;
     bool started;
     LinphoneFactory *factory;
     LinphoneCore *core;
-    LinphoneAccount *account;
-    LinphoneAccountCbs *account_cbs;
+    yoyopy_linphone_account_t *account;
+    yoyopy_linphone_account_cbs_t *account_cbs;
     LinphoneCoreCbs *core_cbs;
     LinphoneChatMessageCbs *message_cbs;
     LinphoneChatRoomCbs *chat_room_cbs;
     LinphoneCall *current_call;
-    LinphoneRecorder *current_recorder;
+    yoyopy_linphone_recorder_t *current_recorder;
     bool recorder_running;
     bool auto_download_incoming_voice_recordings;
     char voice_note_store_dir[512];
     char current_recording_path[512];
+    char configured_conference_factory_uri[256];
+    char configured_file_transfer_server_url[256];
+    char configured_lime_server_url[256];
     LinphoneChatRoom *attached_chat_rooms[64];
     size_t attached_chat_room_count;
     pthread_mutex_t queue_lock;
@@ -130,6 +183,15 @@ static void yoyopy_build_chat_room_peer(
 );
 
 static void yoyopy_build_specs_string(char *buffer, size_t buffer_size);
+static const char *yoyopy_chat_message_text(const LinphoneChatMessage *message);
+static int yoyopy_chat_room_is_read_only_compat(const LinphoneChatRoom *chat_room);
+static int yoyopy_chat_room_params_ephemeral_mode_compat(const LinphoneChatRoomParams *params);
+static long yoyopy_chat_room_params_ephemeral_lifetime_compat(const LinphoneChatRoomParams *params);
+static const LinphoneAddress *yoyopy_event_to_address(const LinphoneEvent *linphone_event);
+static LinphoneChatMessage *yoyopy_chat_room_create_text_message(
+    LinphoneChatRoom *chat_room,
+    const char *text
+);
 
 static void yoyopy_set_error(const char *format, ...) {
     va_list args;
@@ -441,7 +503,7 @@ static void yoyopy_extract_voice_note_payload_mime(
         return;
     }
 
-    text = linphone_chat_message_get_utf8_text(message);
+    text = yoyopy_chat_message_text(message);
     if (!yoyopy_extract_xml_tag_value(
             text,
             "<content-type>",
@@ -460,7 +522,7 @@ static void yoyopy_extract_voice_note_payload_mime(
 
 static int yoyopy_extract_voice_note_duration_ms(LinphoneChatMessage *message) {
     char value[64];
-    const char *text = linphone_chat_message_get_utf8_text(message);
+    const char *text = yoyopy_chat_message_text(message);
     if (
         !yoyopy_extract_xml_tag_value(
             text,
@@ -482,7 +544,7 @@ static void yoyopy_extract_voice_note_extension(
     size_t buffer_size
 ) {
     char file_name[256];
-    const char *text = linphone_chat_message_get_utf8_text(message);
+    const char *text = yoyopy_chat_message_text(message);
     const char *dot;
 
     if (buffer_size == 0) {
@@ -528,7 +590,7 @@ static int yoyopy_is_voice_note_message(LinphoneChatMessage *message) {
     if (!yoyopy_is_file_transfer_xml_content(content)) {
         return 0;
     }
-    text = linphone_chat_message_get_utf8_text(message);
+    text = yoyopy_chat_message_text(message);
     return yoyopy_is_voice_note_xml_text(text);
 }
 
@@ -625,7 +687,7 @@ static void yoyopy_fill_message_event_common(
     yoyopy_copy_string(
         event_value->text,
         sizeof(event_value->text),
-        linphone_chat_message_get_utf8_text(message)
+        yoyopy_chat_message_text(message)
     );
     voice_note_mime[0] = '\0';
     if (event_value->message_kind == YOYOPY_MESSAGE_KIND_VOICE_NOTE) {
@@ -693,6 +755,165 @@ static size_t yoyopy_list_size(const bctbx_list_t *list) {
     return count;
 }
 
+static const char *yoyopy_chat_message_text(const LinphoneChatMessage *message) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    return linphone_chat_message_get_utf8_text(message);
+#else
+    return linphone_chat_message_get_text(message);
+#endif
+}
+
+static int yoyopy_chat_room_is_read_only_compat(const LinphoneChatRoom *chat_room) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    return chat_room != NULL && linphone_chat_room_is_read_only(chat_room) ? 1 : 0;
+#else
+    (void)chat_room;
+    return 0;
+#endif
+}
+
+static int yoyopy_chat_room_params_ephemeral_mode_compat(const LinphoneChatRoomParams *params) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    return params != NULL ? (int)linphone_chat_room_params_get_ephemeral_mode(params) : 0;
+#else
+    (void)params;
+    return 0;
+#endif
+}
+
+static long yoyopy_chat_room_params_ephemeral_lifetime_compat(const LinphoneChatRoomParams *params) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    return params != NULL ? linphone_chat_room_params_get_ephemeral_lifetime(params) : 0L;
+#else
+    (void)params;
+    return 0L;
+#endif
+}
+
+static const LinphoneAddress *yoyopy_event_to_address(const LinphoneEvent *linphone_event) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    return linphone_event_get_to(linphone_event);
+#else
+    (void)linphone_event;
+    return NULL;
+#endif
+}
+
+static LinphoneChatMessage *yoyopy_chat_room_create_text_message(
+    LinphoneChatRoom *chat_room,
+    const char *text
+) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    return linphone_chat_room_create_message_from_utf8(chat_room, text);
+#else
+    return linphone_chat_room_create_message(chat_room, text);
+#endif
+}
+
+static const LinphoneAddress *yoyopy_account_identity_address(void) {
+    if (g_state.account == NULL) {
+        return NULL;
+    }
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    {
+        const LinphoneAccountParams *params = linphone_account_get_params(g_state.account);
+        return params != NULL ? linphone_account_params_get_identity_address(params) : NULL;
+    }
+#else
+    return linphone_proxy_config_get_identity_address(g_state.account);
+#endif
+}
+
+static const char *yoyopy_account_file_transfer_server(void) {
+    if (g_state.account == NULL) {
+        return yoyopy_safe_string(g_state.configured_file_transfer_server_url);
+    }
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    {
+        const LinphoneAccountParams *params = linphone_account_get_params(g_state.account);
+        return params != NULL
+               ? yoyopy_safe_string(linphone_account_params_get_file_transfer_server(params))
+               : yoyopy_safe_string(g_state.configured_file_transfer_server_url);
+    }
+#else
+    return yoyopy_safe_string(g_state.configured_file_transfer_server_url);
+#endif
+}
+
+static const char *yoyopy_account_lime_server_url(void) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    if (g_state.account != NULL) {
+        const LinphoneAccountParams *params = linphone_account_get_params(g_state.account);
+        if (params != NULL) {
+            return yoyopy_safe_string(linphone_account_params_get_lime_server_url(params));
+        }
+    }
+#endif
+    return yoyopy_safe_string(g_state.configured_lime_server_url);
+}
+
+static int yoyopy_account_cpim_enabled(void) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    if (g_state.account != NULL) {
+        const LinphoneAccountParams *params = linphone_account_get_params(g_state.account);
+        return params != NULL && linphone_account_params_cpim_in_basic_chat_room_enabled(params)
+               ? 1
+               : 0;
+    }
+#endif
+    return 0;
+}
+
+static size_t yoyopy_account_room_count(void) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    if (g_state.account != NULL) {
+        bctbx_list_t *rooms = linphone_account_get_chat_rooms(g_state.account);
+        size_t count = yoyopy_list_size(rooms);
+        if (rooms != NULL) {
+            bctbx_list_free(rooms);
+        }
+        return count;
+    }
+#endif
+    return 0U;
+}
+
+static int yoyopy_account_unread_count(void) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    if (g_state.account != NULL) {
+        return linphone_account_get_unread_chat_message_count(g_state.account);
+    }
+#endif
+    return 0;
+}
+
+static void yoyopy_build_account_conference_factory_uri(char *buffer, size_t buffer_size) {
+    if (buffer_size == 0) {
+        return;
+    }
+    buffer[0] = '\0';
+    if (g_state.account == NULL) {
+        yoyopy_copy_string(buffer, buffer_size, g_state.configured_conference_factory_uri);
+        return;
+    }
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    {
+        const LinphoneAccountParams *params = linphone_account_get_params(g_state.account);
+        const LinphoneAddress *conference_factory_address = NULL;
+        if (params != NULL) {
+            conference_factory_address = linphone_account_params_get_conference_factory_address(params);
+        }
+        yoyopy_build_address_uri(conference_factory_address, buffer, buffer_size);
+    }
+#else
+    yoyopy_copy_string(
+        buffer,
+        buffer_size,
+        linphone_proxy_config_get_conference_factory_uri(g_state.account)
+    );
+#endif
+}
+
 static void yoyopy_log_room_snapshot(LinphoneChatRoom *chat_room, const char *phase) {
     const LinphoneChatRoomParams *room_params = NULL;
     char peer[256];
@@ -711,17 +932,14 @@ static void yoyopy_log_room_snapshot(LinphoneChatRoom *chat_room, const char *ph
         room_params != NULL ? (int)linphone_chat_room_params_get_encryption_backend(room_params) : -1,
         room_params != NULL && linphone_chat_room_params_group_enabled(room_params) ? 1 : 0,
         room_params != NULL && linphone_chat_room_params_encryption_enabled(room_params) ? 1 : 0,
-        (chat_room != NULL && linphone_chat_room_is_read_only(chat_room)) ? 1 : 0,
+        yoyopy_chat_room_is_read_only_compat(chat_room),
         chat_room != NULL ? linphone_chat_room_get_nb_participants(chat_room) : -1
     );
 }
 
 static void yoyopy_log_account_diagnostics(const char *phase) {
-    const LinphoneAccountParams *params;
     const bctbx_list_t *core_rooms;
-    bctbx_list_t *account_rooms;
     LinphoneChatRoomParams *default_params;
-    const LinphoneAddress *conference_factory_address = NULL;
     const char *file_transfer_server = "";
     const char *lime_server = "";
     char core_specs[256];
@@ -734,35 +952,23 @@ static void yoyopy_log_account_diagnostics(const char *phase) {
         return;
     }
 
-    params = linphone_account_get_params(g_state.account);
-    conference_factory_uri[0] = '\0';
-    if (params != NULL) {
-        conference_factory_address = linphone_account_params_get_conference_factory_address(params);
-        yoyopy_build_address_uri(
-            conference_factory_address,
-            conference_factory_uri,
-            sizeof(conference_factory_uri)
-        );
-        file_transfer_server = yoyopy_safe_string(
-            linphone_account_params_get_file_transfer_server(params)
-        );
-        lime_server = yoyopy_safe_string(
-            linphone_account_params_get_lime_server_url(params)
-        );
-    }
-
     core_rooms = linphone_core_get_chat_rooms(g_state.core);
-    account_rooms = linphone_account_get_chat_rooms(g_state.account);
     core_room_count = yoyopy_list_size(core_rooms);
-    account_room_count = yoyopy_list_size(account_rooms);
+    account_room_count = yoyopy_account_room_count();
+    yoyopy_build_account_conference_factory_uri(
+        conference_factory_uri,
+        sizeof(conference_factory_uri)
+    );
+    file_transfer_server = yoyopy_account_file_transfer_server();
+    lime_server = yoyopy_account_lime_server_url();
 
     yoyopy_debug_log(
         "diag[%s] account unread=%d core_rooms=%llu account_rooms=%llu cpim_basic=%d conference_factory=%s file_transfer=%s lime=%s",
         phase,
-        linphone_account_get_unread_chat_message_count(g_state.account),
+        yoyopy_account_unread_count(),
         (unsigned long long)core_room_count,
         (unsigned long long)account_room_count,
-        params != NULL && linphone_account_params_cpim_in_basic_chat_room_enabled(params) ? 1 : 0,
+        yoyopy_account_cpim_enabled(),
         conference_factory_uri,
         file_transfer_server,
         lime_server
@@ -780,8 +986,8 @@ static void yoyopy_log_account_diagnostics(const char *phase) {
             linphone_chat_room_params_group_enabled(default_params) ? 1 : 0,
             linphone_chat_room_params_encryption_enabled(default_params) ? 1 : 0,
             linphone_chat_room_params_rtt_enabled(default_params) ? 1 : 0,
-            (int)linphone_chat_room_params_get_ephemeral_mode(default_params),
-            linphone_chat_room_params_get_ephemeral_lifetime(default_params)
+            yoyopy_chat_room_params_ephemeral_mode_compat(default_params),
+            yoyopy_chat_room_params_ephemeral_lifetime_compat(default_params)
         );
         linphone_chat_room_params_unref(default_params);
     }
@@ -791,10 +997,6 @@ static void yoyopy_log_account_diagnostics(const char *phase) {
         LinphoneChatRoom *chat_room = (LinphoneChatRoom *)bctbx_list_get_data(item);
         yoyopy_log_room_snapshot(chat_room, phase);
         item = item->next;
-    }
-
-    if (account_rooms != NULL) {
-        bctbx_list_free(account_rooms);
     }
 }
 
@@ -1063,12 +1265,23 @@ static void yoyopy_queue_download_completed_event(LinphoneChatMessage *message) 
     yoyopy_enqueue_event(&event_value);
 }
 
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
 static void yoyopy_on_registration_state_changed(
     LinphoneAccount *account,
     LinphoneRegistrationState state,
     const char *message
 ) {
     (void)account;
+#else
+static void yoyopy_on_registration_state_changed(
+    LinphoneCore *core,
+    LinphoneProxyConfig *proxy_config,
+    LinphoneRegistrationState state,
+    const char *message
+) {
+    (void)core;
+    (void)proxy_config;
+#endif
     yoyopy_queue_registration_event(state, message);
     if (state == LinphoneRegistrationOk) {
         yoyopy_log_account_diagnostics("registration_ok");
@@ -1200,7 +1413,7 @@ static void yoyopy_attach_chat_room_callbacks(LinphoneChatRoom *chat_room) {
         "attached chat_room callbacks peer=%s state=%d read_only=%d",
         peer,
         (int)linphone_chat_room_get_state(chat_room),
-        linphone_chat_room_is_read_only(chat_room) ? 1 : 0
+        yoyopy_chat_room_is_read_only_compat(chat_room)
     );
 }
 
@@ -1221,7 +1434,6 @@ static void yoyopy_attach_all_chat_room_callbacks(void) {
 
 static LinphoneChatRoomParams *yoyopy_create_preferred_chat_room_params(void) {
     LinphoneChatRoomParams *params;
-    const LinphoneAccountParams *account_params;
     const char *file_transfer_server = "";
     const char *lime_server = "";
 
@@ -1237,19 +1449,14 @@ static LinphoneChatRoomParams *yoyopy_create_preferred_chat_room_params(void) {
     linphone_chat_room_params_enable_group(params, FALSE);
     linphone_chat_room_params_enable_rtt(params, FALSE);
 
-    account_params = g_state.account != NULL ? linphone_account_get_params(g_state.account) : NULL;
-    if (account_params != NULL) {
-        file_transfer_server = yoyopy_safe_string(
-            linphone_account_params_get_file_transfer_server(account_params)
-        );
-        lime_server = yoyopy_safe_string(
-            linphone_account_params_get_lime_server_url(account_params)
-        );
-    }
+    file_transfer_server = yoyopy_account_file_transfer_server();
+    lime_server = yoyopy_account_lime_server_url();
 
     if (file_transfer_server[0] != '\0' || lime_server[0] != '\0') {
         linphone_chat_room_params_set_backend(params, LinphoneChatRoomBackendFlexisipChat);
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
         linphone_chat_room_params_set_subject(params, "YoyoPod");
+#endif
     }
     if (lime_server[0] != '\0') {
         linphone_chat_room_params_set_encryption_backend(params, LinphoneChatRoomEncryptionBackendLime);
@@ -1279,29 +1486,24 @@ static LinphoneChatRoomParams *yoyopy_create_direct_chat_room_params(void) {
 }
 
 static int yoyopy_should_prefer_hosted_chat_rooms(void) {
-    const LinphoneAccountParams *account_params;
     const char *file_transfer_server = "";
-    const char *lime_server = "";
-    const LinphoneAddress *conference_factory_address = NULL;
+    const char *lime_server = yoyopy_account_lime_server_url();
+    char conference_factory_uri[256];
 
     if (g_state.account == NULL) {
         return 0;
     }
 
-    account_params = linphone_account_get_params(g_state.account);
-    if (account_params == NULL) {
-        return 0;
-    }
-
-    conference_factory_address = linphone_account_params_get_conference_factory_address(account_params);
-    file_transfer_server = yoyopy_safe_string(
-        linphone_account_params_get_file_transfer_server(account_params)
+    conference_factory_uri[0] = '\0';
+    yoyopy_build_account_conference_factory_uri(
+        conference_factory_uri,
+        sizeof(conference_factory_uri)
     );
-    lime_server = yoyopy_safe_string(
-        linphone_account_params_get_lime_server_url(account_params)
-    );
+    file_transfer_server = yoyopy_account_file_transfer_server();
 
-    return conference_factory_address != NULL || file_transfer_server[0] != '\0' || lime_server[0] != '\0';
+    return conference_factory_uri[0] != '\0'
+           || file_transfer_server[0] != '\0'
+           || lime_server[0] != '\0';
 }
 
 static void yoyopy_prune_stale_basic_chat_rooms(void) {
@@ -1405,7 +1607,7 @@ static void yoyopy_on_subscription_state_changed(
 
     error_info = linphone_event_get_error_info(linphone_event);
     yoyopy_build_address_uri(linphone_event_get_from(linphone_event), from, sizeof(from));
-    yoyopy_build_address_uri(linphone_event_get_to(linphone_event), to, sizeof(to));
+    yoyopy_build_address_uri(yoyopy_event_to_address(linphone_event), to, sizeof(to));
     yoyopy_build_address_uri(linphone_event_get_resource(linphone_event), resource, sizeof(resource));
     yoyopy_debug_log(
         "subscription_state_changed name=%s state=%s reason=%s protocol_code=%d phrase=%s from=%s to=%s resource=%s",
@@ -1443,11 +1645,31 @@ static int yoyopy_configure_account(
 ) {
     LinphoneAddress *server_address = NULL;
     LinphoneAddress *identity_address = NULL;
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
     LinphoneAddress *conference_factory_address = NULL;
     LinphoneAccountParams *params = NULL;
     LinphoneAccount *account = NULL;
+#else
+    LinphoneProxyConfig *account = NULL;
+#endif
     LinphoneAuthInfo *auth_info = NULL;
     char server_uri[256];
+
+    yoyopy_copy_string(
+        g_state.configured_conference_factory_uri,
+        sizeof(g_state.configured_conference_factory_uri),
+        conference_factory_uri
+    );
+    yoyopy_copy_string(
+        g_state.configured_file_transfer_server_url,
+        sizeof(g_state.configured_file_transfer_server_url),
+        file_transfer_server_url
+    );
+    yoyopy_copy_string(
+        g_state.configured_lime_server_url,
+        sizeof(g_state.configured_lime_server_url),
+        lime_server_url
+    );
 
     snprintf(
         server_uri,
@@ -1457,6 +1679,7 @@ static int yoyopy_configure_account(
         transport != NULL && transport[0] != '\0' ? transport : "tcp"
     );
 
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
     params = linphone_core_create_account_params(g_state.core);
     if (params == NULL) {
         yoyopy_set_error("Failed to create Linphone account params");
@@ -1570,9 +1793,78 @@ fail:
         linphone_account_params_unref(params);
     }
     return -1;
+#else
+    account = linphone_core_create_proxy_config(g_state.core);
+    if (account == NULL) {
+        yoyopy_set_error("Failed to create Linphone proxy config");
+        return -1;
+    }
+
+    identity_address = linphone_factory_create_address(g_state.factory, sip_identity);
+    if (identity_address == NULL) {
+        yoyopy_set_error("Failed to create Linphone identity address");
+        goto fail;
+    }
+
+    if (linphone_proxy_config_set_server_addr(account, server_uri) != 0) {
+        yoyopy_set_error("Failed to set Linphone proxy server address");
+        goto fail;
+    }
+    if (linphone_proxy_config_set_identity_address(account, identity_address) != 0) {
+        yoyopy_set_error("Failed to set Linphone proxy identity address");
+        goto fail;
+    }
+    linphone_proxy_config_enable_register(account, TRUE);
+    if (conference_factory_uri != NULL && conference_factory_uri[0] != '\0') {
+        linphone_proxy_config_set_conference_factory_uri(account, conference_factory_uri);
+    }
+    if (file_transfer_server_url != NULL && file_transfer_server_url[0] != '\0') {
+        linphone_core_set_file_transfer_server(g_state.core, file_transfer_server_url);
+    }
+    if (lime_server_url != NULL && lime_server_url[0] != '\0') {
+        linphone_core_enable_lime_x3dh(g_state.core, TRUE);
+    } else {
+        linphone_core_enable_lime_x3dh(g_state.core, FALSE);
+    }
+
+    auth_info = linphone_factory_create_auth_info_2(
+        g_state.factory,
+        sip_username,
+        sip_username,
+        (sip_password != NULL && sip_password[0] != '\0') ? sip_password : NULL,
+        (sip_password_ha1 != NULL && sip_password_ha1[0] != '\0') ? sip_password_ha1 : NULL,
+        sip_server,
+        sip_server,
+        "SHA-256"
+    );
+    if (auth_info != NULL) {
+        linphone_core_add_auth_info(g_state.core, auth_info);
+        linphone_auth_info_unref(auth_info);
+    }
+
+    if (linphone_core_add_proxy_config(g_state.core, account) != 0) {
+        yoyopy_set_error("Failed to add Linphone proxy config to core");
+        goto fail;
+    }
+    linphone_core_set_default_proxy_config(g_state.core, account);
+    g_state.account = account;
+
+    linphone_address_unref(identity_address);
+    return 0;
+
+fail:
+    if (identity_address != NULL) {
+        linphone_address_unref(identity_address);
+    }
+    if (account != NULL) {
+        linphone_proxy_config_unref(account);
+    }
+    return -1;
+#endif
 }
 
 static void yoyopy_cleanup_recorder(void) {
+#if YOYOPY_HAS_LINPHONE_RECORDER_API
     if (g_state.current_recorder != NULL) {
         if (g_state.recorder_running) {
             linphone_recorder_pause(g_state.current_recorder);
@@ -1581,6 +1873,9 @@ static void yoyopy_cleanup_recorder(void) {
         linphone_recorder_unref(g_state.current_recorder);
         g_state.current_recorder = NULL;
     }
+#else
+    g_state.current_recorder = NULL;
+#endif
     g_state.recorder_running = false;
     g_state.current_recording_path[0] = '\0';
 }
@@ -1695,7 +1990,9 @@ int yoyopy_liblinphone_start(
 
     linphone_chat_message_cbs_set_msg_state_changed(g_state.message_cbs, yoyopy_on_message_state_changed);
     linphone_chat_room_cbs_set_message_received(g_state.chat_room_cbs, yoyopy_on_chat_room_message_received);
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
     linphone_chat_room_cbs_set_messages_received(g_state.chat_room_cbs, yoyopy_on_chat_room_messages_received);
+#endif
     linphone_chat_room_cbs_set_chat_message_received(
         g_state.chat_room_cbs,
         yoyopy_on_chat_room_chat_message_received
@@ -1705,11 +2002,19 @@ int yoyopy_liblinphone_start(
         yoyopy_on_chat_room_undecryptable_message_received
     );
     linphone_core_cbs_set_call_state_changed(g_state.core_cbs, yoyopy_on_call_state_changed);
+#if !YOYOPY_HAS_LINPHONE_ACCOUNT_API
+    linphone_core_cbs_set_registration_state_changed(
+        g_state.core_cbs,
+        yoyopy_on_registration_state_changed
+    );
+#endif
     linphone_core_cbs_set_subscription_state_changed(
         g_state.core_cbs,
         yoyopy_on_subscription_state_changed
     );
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
     linphone_core_cbs_set_messages_received(g_state.core_cbs, yoyopy_on_messages_received);
+#endif
     linphone_core_cbs_set_message_received(g_state.core_cbs, yoyopy_on_message_received);
     linphone_core_cbs_set_message_received_unable_decrypt(
         g_state.core_cbs,
@@ -1727,7 +2032,9 @@ int yoyopy_liblinphone_start(
     }
     yoyopy_ensure_core_spec("conference/2.0");
     linphone_core_enable_echo_cancellation(g_state.core, echo_cancellation != 0);
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
     linphone_core_set_chat_messages_aggregation_enabled(g_state.core, FALSE);
+#endif
     linphone_core_set_mic_gain_db(g_state.core, ((float)mic_gain * 0.3f));
     linphone_core_set_playback_gain_db(g_state.core, ((float)output_volume * 0.12f) - 6.0f);
     if (yoyopy_configure_media_policy(g_state.core, g_state.factory) != 0) {
@@ -1748,7 +2055,9 @@ int yoyopy_liblinphone_start(
     if (file_transfer_server_url != NULL && file_transfer_server_url[0] != '\0') {
         linphone_core_set_file_transfer_server(g_state.core, file_transfer_server_url);
     }
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
     linphone_core_enable_auto_download_voice_recordings(g_state.core, FALSE);
+#endif
 
     if (
         yoyopy_configure_account(
@@ -1789,10 +2098,14 @@ void yoyopy_liblinphone_stop(void) {
     yoyopy_cleanup_recorder();
     g_state.current_call = NULL;
 
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
     if (g_state.account_cbs != NULL) {
         linphone_account_cbs_unref(g_state.account_cbs);
         g_state.account_cbs = NULL;
     }
+#else
+    g_state.account_cbs = NULL;
+#endif
     if (g_state.message_cbs != NULL) {
         linphone_chat_message_cbs_unref(g_state.message_cbs);
         g_state.message_cbs = NULL;
@@ -1806,7 +2119,15 @@ void yoyopy_liblinphone_stop(void) {
         g_state.core_cbs = NULL;
     }
     if (g_state.account != NULL) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
         linphone_account_unref(g_state.account);
+#else
+        if (g_state.core != NULL) {
+            linphone_core_remove_proxy_config(g_state.core, g_state.account);
+        } else {
+            linphone_proxy_config_unref(g_state.account);
+        }
+#endif
         g_state.account = NULL;
     }
     if (g_state.core != NULL) {
@@ -1924,8 +2245,6 @@ static LinphoneChatRoom *yoyopy_get_chat_room_for_params(
     LinphoneChatRoom *chat_room = NULL;
     LinphoneAddress *remote_address = NULL;
     const LinphoneAddress *local_address = NULL;
-    const LinphoneAccountParams *account_params = NULL;
-    bctbx_list_t *participants = NULL;
 
     if (!g_state.started || g_state.core == NULL) {
         if (params != NULL) {
@@ -1935,10 +2254,11 @@ static LinphoneChatRoom *yoyopy_get_chat_room_for_params(
     }
 
     remote_address = linphone_factory_create_address(g_state.factory, sip_address);
-    account_params = g_state.account != NULL ? linphone_account_get_params(g_state.account) : NULL;
-    local_address = account_params != NULL ? linphone_account_params_get_identity_address(account_params) : NULL;
+    local_address = yoyopy_account_identity_address();
 
     if (params != NULL && remote_address != NULL) {
+#if YOYOPY_HAS_LINPHONE_ACCOUNT_API
+        bctbx_list_t *participants = NULL;
         chat_room = linphone_core_search_chat_room(
             g_state.core,
             params,
@@ -1955,6 +2275,27 @@ static LinphoneChatRoom *yoyopy_get_chat_room_for_params(
                 participants
             );
         }
+        if (participants != NULL) {
+            bctbx_list_free(participants);
+        }
+#else
+        chat_room = linphone_core_find_chat_room(g_state.core, remote_address, local_address);
+        if (chat_room == NULL && local_address != NULL) {
+            chat_room = linphone_core_create_chat_room_4(
+                g_state.core,
+                params,
+                local_address,
+                remote_address
+            );
+        }
+        if (chat_room == NULL && local_address != NULL) {
+            chat_room = linphone_core_get_chat_room_2(
+                g_state.core,
+                remote_address,
+                local_address
+            );
+        }
+#endif
     }
 
     if (chat_room == NULL) {
@@ -1966,9 +2307,6 @@ static LinphoneChatRoom *yoyopy_get_chat_room_for_params(
         yoyopy_log_room_snapshot(chat_room, phase != NULL ? phase : "lookup");
     }
 
-    if (participants != NULL) {
-        bctbx_list_free(participants);
-    }
     if (remote_address != NULL) {
         linphone_address_unref(remote_address);
     }
@@ -2026,7 +2364,7 @@ int yoyopy_liblinphone_send_text_message(
         return -1;
     }
 
-    message = linphone_chat_room_create_message_from_utf8(chat_room, text);
+    message = yoyopy_chat_room_create_text_message(chat_room, text);
     if (message == NULL) {
         yoyopy_set_error("Liblinphone failed to create a text chat message");
         return -1;
@@ -2039,6 +2377,7 @@ int yoyopy_liblinphone_send_text_message(
 }
 
 int yoyopy_liblinphone_start_voice_recording(const char *file_path) {
+#if YOYOPY_HAS_LINPHONE_RECORDER_API
     LinphoneRecorderParams *params;
     if (!g_state.started || g_state.core == NULL || file_path == NULL || file_path[0] == '\0') {
         yoyopy_set_error("Liblinphone voice-note recording requires an active core and target path");
@@ -2075,9 +2414,15 @@ int yoyopy_liblinphone_start_voice_recording(const char *file_path) {
 
     g_state.recorder_running = true;
     return 0;
+#else
+    (void)file_path;
+    yoyopy_set_error("Installed Liblinphone build does not support recorder-based voice notes");
+    return -1;
+#endif
 }
 
 int yoyopy_liblinphone_stop_voice_recording(int32_t *duration_ms_out) {
+#if YOYOPY_HAS_LINPHONE_RECORDER_API
     int duration_ms;
     if (!g_state.started || g_state.current_recorder == NULL || !g_state.recorder_running) {
         yoyopy_set_error("No active Liblinphone voice-note recording is running");
@@ -2092,6 +2437,11 @@ int yoyopy_liblinphone_stop_voice_recording(int32_t *duration_ms_out) {
         *duration_ms_out = duration_ms;
     }
     return 0;
+#else
+    (void)duration_ms_out;
+    yoyopy_set_error("Installed Liblinphone build does not support recorder-based voice notes");
+    return -1;
+#endif
 }
 
 int yoyopy_liblinphone_cancel_voice_recording(void) {
@@ -2110,6 +2460,7 @@ int yoyopy_liblinphone_send_voice_note(
     char *message_id_out,
     uint32_t message_id_out_size
 ) {
+#if YOYOPY_HAS_LINPHONE_RECORDER_API
     LinphoneChatRoom *chat_room;
     LinphoneChatMessage *message;
 
@@ -2149,6 +2500,16 @@ int yoyopy_liblinphone_send_voice_note(
     yoyopy_fill_message_id_out(message, message_id_out, message_id_out_size);
     linphone_chat_message_send(message);
     return 0;
+#else
+    (void)sip_address;
+    (void)file_path;
+    (void)duration_ms;
+    (void)mime_type;
+    (void)message_id_out;
+    (void)message_id_out_size;
+    yoyopy_set_error("Installed Liblinphone build does not support recorder-based voice notes");
+    return -1;
+#endif
 }
 
 const char *yoyopy_liblinphone_last_error(void) {


### PR DESCRIPTION
## What changed
- add tracked board-specific config overlays for `rpi-zero-2w` and `radxa-cubie-a7z`
- teach `ConfigManager` to auto-detect known hardware and layer `config/boards/<board>/...` over the shared base config
- rename the explicit override env var to `YOYOPOD_CONFIG_BOARD`
- remove the old `YOYOPOD_CONFIG_PROFILE` fallback entirely
- document the board-aware config flow and PiSugar watchdog bus differences

## Why
The Cubie A7Z needs different hardware defaults from the Pi Zero 2W, especially for PiSugar watchdog I2C wiring and board-local paths. This change lets the same repo switch cleanly between both boards without hand-editing tracked config.

## Validation
- `uv run pytest -q tests/test_config_manager.py tests/test_config_models.py`
- `python -m compileall yoyopy/config tests/test_config_manager.py`
- deployed the current branch working tree to the Cubie with `uv run yoyoctl remote rsync --skip-restart`
- verified on the Cubie that:
  - `ConfigManager` auto-selects `radxa-cubie-a7z`
  - active overlay config is `config/boards/radxa-cubie-a7z/yoyopod_config.yaml`
  - `power.watchdog_i2c_bus == 7`
  - `/dev/i2c-7` and `/dev/spidev1.0` exist
  - `wm8960-soundcard` playback/capture devices are present

## Board notes
- The Cubie boot-order fix for `wm8960-fix.service` before `pisugar-server.service` is installed on the board and had previously verified correctly.
- After the latest hard reset/power cycle, PiSugar is currently not responding on `i2c-7` on this boot: `i2cdetect -y 7` shows only the WM8960 codec at `0x1a`, and `pisugar-server` reports `I2C not connected`.
- That remaining issue appears hardware/runtime on the board rather than caused by this config-overlay change, so the PR is left as a draft until the hardware state is stable again.
