### PR TITLE
docs: clarify agent guidance hierarchy and architecture boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,23 @@
 
 ---
 
+## Guidance Hierarchy
+
+Use the repo guidance in this order:
+
+1. Current code in `yoyopy/`
+2. [`README.md`](README.md) and [`docs/README.md`](docs/README.md)
+3. `rules/` for project constraints and architecture/style rules
+4. `AGENTS.md` for current runtime status and agent workflow
+5. `skills/` for task-specific operational playbooks
+6. `.claude/` and `.agents/` as tool-facing overlays and mirrors
+
+Canonical locations:
+- `skills/` is the canonical skill source
+- `.claude/skills/` and `.agents/skills/` are tool-facing mirrors
+- current runtime docs beat older plan docs when they disagree
+- `docs/archive/` is historical context only
+
 ## Project Rules
 
 Follow all instructions in the `rules/` directory:
@@ -20,7 +37,7 @@ Follow all instructions in the `rules/` directory:
 
 ## Pi Deployment Skills
 
-Workflow instructions for deploying and debugging on Raspberry Pi are in `skills/`:
+Workflow instructions for deploying and debugging on Raspberry Pi are in canonical files under `skills/`:
 
 | Skill | File | Purpose |
 |---|---|---|

--- a/rules/architecture.md
+++ b/rules/architecture.md
@@ -41,3 +41,63 @@ yoyopod.py / yoyopy/main.py  (entry points)
 - mpv pushes playback and property-change events over JSON IPC rather than using polling
 - Liblinphone backend events are drained on the coordinator thread for UI and state updates
 - `EventBus` serializes typed app events on the coordinator thread
+
+## Module Boundary Rules
+
+### Entry points and composition
+
+- `yoyopod.py`, `yoyopy/main.py`, and `yoyopy/app.py` are composition and lifecycle layers.
+- Do not turn entrypoint files into feature homes for UI, business rules, or backend-specific logic.
+- If `YoyoPodApp` grows, extract focused runtime services instead of adding more feature logic there.
+
+### Screens and UI
+
+- `yoyopy/ui/screens/` owns presentation, user interaction, and screen-local state.
+- Screens should not own hardware lifecycle, process supervision, watchdog behavior, or cross-feature orchestration.
+- Heavy voice, playback, call, or power policy should live outside screens and be consumed by screens.
+
+### Coordinators
+
+- `yoyopy/coordinators/` owns cross-subsystem orchestration.
+- Coordinators may translate events into runtime state changes and navigation changes.
+- Coordinators should not contain rendering code, hardware-driver code, or long-lived persistence logic.
+
+### Subsystem managers and backends
+
+- `audio/`, `voip/`, `power/`, `network/`, and `voice/` own subsystem behavior and backend integration.
+- Manager layers provide the app-facing facade.
+- Backend-specific details stay behind the subsystem boundary whenever possible.
+
+### Hardware abstraction
+
+- Raw hardware behavior stays behind `ui/display/`, `ui/input/`, or the relevant subsystem backend.
+- Keep Pimoroni, Whisplay, GPIO, LVGL, PiSugar, and modem-specific details out of generic UI and orchestration layers.
+- Raw LVGL usage should remain confined to `yoyopy/ui/lvgl_binding/` and LVGL-specific view code.
+
+### State and models
+
+- Prefer canonical typed models over parallel shape duplication across UI and runtime layers.
+- `AppContext` is shared runtime state, not a dumping ground for every new feature field.
+- New domain objects should be introduced in clear model modules before being copied into screen-only state.
+
+### Events and threading
+
+- Background callbacks should publish typed events onto `EventBus` or pass through a narrow coordinator-safe boundary.
+- Do not mutate UI state directly from background threads.
+- Favor typed events and explicit seams over reaching into concrete screen instances.
+
+## Dependency Direction
+
+Prefer this direction of dependency:
+
+- entrypoints -> coordinators / managers / UI wiring
+- coordinators -> runtime state + subsystem facades + screen manager
+- screens -> display/input abstractions + typed runtime state + narrow feature actions
+- managers -> backends / persistence / subprocess control
+- backends -> hardware / native bindings / external processes
+
+Avoid the reverse when possible, especially:
+- screens importing hardware-specific backends directly
+- generic models importing UI code
+- subsystem backends depending on concrete screens
+- plan docs being treated as the runtime source of truth


### PR DESCRIPTION
## Summary
- clarify the repo guidance hierarchy for agents and contributors
- make canonical vs mirrored agent guidance locations explicit
- add stronger module-boundary and dependency-direction rules

## Why
The repo already has strong agent support, but the hierarchy was still too implicit. This PR makes the guidance surface easier to navigate and gives contributors clearer architecture guardrails.

## Changes
- updated `AGENTS.md` with:
  - guidance hierarchy
  - canonical vs tool-facing locations
  - clearer positioning of `skills/`, `.claude/`, and `.agents/`
- updated `rules/architecture.md` with:
  - entrypoint/composition rules
  - screen/coordinator/subsystem boundary rules
  - hardware abstraction rules
  - state/model guidance
  - event/threading rules
  - preferred dependency direction

## Tracking
Closes #96
Closes #97
