### PR TITLE
docs: add contributor workflow guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,16 @@ Supported display/input modes:
 ## Quick Start
 
 ```bash
-uv sync --extra dev
+uv run yoyoctl setup host
+uv run yoyoctl setup verify-host
 python yoyopod.py --simulate
+uv run python scripts/quality.py gate
 uv run pytest -q
 ```
 
 For the full setup, validation, and Pi workflow, start with:
 - [`docs/README.md`](docs/README.md)
+- [`docs/CONTRIBUTOR_WORKFLOW.md`](docs/CONTRIBUTOR_WORKFLOW.md)
 - [`docs/DEVELOPMENT_GUIDE.md`](docs/DEVELOPMENT_GUIDE.md)
 - [`docs/SETUP_CONTRACT.md`](docs/SETUP_CONTRACT.md)
 
@@ -49,11 +52,13 @@ YOYOPOD_CONFIG_BOARD=rpi-zero-2w python yoyopod.py
 
 Start here:
 - [Documentation Guide](docs/README.md)
+- [Contributor Workflow](docs/CONTRIBUTOR_WORKFLOW.md)
 - [Development Guide](docs/DEVELOPMENT_GUIDE.md)
 - [System Architecture](docs/SYSTEM_ARCHITECTURE.md)
 
 Setup and operations:
 - [Setup Contract](docs/SETUP_CONTRACT.md)
+- [Quality Gates](docs/QUALITY_GATES.md)
 - [Pi Dev Workflow](docs/PI_DEV_WORKFLOW.md)
 - [Pi Smoke Validation](docs/RPI_SMOKE_VALIDATION.md)
 - [Deployed Pi Dependencies](docs/DEPLOYED_PI_DEPENDENCIES.md)

