### PR TITLE
[codex] Fix repo rename paths for Pi workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,4 +398,4 @@ The current codebase is in a good place to focus on product behavior instead of 
 - `docs/RPI_SMOKE_VALIDATION.md`
 - `docs/PI_DEV_WORKFLOW.md`
 - `docs/archive/`
-- Project repository: `https://github.com/moustafattia/yoyo-py`
+- Project repository: `https://github.com/moustafattia/YoyoPod_Core`

--- a/deploy/pi-deploy.yaml
+++ b/deploy/pi-deploy.yaml
@@ -7,7 +7,7 @@
 
 host: ""
 user: ""
-project_dir: ~/yoyo-py
+project_dir: ~/YoyoPod_Core
 branch: main
 venv: .venv
 start_cmd: python yoyopod.py

--- a/deploy/systemd/yoyopod@.service
+++ b/deploy/systemd/yoyopod@.service
@@ -7,11 +7,11 @@ Wants=network-online.target
 Type=simple
 User=%i
 Group=%i
-WorkingDirectory=/home/%i/yoyo-py
+WorkingDirectory=/home/%i
 Environment=PYTHONUNBUFFERED=1
 Environment=PATH=/home/%i/.local/bin:/usr/local/bin:/usr/bin:/bin
 EnvironmentFile=-/etc/default/yoyopod
-ExecStart=/usr/bin/env bash -lc 'exec uv run python yoyopod.py'
+ExecStart=/usr/bin/env bash -lc 'PROJECT_DIR="${YOYOPOD_PROJECT_DIR:-$HOME/YoyoPod_Core}"; case "$PROJECT_DIR" in "~") PROJECT_DIR="$HOME" ;; "~/"*) PROJECT_DIR="$HOME/${PROJECT_DIR#~/}" ;; esac; if [ ! -f "$PROJECT_DIR/pyproject.toml" ] && [ -f "$HOME/yoyo-py/pyproject.toml" ]; then PROJECT_DIR="$HOME/yoyo-py"; fi; if [ ! -f "$PROJECT_DIR/pyproject.toml" ]; then echo "Could not find a YoyoPod checkout at $PROJECT_DIR" >&2; exit 1; fi; cd "$PROJECT_DIR"; exec uv run python yoyopod.py'
 Restart=always
 RestartSec=5
 KillSignal=SIGTERM

--- a/docs/CUBIE_A7Z_BRINGUP.md
+++ b/docs/CUBIE_A7Z_BRINGUP.md
@@ -16,7 +16,7 @@ This bringup was done on:
 - OS: `Debian Bullseye`
 - kernel family: Radxa vendor BSP `5.15.147-18-a733`
 - user: `radxa`
-- project dir: `~/yoyo-py`
+- project dir: `~/YoyoPod_Core`
 
 The Cubie A7Z is now a usable YoyoPod development target, but it is not yet a drop-in replacement for the Raspberry Pi Zero 2W. The major caveat is the Whisplay physical button behavior on this board.
 
@@ -61,7 +61,7 @@ Important note:
 Project setup on the board:
 
 ```bash
-cd ~/yoyo-py
+cd ~/YoyoPod_Core
 ~/.local/bin/uv venv --python 3.12 .venv
 ~/.local/bin/uv sync --extra dev
 ```
@@ -162,7 +162,7 @@ The Cubie board was validated with:
 - `espeak-ng`
 - Vosk Python package from the project environment
 - local Vosk model installed at:
-  - `~/yoyo-py/models/vosk-model-small-en-us`
+- `~/YoyoPod_Core/models/vosk-model-small-en-us`
 
 Verified state on the board:
 

