### PR TITLE
[codex] Stabilize environment-independent test contracts

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,12 +5,13 @@ from types import SimpleNamespace
 import yoyopy.main as main_module
 
 
-def test_configure_logger_uses_shared_utility(monkeypatch) -> None:
+def test_configure_logger_uses_shared_utility(monkeypatch, tmp_path) -> None:
     """Keep the app entrypoint aligned with the shared logging helper."""
 
     fake_settings = SimpleNamespace(logging=object())
     fake_runtime = object()
     calls = []
+    fake_base_dir = tmp_path / "checkout-with-any-name"
 
     def fake_load_app_settings(config_dir: str) -> object:
         assert config_dir == "config"
@@ -18,14 +19,17 @@ def test_configure_logger_uses_shared_utility(monkeypatch) -> None:
 
     def fake_build_logging_runtime_config(settings, *, base_dir):
         assert settings is fake_settings.logging
-        assert base_dir == Path.cwd()
-        assert (base_dir / "pyproject.toml").exists()
-        assert (base_dir / "yoyopod.py").exists()
+        assert base_dir == fake_base_dir
         return fake_runtime
 
     def fake_init_logger(**kwargs) -> None:
         calls.append(kwargs)
         return fake_runtime
+
+    class FakePath:
+        @staticmethod
+        def cwd() -> Path:
+            return fake_base_dir
 
     monkeypatch.setattr(main_module, "load_app_settings", fake_load_app_settings)
     monkeypatch.setattr(
@@ -34,6 +38,7 @@ def test_configure_logger_uses_shared_utility(monkeypatch) -> None:
         fake_build_logging_runtime_config,
     )
     monkeypatch.setattr(main_module, "init_logger", fake_init_logger)
+    monkeypatch.setattr(main_module, "Path", FakePath)
 
     runtime = main_module.configure_logger()
 

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -1,6 +1,9 @@
 """Tests for Raspberry Pi remote workflow helpers."""
 
