### PR TITLE
[codex] Add staged quality gates for the workflow surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,29 @@ on:
   pull_request:
 
 jobs:
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run staged quality gate
+        run: uv run python scripts/quality.py gate
+
   test:
     runs-on: ubuntu-latest
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -117,8 +117,17 @@ Local validation:
 
 ```bash
 python -m compileall yoyopy tests demos scripts
+uv run python scripts/quality.py gate
 uv run pytest -q
 ```
+
+Full quality audit of the current repo debt:
+
+```bash
+uv run python scripts/quality.py audit
+```
+
+The staged gate contract and exact target set live in [`QUALITY_GATES.md`](QUALITY_GATES.md).
 
 Pi smoke:
 

--- a/docs/QUALITY_GATES.md
+++ b/docs/QUALITY_GATES.md
@@ -1,0 +1,54 @@
+# Quality Gates
+
+This repo now owns one executable quality contract instead of relying on tribal knowledge:
+
+```bash
+uv run python scripts/quality.py gate
+```
+
+CI runs that exact command.
+
+## Gated now
+
+The staged gate currently covers the developer-workflow surface tracked in `[tool.yoyopod_quality]` inside `pyproject.toml`:
+
+- `scripts/quality.py`
+- `yoyopy/main.py`
+- `yoyopy/cli/__init__.py`
+- `yoyopy/cli/common.py`
+- `yoyopy/cli/build.py`
+- `yoyopy/cli/remote/`
+
+The gate enforces:
+
+- `black --check`
+- `ruff check`
+- `mypy`
+
+That means pull requests can no longer regress the entrypoint and Pi workflow tooling without CI calling it out.
+
+## Ungated now
+
+Everything outside the staged target lists above is still outside the lint/type/format gate.
+
+That is deliberate, not hidden:
+
+- full-repo `black --check` still wants to rewrite a large chunk of the tree
+- full-repo `ruff check .` still reports existing violations outside the gated workflow surface
+- full-repo `mypy yoyopy` still reports substantial legacy type debt outside the gated workflow surface
+
+You can measure the current full-repo debt with:
+
+```bash
+uv run python scripts/quality.py audit
+```
+
+## Path to full gating
+
+The rollout path is explicit:
+
+1. Clean one subsystem at a time with `uv run python scripts/quality.py audit`.
+2. Expand the `[tool.yoyopod_quality]` gate target lists in `pyproject.toml`.
+3. Once the repo is clean enough, replace the staged lists with whole-tree targets.
+
+The point is to make progress visible and enforceable without pretending the repo is already cleaner than it is.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "black>=24.0.0",
     "ruff>=0.3.0",
     "mypy>=1.8.0",
+    "types-PyYAML",
     "typer>=0.12.0",
 ]
 
@@ -73,3 +74,32 @@ disallow_untyped_defs = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.yoyopod_quality]
+gate_format_paths = [
+    "scripts/quality.py",
+    "yoyopy/main.py",
+    "yoyopy/cli/__init__.py",
+    "yoyopy/cli/common.py",
+    "yoyopy/cli/build.py",
+    "yoyopy/cli/remote",
+]
+gate_lint_paths = [
+    "scripts/quality.py",
+    "yoyopy/main.py",
+    "yoyopy/cli/__init__.py",
+    "yoyopy/cli/common.py",
+    "yoyopy/cli/build.py",
+    "yoyopy/cli/remote",
+]
+gate_type_paths = [
+    "scripts/quality.py",
+    "yoyopy/main.py",
+    "yoyopy/cli/__init__.py",
+    "yoyopy/cli/common.py",
+    "yoyopy/cli/build.py",
+    "yoyopy/cli/remote",
+]
+audit_format_paths = ["."]
+audit_lint_paths = ["."]
+audit_type_paths = ["yoyopy"]

--- a/rules/code-style.md
+++ b/rules/code-style.md
@@ -4,5 +4,5 @@
 - Black formatting, 100 char line length
 - Logging via `loguru` (not stdlib logging) -- see `rules/logging.md`
 - Build system: hatchling
-- Linting: `ruff check .`
-- Type checking: `mypy yoyopy/`
+- Repo-owned staged quality gate: `uv run python scripts/quality.py gate`
+- Full quality debt audit: `uv run python scripts/quality.py audit`

--- a/rules/project.md
+++ b/rules/project.md
@@ -18,9 +18,11 @@ python yoyopod.py --simulate
 uv run pytest -q
 uv run pytest -q tests/test_fsm_runtime.py
 