--- a/docs/CUBIE_A7Z_PIMORONI_SETUP.md
+++ b/docs/CUBIE_A7Z_PIMORONI_SETUP.md
@@ -8,7 +8,7 @@ The Pimoroni HAT was designed for the Raspberry Pi. On the Cubie, the Pi-specifi
 
 - Radxa Cubie A7Z with Debian Bullseye and vendor BSP kernel `5.15.147-18-a733`
 - SPI1 enabled via `sun60iw2p1-spi1-spidev.dtbo` overlay (see `docs/CUBIE_A7Z_BRINGUP.md`)
-- YoyoPod project deployed at `~/yoyo-py` with Python 3.12 venv
+- YoyoPod project deployed at `~/YoyoPod_Core` with Python 3.12 venv
 - `dtc` (device tree compiler) installed: `sudo apt install device-tree-compiler`
 
 ## Pin Mapping
@@ -199,7 +199,7 @@ The GPIO pin mapping is already configured in the tracked board overlay at `conf
 ### Launch with Pimoroni display
 
 ```bash
-cd ~/yoyo-py
+cd ~/YoyoPod_Core
 YOYOPOD_DISPLAY=pimoroni YOYOPOD_CONFIG_BOARD=radxa-cubie-a7z .venv/bin/python yoyopod.py
 ```
 

--- a/docs/DEPLOYED_PI_DEPENDENCIES.md
+++ b/docs/DEPLOYED_PI_DEPENDENCIES.md
@@ -36,7 +36,7 @@ No separate Mopidy process or music daemon is part of the stack anymore.
 
 - `python3`
 - `uv`
-- YoyoPod virtual environment under `/home/tifo/yoyo-py/.venv`
+- YoyoPod virtual environment under `/home/tifo/YoyoPod_Core/.venv`
 
 ### Music playback
 

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -41,7 +41,7 @@ Optional environment defaults:
 
 ```bash
 export YOYOPOD_PI_HOST=rpi-zero
-export YOYOPOD_PI_PROJECT_DIR=~/yoyo-py
+export YOYOPOD_PI_PROJECT_DIR=~/YoyoPod_Core
 export YOYOPOD_PI_BRANCH=main
 ```
 
@@ -49,7 +49,7 @@ On Windows PowerShell:
 
 ```powershell
 $env:YOYOPOD_PI_HOST="rpi-zero"
-$env:YOYOPOD_PI_PROJECT_DIR="~/yoyo-py"
+$env:YOYOPOD_PI_PROJECT_DIR="~/YoyoPod_Core"
 $env:YOYOPOD_PI_BRANCH="main"
 ```
 
@@ -150,6 +150,7 @@ yoyoctl remote service logs --lines 150
 ```
 
 This installs `deploy/systemd/yoyopod@.service` onto the Pi as `yoyopod@<remote-user>.service`, enables it at boot, and keeps the app paired with the PiSugar watchdog recovery loop. `service install`, `start`, and `restart` now wait for the file-log startup marker and verify that it matches the PID file before returning success.
+The install step also records the merged `project_dir` in `/etc/default/yoyopod`, so the service keeps following your configured checkout path after the repo rename.
 
 ### Structured file logs
 

--- a/rules/deploy.md
+++ b/rules/deploy.md
@@ -9,8 +9,8 @@ Applies to: `deploy/pi-deploy.yaml`, deployment and debugging on Raspberry Pi
 git push
 
 # RPi: pull and run