+import yaml
+
 from yoyopy.cli.remote.ops import (
+    DEPLOY_CONFIG_PATH,
     PiDeployConfig,
     RemoteConfig,
     build_archive_sync_extract_command,
@@ -35,7 +38,15 @@ from argparse import Namespace
 from pathlib import Path
 from types import SimpleNamespace
 
-DEFAULT_PROJECT_DIR = "~/YoyoPod_Core"
+
+def _tracked_project_dir() -> str:
+    """Read the repo-owned default project dir from the tracked deploy contract."""
+
+    payload = yaml.safe_load(DEPLOY_CONFIG_PATH.read_text(encoding="utf-8"))
+    return str(payload["project_dir"])
+
+
+DEFAULT_PROJECT_DIR = _tracked_project_dir()
 
 DEPLOY_CONFIG = PiDeployConfig(
     host="rpi-zero",
@@ -57,7 +68,7 @@ DEPLOY_CONFIG = PiDeployConfig(
 def test_quote_remote_project_dir_preserves_home_expansion() -> None:
     """Tilde-based project paths should still expand on the remote shell."""
     assert quote_remote_project_dir("~") == '"$HOME"'
-    assert quote_remote_project_dir(DEFAULT_PROJECT_DIR) == '"$HOME/YoyoPod_Core"'
+    assert quote_remote_project_dir(DEFAULT_PROJECT_DIR) == f'"$HOME/{DEFAULT_PROJECT_DIR[2:]}"'
 
 
 def test_quote_remote_project_dir_quotes_plain_paths() -> None:
@@ -74,7 +85,7 @@ def test_load_pi_deploy_config_merges_local_override(tmp_path) -> None:
         "\n".join(
             [
                 'host: ""',
-                "user: \"\"",
+                'user: ""',
                 f"project_dir: {DEFAULT_PROJECT_DIR}",
                 "branch: main",
                 "venv: .venv",
@@ -158,7 +169,7 @@ def test_build_rsync_command_uses_excludes_and_remote_target() -> None:
     command = build_rsync_command(config, DEPLOY_CONFIG)
 
     assert command[:3] == ["rsync", "-avz", "--delete"]
-    assert command[-2:] == ["./", "pi@rpi-zero:~/YoyoPod_Core/"]
+    assert command[-2:] == ["./", f"pi@rpi-zero:{DEFAULT_PROJECT_DIR}/"]
     assert "--exclude" in command
     assert ".git/" in command
     assert "logs/" in command
@@ -289,9 +300,9 @@ def test_build_archive_sync_extract_command_targets_remote_project_dir() -> None
     )
 
     assert "python - <<'PY'" in command
-    assert "Path(os.path.expanduser('~/YoyoPod_Core')).resolve()" in command
-    assert 'payload = json.load(handle)' in command
-    assert 'archive.extractall(project_dir)' in command
+    assert f"Path(os.path.expanduser('{DEFAULT_PROJECT_DIR}')).resolve()" in command
+    assert "payload = json.load(handle)" in command
+    assert "archive.extractall(project_dir)" in command
 
 
 def test_build_smoke_command_adds_optional_checks() -> None:
@@ -419,7 +430,10 @@ def test_build_restart_command_reuses_pid_and_startup_contract() -> None:
 
     assert "'yoyoctl', 'build', 'lvgl'" in command
     assert "'yoyoctl', 'build', 'liblinphone'" in command
-    assert 'if systemctl cat yoyopod@"$(id -un)".service >/dev/null 2>&1; then sudo systemctl stop yoyopod@"$(id -un)".service >/dev/null 2>&1 || true;' in command
+    assert (
+        'if systemctl cat yoyopod@"$(id -un)".service >/dev/null 2>&1; then sudo systemctl stop yoyopod@"$(id -un)".service >/dev/null 2>&1 || true;'
+        in command
+    )
     assert 'sudo systemctl start yoyopod@"$(id -un)".service;' in command
     assert "rm -f /tmp/yoyopod.pid" in command
     assert "killall -9 python" in command
@@ -547,6 +561,6 @@ def test_build_startup_verification_command_checks_pid_and_marker() -> None:
     command = build_startup_verification_command(DEPLOY_CONFIG, attempts=3)
 
     assert "test -f /tmp/yoyopod.pid" in command
-    assert "kill -0 \"$pid\"" in command
+    assert 'kill -0 "$pid"' in command
     assert "grep -F 'YoyoPod starting' logs/yoyopod.log" in command
-    assert "grep -F \"pid=$pid\"" in command
+    assert 'grep -F "pid=$pid"' in command


### PR DESCRIPTION
## Summary

This removes brittle environment-coupled test assumptions and anchors the affected contracts to actual behavior and tracked repo configuration instead.

Closes #86.

## What changed

- rewrote `tests/test_main.py::test_configure_logger_uses_shared_utility` so it verifies that `configure_logger()` forwards the current working directory into the shared logging utility instead of assuming the checkout has a particular name or file layout
- updated the affected Raspberry Pi remote tests to derive the default project directory from tracked `deploy/pi-deploy.yaml` instead of hardcoding the repo name in test-local constants
- fixed the adjacent rsync/archive expectations in the same test module so the contract follows the tracked deploy config rather than repeating branding assumptions in assertions

## Root cause

The previous tests were asserting facts about the local environment instead of the code contract:

- checkout name assumptions (`YoyoPod_Core` vs historical names)
- direct dependence on the real current working directory layout
- test-local duplication of the tracked deploy project path

That made the suite fail for reasons unrelated to product behavior.

## Impact

- local and CI test results are no longer sensitive to what the checkout folder happens to be called
- the remote workflow tests now follow the repo-owned deploy contract
- this removes a fake red signal without weakening the actual behavior under test

## Validation

- `uv run pytest -q tests/test_main.py tests/test_pi_remote.py`
- `uv run ruff check tests/test_main.py tests/test_pi_remote.py`
- `uv run black --check tests/test_main.py tests/test_pi_remote.py`
- `uv run pytest -q`