-# Code quality
-uv run black .
-uv run ruff check .
+# Repo-owned code quality gate
+uv run python scripts/quality.py gate
+
+# Full quality debt audit
+uv run python scripts/quality.py audit
 ```
 
 ## Configuration

--- a/scripts/quality.py
+++ b/scripts/quality.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Repo-owned quality command runner used by both local workflow and CI."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+
+@dataclass(frozen=True)
+class QualityConfig:
+    """Tracked quality target sets loaded from ``pyproject.toml``."""
+
+    gate_format_paths: tuple[str, ...]
+    gate_lint_paths: tuple[str, ...]
+    gate_type_paths: tuple[str, ...]
+    audit_format_paths: tuple[str, ...]
+    audit_lint_paths: tuple[str, ...]
+    audit_type_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class QualityStep:
+    """One executable quality command."""
+
+    label: str
+    command: tuple[str, ...]
+
+
+def _load_pyproject() -> dict[str, Any]:
+    with PYPROJECT_PATH.open("rb") as handle:
+        payload = tomllib.load(handle)
+    if not isinstance(payload, dict):
+        raise SystemExit(f"Expected a TOML mapping in {PYPROJECT_PATH}")
+    return payload
+
+
+def _load_string_list(section: dict[str, Any], key: str) -> tuple[str, ...]:
+    raw_value = section.get(key)
+    if not isinstance(raw_value, list) or not raw_value:
+        raise SystemExit(f"Expected a non-empty string list for [tool.yoyopod_quality].{key}")
+
+    normalized: list[str] = []
+    for item in raw_value:
+        if not isinstance(item, str) or not item.strip():
+            raise SystemExit(
+                f"Expected [tool.yoyopod_quality].{key} to contain only non-empty strings"
+            )
+        normalized.append(item.strip())
+    return tuple(normalized)
+
+
+def load_quality_config() -> QualityConfig:
+    """Load the tracked quality target sets from ``pyproject.toml``."""
+
+    payload = _load_pyproject()
+    tool_section = payload.get("tool")
+    if not isinstance(tool_section, dict):
+        raise SystemExit(f"Missing [tool] section in {PYPROJECT_PATH}")
+
+    quality_section = tool_section.get("yoyopod_quality")
+    if not isinstance(quality_section, dict):
+        raise SystemExit(f"Missing [tool.yoyopod_quality] section in {PYPROJECT_PATH}")
+
+    return QualityConfig(
+        gate_format_paths=_load_string_list(quality_section, "gate_format_paths"),
+        gate_lint_paths=_load_string_list(quality_section, "gate_lint_paths"),
+        gate_type_paths=_load_string_list(quality_section, "gate_type_paths"),
+        audit_format_paths=_load_string_list(quality_section, "audit_format_paths"),
+        audit_lint_paths=_load_string_list(quality_section, "audit_lint_paths"),
+        audit_type_paths=_load_string_list(quality_section, "audit_type_paths"),
+    )
+
+
+def _python_module_command(module: str, *args: str) -> tuple[str, ...]:
+    return (sys.executable, "-m", module, *args)
+
+
+def build_gate_steps(config: QualityConfig) -> tuple[QualityStep, ...]:
+    """Build the staged, CI-gated workflow checks."""
+
+    return (
+        QualityStep(
+            label="black --check (workflow surface)",
+            command=_python_module_command("black", "--check", *config.gate_format_paths),
+        ),
+        QualityStep(
+            label="ruff check (workflow surface)",
+            command=_python_module_command("ruff", "check", *config.gate_lint_paths),
+        ),
+        QualityStep(
+            label="mypy (workflow surface)",
+            command=_python_module_command("mypy", *config.gate_type_paths),
+        ),
+    )
+
+
+def build_audit_steps(config: QualityConfig) -> tuple[QualityStep, ...]:
+    """Build the non-gating full-repo audit commands."""
+
+    return (
+        QualityStep(
+            label="black --check (full repo audit)",
+            command=_python_module_command("black", "--check", *config.audit_format_paths),
+        ),
+        QualityStep(
+            label="ruff check (full repo audit)",
+            command=_python_module_command("ruff", "check", *config.audit_lint_paths),
+        ),
+        QualityStep(
+            label="mypy (full repo audit)",
+            command=_python_module_command("mypy", *config.audit_type_paths),
+        ),
+    )
+
+
+def run_steps(steps: tuple[QualityStep, ...]) -> int:
+    """Run every step and return a non-zero exit code when any fail."""
+
+    failures: list[tuple[str, int]] = []
+    for step in steps:
+        print("")
+        print(f"[quality] step={step.label}")
+        print(f"[quality] cmd={shlex.join(step.command)}")
+        completed = subprocess.run(step.command, cwd=REPO_ROOT, check=False)
+        if completed.returncode != 0:
+            failures.append((step.label, completed.returncode))
+
+    print("")
+    if failures:
+        print("[quality] result=failed")
+        for label, return_code in failures:
+            print(f"[quality] failed_step={label} exit_code={return_code}")
+        return 1
+
+    print("[quality] result=passed")
+    return 0
+
+
+def print_targets(config: QualityConfig) -> None:
+    """Print the tracked gate and audit target sets."""
+
+    sections = (
+        ("gate_format_paths", config.gate_format_paths),
+        ("gate_lint_paths", config.gate_lint_paths),
+        ("gate_type_paths", config.gate_type_paths),
+        ("audit_format_paths", config.audit_format_paths),
+        ("audit_lint_paths", config.audit_lint_paths),
+        ("audit_type_paths", config.audit_type_paths),
+    )
+    for name, values in sections:
+        print(f"{name}:")
+        for value in values:
+            print(f"  - {value}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+
+    parser = argparse.ArgumentParser(
+        description="Run repo-owned quality commands for YoyoPod Core."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("gate", help="Run the staged CI-gated workflow checks.")
+    subparsers.add_parser("audit", help="Run the non-gating full-repo quality audit.")
+    subparsers.add_parser("targets", help="Print the tracked gate and audit target sets.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+
+    args = build_parser().parse_args(argv)
+    config = load_quality_config()
+
+    if args.command == "gate":
+        return run_steps(build_gate_steps(config))
+    if args.command == "audit":
+        return run_steps(build_audit_steps(config))
+    if args.command == "targets":
+        print_targets(config)
+        return 0
+    raise SystemExit(f"Unsupported quality command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/yoyopy/cli/__init__.py
+++ b/yoyopy/cli/__init__.py
@@ -8,8 +8,7 @@ except ImportError:
     import sys
 
     print(
-        "yoyoctl requires dev dependencies. Install with:\n"
-        "  uv sync --extra dev",
+        "yoyoctl requires dev dependencies. Install with:\n" "  uv sync --extra dev",
         file=sys.stderr,
     )
     raise SystemExit(1)
@@ -22,14 +21,17 @@ app = typer.Typer(
 
 # -- pi group (on-device commands) -----------------------------------------
 from yoyopy.cli.pi import pi_app  # noqa: E402
+
 app.add_typer(pi_app)
 
 # -- remote group (SSH wrapper commands) ------------------------------------
 from yoyopy.cli.remote import remote_app  # noqa: E402
+
 app.add_typer(remote_app)
 
 # -- build group (native extension builds) ----------------------------------
 from yoyopy.cli.build import build_app  # noqa: E402
+
 app.add_typer(build_app)
 
 

--- a/yoyopy/cli/build.py
+++ b/yoyopy/cli/build.py
@@ -33,6 +33,7 @@ def _run(command: list[str], cwd: Path | None = None) -> None:
 # LVGL helpers (inlined from scripts/lvgl_build.py)
 # ---------------------------------------------------------------------------
 
+
 def _has_valid_lvgl_source(source_dir: Path) -> bool:
     required_paths = (
         source_dir / "CMakeLists.txt",
@@ -83,6 +84,7 @@ def _build_lvgl(native_dir: Path, source_dir: Path, build_dir: Path) -> None:
 # Liblinphone helpers (inlined from scripts/liblinphone_build.py)
 # ---------------------------------------------------------------------------
 
+
 def _build_liblinphone(native_dir: Path, build_dir: Path) -> None:
     build_dir.mkdir(parents=True, exist_ok=True)
     _run(
@@ -102,6 +104,7 @@ def _build_liblinphone(native_dir: Path, build_dir: Path) -> None:
 # Commands
 # ---------------------------------------------------------------------------
 
+
 @build_app.command("lvgl")
 def build_lvgl(
     source_dir: Annotated[
@@ -119,7 +122,11 @@ def build_lvgl(
 ) -> None:
     """Build the pinned LVGL shim for the current platform."""
     native_dir = _REPO_ROOT / "yoyopy" / "ui" / "lvgl_binding" / "native"
-    resolved_source = source_dir if source_dir is not None else _REPO_ROOT / ".cache" / "lvgl" / f"lvgl-{LVGL_VERSION}"
+    resolved_source = (
+        source_dir
+        if source_dir is not None
+        else _REPO_ROOT / ".cache" / "lvgl" / f"lvgl-{LVGL_VERSION}"
+    )
     resolved_build = build_dir if build_dir is not None else native_dir / "build"
 
     if not skip_fetch:

--- a/yoyopy/cli/common.py
+++ b/yoyopy/cli/common.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from loguru import logger
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 

--- a/yoyopy/cli/remote/__init__.py
+++ b/yoyopy/cli/remote/__init__.py
@@ -6,7 +6,18 @@ import typer
 
 from yoyopy.cli.remote.infra import config, power, service
 from yoyopy.cli.remote.lvgl import lvgl_soak
-from yoyopy.cli.remote.ops import logs, preflight, restart, rsync, rtc, screenshot, smoke, status, sync, whisplay
+from yoyopy.cli.remote.ops import (
+    logs,
+    preflight,
+    restart,
+    rsync,
+    rtc,
+    screenshot,
+    smoke,
+    status,
+    sync,
+    whisplay,
+)
 
 remote_app = typer.Typer(
     name="remote",

--- a/yoyopy/cli/remote/infra.py
+++ b/yoyopy/cli/remote/infra.py
@@ -26,10 +26,10 @@ from yoyopy.cli.remote.ops import (
     validate_config,
 )
 
-
 # ---------------------------------------------------------------------------
 # Config helpers (inlined from pi_remote.py)
 # ---------------------------------------------------------------------------
+
 
 def build_local_override_template(base_config: PiDeployConfig) -> str:
     """Create the starter template for the gitignored local override file."""
@@ -97,6 +97,7 @@ def build_config_editor_command(
 # Service command builder
 # ---------------------------------------------------------------------------
 
+
 def build_service_command(
     action: str,
     *,
@@ -155,6 +156,7 @@ def build_service_command(
 # Power command builder
 # ---------------------------------------------------------------------------
 
+
 def build_power_command(*, verbose: bool = False) -> str:
     """Create the remote PiSugar power-status command."""
     parts = ["uv run yoyoctl pi power battery"]
@@ -167,12 +169,23 @@ def build_power_command(*, verbose: bool = False) -> str:
 # Typer commands
 # ---------------------------------------------------------------------------
 
+
 def power(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
-    verbose: Annotated[bool, typer.Option("--verbose", help="Enable verbose power helper logging.")] = False,
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    verbose: Annotated[
+        bool, typer.Option("--verbose", help="Enable verbose power helper logging.")
+    ] = False,
 ) -> None:
     """Inspect PiSugar power telemetry remotely."""
     config = _resolve_remote_config(host, user, project_dir, branch)
@@ -183,12 +196,25 @@ def power(
 
 
 def config(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
-    action: Annotated[str, typer.Argument(help="Config action to run locally (show, paths, init-local, edit).")] = "show",
-    editor: Annotated[Optional[str], typer.Option("--editor", help="Override the editor command for `config edit`.")] = None,
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    action: Annotated[
+        str, typer.Argument(help="Config action to run locally (show, paths, init-local, edit).")
+    ] = "show",
+    editor: Annotated[
+        Optional[str],
+        typer.Option("--editor", help="Override the editor command for `config edit`."),
+    ] = None,
 ) -> None:
     """Show or edit the merged Raspberry Pi deploy config."""
     deploy_config = load_pi_deploy_config()
@@ -234,12 +260,27 @@ def config(
 
 
 def service(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
-    action: Annotated[str, typer.Argument(help="Service action to run remotely (status, install, start, stop, restart, logs).")] = "status",
-    lines: Annotated[int, typer.Option("--lines", help="How many journal lines to show for `service logs`.")] = 100,
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    action: Annotated[
+        str,
+        typer.Argument(
+            help="Service action to run remotely (status, install, start, stop, restart, logs)."
+        ),
+    ] = "status",
+    lines: Annotated[
+        int, typer.Option("--lines", help="How many journal lines to show for `service logs`.")
+    ] = 100,
 ) -> None:
     """Install or inspect the production YoyoPod systemd service."""
     config_obj = _resolve_remote_config(host, user, project_dir, branch)

--- a/yoyopy/cli/remote/lvgl.py
+++ b/yoyopy/cli/remote/lvgl.py
@@ -12,10 +12,10 @@ from yoyopy.cli.remote.ops import (
     validate_config,
 )
 
-
 # ---------------------------------------------------------------------------
 # Command builder
 # ---------------------------------------------------------------------------
+
 
 def build_lvgl_soak_command(
     *,
@@ -41,15 +41,32 @@ def build_lvgl_soak_command(
 # Typer command
 # ---------------------------------------------------------------------------
 
+
 def lvgl_soak(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
-    cycles: Annotated[int, typer.Option("--cycles", help="How many full transition cycles to run.")] = 2,
-    hold_seconds: Annotated[float, typer.Option("--hold-seconds", help="How long to keep each screen active.")] = 0.2,
-    skip_sleep: Annotated[bool, typer.Option("--skip-sleep", help="Skip the sleep/wake exercise.")] = False,
-    verbose: Annotated[bool, typer.Option("--verbose", help="Enable verbose soak logging.")] = False,
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    cycles: Annotated[
+        int, typer.Option("--cycles", help="How many full transition cycles to run.")
+    ] = 2,
+    hold_seconds: Annotated[
+        float, typer.Option("--hold-seconds", help="How long to keep each screen active.")
+    ] = 0.2,
+    skip_sleep: Annotated[
+        bool, typer.Option("--skip-sleep", help="Skip the sleep/wake exercise.")
+    ] = False,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", help="Enable verbose soak logging.")
+    ] = False,
 ) -> None:
     """Run the LVGL Whisplay soak helper remotely."""
     config = _resolve_remote_config(host, user, project_dir, branch)

--- a/yoyopy/cli/remote/ops.py
+++ b/yoyopy/cli/remote/ops.py
@@ -81,6 +81,7 @@ class PiDeployConfig:
 # Config loading
 # ---------------------------------------------------------------------------
 
+
 def load_yaml_mapping(path: Path) -> dict[str, object]:
     """Load one YAML mapping from disk."""
     with open(path, "r", encoding="utf-8") as handle:
@@ -100,6 +101,20 @@ def merge_pi_deploy_layers(*layers: dict[str, object]) -> dict[str, object]:
     return merged
 
 
+def _as_string_tuple(value: object, *, default: tuple[str, ...]) -> tuple[str, ...]:
+    """Normalize one YAML sequence-like value into a tuple of non-empty strings."""
+
+    if isinstance(value, str):
+        candidates: Sequence[object] = (value,)
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        candidates = value
+    else:
+        return default
+
+    normalized = tuple(str(item).strip() for item in candidates if str(item).strip())
+    return normalized or default
+
+
 def parse_pi_deploy_config(data: dict[str, object]) -> PiDeployConfig:
     """Normalize raw YAML data into a deploy config object."""
     return PiDeployConfig(
@@ -111,25 +126,19 @@ def parse_pi_deploy_config(data: dict[str, object]) -> PiDeployConfig:
         or DEFAULT_PI_PROJECT_DIR,
         branch=str(data.get("branch", "main")).strip() or "main",
         venv=str(data.get("venv", ".venv")).strip() or ".venv",
-        start_cmd=str(data.get("start_cmd", "python yoyopod.py")).strip()
-        or "python yoyopod.py",
-        kill_processes=tuple(
-            str(process).strip()
-            for process in data.get("kill_processes", ("python", "linphonec"))
-            if str(process).strip()
-        )
-        or ("python", "linphonec"),
+        start_cmd=str(data.get("start_cmd", "python yoyopod.py")).strip() or "python yoyopod.py",
+        kill_processes=_as_string_tuple(
+            data.get("kill_processes", ("python", "linphonec")),
+            default=("python", "linphonec"),
+        ),
         log_file=str(data["log_file"]).strip(),
         error_log_file=str(data["error_log_file"]).strip(),
         pid_file=str(data["pid_file"]).strip(),
         startup_marker=str(data["startup_marker"]).strip(),
-        screenshot_path=str(
-            data.get("screenshot_path", "/tmp/yoyopod_screenshot.png")
-        ).strip()
+        screenshot_path=str(data.get("screenshot_path", "/tmp/yoyopod_screenshot.png")).strip()
         or "/tmp/yoyopod_screenshot.png",
-        rsync_exclude=tuple(
-            str(pattern)
-            for pattern in data.get(
+        rsync_exclude=_as_string_tuple(
+            data.get(
                 "rsync_exclude",
                 (
                     ".git/",
@@ -143,7 +152,19 @@ def parse_pi_deploy_config(data: dict[str, object]) -> PiDeployConfig:
                     "node_modules/",
                     "*.egg-info/",
                 ),
-            )
+            ),
+            default=(
+                ".git/",
+                ".cache/",
+                "__pycache__/",
+                "*.pyc",
+                ".venv/",
+                "build/",
+                "logs/",
+                "models/",
+                "node_modules/",
+                "*.egg-info/",
+            ),
         ),
     )
 
@@ -190,6 +211,7 @@ def pi_deploy_config_to_dict(config: PiDeployConfig) -> dict[str, object]:
 # SSH and subprocess helpers
 # ---------------------------------------------------------------------------
 
+
 def shell_quote(value: str) -> str:
     """Shell-escape one literal value for the remote command string."""
     return shlex.quote(value)
@@ -212,9 +234,7 @@ def build_ssh_command(
     tty: bool = False,
 ) -> list[str]:
     """Build one SSH command targeting the Raspberry Pi."""
-    wrapped_command = (
-        f"cd {quote_remote_project_dir(config.project_dir)} && {remote_command}"
-    )
+    wrapped_command = f"cd {quote_remote_project_dir(config.project_dir)} && {remote_command}"
     ssh_command = ["ssh"]
     if tty:
         ssh_command.append("-t")
@@ -309,6 +329,7 @@ def _resolve_remote_config(
 # Startup verification and native shim helpers
 # ---------------------------------------------------------------------------
 
+
 def build_startup_verification_command(
     deploy_config: PiDeployConfig | None = None,
     *,
@@ -328,19 +349,19 @@ def build_startup_verification_command(
                 "done"
             ),
             f"test -f {pid_file}",
-            f'pid="$(tr -d \'\\n\' < {pid_file})"',
+            f"pid=\"$(tr -d '\\n' < {pid_file})\"",
             'test -n "$pid"',
             'kill -0 "$pid"',
             (
                 f"for _ in $(seq 1 {attempts}); do "
                 f"if test -f {log_file} && "
-                f"grep -F {startup_marker} {log_file} | tail -n 1 | grep -F \"pid=$pid\" >/dev/null; then "
+                f'grep -F {startup_marker} {log_file} | tail -n 1 | grep -F "pid=$pid" >/dev/null; then '
                 "break; "
                 "fi; "
                 "sleep 1; "
                 "done"
             ),
-            f"grep -F {startup_marker} {log_file} | tail -n 1 | grep -F \"pid=$pid\"",
+            f'grep -F {startup_marker} {log_file} | tail -n 1 | grep -F "pid=$pid"',
         ]
     )
 
@@ -411,9 +432,7 @@ def build_restart_command(deploy_config: PiDeployConfig) -> str:
         f"rm -f {pid_file}",
     ]
     for process_name in deploy_config.kill_processes:
-        cleanup_commands.append(
-            f"killall -9 {shell_quote(process_name)} >/dev/null 2>&1 || true"
-        )
+        cleanup_commands.append(f"killall -9 {shell_quote(process_name)} >/dev/null 2>&1 || true")
 
     cleanup_sequence = "; ".join(cleanup_commands)
     manual_restart = (
@@ -442,6 +461,7 @@ def build_restart_command(deploy_config: PiDeployConfig) -> str:
 # ---------------------------------------------------------------------------
 # Rsync / archive sync helpers
 # ---------------------------------------------------------------------------
+
 
 def resolve_local_executable(program: str) -> str | None:
     """Resolve one local executable, including common Windows install paths."""
@@ -662,6 +682,10 @@ def run_rsync_deploy(
     """Rsync the local working tree to the Pi and optionally restart the app."""
     rsync_binary = resolve_local_executable("rsync")
     if should_use_direct_rsync(rsync_binary):
+        if rsync_binary is None:
+            raise SystemExit(
+                "Direct rsync requested, but the local rsync binary could not be resolved."
+            )
         exit_code = run_local(
             build_rsync_command(config, deploy_config, executable=rsync_binary),
             "rsync",
@@ -733,6 +757,7 @@ def run_rsync_deploy(
 # Command builders
 # ---------------------------------------------------------------------------
 
+
 def build_status_command(deploy_config: PiDeployConfig | None = None) -> str:
     """Create the remote status command."""
     deploy = deploy_config or load_pi_deploy_config()
@@ -747,7 +772,7 @@ def build_status_command(deploy_config: PiDeployConfig | None = None) -> str:
             "pgrep -af mpv || true",
             "echo",
             "echo '== YoyoPod Service ==' ",
-            "systemctl is-active \"yoyopod@$(id -un).service\" || true",
+            'systemctl is-active "yoyopod@$(id -un).service" || true',
             "echo",
             "echo '== PiSugar Server ==' ",
             "systemctl is-active pisugar-server || true",
@@ -845,11 +870,20 @@ def build_local_preflight_commands() -> list[tuple[str, list[str]]]:
 # Typer commands
 # ---------------------------------------------------------------------------
 
+
 def status(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
 ) -> None:
     """Show remote repo, music backend, and process status."""
     config = _resolve_remote_config(host, user, project_dir, branch)
@@ -861,11 +895,21 @@ def status(
 
 
 def sync(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
-    skip_uv_sync: Annotated[bool, typer.Option("--skip-uv-sync", help="Skip `uv sync --extra dev` after pulling.")] = False,
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    skip_uv_sync: Annotated[
+        bool, typer.Option("--skip-uv-sync", help="Skip `uv sync --extra dev` after pulling.")
+    ] = False,
 ) -> None:
     """Fetch, checkout, pull, and optionally run uv sync on the Raspberry Pi."""
     config = _resolve_remote_config(host, user, project_dir, branch)
@@ -876,18 +920,45 @@ def sync(
 
 
 def smoke(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
-    with_power: Annotated[bool, typer.Option("--with-power", help="Include PiSugar power checks.")] = False,
-    with_rtc: Annotated[bool, typer.Option("--with-rtc", help="Include PiSugar RTC checks.")] = False,
-    with_music: Annotated[bool, typer.Option("--with-music", help="Include music-backend startup checks.")] = False,
-    with_voip: Annotated[bool, typer.Option("--with-voip", help="Include SIP registration checks.")] = False,
-    with_lvgl_soak: Annotated[bool, typer.Option("--with-lvgl-soak", help="Include a short LVGL transition and sleep/wake soak.")] = False,
-    verbose: Annotated[bool, typer.Option("--verbose", help="Enable verbose smoke-script logging.")] = False,
-    music_timeout: Annotated[int, typer.Option("--music-timeout", help="Music-backend startup timeout in seconds.")] = 5,
-    voip_timeout: Annotated[float, typer.Option("--voip-timeout", help="VoIP registration timeout in seconds.")] = 90.0,
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    with_power: Annotated[
+        bool, typer.Option("--with-power", help="Include PiSugar power checks.")
+    ] = False,
+    with_rtc: Annotated[
+        bool, typer.Option("--with-rtc", help="Include PiSugar RTC checks.")
+    ] = False,
+    with_music: Annotated[
+        bool, typer.Option("--with-music", help="Include music-backend startup checks.")
+    ] = False,
+    with_voip: Annotated[
+        bool, typer.Option("--with-voip", help="Include SIP registration checks.")
+    ] = False,
+    with_lvgl_soak: Annotated[
+        bool,
+        typer.Option(
+            "--with-lvgl-soak", help="Include a short LVGL transition and sleep/wake soak."
+        ),
+    ] = False,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", help="Enable verbose smoke-script logging.")
+    ] = False,
+    music_timeout: Annotated[
+        int, typer.Option("--music-timeout", help="Music-backend startup timeout in seconds.")
+    ] = 5,
+    voip_timeout: Annotated[
+        float, typer.Option("--voip-timeout", help="VoIP registration timeout in seconds.")
+    ] = 90.0,
 ) -> None:
     """Run the Raspberry Pi smoke validator remotely."""
     config = _resolve_remote_config(host, user, project_dir, branch)
@@ -910,21 +981,68 @@ def smoke(
 
 
 def preflight(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
-    skip_local: Annotated[bool, typer.Option("--skip-local", help="Skip local compile/test verification before remote work.")] = False,
-    skip_sync: Annotated[bool, typer.Option("--skip-sync", help="Skip the remote git pull and dependency sync step.")] = False,
-    skip_uv_sync: Annotated[bool, typer.Option("--skip-uv-sync", help="Skip `uv sync --extra dev` during the remote sync step.")] = False,
-    with_power: Annotated[bool, typer.Option("--with-power", help="Include PiSugar power checks in the remote smoke pass.")] = False,
-    with_rtc: Annotated[bool, typer.Option("--with-rtc", help="Include PiSugar RTC checks in the remote smoke pass.")] = False,
-    with_music: Annotated[bool, typer.Option("--with-music", help="Include music-backend startup checks in the remote smoke pass.")] = False,
-    with_voip: Annotated[bool, typer.Option("--with-voip", help="Include SIP registration checks in the remote smoke pass.")] = False,
-    with_lvgl_soak: Annotated[bool, typer.Option("--with-lvgl-soak", help="Include the LVGL soak helper in the remote smoke pass.")] = False,
-    verbose: Annotated[bool, typer.Option("--verbose", help="Enable verbose smoke-script logging.")] = False,
-    music_timeout: Annotated[int, typer.Option("--music-timeout", help="Music-backend startup timeout in seconds.")] = 5,
-    voip_timeout: Annotated[float, typer.Option("--voip-timeout", help="VoIP registration timeout in seconds.")] = 90.0,
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    skip_local: Annotated[
+        bool,
+        typer.Option(
+            "--skip-local", help="Skip local compile/test verification before remote work."
+        ),
+    ] = False,
+    skip_sync: Annotated[
+        bool, typer.Option("--skip-sync", help="Skip the remote git pull and dependency sync step.")
+    ] = False,
+    skip_uv_sync: Annotated[
+        bool,
+        typer.Option(
+            "--skip-uv-sync", help="Skip `uv sync --extra dev` during the remote sync step."
+        ),
+    ] = False,
+    with_power: Annotated[
+        bool,
+        typer.Option("--with-power", help="Include PiSugar power checks in the remote smoke pass."),
+    ] = False,
+    with_rtc: Annotated[
+        bool,
+        typer.Option("--with-rtc", help="Include PiSugar RTC checks in the remote smoke pass."),
+    ] = False,
+    with_music: Annotated[
+        bool,
+        typer.Option(
+            "--with-music", help="Include music-backend startup checks in the remote smoke pass."
+        ),
+    ] = False,
+    with_voip: Annotated[
+        bool,
+        typer.Option(
+            "--with-voip", help="Include SIP registration checks in the remote smoke pass."
+        ),
+    ] = False,
+    with_lvgl_soak: Annotated[
+        bool,
+        typer.Option(
+            "--with-lvgl-soak", help="Include the LVGL soak helper in the remote smoke pass."
+        ),
+    ] = False,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", help="Enable verbose smoke-script logging.")
+    ] = False,
+    music_timeout: Annotated[
+        int, typer.Option("--music-timeout", help="Music-backend startup timeout in seconds.")
+    ] = 5,
+    voip_timeout: Annotated[
+        float, typer.Option("--voip-timeout", help="VoIP registration timeout in seconds.")
+    ] = 90.0,
 ) -> None:
     """Run local checks, sync the Pi, and execute the Pi smoke pass."""
     config = _resolve_remote_config(host, user, project_dir, branch)
@@ -962,10 +1080,18 @@ def preflight(
 
 
 def restart(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable debug logging.")] = False,
 ) -> None:
     """Restart the yoyopod app on the Pi."""
@@ -978,14 +1104,26 @@ def restart(
 
 
 def logs(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
     lines: Annotated[int, typer.Option("--lines", help="Number of log lines to tail.")] = 50,
     follow: Annotated[bool, typer.Option("--follow", "-f", help="Follow log output.")] = False,
-    errors: Annotated[bool, typer.Option("--errors", help="Tail the error log instead of the main log.")] = False,
-    filter: Annotated[Optional[str], typer.Option("--filter", help="Grep filter to apply to log output.")] = None,
+    errors: Annotated[
+        bool, typer.Option("--errors", help="Tail the error log instead of the main log.")
+    ] = False,
+    filter: Annotated[
+        Optional[str], typer.Option("--filter", help="Grep filter to apply to log output.")
+    ] = None,
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable debug logging.")] = False,
 ) -> None:
     """Tail yoyopod logs on the Pi."""
@@ -1004,12 +1142,27 @@ def logs(
 
 
 def screenshot(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
-    output: Annotated[str, typer.Option("--output", help="Local output file path.")] = "screenshot.png",
-    readback: Annotated[bool, typer.Option("--readback", help="Use LVGL readback (SIGUSR1) instead of shadow path (SIGUSR2).")] = False,
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    output: Annotated[
+        str, typer.Option("--output", help="Local output file path.")
+    ] = "screenshot.png",
+    readback: Annotated[
+        bool,
+        typer.Option(
+            "--readback", help="Use LVGL readback (SIGUSR1) instead of shadow path (SIGUSR2)."
+        ),
+    ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable debug logging.")] = False,
 ) -> None:
     """Capture a screenshot from the Pi display."""
@@ -1023,11 +1176,21 @@ def screenshot(
 
 
 def rsync(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
-    skip_restart: Annotated[bool, typer.Option("--skip-restart", help="Skip restart after sync.")] = False,
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    skip_restart: Annotated[
+        bool, typer.Option("--skip-restart", help="Skip restart after sync.")
+    ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable debug logging.")] = False,
 ) -> None:
     """Rsync the local working tree to the Pi (no git commit needed)."""
@@ -1040,15 +1203,33 @@ def rsync(
 
 
 def whisplay(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
-    duration_seconds: Annotated[float, typer.Option("--duration-seconds", help="Session duration in seconds.")] = 30.0,
-    debounce_ms: Annotated[Optional[int], typer.Option("--debounce-ms", help="Debounce threshold in ms.")] = None,
-    double_tap_ms: Annotated[Optional[int], typer.Option("--double-tap-ms", help="Double-tap window in ms.")] = None,
-    long_hold_ms: Annotated[Optional[int], typer.Option("--long-hold-ms", help="Long-hold threshold in ms.")] = None,
-    no_display: Annotated[bool, typer.Option("--no-display", help="Disable display rendering.")] = False,
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    duration_seconds: Annotated[
+        float, typer.Option("--duration-seconds", help="Session duration in seconds.")
+    ] = 30.0,
+    debounce_ms: Annotated[
+        Optional[int], typer.Option("--debounce-ms", help="Debounce threshold in ms.")
+    ] = None,
+    double_tap_ms: Annotated[
+        Optional[int], typer.Option("--double-tap-ms", help="Double-tap window in ms.")
+    ] = None,
+    long_hold_ms: Annotated[
+        Optional[int], typer.Option("--long-hold-ms", help="Long-hold threshold in ms.")
+    ] = None,
+    no_display: Annotated[
+        bool, typer.Option("--no-display", help="Disable display rendering.")
+    ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable debug logging.")] = False,
 ) -> None:
     """Run the Whisplay gesture-tuning helper remotely."""
@@ -1068,13 +1249,28 @@ def whisplay(
 
 
 def rtc(
-    host: Annotated[str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")] = "",
-    user: Annotated[str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")] = "",
-    project_dir: Annotated[str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")] = "",
-    branch: Annotated[str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")] = "",
-    action: Annotated[str, typer.Argument(help="RTC action: status, sync-to, sync-from, set-alarm, disable-alarm.")] = "status",
-    time: Annotated[Optional[str], typer.Option("--time", help="Alarm time in ISO 8601 format (for set-alarm).")] = None,
-    repeat_mask: Annotated[int, typer.Option("--repeat-mask", help="Repeat bitmask (default: every day).")] = 127,
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    action: Annotated[
+        str,
+        typer.Argument(help="RTC action: status, sync-to, sync-from, set-alarm, disable-alarm."),
+    ] = "status",
+    time: Annotated[
+        Optional[str], typer.Option("--time", help="Alarm time in ISO 8601 format (for set-alarm).")
+    ] = None,
+    repeat_mask: Annotated[
+        int, typer.Option("--repeat-mask", help="Repeat bitmask (default: every day).")
+    ] = 127,
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable debug logging.")] = False,
 ) -> None:
     """Inspect or control PiSugar RTC state remotely."""
@@ -1095,6 +1291,7 @@ def rtc(
 # Compat builder functions (argparse.Namespace-based, used by tests and legacy
 # callers; these mirror the old scripts/pi_remote.py builder API)
 # ---------------------------------------------------------------------------
+
 
 def build_logs_command(
     args: argparse.Namespace,

--- a/yoyopy/main.py
+++ b/yoyopy/main.py
@@ -5,10 +5,14 @@ This module provides the console-script target used by `pyproject.toml`
 and keeps the installed entry point aligned with the top-level launcher.
 """
 
+from __future__ import annotations
+
 import os
-import sys
 import signal
+import sys
 from pathlib import Path
+from types import FrameType
+from typing import Any
 
 from loguru import logger
 
@@ -31,7 +35,7 @@ def _capture_screenshot(
     *,
     adapter: object | None,
     screenshot_path: str,
-    app_log,
+    app_log: Any,
     prefer_readback: bool,
 ) -> bool:
     """Capture a screenshot using readback-first or shadow-first fallback order."""
@@ -41,11 +45,15 @@ def _capture_screenshot(
         return False
 
     ordered_methods = (
-        ("save_screenshot_readback", "LVGL readback"),
-        ("save_screenshot", "shadow buffer"),
-    ) if prefer_readback else (
-        ("save_screenshot", "shadow buffer"),
-        ("save_screenshot_readback", "LVGL readback"),
+        (
+            ("save_screenshot_readback", "LVGL readback"),
+            ("save_screenshot", "shadow buffer"),
+        )
+        if prefer_readback
+        else (
+            ("save_screenshot", "shadow buffer"),
+            ("save_screenshot_readback", "LVGL readback"),
+        )
     )
 
     for method_name, label in ordered_methods:
@@ -68,7 +76,7 @@ def _request_screenshot_capture(
     *,
     app: object,
     screenshot_path: str,
-    app_log,
+    app_log: Any,
     prefer_readback: bool,
 ) -> None:
     """Queue screenshot capture onto the app loop when possible."""
@@ -101,7 +109,9 @@ def _request_screenshot_capture(
             get_ui_backend = getattr(display, "get_ui_backend", None)
             if callable(get_ui_backend):
                 ui_backend = get_ui_backend()
-                force_refresh = getattr(ui_backend, "force_refresh", None) if ui_backend is not None else None
+                force_refresh = (
+                    getattr(ui_backend, "force_refresh", None) if ui_backend is not None else None
+                )
                 if callable(force_refresh):
                     force_refresh()
 
@@ -214,7 +224,7 @@ def main() -> int:
         app_log.info("=" * 60)
         app_log.info("")
 
-        def handle_shutdown_signal(signum, _frame) -> None:
+        def handle_shutdown_signal(signum: int, _frame: FrameType | None) -> None:
             signal_name = signal.Signals(signum).name
             app_log.info(f"Received {signal_name}, shutting down...")
             raise KeyboardInterrupt
@@ -224,9 +234,11 @@ def main() -> int:
 
         # Screenshot signal handlers (Unix only — SIGUSR1/SIGUSR2 unavailable on Windows).
         screenshot_path = "/tmp/yoyopod_screenshot.png"
-        if hasattr(signal, "SIGUSR1"):
+        sigusr1 = getattr(signal, "SIGUSR1", None)
+        sigusr2 = getattr(signal, "SIGUSR2", None)
+        if sigusr1 is not None and sigusr2 is not None:
 
-            def handle_screenshot_default(_signum: int, _frame: object) -> None:
+            def handle_screenshot_default(_signum: int, _frame: FrameType | None) -> None:
                 """SIGUSR1: save a screenshot using readback-first capture."""
                 _request_screenshot_capture(
                     app=app,
@@ -235,7 +247,7 @@ def main() -> int:
                     prefer_readback=True,
                 )
 
-            def handle_screenshot_legacy_shadow(_signum: int, _frame: object) -> None:
+            def handle_screenshot_legacy_shadow(_signum: int, _frame: FrameType | None) -> None:
                 """SIGUSR2: save a screenshot using shadow-first capture for debugging."""
                 _request_screenshot_capture(
                     app=app,
@@ -244,8 +256,8 @@ def main() -> int:
                     prefer_readback=False,
                 )
 
-            signal.signal(signal.SIGUSR1, handle_screenshot_default)
-            signal.signal(signal.SIGUSR2, handle_screenshot_legacy_shadow)
+            signal.signal(sigusr1, handle_screenshot_default)
+            signal.signal(sigusr2, handle_screenshot_legacy_shadow)
             app_log.info(
                 "Screenshot handlers installed (SIGUSR1=default/readback-first, SIGUSR2=legacy shadow-first) -> {}",
                 screenshot_path,


### PR DESCRIPTION
## Summary

This adds repo-owned quality commands and CI wiring for the workflow surface that matters right now, without pretending the full repo is already clean.

Closes #85.

## What changed

- added `scripts/quality.py` as the single repo-owned quality runner used both locally and in CI
- added tracked gate and audit target sets under `[tool.yoyopod_quality]` in `pyproject.toml`
- wired CI to run `uv run python scripts/quality.py gate`
- documented the gate contract and rollout path in `docs/QUALITY_GATES.md`
- updated the development and rules docs to point contributors at the repo-owned quality commands
- cleaned the targeted workflow surface enough for `black`, `ruff`, and `mypy` to pass there
- added `types-PyYAML` to dev dependencies so the gated mypy surface can type-check honestly

## Gated now

The staged gate currently enforces all three checks on this tracked workflow surface:

- `scripts/quality.py`
- `yoyopy/main.py`
- `yoyopy/cli/__init__.py`
- `yoyopy/cli/common.py`
- `yoyopy/cli/build.py`
- `yoyopy/cli/remote/`

Checks enforced in CI now:

- `black --check`
- `ruff check`
- `mypy`

## Still ungated

Everything outside the staged target lists above is still outside the lint/type/format gate.

That is deliberate and documented, because the repo is not ready for whole-tree enforcement yet.

Current full-repo audit snapshot from this branch:

- `black --check .` still wants `108` files reformatted
- `ruff check .` still reports `52` existing violations
- `mypy yoyopy` still reports `520` errors in `65` files

## Why this rollout is staged

The previous CI only ran `pytest`, which meant obvious quality regressions on the developer workflow surface could slip through.

Trying to jump straight to full-tree gating in one pass would have been fake discipline: the repo currently has too much existing lint/format/type debt for that to be credible.

This PR makes the quality contract executable and enforceable now, while making the remaining debt explicit instead of hiding it.

## Path to full gating

- clean one subsystem at a time using `uv run python scripts/quality.py audit`
- expand the `[tool.yoyopod_quality]` target lists as each subsystem becomes clean
- switch the staged lists to whole-tree targets once the debt is actually burned down

## Validation

- `uv sync --extra dev`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`
- `uv run python scripts/quality.py audit`