-ssh rpi-zero "cd yoyo-py && git pull origin main"
-ssh rpi-zero "cd yoyo-py && source .venv/bin/activate && python yoyopod.py"
+ssh rpi-zero "cd YoyoPod_Core && git pull origin main"
+ssh rpi-zero "cd YoyoPod_Core && source .venv/bin/activate && python yoyopod.py"
 ```
 
 Kill stuck processes before restarting:
@@ -45,5 +45,5 @@ Plugin repo: https://github.com/moustafattia/rpi-deploy
 
 - Raspberry Pi Zero 2W (416 MB RAM)
 - SSH host alias: `rpi-zero` (configured in `~/.ssh/config`)
-- Project dir on Pi: `/home/pi/yoyo-py`
-- Venv on Pi: `/home/pi/yoyo-py/.venv`
+- Project dir on Pi: `/home/pi/YoyoPod_Core`
+- Venv on Pi: `/home/pi/YoyoPod_Core/.venv`

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,7 +20,7 @@ def test_configure_logger_uses_shared_utility(monkeypatch) -> None:
         assert settings is fake_settings.logging
         assert base_dir == Path.cwd()
         assert (base_dir / "pyproject.toml").exists()
-        assert base_dir.name.startswith("yoyo-py")
+        assert (base_dir / "yoyopod.py").exists()
         return fake_runtime
 
     def fake_init_logger(**kwargs) -> None:

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -35,10 +35,12 @@ from argparse import Namespace
 from pathlib import Path
 from types import SimpleNamespace
 
+DEFAULT_PROJECT_DIR = "~/YoyoPod_Core"
+
 DEPLOY_CONFIG = PiDeployConfig(
     host="rpi-zero",
     user="pi",
-    project_dir="~/yoyo-py",
+    project_dir=DEFAULT_PROJECT_DIR,
     branch="main",
     venv=".venv",
     start_cmd="python yoyopod.py",
@@ -55,7 +57,7 @@ DEPLOY_CONFIG = PiDeployConfig(
 def test_quote_remote_project_dir_preserves_home_expansion() -> None:
     """Tilde-based project paths should still expand on the remote shell."""
     assert quote_remote_project_dir("~") == '"$HOME"'
-    assert quote_remote_project_dir("~/yoyo-py") == '"$HOME/yoyo-py"'
+    assert quote_remote_project_dir(DEFAULT_PROJECT_DIR) == '"$HOME/YoyoPod_Core"'
 
 
 def test_quote_remote_project_dir_quotes_plain_paths() -> None:
@@ -73,7 +75,7 @@ def test_load_pi_deploy_config_merges_local_override(tmp_path) -> None:
             [
                 'host: ""',
                 "user: \"\"",
-                "project_dir: ~/yoyo-py",
+                f"project_dir: {DEFAULT_PROJECT_DIR}",
                 "branch: main",
                 "venv: .venv",
                 "start_cmd: python yoyopod.py",
@@ -118,7 +120,7 @@ def test_build_local_override_template_targets_machine_specific_fields() -> None
     assert "machine-specific defaults" in template
     assert "host: rpi-zero" in template
     assert "user: pi" in template
-    assert "project_dir: ~/yoyo-py" in template
+    assert f"project_dir: {DEFAULT_PROJECT_DIR}" in template
     assert "branch: main" in template
 
 
@@ -136,7 +138,7 @@ def test_build_sync_command_includes_uv_sync_by_default() -> None:
     config = RemoteConfig(
         host="rpi-zero",
         user="pi",
-        project_dir="~/yoyo-py",
+        project_dir=DEFAULT_PROJECT_DIR,
         branch="main",
     )
 
@@ -149,14 +151,14 @@ def test_build_rsync_command_uses_excludes_and_remote_target() -> None:
     config = RemoteConfig(
         host="rpi-zero",
         user="pi",
-        project_dir="~/yoyo-py",
+        project_dir=DEFAULT_PROJECT_DIR,
         branch="main",
     )
 
     command = build_rsync_command(config, DEPLOY_CONFIG)
 
     assert command[:3] == ["rsync", "-avz", "--delete"]
-    assert command[-2:] == ["./", "pi@rpi-zero:~/yoyo-py/"]
+    assert command[-2:] == ["./", "pi@rpi-zero:~/YoyoPod_Core/"]
     assert "--exclude" in command
     assert ".git/" in command
     assert "logs/" in command
@@ -168,7 +170,7 @@ def test_build_rsync_command_supports_custom_executable() -> None:
     config = RemoteConfig(
         host="rpi-zero",
         user="pi",
-        project_dir="~/yoyo-py",
+        project_dir=DEFAULT_PROJECT_DIR,
         branch="main",
     )
 
@@ -227,7 +229,7 @@ def test_build_sync_file_manifest_skips_excluded_entries(tmp_path) -> None:
     deploy_config = PiDeployConfig(
         host="rpi-zero",
         user="pi",
-        project_dir="~/yoyo-py",
+        project_dir=DEFAULT_PROJECT_DIR,
         branch="main",
         venv=".venv",
         start_cmd="python yoyopod.py",
@@ -276,7 +278,7 @@ def test_build_archive_sync_extract_command_targets_remote_project_dir() -> None
     config = RemoteConfig(
         host="rpi-zero",
         user="pi",
-        project_dir="~/yoyo-py",
+        project_dir=DEFAULT_PROJECT_DIR,
         branch="main",
     )
 
@@ -287,7 +289,7 @@ def test_build_archive_sync_extract_command_targets_remote_project_dir() -> None
     )
 
     assert "python - <<'PY'" in command
-    assert "Path(os.path.expanduser('~/yoyo-py')).resolve()" in command
+    assert "Path(os.path.expanduser('~/YoyoPod_Core')).resolve()" in command
     assert 'payload = json.load(handle)' in command
     assert 'archive.extractall(project_dir)' in command
 
@@ -469,7 +471,7 @@ def test_run_screenshot_uses_sigusr1_for_readback(monkeypatch, tmp_path) -> None
 
     args = Namespace(readback=True, output=str(tmp_path / "pi_screenshot.png"))
     exit_code = run_screenshot(
-        RemoteConfig(host="rpi-zero", user="pi", project_dir="~/yoyo-py", branch="main"),
+        RemoteConfig(host="rpi-zero", user="pi", project_dir=DEFAULT_PROJECT_DIR, branch="main"),
         DEPLOY_CONFIG,
         args,
     )
@@ -501,7 +503,7 @@ def test_run_screenshot_uses_sigusr2_for_default_shadow_path(monkeypatch, tmp_pa
 
     args = Namespace(readback=False, output=str(tmp_path / "pi_screenshot.png"))
     exit_code = run_screenshot(
-        RemoteConfig(host="rpi-zero", user="pi", project_dir="~/yoyo-py", branch="main"),
+        RemoteConfig(host="rpi-zero", user="pi", project_dir=DEFAULT_PROJECT_DIR, branch="main"),
         DEPLOY_CONFIG,
         args,
     )
@@ -519,6 +521,9 @@ def test_build_service_command_supports_install_and_logs() -> None:
     logs_command = build_service_command("logs", lines=25, deploy_config=DEPLOY_CONFIG)
 
     assert "deploy/systemd/yoyopod@.service" in install_command
+    assert "printf 'YOYOPOD_PROJECT_DIR=%s\\n'" in install_command
+    assert DEFAULT_PROJECT_DIR in install_command
+    assert "/etc/default/yoyopod" in install_command
     assert 'sudo systemctl enable --now yoyopod@"$(id -un)".service' in install_command
     assert "/tmp/yoyopod.pid" in install_command
     assert "YoyoPod starting" in install_command

--- a/yoyopy/cli/remote/infra.py
+++ b/yoyopy/cli/remote/infra.py
@@ -17,8 +17,6 @@ from yoyopy.cli.remote.ops import (
     DEPLOY_CONFIG_PATH,
     LOCAL_DEPLOY_CONFIG_PATH,
     PiDeployConfig,
-    RemoteConfig,
-    _activate_script_path,
     _resolve_remote_config,
     build_startup_verification_command,
     load_pi_deploy_config,
@@ -117,6 +115,11 @@ def build_service_command(
         return " && ".join(
             [
                 "test -f deploy/systemd/yoyopod@.service",
+                (
+                    "printf 'YOYOPOD_PROJECT_DIR=%s\\n' "
+                    f"{shell_quote(deploy.project_dir)} | "
+                    "sudo tee /etc/default/yoyopod >/dev/null"
+                ),
                 "sudo cp deploy/systemd/yoyopod@.service /etc/systemd/system/yoyopod@.service",
                 "sudo systemctl daemon-reload",
                 f"sudo systemctl enable --now {service_name}",

--- a/yoyopy/cli/remote/ops.py
+++ b/yoyopy/cli/remote/ops.py
@@ -27,6 +27,7 @@ from yoyopy.cli.common import REPO_ROOT
 
 DEPLOY_CONFIG_PATH = REPO_ROOT / "deploy" / "pi-deploy.yaml"
 LOCAL_DEPLOY_CONFIG_PATH = REPO_ROOT / "deploy" / "pi-deploy.local.yaml"
+DEFAULT_PI_PROJECT_DIR = "~/YoyoPod_Core"
 
 
 @dataclass
@@ -52,7 +53,7 @@ class PiDeployConfig:
 
     host: str = ""
     user: str = ""
-    project_dir: str = "~/yoyo-py"
+    project_dir: str = DEFAULT_PI_PROJECT_DIR
     branch: str = "main"
     venv: str = ".venv"
     start_cmd: str = "python yoyopod.py"
@@ -105,9 +106,9 @@ def parse_pi_deploy_config(data: dict[str, object]) -> PiDeployConfig:
         host=str(data.get("host", "")).strip(),
         user=str(data.get("user", "")).strip(),
         project_dir=str(
-            data.get("project_dir", data.get("remote_dir", "~/yoyo-py"))
+            data.get("project_dir", data.get("remote_dir", DEFAULT_PI_PROJECT_DIR))
         ).strip()
-        or "~/yoyo-py",
+        or DEFAULT_PI_PROJECT_DIR,
         branch=str(data.get("branch", "main")).strip() or "main",
         venv=str(data.get("venv", ".venv")).strip() or ".venv",
         start_cmd=str(data.get("start_cmd", "python yoyopod.py")).strip()
@@ -1171,7 +1172,7 @@ def build_parser(deploy_config: PiDeployConfig) -> argparse.ArgumentParser:
     parser.add_argument(
         "--project-dir",
         default=os.getenv("YOYOPOD_PI_PROJECT_DIR", deploy_config.project_dir),
-        help="Project directory on the Raspberry Pi (default: ~/yoyo-py)",
+        help=f"Project directory on the Raspberry Pi (default: {DEFAULT_PI_PROJECT_DIR})",
     )
     parser.add_argument(
         "--branch",


### PR DESCRIPTION
## What changed
- switched the tracked Raspberry Pi deploy default from `~/yoyo-py` to `~/YoyoPod_Core`
- updated the remote CLI helpers and tests to use the renamed checkout path without hardcoding the old repo directory name
- made the systemd unit resilient by reading `YOYOPOD_PROJECT_DIR` from `/etc/default/yoyopod`, defaulting to `~/YoyoPod_Core`, and falling back to legacy `~/yoyo-py` installs
- refreshed current deploy/bringup docs plus the repo URL in `AGENTS.md`

## Why
Renaming the GitHub repo to `YoyoPod_Core` leaves several Pi-facing defaults stale. New clones and fresh service installs would otherwise look in the old `yoyo-py` checkout path, and one test still assumed the repo directory name itself.

## Impact
- new Pi deploys now target the renamed checkout path by default
- existing installs can still work by keeping their configured `project_dir`, and the service unit still falls back to the legacy `~/yoyo-py` path
- repo-name-sensitive tests no longer break on future directory renames

## Validation
- `uv sync --extra dev`
- `uv run ruff check yoyopy/cli/remote/ops.py yoyopy/cli/remote/infra.py tests/test_main.py tests/test_pi_remote.py`
- `uv run pytest -q tests/test_main.py tests/test_pi_remote.py`
- `uv run pytest -q`