--- a/docs/CONTRIBUTOR_WORKFLOW.md
+++ b/docs/CONTRIBUTOR_WORKFLOW.md
@@ -1,0 +1,165 @@
+# Contributor Workflow
+
+This guide is the shortest path from fresh checkout to a credible YoyoPod contribution.
+
+It is not a full architecture document and it is not a board bringup manual.
+
+It is the day-to-day contributor path.
+
+## Read this first
+
+If you are new here, read in this order:
+
+1. [`../README.md`](../README.md)
+2. [`README.md`](README.md)
+3. [`DEVELOPMENT_GUIDE.md`](DEVELOPMENT_GUIDE.md)
+4. [`SYSTEM_ARCHITECTURE.md`](SYSTEM_ARCHITECTURE.md)
+5. [`QUALITY_GATES.md`](QUALITY_GATES.md)
+6. `rules/project.md`
+7. `rules/architecture.md`
+
+## Baseline local setup
+
+Use the repo-owned setup contract first:
+
+```bash
+uv run yoyoctl setup host
+uv run yoyoctl setup verify-host
+```
+
+This is the baseline executable setup contract.
+
+It is not the same thing as complete setup ownership. Feature-specific assets and unusual hardware edges can still need extra follow-through.
+
+## Fast local loop
+
+Simulation run:
+
+```bash
+python yoyopod.py --simulate
+```
+
+Core validation loop:
+
+```bash
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+Full quality debt audit:
+
+```bash
+uv run python scripts/quality.py audit
+```
+
+Use `gate` for the tracked workflow surface that CI enforces now.
+Use `audit` when you want to see the broader repo debt without pretending it is all gated yet.
+
+## Choose the right doc path for the work
+
+### Runtime and orchestration work
+
+Read:
+
+1. [`SYSTEM_ARCHITECTURE.md`](SYSTEM_ARCHITECTURE.md)
+2. subsystem docs for the area you are touching
+3. `rules/architecture.md`
+4. the relevant files under `yoyopy/`
+
+Current reality:
+
+- `YoyoPodApp` is thinner than before, but runtime cleanup is still in progress
+- `yoyopy/runtime/boot.py` is still a hotspot, not a final architecture destination
+- runtime/state/model cleanup should prefer clearer ownership over broad rewrites
+
+### Raspberry Pi and setup work
+
+Read:
+
+1. [`SETUP_CONTRACT.md`](SETUP_CONTRACT.md)
+2. [`DEVELOPMENT_GUIDE.md`](DEVELOPMENT_GUIDE.md)
+3. [`PI_DEV_WORKFLOW.md`](PI_DEV_WORKFLOW.md)
+4. [`RPI_SMOKE_VALIDATION.md`](RPI_SMOKE_VALIDATION.md)
+5. `rules/deploy.md`
+
+Baseline commands:
+
+```bash
+uv run yoyoctl setup pi
+uv run yoyoctl setup verify-pi
+uv run yoyoctl remote setup
+uv run yoyoctl remote verify-setup
+```
+
+These are the canonical baseline commands.
+They do not yet fully solve non-apt assets, every board/modem bringup edge, or deep native-health validation.
+
+### Docs and contributor guidance work
+
+Read:
+
+1. [`README.md`](../README.md)
+2. [`README.md`](README.md)
+3. this file
+4. `rules/project.md`
+5. `rules/architecture.md`
+
+When updating docs:
+
+- prefer source-of-truth docs over plan docs
+- keep the staged-vs-complete distinction honest
+- do not describe debt as solved just because a baseline contract exists
+
+## Before opening a PR
+
+At minimum, run:
+
+```bash
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+Then add any focused commands relevant to your area, for example:
+
+```bash
+python -m compileall yoyopy tests demos scripts
+uv run pytest -q tests/test_app_orchestration.py
+uv run pytest -q tests/test_setup_cli.py tests/test_pi_remote.py tests/test_cli.py
+```
+
+If your change is outside the currently gated surface, say so plainly in the PR instead of pretending CI covered more than it did.
+
+## What a good PR looks like here
+
+A good YoyoPod PR:
+
+- stays within one coherent problem slice
+- updates docs when the contract changes
+- says exactly what is now enforced vs still debt
+- avoids fake completeness
+- leaves the repo more navigable than before
+
+## Current contributor traps
+
+Watch for these recurring mistakes:
+
+- treating the staged quality gate as whole-repo cleanliness
+- treating the setup contract as fully solved setup ownership
+- mixing unrelated cleanup into architecture PRs
+- moving complexity into a new file and calling the architecture done
+- updating plan docs while leaving source-of-truth docs stale
+
+## Current hotspots
+
+These are good places to be extra careful:
+
+- `yoyopy/runtime/boot.py`
+- `yoyopy/app_context.py`
+- duplicated domain/state models that drift across layers
+- setup/docs wording that can overstate what the new commands guarantee
+
+## If you only remember one thing
+
+Be honest about the repo’s current state.
+
+This project is making real foundation progress, but it is still alpha. The right move is to land executable improvements without pretending the remaining debt disappeared.

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -6,7 +6,8 @@ If you are new here, read these first:
 
 1. [`../README.md`](../README.md)
 2. [`README.md`](README.md)
-3. [`SYSTEM_ARCHITECTURE.md`](SYSTEM_ARCHITECTURE.md)
+3. [`CONTRIBUTOR_WORKFLOW.md`](CONTRIBUTOR_WORKFLOW.md)
+4. [`SYSTEM_ARCHITECTURE.md`](SYSTEM_ARCHITECTURE.md)
 
 ## Source of truth
 
@@ -199,6 +200,20 @@ yoyopy/
   fsm.py
   app_context.py
   coordinators/
+  runtime/
+    boot.py
+    loop.py
+    recovery.py
+    screen_power.py
+    shutdown.py
+    models.py
+  cli/
+    setup.py
+    remote/
+      setup.py
+      ops.py
+      infra.py
+      lvgl.py
   audio/
     history.py
     local_service.py
@@ -222,13 +237,19 @@ yoyopy/
     lvgl_binding/
     screens/
     web_server.py
+scripts/
+  quality.py
+sitecustomize.py
 ```
 
 ## Current Active Docs
 
 Start with [`README.md`](README.md) for the full docs map.
 
-Current runtime and setup docs:
+Current contributor, runtime, and setup docs:
+- `docs/CONTRIBUTOR_WORKFLOW.md`
+- `docs/QUALITY_GATES.md`
+- `docs/SETUP_CONTRACT.md`
 - `docs/SYSTEM_ARCHITECTURE.md`
 - `docs/POWER_MODULE.md`
 - `docs/LOCAL_FIRST_MUSIC_PLAN.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,13 +25,16 @@ Plan docs are useful, but they are not automatically the current implementation 
 ### Start here
 
 - [`../README.md`](../README.md), repo overview and quick start
+- [`CONTRIBUTOR_WORKFLOW.md`](CONTRIBUTOR_WORKFLOW.md), day-to-day contributor path and PR checklist
 - [`DEVELOPMENT_GUIDE.md`](DEVELOPMENT_GUIDE.md), setup, running, validation, package layout
 - [`SYSTEM_ARCHITECTURE.md`](SYSTEM_ARCHITECTURE.md), current runtime architecture
 
 ### Setup, bringup, and deployment
 
+- [`CONTRIBUTOR_WORKFLOW.md`](CONTRIBUTOR_WORKFLOW.md), contributor onboarding and daily workflow
 - [`DEVELOPMENT_GUIDE.md`](DEVELOPMENT_GUIDE.md), main developer setup guide
 - [`SETUP_CONTRACT.md`](SETUP_CONTRACT.md), repo-owned setup and dependency contract
+- [`QUALITY_GATES.md`](QUALITY_GATES.md), current staged quality gate and audit contract
 - [`DEPLOYED_PI_DEPENDENCIES.md`](DEPLOYED_PI_DEPENDENCIES.md), deployed/runtime dependency inventory
 - [`PI_DEV_WORKFLOW.md`](PI_DEV_WORKFLOW.md), day-to-day Raspberry Pi workflow
 - [`RPI_SMOKE_VALIDATION.md`](RPI_SMOKE_VALIDATION.md), validation checklist for CI-safe and on-device checks
@@ -84,9 +87,10 @@ Archive files are for historical context only. They are not the source of truth 
 
 1. `README.md`
 2. `docs/README.md`
-3. `docs/DEVELOPMENT_GUIDE.md`
-4. `docs/SYSTEM_ARCHITECTURE.md`
-5. `rules/project.md`
+3. `docs/CONTRIBUTOR_WORKFLOW.md`
+4. `docs/DEVELOPMENT_GUIDE.md`
+5. `docs/SYSTEM_ARCHITECTURE.md`
+6. `rules/project.md`
 
 ### Working on runtime code
 
@@ -97,7 +101,9 @@ Archive files are for historical context only. They are not the source of truth 
 
 ### Working on Raspberry Pi deployment
 
-1. `docs/DEVELOPMENT_GUIDE.md`
-2. `docs/PI_DEV_WORKFLOW.md`
-3. `docs/RPI_SMOKE_VALIDATION.md`
-4. `skills/yoyopod-*.md` guidance via `AGENTS.md`
+1. `docs/CONTRIBUTOR_WORKFLOW.md`
+2. `docs/SETUP_CONTRACT.md`
+3. `docs/DEVELOPMENT_GUIDE.md`
+4. `docs/PI_DEV_WORKFLOW.md`
+5. `docs/RPI_SMOKE_VALIDATION.md`
+6. `skills/yoyopod-*.md` guidance via `AGENTS.md`


### PR DESCRIPTION
## What changed
- add a dedicated contributor workflow guide that gives new contributors one current path from setup to validation to PR prep
- thread that guide through the repo landing page, docs entrypoint, and development guide
- update the development guide package-layout section so it reflects the post-runtime-extraction and setup-command shape
- surface the staged quality-gate docs alongside the setup contract instead of leaving the workflow split across files

## Why
The repo now has better setup and quality contracts, but the contributor path is still too scattered. This PR makes the day-to-day workflow easier to find and harder to misread.

## Notes
- this is a docs slice, not a behavior change
- it keeps the repo honest about staged quality gates and baseline setup vs fully solved setup ownership

## Validation
- `git diff --check`
- `rg -n "CONTRIBUTOR_WORKFLOW|QUALITY_GATES" README.md docs/README.md docs/DEVELOPMENT_GUIDE.md docs/CONTRIBUTOR_WORKFLOW.md`

Related to #85
Related to #87