### PR TITLE
[codex] Refactor AppContext into focused runtime state objects

### DIFF
--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -51,6 +51,8 @@ yoyopod.py / yoyopy.main
       -> CoordinatorRuntime
       -> CallCoordinator / PlaybackCoordinator / ScreenCoordinator / PowerCoordinator
       -> AppContext
+         -> focused runtime state objects (`media`, `power`, `network`, `screen`, `voip`, `talk`, `voice`)
+         -> media state composes with canonical music models from `yoyopy/audio/music/models.py`
       -> LocalMusicService
       -> MpvBackend
         -> MpvProcess
@@ -79,7 +81,8 @@ yoyopod.py / yoyopy.main
 - `yoyopy/main.py`: package entry point
 - `yoyopy/fsm.py`: split music and call state models
 - `yoyopy/coordinators/runtime.py`: derived app runtime state
-- `yoyopy/app_context.py`: shared app state
+- `yoyopy/app_context.py`: compatibility wrapper over focused shared runtime state
+- `yoyopy/runtime_state.py`: focused runtime state objects owned by `AppContext`
 - `yoyopy/runtime/boot.py`: boot-time composition and manager wiring
 - `yoyopy/runtime/loop.py`: coordinator-loop scheduling and queued main-thread work
 - `yoyopy/runtime/recovery.py`: backend recovery, power polling, and watchdog supervision
@@ -197,6 +200,7 @@ and updates:
 - screen stack
 - music pause/resume behavior
 - state machine state
+- focused runtime state objects through `AppContext`
 
 ## Event Flows
 

--- a/rules/architecture.md
+++ b/rules/architecture.md
@@ -11,7 +11,8 @@ yoyopod.py / yoyopy/main.py  (entry points)
     |- ShutdownLifecycleService (runtime/shutdown.py)
     |- MusicFSM + CallFSM (fsm.py) -- composed playback and call state machines
     |- CoordinatorRuntime (coordinators/runtime.py) -- derived app state
-    |- AppContext (app_context.py) -- shared state
+    |- AppContext (app_context.py) -- compatibility wrapper over focused runtime state objects
+    |  |- media / power / network / screen / voip / talk / voice
     |- LocalMusicService (audio/local_service.py) -- playlists, recents, shuffle
     |- MpvBackend (audio/music/backend.py)
     |  |- MpvProcess (audio/music/process.py)
@@ -84,6 +85,11 @@ yoyopod.py / yoyopy/main.py  (entry points)
 
 - Prefer canonical typed models over parallel shape duplication across UI and runtime layers.
 - `AppContext` is shared runtime state, not a dumping ground for every new feature field.
+- Prefer adding new mutable runtime fields to the focused state objects in `yoyopy/runtime_state.py`
+  before extending `AppContext` directly.
+- Music runtime state should compose with the canonical models in `yoyopy/audio/music/models.py`.
+- Use `PlaybackQueue` for ordered playback state instead of defining alternate runtime `Track` or
+  `Playlist` shapes under `AppContext` or `runtime_state.py`.
 - New domain objects should be introduced in clear model modules before being copied into screen-only state.
 
 ### Events and threading

--- a/tests/test_app_context_runtime_state.py
+++ b/tests/test_app_context_runtime_state.py
@@ -1,0 +1,126 @@
+"""Tests for focused AppContext runtime state ownership."""
+
+from __future__ import annotations
+
+from yoyopy.app_context import AppContext
+from yoyopy.audio.music.models import PlaybackQueue, Track
+
+
+def test_app_context_groups_runtime_state_by_concern() -> None:
+    """The shared context should expose focused state objects for major runtime concerns."""
+
+    context = AppContext()
+    playlist = PlaybackQueue(
+        name="Bedtime Mix",
+        tracks=[
+            Track(
+                uri="demo://stars",
+                name="Stars",
+                artists=["Mama"],
+                length=180_000,
+            )
+        ],
+    )
+
+    context.set_playlist(playlist)
+    context.update_voip_status(configured=True, ready=False)
+    context.update_network_status(
+        network_enabled=True,
+        signal_bars=3,
+        connection_type="4g",
+        connected=True,
+        gps_has_fix=True,
+    )
+    context.update_screen_runtime(
+        screen_awake=False,
+        app_uptime_seconds=93.4,
+        screen_on_seconds=45.1,
+        idle_seconds=12.2,
+    )
+    context.update_call_summary(missed_calls=2, recent_calls=["Mama"])
+    context.set_talk_contact(name="Mama", sip_address="sip:alice@example.com")
+    context.set_voice_note_recipient(name="Mama", sip_address="sip:alice@example.com")
+    context.update_active_voice_note(
+        send_state="review",
+        status_text="Ready to send",
+        file_path="/tmp/voice-note.wav",
+        duration_ms=3200,
+    )
+
+    assert context.media.current_playlist is playlist
+    assert context.media.current_track() == playlist.current_track()
+    assert context.voip.configured is True
+    assert context.voip.ready is False
+    assert context.network.enabled is True
+    assert context.network.signal_strength == 3
+    assert context.network.connection_type == "4g"
+    assert context.network.connected is True
+    assert context.network.gps_has_fix is True
+    assert context.screen.awake is False
+    assert context.screen.app_uptime_seconds == 93
+    assert context.screen.on_seconds == 45
+    assert context.screen.idle_seconds == 12
+    assert context.talk.missed_calls == 2
+    assert context.talk.recent_calls == ["Mama"]
+    assert context.talk.selected_contact_name == "Mama"
+    assert context.talk.selected_contact_address == "sip:alice@example.com"
+    assert context.talk.active_voice_note.recipient_name == "Mama"
+    assert context.talk.active_voice_note.recipient_address == "sip:alice@example.com"
+    assert context.talk.active_voice_note.send_state == "review"
+    assert context.talk.active_voice_note.status_text == "Ready to send"
+    assert context.talk.active_voice_note.file_path == "/tmp/voice-note.wav"
+    assert context.talk.active_voice_note.duration_ms == 3200
+
+
+def test_app_context_compatibility_aliases_write_through_nested_state() -> None:
+    """Legacy top-level fields should still update the focused runtime state objects."""
+
+    context = AppContext()
+    playlist = PlaybackQueue(name="Demo")
+
+    context.current_playlist = playlist
+    context.playlists = {"demo": playlist}
+    context.battery_percent = 77
+    context.battery_charging = True
+    context.power_available = True
+    context.connection_type = "wifi"
+    context.network_enabled = True
+    context.is_connected = True
+    context.gps_has_fix = True
+    context.screen_awake = False
+    context.screen_on_seconds = 31
+    context.screen_idle_seconds = 9
+    context.app_uptime_seconds = 120
+    context.talk_contact_name = "Mama"
+    context.talk_contact_address = "sip:alice@example.com"
+    context.voice_note_recipient_name = "Mama"
+    context.voice_note_recipient_address = "sip:alice@example.com"
+    context.voice_note_send_state = "sent"
+    context.voice_note_status_text = "Delivered"
+    context.voice_note_file_path = "/tmp/note.wav"
+    context.voice_note_duration_ms = 2800
+    context.cache_output_volume(64)
+
+    assert context.media.current_playlist is playlist
+    assert context.media.playlists == {"demo": playlist}
+    assert context.power.battery_percent == 77
+    assert context.power.battery_charging is True
+    assert context.power.available is True
+    assert context.network.connection_type == "wifi"
+    assert context.network.enabled is True
+    assert context.network.connected is True
+    assert context.network.gps_has_fix is True
+    assert context.screen.awake is False
+    assert context.screen.on_seconds == 31
+    assert context.screen.idle_seconds == 9
+    assert context.screen.app_uptime_seconds == 120
+    assert context.talk.selected_contact_name == "Mama"
+    assert context.talk.selected_contact_address == "sip:alice@example.com"
+    assert context.talk.active_voice_note.recipient_name == "Mama"
+    assert context.talk.active_voice_note.recipient_address == "sip:alice@example.com"
+    assert context.talk.active_voice_note.send_state == "sent"
+    assert context.talk.active_voice_note.status_text == "Delivered"
+    assert context.talk.active_voice_note.file_path == "/tmp/note.wav"
+    assert context.talk.active_voice_note.duration_ms == 2800
+    assert context.media.playback.volume == 64
+    assert context.voice.output_volume == 64

--- a/tests/test_network_status_sync.py
+++ b/tests/test_network_status_sync.py
@@ -87,15 +87,20 @@ def test_network_event_handlers_keep_context_status_in_sync() -> None:
     assert app.context.network_enabled is True
     assert app.context.is_connected is True
     assert app.context.connection_type == "4g"
+    assert app.context.network.enabled is True
+    assert app.context.network.connected is True
 
     app._handle_network_signal_update(NetworkSignalUpdateEvent(bars=2, csq=12))
     assert app.context.signal_strength == 2
+    assert app.context.network.signal_strength == 2
 
     app._handle_network_gps_fix(NetworkGpsFixEvent(lat=0.0, lng=0.0))
     assert app.context.gps_has_fix is True
+    assert app.context.network.gps_has_fix is True
 
     app._handle_network_gps_no_fix(NetworkGpsNoFixEvent(reason="no_fix"))
     assert app.context.gps_has_fix is False
+    assert app.context.network.gps_has_fix is False
 
     app._handle_network_ppp_down(NetworkPppDownEvent(reason="link lost"))
     assert app.context.network_enabled is True
@@ -137,10 +142,13 @@ def test_network_event_handlers_prefer_live_manager_state_over_latched_flags() -
     assert app.context.connection_type == "4g"
     assert app.context.is_connected is False
     assert app.context.gps_has_fix is True
+    assert app.context.network.enabled is True
+    assert app.context.network.signal_strength == 3
 
     app.network_manager.modem_state.gps = None
     app._handle_network_gps_no_fix(NetworkGpsNoFixEvent(reason="no_fix"))
     assert app.context.gps_has_fix is False
+    assert app.context.network.gps_has_fix is False
 
     app._handle_network_ppp_down(NetworkPppDownEvent(reason="link lost"))
     assert app.context.connection_type == "4g"

--- a/yoyopy/app_context.py
+++ b/yoyopy/app_context.py
@@ -1,203 +1,393 @@
 """
-Application context for YoyoPod.
-
-Maintains shared state across the application including
-current playlist, playback status, volume, and user settings.
+Compatibility wrapper around focused YoyoPod runtime state objects.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional, List, Dict, Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
 from yoyopy.audio.music.models import PlaybackQueue, Track
+from yoyopy.runtime_state import (
+    ActiveVoiceNoteState,
+    MediaRuntimeState,
+    NetworkRuntimeState,
+    PlaybackState,
+    PowerRuntimeState,
+    ScreenRuntimeState,
+    TalkRuntimeState,
+    VoiceState,
+    VoipRuntimeState,
+)
 from yoyopy.ui.input.hal import InteractionProfile
 
 if TYPE_CHECKING:
     from yoyopy.audio.manager import AudioManager
     from yoyopy.power import PowerSnapshot
 
-
-@dataclass
-class PlaybackState:
-    """Current playback state."""
-
-    is_playing: bool = False
-    is_paused: bool = False
-    is_stopped: bool = True
-    position: float = 0.0  # Current position in seconds
-    volume: int = 50  # Volume 0-100
-    is_muted: bool = False
-
-
-@dataclass
-class VoiceState:
-    """Runtime voice settings and recent voice activity."""
-
-    commands_enabled: bool = True
-    ai_requests_enabled: bool = True
-    screen_read_enabled: bool = False
-    stt_enabled: bool = True
-    tts_enabled: bool = True
-    mic_muted: bool = False
-    speaker_device_id: str | None = None
-    capture_device_id: str | None = None
-    stt_available: bool = False
-    tts_available: bool = False
-    last_transcript: str = ""
-    last_spoken_text: str = ""
-    last_mode: str = ""
-    output_volume: int = 50
-
+__all__ = [
+    "ActiveVoiceNoteState",
+    "AppContext",
+    "MediaRuntimeState",
+    "NetworkRuntimeState",
+    "PlaybackState",
+    "PowerRuntimeState",
+    "ScreenRuntimeState",
+    "TalkRuntimeState",
+    "VoiceState",
+    "VoipRuntimeState",
+]
 
 _VOICE_UNSET = object()
 
 
 class AppContext:
     """
-    Central application context.
+    Shared app-facing runtime state.
 
-    Maintains all shared state including playback, playlists,
-    user settings, and system status.
+    `AppContext` now owns focused runtime state objects and keeps a light
+    compatibility surface for existing callers that still read or write the
+    old top-level fields.
     """
 
     def __init__(
         self,
-        audio_manager: Optional["AudioManager"] = None,
+        audio_manager: "AudioManager | None" = None,
         interaction_profile: InteractionProfile = InteractionProfile.STANDARD,
     ) -> None:
-        """
-        Initialize application context.
-
-        Args:
-            audio_manager: Optional AudioManager instance for actual playback
-        """
-        # Playback state
-        self.playback = PlaybackState()
-
-        # Audio manager (optional, for actual audio playback)
         self.audio_manager = audio_manager
         self.interaction_profile = interaction_profile
 
-        # Current playlist
-        self.current_playlist: Optional[PlaybackQueue] = None
+        self.media = MediaRuntimeState()
+        self.power = PowerRuntimeState()
+        self.network = NetworkRuntimeState()
+        self.screen = ScreenRuntimeState()
+        self.voip = VoipRuntimeState()
+        self.talk = TalkRuntimeState()
+        self.voice = VoiceState(output_volume=self.media.playback.volume)
 
-        # Available playlists
-        self.playlists: Dict[str, PlaybackQueue] = {}
-
-        # User settings
+        # Existing user-tunable values still live as a simple compatibility bag.
         self.settings = {
             "brightness": 100,
             "auto_sleep_minutes": 30,
             "parental_controls_enabled": False,
-            "max_volume": 80,  # Parental control default
+            "max_volume": 80,
         }
-        self.voice = VoiceState(output_volume=self.playback.volume)
 
-        # System status
-        self.battery_percent: int = 100
-        self.battery_charging: bool = False
-        self.external_power: bool = False
-        self.power_available: bool = False
-        self.power_error: str = ""
-        self.voip_configured: bool = False
-        self.voip_ready: bool = False
-        self.screen_awake: bool = True
-        self.screen_idle_seconds: int = 0
-        self.screen_on_seconds: int = 0
-        self.app_uptime_seconds: int = 0
-        self.signal_strength: int = 4  # 0-4 bars
-        self.is_connected: bool = False
-        self.connection_type: str = "none"  # wifi, 4g, none
-        self.network_enabled: bool = False
-        self.gps_has_fix: bool = False
-        self.missed_calls: int = 0
-        self.recent_calls: List[str] = []
-        self.unread_voice_notes: int = 0
-        self.latest_voice_note_by_contact: Dict[str, Dict[str, Any]] = {}
-        self.talk_contact_name: str = ""
-        self.talk_contact_address: str = ""
-        self.voice_note_recipient_name: str = ""
-        self.voice_note_recipient_address: str = ""
-        self.voice_note_send_state: str = "idle"
-        self.voice_note_status_text: str = ""
-        self.voice_note_file_path: str = ""
-        self.voice_note_duration_ms: int = 0
-
-        # Navigation history for back button
-        self.navigation_history: List[str] = []
+        # Navigation history remains screen-manager-adjacent scratch state.
+        self.navigation_history: list[str] = []
 
         logger.info("AppContext initialized")
 
-    def set_playlist(self, playlist: PlaybackQueue) -> None:
-        """
-        Set the current playlist.
+    @property
+    def playback(self) -> PlaybackState:
+        """Expose playback state for existing callers."""
 
-        Args:
-            playlist: Playlist to set as current
-        """
-        self.current_playlist = playlist
+        return self.media.playback
+
+    @playback.setter
+    def playback(self, value: PlaybackState) -> None:
+        self.media.playback = value
+
+    @property
+    def current_playlist(self) -> PlaybackQueue | None:
+        """Expose the active playlist for existing callers."""
+
+        return self.media.current_playlist
+
+    @current_playlist.setter
+    def current_playlist(self, value: PlaybackQueue | None) -> None:
+        self.media.current_playlist = value
+
+    @property
+    def playlists(self) -> dict[str, PlaybackQueue]:
+        """Expose cached playlists for existing callers."""
+
+        return self.media.playlists
+
+    @playlists.setter
+    def playlists(self, value: dict[str, PlaybackQueue]) -> None:
+        self.media.playlists = value
+
+    @property
+    def battery_percent(self) -> int:
+        return self.power.battery_percent
+
+    @battery_percent.setter
+    def battery_percent(self, value: int) -> None:
+        self.power.update_battery_percent(value)
+
+    @property
+    def battery_charging(self) -> bool:
+        return self.power.battery_charging
+
+    @battery_charging.setter
+    def battery_charging(self, value: bool) -> None:
+        self.power.battery_charging = value
+
+    @property
+    def external_power(self) -> bool:
+        return self.power.external_power
+
+    @external_power.setter
+    def external_power(self, value: bool) -> None:
+        self.power.external_power = value
+
+    @property
+    def power_available(self) -> bool:
+        return self.power.available
+
+    @power_available.setter
+    def power_available(self, value: bool) -> None:
+        self.power.available = value
+
+    @property
+    def power_error(self) -> str:
+        return self.power.error
+
+    @power_error.setter
+    def power_error(self, value: str) -> None:
+        self.power.error = value
+
+    @property
+    def voip_configured(self) -> bool:
+        return self.voip.configured
+
+    @voip_configured.setter
+    def voip_configured(self, value: bool) -> None:
+        self.voip.configured = value
+
+    @property
+    def voip_ready(self) -> bool:
+        return self.voip.ready
+
+    @voip_ready.setter
+    def voip_ready(self, value: bool) -> None:
+        self.voip.ready = value
+
+    @property
+    def screen_awake(self) -> bool:
+        return self.screen.awake
+
+    @screen_awake.setter
+    def screen_awake(self, value: bool) -> None:
+        self.screen.awake = value
+
+    @property
+    def screen_idle_seconds(self) -> int:
+        return self.screen.idle_seconds
+
+    @screen_idle_seconds.setter
+    def screen_idle_seconds(self, value: int) -> None:
+        self.screen.idle_seconds = max(0, int(value))
+
+    @property
+    def screen_on_seconds(self) -> int:
+        return self.screen.on_seconds
+
+    @screen_on_seconds.setter
+    def screen_on_seconds(self, value: int) -> None:
+        self.screen.on_seconds = max(0, int(value))
+
+    @property
+    def app_uptime_seconds(self) -> int:
+        return self.screen.app_uptime_seconds
+
+    @app_uptime_seconds.setter
+    def app_uptime_seconds(self, value: int) -> None:
+        self.screen.app_uptime_seconds = max(0, int(value))
+
+    @property
+    def signal_strength(self) -> int:
+        return self.network.signal_strength
+
+    @signal_strength.setter
+    def signal_strength(self, value: int) -> None:
+        self.network.signal_strength = max(0, min(4, int(value)))
+
+    @property
+    def is_connected(self) -> bool:
+        return self.network.connected
+
+    @is_connected.setter
+    def is_connected(self, value: bool) -> None:
+        self.network.connected = value
+
+    @property
+    def connection_type(self) -> str:
+        return self.network.connection_type
+
+    @connection_type.setter
+    def connection_type(self, value: str) -> None:
+        self.network.connection_type = value
+
+    @property
+    def network_enabled(self) -> bool:
+        return self.network.enabled
+
+    @network_enabled.setter
+    def network_enabled(self, value: bool) -> None:
+        self.network.enabled = value
+
+    @property
+    def gps_has_fix(self) -> bool:
+        return self.network.gps_has_fix
+
+    @gps_has_fix.setter
+    def gps_has_fix(self, value: bool) -> None:
+        self.network.gps_has_fix = value
+
+    @property
+    def missed_calls(self) -> int:
+        return self.talk.missed_calls
+
+    @missed_calls.setter
+    def missed_calls(self, value: int) -> None:
+        self.talk.missed_calls = max(0, int(value))
+
+    @property
+    def recent_calls(self) -> list[str]:
+        return self.talk.recent_calls
+
+    @recent_calls.setter
+    def recent_calls(self, value: list[str]) -> None:
+        self.talk.recent_calls = list(value)
+
+    @property
+    def unread_voice_notes(self) -> int:
+        return self.talk.unread_voice_notes
+
+    @unread_voice_notes.setter
+    def unread_voice_notes(self, value: int) -> None:
+        self.talk.unread_voice_notes = max(0, int(value))
+
+    @property
+    def latest_voice_note_by_contact(self) -> dict[str, dict[str, object]]:
+        return self.talk.latest_voice_note_by_contact
+
+    @latest_voice_note_by_contact.setter
+    def latest_voice_note_by_contact(self, value: dict[str, dict[str, object]]) -> None:
+        self.talk.latest_voice_note_by_contact = dict(value)
+
+    @property
+    def talk_contact_name(self) -> str:
+        return self.talk.selected_contact_name
+
+    @talk_contact_name.setter
+    def talk_contact_name(self, value: str) -> None:
+        self.talk.selected_contact_name = value
+
+    @property
+    def talk_contact_address(self) -> str:
+        return self.talk.selected_contact_address
+
+    @talk_contact_address.setter
+    def talk_contact_address(self, value: str) -> None:
+        self.talk.selected_contact_address = value
+
+    @property
+    def voice_note_recipient_name(self) -> str:
+        return self.talk.active_voice_note.recipient_name
+
+    @voice_note_recipient_name.setter
+    def voice_note_recipient_name(self, value: str) -> None:
+        self.talk.active_voice_note.recipient_name = value
+
+    @property
+    def voice_note_recipient_address(self) -> str:
+        return self.talk.active_voice_note.recipient_address
+
+    @voice_note_recipient_address.setter
+    def voice_note_recipient_address(self, value: str) -> None:
+        self.talk.active_voice_note.recipient_address = value
+
+    @property
+    def voice_note_send_state(self) -> str:
+        return self.talk.active_voice_note.send_state
+
+    @voice_note_send_state.setter
+    def voice_note_send_state(self, value: str) -> None:
+        self.talk.active_voice_note.send_state = value
+
+    @property
+    def voice_note_status_text(self) -> str:
+        return self.talk.active_voice_note.status_text
+
+    @voice_note_status_text.setter
+    def voice_note_status_text(self, value: str) -> None:
+        self.talk.active_voice_note.status_text = value
+
+    @property
+    def voice_note_file_path(self) -> str:
+        return self.talk.active_voice_note.file_path
+
+    @voice_note_file_path.setter
+    def voice_note_file_path(self, value: str) -> None:
+        self.talk.active_voice_note.file_path = value
+
+    @property
+    def voice_note_duration_ms(self) -> int:
+        return self.talk.active_voice_note.duration_ms
+
+    @voice_note_duration_ms.setter
+    def voice_note_duration_ms(self, value: int) -> None:
+        self.talk.active_voice_note.duration_ms = max(0, int(value))
+
+    def set_playlist(self, playlist: PlaybackQueue) -> None:
+        """Set the current playlist."""
+
+        self.media.set_playlist(playlist)
         logger.info(f"Playlist set: {playlist.name} ({len(playlist.tracks)} tracks)")
 
-    def get_current_track(self) -> Optional[Track]:
+    def get_current_track(self) -> Track | None:
         """Get the currently playing/selected track."""
-        if self.current_playlist:
-            return self.current_playlist.current_track()
-        return None
+
+        return self.media.current_track()
 
     def play(self) -> bool:
-        """
-        Start playback.
+        """Start playback when a current track exists."""
 
-        Returns:
-            True if playback started, False otherwise
-        """
-        track = self.get_current_track()
+        track = self.media.current_track()
         if track is None:
             logger.warning("Cannot play: no track selected")
             return False
 
-        self.playback.is_playing = True
-        self.playback.is_paused = False
-        self.playback.is_stopped = False
+        self.media.play()
         logger.info(f"Playing: {track.name}")
         return True
 
     def pause(self) -> None:
         """Pause playback."""
-        if self.playback.is_playing:
-            self.playback.is_playing = False
-            self.playback.is_paused = True
-            logger.info("Playback paused")
+
+        if not self.playback.is_playing:
+            return
+
+        self.media.pause()
+        logger.info("Playback paused")
 
     def resume(self) -> None:
         """Resume playback."""
-        if self.playback.is_paused:
-            self.playback.is_playing = True
-            self.playback.is_paused = False
-            logger.info("Playback resumed")
+
+        if not self.playback.is_paused:
+            return
+
+        self.media.resume()
+        logger.info("Playback resumed")
 
     def stop(self) -> None:
         """Stop playback."""
-        self.playback.is_playing = False
-        self.playback.is_paused = False
-        self.playback.is_stopped = True
-        self.playback.position = 0.0
+
+        self.media.stop()
         logger.info("Playback stopped")
 
     def toggle_playback(self) -> bool:
-        """
-        Toggle between play and pause.
+        """Toggle between play and pause."""
 
-        Returns:
-            True if now playing, False if paused
-        """
         if self.playback.is_playing:
             self.pause()
             return False
-        elif self.playback.is_paused or self.playback.is_stopped:
+        if self.playback.is_paused or self.playback.is_stopped:
             if self.playback.is_stopped:
                 self.play()
             else:
@@ -205,76 +395,63 @@ class AppContext:
             return True
         return False
 
+    def cache_output_volume(self, volume: int) -> int:
+        """Keep playback and voice volume caches aligned."""
+
+        cached_volume = max(0, min(100, int(volume)))
+        self.media.playback.volume = cached_volume
+        self.voice.output_volume = cached_volume
+        if self.audio_manager is not None:
+            self.audio_manager.volume = cached_volume
+        return cached_volume
+
     def set_volume(self, volume: int) -> None:
-        """
-        Set playback volume.
+        """Set playback volume while respecting the configured max volume."""
 
-        Args:
-            volume: Volume level (0-100)
-        """
         max_volume = self.settings.get("max_volume", 100)
-        volume = max(0, min(volume, max_volume))
-        self.playback.volume = volume
-        self.voice.output_volume = volume
-
-        # Sync with audio manager if available
-        if self.audio_manager:
-            self.audio_manager.volume = volume
-
+        volume = max(0, min(int(volume), int(max_volume)))
+        self.cache_output_volume(volume)
         logger.debug(f"Volume set to {volume}")
 
     def volume_up(self, step: int = 5) -> int:
-        """
-        Increase volume.
+        """Increase volume."""
 
-        Args:
-            step: Amount to increase (default 5)
-
-        Returns:
-            New volume level
-        """
-        new_volume = self.playback.volume + step
-        self.set_volume(new_volume)
+        self.set_volume(self.playback.volume + step)
         return self.playback.volume
 
     def volume_down(self, step: int = 5) -> int:
-        """
-        Decrease volume.
+        """Decrease volume."""
 
-        Args:
-            step: Amount to decrease (default 5)
-
-        Returns:
-            New volume level
-        """
-        new_volume = self.playback.volume - step
-        self.set_volume(new_volume)
+        self.set_volume(self.playback.volume - step)
         return self.playback.volume
 
-    def next_track(self) -> Optional[Track]:
-        """Skip to next track."""
-        if self.current_playlist:
-            track = self.current_playlist.next_track()
-            if track:
-                logger.info(f"Next track: {track.name}")
-                if self.playback.is_playing:
-                    self.play()
-            return track
-        return None
+    def next_track(self) -> Track | None:
+        """Skip to the next track."""
 
-    def previous_track(self) -> Optional[Track]:
-        """Go to previous track."""
-        if self.current_playlist:
-            track = self.current_playlist.previous_track()
-            if track:
-                logger.info(f"Previous track: {track.name}")
-                if self.playback.is_playing:
-                    self.play()
-            return track
-        return None
+        track = self.media.next_track()
+        if track is None:
+            return None
+
+        logger.info(f"Next track: {track.name}")
+        if self.playback.is_playing:
+            self.play()
+        return track
+
+    def previous_track(self) -> Track | None:
+        """Go to the previous track."""
+
+        track = self.media.previous_track()
+        if track is None:
+            return None
+
+        logger.info(f"Previous track: {track.name}")
+        if self.playback.is_playing:
+            self.play()
+        return track
 
     def create_demo_playlist(self) -> PlaybackQueue:
         """Create a demo playlist for testing."""
+
         demo_tracks = [
             Track(
                 uri="demo://the-adventure-begins",
@@ -303,63 +480,37 @@ class AppContext:
         ]
 
         playlist = PlaybackQueue(name="Demo Playlist", tracks=demo_tracks)
-        self.playlists["demo"] = playlist
+        self.media.playlists["demo"] = playlist
         logger.info(f"Created demo playlist with {len(demo_tracks)} tracks")
         return playlist
 
     def get_playback_progress(self) -> float:
-        """
-        Get current playback progress as percentage.
+        """Get current playback progress as a percentage."""
 
-        Returns:
-            Progress from 0.0 to 1.0
-        """
-        track = self.get_current_track()
-        if track and track.length > 0:
-            return min(1.0, self.playback.position / (track.length / 1000))
-        return 0.0
+        return self.media.playback_progress()
 
     def update_system_status(
         self,
-        battery: Optional[int] = None,
-        signal: Optional[int] = None,
-        connected: Optional[bool] = None,
+        battery: int | None = None,
+        signal: int | None = None,
+        connected: bool | None = None,
     ) -> None:
-        """
-        Update system status information.
+        """Update simple cross-cutting status information."""
 
-        Args:
-            battery: Battery percentage (0-100)
-            signal: Signal strength (0-4)
-            connected: Connection status
-        """
         if battery is not None:
-            self.battery_percent = max(0, min(100, battery))
-        if signal is not None:
-            self.signal_strength = max(0, min(4, signal))
-        if connected is not None:
-            self.is_connected = connected
+            self.power.update_battery_percent(battery)
+        if signal is not None or connected is not None:
+            self.network.update(signal_bars=signal, connected=connected)
 
     def update_power_status(self, snapshot: "PowerSnapshot") -> None:
         """Update cached power telemetry from the latest backend snapshot."""
-        self.power_available = snapshot.available
-        self.power_error = snapshot.error
 
-        if snapshot.battery.level_percent is not None:
-            level = round(snapshot.battery.level_percent)
-            self.battery_percent = max(0, min(100, level))
-
-        if snapshot.battery.charging is not None:
-            self.battery_charging = snapshot.battery.charging
-
-        if snapshot.battery.power_plugged is not None:
-            self.external_power = snapshot.battery.power_plugged
+        self.power.update_from_snapshot(snapshot)
 
     def update_voip_status(self, *, configured: bool, ready: bool) -> None:
-        """Update cached VoIP availability used by the simplified chrome."""
+        """Update cached VoIP availability used by simplified chrome."""
 
-        self.voip_configured = configured
-        self.voip_ready = ready
+        self.voip.update(configured=configured, ready=ready)
 
     def update_network_status(
         self,
@@ -371,16 +522,14 @@ class AppContext:
         gps_has_fix: bool | None = None,
     ) -> None:
         """Update cached network telemetry from the modem backend."""
-        if network_enabled is not None:
-            self.network_enabled = network_enabled
-        if signal_bars is not None:
-            self.signal_strength = max(0, min(4, signal_bars))
-        if connection_type is not None:
-            self.connection_type = connection_type
-        if connected is not None:
-            self.is_connected = connected
-        if gps_has_fix is not None:
-            self.gps_has_fix = gps_has_fix
+
+        self.network.update(
+            enabled=network_enabled,
+            signal_bars=signal_bars,
+            connection_type=connection_type,
+            connected=connected,
+            gps_has_fix=gps_has_fix,
+        )
 
     def update_screen_runtime(
         self,
@@ -391,43 +540,41 @@ class AppContext:
         idle_seconds: float,
     ) -> None:
         """Update runtime metrics for app uptime and display activity."""
-        self.screen_awake = screen_awake
-        self.app_uptime_seconds = max(0, int(app_uptime_seconds))
-        self.screen_on_seconds = max(0, int(screen_on_seconds))
-        self.screen_idle_seconds = max(0, int(idle_seconds))
+
+        self.screen.update(
+            awake=screen_awake,
+            app_uptime_seconds=app_uptime_seconds,
+            on_seconds=screen_on_seconds,
+            idle_seconds=idle_seconds,
+        )
 
     def update_call_summary(self, *, missed_calls: int, recent_calls: list[str]) -> None:
-        """Update Talk summary state used by the hub and call-related screens."""
+        """Update Talk summary state used by hub and call-related screens."""
 
-        self.missed_calls = max(0, int(missed_calls))
-        self.recent_calls = list(recent_calls)
+        self.talk.update_call_summary(missed_calls=missed_calls, recent_calls=recent_calls)
 
     def set_talk_contact(self, *, name: str, sip_address: str) -> None:
         """Store the currently selected Talk contact."""
 
-        self.talk_contact_name = name
-        self.talk_contact_address = sip_address
+        self.talk.set_selected_contact(name=name, sip_address=sip_address)
 
     def set_voice_note_recipient(self, *, name: str, sip_address: str) -> None:
         """Store the currently selected voice-note recipient."""
 
-        self.voice_note_recipient_name = name
-        self.voice_note_recipient_address = sip_address
-        self.voice_note_send_state = "idle"
-        self.voice_note_status_text = ""
-        self.voice_note_file_path = ""
-        self.voice_note_duration_ms = 0
+        self.talk.set_voice_note_recipient(name=name, sip_address=sip_address)
 
     def update_voice_note_summary(
         self,
         *,
         unread_voice_notes: int,
-        latest_voice_note_by_contact: Dict[str, Dict[str, Any]],
+        latest_voice_note_by_contact: dict[str, dict[str, object]],
     ) -> None:
         """Update unread counts and latest voice-note metadata exposed to Talk."""
 
-        self.unread_voice_notes = max(0, int(unread_voice_notes))
-        self.latest_voice_note_by_contact = dict(latest_voice_note_by_contact)
+        self.talk.update_voice_note_summary(
+            unread_voice_notes=unread_voice_notes,
+            latest_voice_note_by_contact=latest_voice_note_by_contact,
+        )
 
     def update_active_voice_note(
         self,
@@ -439,10 +586,12 @@ class AppContext:
     ) -> None:
         """Update the active voice-note UI state for the selected recipient."""
 
-        self.voice_note_send_state = send_state
-        self.voice_note_status_text = status_text
-        self.voice_note_file_path = file_path
-        self.voice_note_duration_ms = max(0, int(duration_ms))
+        self.talk.update_active_voice_note(
+            send_state=send_state,
+            status_text=status_text,
+            file_path=file_path,
+            duration_ms=duration_ms,
+        )
 
     def configure_voice(
         self,

--- a/yoyopy/runtime_state.py
+++ b/yoyopy/runtime_state.py
@@ -1,0 +1,328 @@
+"""
+Focused runtime state objects owned by ``AppContext``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from yoyopy.audio.music.models import PlaybackQueue, Track
+
+if TYPE_CHECKING:
+    from yoyopy.power import PowerSnapshot
+
+
+@dataclass(slots=True)
+class PlaybackState:
+    """Current playback state."""
+
+    is_playing: bool = False
+    is_paused: bool = False
+    is_stopped: bool = True
+    position: float = 0.0
+    volume: int = 50
+    is_muted: bool = False
+
+
+@dataclass(slots=True)
+class MediaRuntimeState:
+    """Shared playback session and playlist selection state."""
+
+    playback: PlaybackState = field(default_factory=PlaybackState)
+    current_playlist: PlaybackQueue | None = None
+    playlists: dict[str, PlaybackQueue] = field(default_factory=dict)
+
+    def set_playlist(self, playlist: PlaybackQueue) -> None:
+        """Set the active playlist."""
+
+        self.current_playlist = playlist
+
+    def current_track(self) -> Track | None:
+        """Return the active track from the selected playlist."""
+
+        if self.current_playlist is None:
+            return None
+        return self.current_playlist.current_track()
+
+    def play(self) -> bool:
+        """Mark playback as active when a track is available."""
+
+        if self.current_track() is None:
+            return False
+
+        self.playback.is_playing = True
+        self.playback.is_paused = False
+        self.playback.is_stopped = False
+        return True
+
+    def pause(self) -> None:
+        """Mark playback as paused."""
+
+        if not self.playback.is_playing:
+            return
+
+        self.playback.is_playing = False
+        self.playback.is_paused = True
+
+    def resume(self) -> None:
+        """Mark playback as resumed."""
+
+        if not self.playback.is_paused:
+            return
+
+        self.playback.is_playing = True
+        self.playback.is_paused = False
+
+    def stop(self) -> None:
+        """Mark playback as stopped and reset position."""
+
+        self.playback.is_playing = False
+        self.playback.is_paused = False
+        self.playback.is_stopped = True
+        self.playback.position = 0.0
+
+    def next_track(self) -> Track | None:
+        """Advance the current playlist."""
+
+        if self.current_playlist is None:
+            return None
+        return self.current_playlist.next_track()
+
+    def previous_track(self) -> Track | None:
+        """Move to the previous track in the current playlist."""
+
+        if self.current_playlist is None:
+            return None
+        return self.current_playlist.previous_track()
+
+    def playback_progress(self) -> float:
+        """Return the active track progress from 0.0 to 1.0."""
+
+        track = self.current_track()
+        if track is None or track.length <= 0:
+            return 0.0
+        return min(1.0, self.playback.position / (track.length / 1000))
+
+
+@dataclass(slots=True)
+class PowerRuntimeState:
+    """Battery and external power telemetry exposed to UI/runtime flows."""
+
+    battery_percent: int = 100
+    battery_charging: bool = False
+    external_power: bool = False
+    available: bool = False
+    error: str = ""
+
+    def update_battery_percent(self, percent: int) -> None:
+        """Clamp and store battery percentage."""
+
+        self.battery_percent = max(0, min(100, int(percent)))
+
+    def update_from_snapshot(self, snapshot: "PowerSnapshot") -> None:
+        """Refresh power telemetry from the latest backend snapshot."""
+
+        self.available = snapshot.available
+        self.error = snapshot.error
+
+        if snapshot.battery.level_percent is not None:
+            self.update_battery_percent(round(snapshot.battery.level_percent))
+
+        if snapshot.battery.charging is not None:
+            self.battery_charging = snapshot.battery.charging
+
+        if snapshot.battery.power_plugged is not None:
+            self.external_power = snapshot.battery.power_plugged
+
+
+@dataclass(slots=True)
+class NetworkRuntimeState:
+    """Connectivity telemetry shown in status chrome and Setup."""
+
+    enabled: bool = False
+    signal_strength: int = 4
+    connected: bool = False
+    connection_type: str = "none"
+    gps_has_fix: bool = False
+
+    def update(
+        self,
+        *,
+        enabled: bool | None = None,
+        signal_bars: int | None = None,
+        connection_type: str | None = None,
+        connected: bool | None = None,
+        gps_has_fix: bool | None = None,
+    ) -> None:
+        """Refresh the cached network telemetry."""
+
+        if enabled is not None:
+            self.enabled = enabled
+        if signal_bars is not None:
+            self.signal_strength = max(0, min(4, int(signal_bars)))
+        if connection_type is not None:
+            self.connection_type = connection_type
+        if connected is not None:
+            self.connected = connected
+        if gps_has_fix is not None:
+            self.gps_has_fix = gps_has_fix
+
+
+@dataclass(slots=True)
+class ScreenRuntimeState:
+    """Runtime metrics for display activity and app uptime."""
+
+    awake: bool = True
+    idle_seconds: int = 0
+    on_seconds: int = 0
+    app_uptime_seconds: int = 0
+
+    def update(
+        self,
+        *,
+        awake: bool,
+        app_uptime_seconds: float,
+        on_seconds: float,
+        idle_seconds: float,
+    ) -> None:
+        """Clamp and store display activity metrics."""
+
+        self.awake = awake
+        self.app_uptime_seconds = max(0, int(app_uptime_seconds))
+        self.on_seconds = max(0, int(on_seconds))
+        self.idle_seconds = max(0, int(idle_seconds))
+
+
+@dataclass(slots=True)
+class VoipRuntimeState:
+    """App-facing VoIP availability used by chrome and routing."""
+
+    configured: bool = False
+    ready: bool = False
+
+    def update(self, *, configured: bool, ready: bool) -> None:
+        """Refresh the cached VoIP availability."""
+
+        self.configured = configured
+        self.ready = ready
+
+
+@dataclass(slots=True)
+class VoiceState:
+    """Runtime voice settings and recent voice activity."""
+
+    commands_enabled: bool = True
+    ai_requests_enabled: bool = True
+    screen_read_enabled: bool = False
+    stt_enabled: bool = True
+    tts_enabled: bool = True
+    mic_muted: bool = False
+    speaker_device_id: str | None = None
+    capture_device_id: str | None = None
+    stt_available: bool = False
+    tts_available: bool = False
+    last_transcript: str = ""
+    last_spoken_text: str = ""
+    last_mode: str = ""
+    output_volume: int = 50
+
+
+@dataclass(slots=True)
+class ActiveVoiceNoteState:
+    """Selected voice-note recipient plus the in-flight draft state."""
+
+    recipient_name: str = ""
+    recipient_address: str = ""
+    send_state: str = "idle"
+    status_text: str = ""
+    file_path: str = ""
+    duration_ms: int = 0
+
+    def set_recipient(self, *, name: str, sip_address: str) -> None:
+        """Store the selected recipient and reset any previous draft state."""
+
+        self.recipient_name = name
+        self.recipient_address = sip_address
+        self.reset()
+
+    def update(
+        self,
+        *,
+        send_state: str,
+        status_text: str = "",
+        file_path: str = "",
+        duration_ms: int = 0,
+    ) -> None:
+        """Refresh the active draft status."""
+
+        self.send_state = send_state
+        self.status_text = status_text
+        self.file_path = file_path
+        self.duration_ms = max(0, int(duration_ms))
+
+    def reset(self) -> None:
+        """Clear transient draft state while retaining the recipient."""
+
+        self.send_state = "idle"
+        self.status_text = ""
+        self.file_path = ""
+        self.duration_ms = 0
+
+
+@dataclass(slots=True)
+class TalkRuntimeState:
+    """Talk flow summaries, selected contact, and voice-note draft state."""
+
+    missed_calls: int = 0
+    recent_calls: list[str] = field(default_factory=list)
+    unread_voice_notes: int = 0
+    latest_voice_note_by_contact: dict[str, dict[str, Any]] = field(default_factory=dict)
+    selected_contact_name: str = ""
+    selected_contact_address: str = ""
+    active_voice_note: ActiveVoiceNoteState = field(default_factory=ActiveVoiceNoteState)
+
+    def update_call_summary(self, *, missed_calls: int, recent_calls: list[str]) -> None:
+        """Refresh Talk summary values used by hub and history flows."""
+
+        self.missed_calls = max(0, int(missed_calls))
+        self.recent_calls = list(recent_calls)
+
+    def set_selected_contact(self, *, name: str, sip_address: str) -> None:
+        """Store the currently selected Talk contact."""
+
+        self.selected_contact_name = name
+        self.selected_contact_address = sip_address
+
+    def set_voice_note_recipient(self, *, name: str, sip_address: str) -> None:
+        """Store the selected voice-note recipient and reset its draft state."""
+
+        self.active_voice_note.set_recipient(name=name, sip_address=sip_address)
+
+    def update_voice_note_summary(
+        self,
+        *,
+        unread_voice_notes: int,
+        latest_voice_note_by_contact: dict[str, dict[str, Any]],
+    ) -> None:
+        """Refresh unread counts and latest voice-note metadata."""
+
+        self.unread_voice_notes = max(0, int(unread_voice_notes))
+        self.latest_voice_note_by_contact = dict(latest_voice_note_by_contact)
+
+    def update_active_voice_note(
+        self,
+        *,
+        send_state: str,
+        status_text: str = "",
+        file_path: str = "",
+        duration_ms: int = 0,
+    ) -> None:
+        """Refresh the active voice-note draft state."""
+
+        self.active_voice_note.update(
+            send_state=send_state,
+            status_text=status_text,
+            file_path=file_path,
+            duration_ms=duration_ms,
+        )

--- a/yoyopy/ui/screens/lvgl_status.py
+++ b/yoyopy/ui/screens/lvgl_status.py
@@ -20,15 +20,15 @@ def network_status_kwargs(context: "AppContext | None") -> dict[str, int]:
             "gps_has_fix": 0,
         }
 
-    signal_strength = max(0, min(4, int(getattr(context, "signal_strength", 0))))
-    connection_type = str(getattr(context, "connection_type", "none")).lower()
-    is_connected = bool(getattr(context, "is_connected", False))
+    signal_strength = max(0, min(4, int(context.network.signal_strength)))
+    connection_type = str(context.network.connection_type).lower()
+    is_connected = context.network.connected
     return {
-        "network_enabled": 1 if bool(getattr(context, "network_enabled", False)) else 0,
+        "network_enabled": 1 if context.network.enabled else 0,
         "network_connected": 1 if is_connected and connection_type == "4g" else 0,
         "wifi_connected": 1 if is_connected and connection_type == "wifi" else 0,
         "signal_strength": signal_strength,
-        "gps_has_fix": 1 if bool(getattr(context, "gps_has_fix", False)) else 0,
+        "gps_has_fix": 1 if context.network.gps_has_fix else 0,
     }
 
 

--- a/yoyopy/ui/screens/navigation/hub.py
+++ b/yoyopy/ui/screens/navigation/hub.py
@@ -81,7 +81,9 @@ class HubScreen(Screen):
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
             return None
 
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
             return None
 
@@ -134,8 +136,8 @@ class HubScreen(Screen):
 
     def _talk_subtitle(self) -> str:
         """Return the compact Talk card subtitle."""
-        if self.context is not None and getattr(self.context, "missed_calls", 0) > 0:
-            missed_calls = int(self.context.missed_calls)
+        if self.context is not None and self.context.talk.missed_calls > 0:
+            missed_calls = self.context.talk.missed_calls
             label = "call" if missed_calls == 1 else "calls"
             return f"{missed_calls} missed {label}"
 
@@ -241,7 +243,9 @@ class HubScreen(Screen):
             self.display.circle(dots_x + (index * dot_gap), dots_y, 2, fill=dot_color)
 
         footer_top = self.display.HEIGHT - 32
-        self.display.rectangle(0, footer_top, self.display.WIDTH, self.display.HEIGHT, fill=FOOTER_BAR)
+        self.display.rectangle(
+            0, footer_top, self.display.WIDTH, self.display.HEIGHT, fill=FOOTER_BAR
+        )
         footer_text = "Tap = Next \u00b7 2\u00d7 = Open \u00b7 Hold = Ask"
         footer_width, footer_height = self.display.get_text_size(footer_text, 10)
         self.display.text(

--- a/yoyopy/ui/screens/system/power.py
+++ b/yoyopy/ui/screens/system/power.py
@@ -191,7 +191,9 @@ class PowerScreen(Screen):
                 row_bottom = row_y + row_height
                 if row_bottom > max_row_bottom:
                     break
-                is_selected = visible_selected_index is not None and row_index == visible_selected_index
+                is_selected = (
+                    visible_selected_index is not None and row_index == visible_selected_index
+                )
                 rounded_panel(
                     self.display,
                     16,
@@ -1015,5 +1017,4 @@ class PowerScreen(Screen):
 
         if volume is None or self.context is None:
             return
-        self.context.playback.volume = volume
-        self.context.voice.output_volume = volume
+        self.context.cache_output_volume(volume)

--- a/yoyopy/ui/screens/theme.py
+++ b/yoyopy/ui/screens/theme.py
@@ -326,14 +326,12 @@ def render_status_bar(
     battery_gap = STATUS_BATTERY_GAP_PORTRAIT if is_portrait else STATUS_BATTERY_GAP_LANDSCAPE
 
     cursor_x = side_inset
-    connection_type = (
-        "none" if context is None else str(getattr(context, "connection_type", "none")).lower()
-    )
-    is_connected = False if context is None else bool(getattr(context, "is_connected", False))
+    connection_type = "none" if context is None else str(context.network.connection_type).lower()
+    is_connected = False if context is None else context.network.connected
 
     # -- Signal bars (visible when network module is enabled) --
-    if context is not None and getattr(context, "network_enabled", False):
-        signal = context.signal_strength
+    if context is not None and context.network.enabled:
+        signal = context.network.signal_strength
         connected = is_connected and connection_type == "4g"
         for i, h in enumerate(STATUS_SIGNAL_BAR_HEIGHTS):
             bx = cursor_x + i * (STATUS_SIGNAL_BAR_WIDTH + STATUS_SIGNAL_BAR_GAP)
@@ -356,8 +354,8 @@ def render_status_bar(
         cursor_x += STATUS_WIFI_ICON_WIDTH + cluster_gap
 
     # -- GPS indicator (visible when network module is enabled) --
-    if context is not None and getattr(context, "network_enabled", False):
-        gps_fix = getattr(context, "gps_has_fix", False)
+    if context is not None and context.network.enabled:
+        gps_fix = context.network.gps_has_fix
         gps_color = SUCCESS if gps_fix else MUTED
         _draw_status_gps_icon(display, cursor_x, icon_bottom, gps_color)
         cursor_x += STATUS_GPS_ICON_WIDTH + cluster_gap
@@ -380,9 +378,9 @@ def render_status_bar(
         time_x = max(0, (display.WIDTH - time_width) // 2)
         display.text(time_text, time_x, clock_top, color=MUTED, font_size=STATUS_TIME_FONT_SIZE)
 
-    battery_level = 100 if context is None else int(round(context.battery_percent))
-    charging = False if context is None else context.battery_charging
-    power_available = True if context is None else context.power_available
+    battery_level = 100 if context is None else int(round(context.power.battery_percent))
+    charging = False if context is None else context.power.battery_charging
+    power_available = True if context is None else context.power.available
 
     battery_text = f"{max(0, min(100, battery_level))}%"
     battery_text_width, _ = display.get_text_size(battery_text, STATUS_TIME_FONT_SIZE)
@@ -1554,17 +1552,17 @@ def _draw_signal_icon(display: Display, draw, x: int, y: int, size: int, color: 
 def _voip_state(context: AppContext | None) -> str:
     """Return ready/offline/none for the simplified status bar."""
 
-    if context is None or not getattr(context, "voip_configured", False):
+    if context is None or not context.voip.configured:
         return "none"
-    return "ready" if getattr(context, "voip_ready", False) else "offline"
+    return "ready" if context.voip.ready else "offline"
 
 
 def format_battery_compact(context: AppContext | None) -> str:
     """Return a tiny battery summary for cards."""
 
-    if context is None or not getattr(context, "power_available", False):
+    if context is None or not context.power.available:
         return "Power offline"
-    level = getattr(context, "battery_percent", 100)
-    if getattr(context, "battery_charging", False):
+    level = context.power.battery_percent
+    if context.power.battery_charging:
         return f"{level}% charging"
     return f"{level}% battery"

--- a/yoyopy/ui/screens/voip/quick_call.py
+++ b/yoyopy/ui/screens/voip/quick_call.py
@@ -9,16 +9,10 @@ from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
 from yoyopy.ui.screens.theme import (
     INK,
-    MUTED,
-    SURFACE,
-    TALK,
     draw_empty_state,
-    draw_icon,
-    mix,
     render_backdrop,
     render_footer,
     render_status_bar,
-    rounded_panel,
     text_fit,
 )
 from yoyopy.ui.screens.voip.lvgl import LvglCallView
@@ -98,7 +92,9 @@ class CallScreen(Screen):
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
             return None
 
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
             return None
 
@@ -156,7 +152,7 @@ class CallScreen(Screen):
 
         preferred_address = ""
         if self.context is not None:
-            preferred_address = self.context.talk_contact_address
+            preferred_address = self.context.talk.selected_contact_address
 
         if preferred_address:
             for index, person in enumerate(self.people):
@@ -214,10 +210,15 @@ class CallScreen(Screen):
             }
         subtitle = selected_person.subtitle
         if self.context is not None:
-            latest_note = self.context.latest_voice_note_by_contact.get(selected_person.sip_address, {})
+            latest_note = self.context.talk.latest_voice_note_by_contact.get(
+                selected_person.sip_address,
+                {},
+            )
             if latest_note.get("unread"):
                 subtitle = "New voice note"
-            elif latest_note.get("direction") == "outgoing" and latest_note.get("delivery_state") in {"sent", "delivered"}:
+            elif latest_note.get("direction") == "outgoing" and latest_note.get(
+                "delivery_state"
+            ) in {"sent", "delivered"}:
                 subtitle = "Latest note sent"
             elif latest_note.get("local_file_path"):
                 subtitle = "Play latest note"
@@ -305,12 +306,12 @@ class CallScreen(Screen):
     def _show_missed_calls(self) -> bool:
         """Return True when a missed-call badge should be shown on the deck."""
 
-        return bool(self.context is not None and getattr(self.context, "missed_calls", 0) > 0)
+        return bool(self.context is not None and self.context.talk.missed_calls > 0)
 
     def _missed_calls_badge(self) -> str:
         """Return the compact missed-call badge copy."""
 
-        missed_calls = 0 if self.context is None else int(getattr(self.context, "missed_calls", 0))
+        missed_calls = 0 if self.context is None else self.context.talk.missed_calls
         label = "missed call" if missed_calls == 1 else "missed calls"
         return f"{missed_calls} {label}"
 

--- a/yoyopy/ui/screens/voip/talk_contact.py
+++ b/yoyopy/ui/screens/voip/talk_contact.py
@@ -73,7 +73,9 @@ class TalkContactScreen(Screen):
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
             return None
 
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
             return None
 
@@ -86,14 +88,14 @@ class TalkContactScreen(Screen):
 
         if self.context is None:
             return "Friend"
-        return self.context.talk_contact_name or "Friend"
+        return self.context.talk.selected_contact_name or "Friend"
 
     def current_contact_address(self) -> str:
         """Return the selected contact SIP address."""
 
         if self.context is None:
             return ""
-        return self.context.talk_contact_address
+        return self.context.talk.selected_contact_address
 
     def current_contact_monogram(self) -> str:
         """Return a compact label for the current contact."""
@@ -108,7 +110,9 @@ class TalkContactScreen(Screen):
             TalkAction("voice_note", "Voice Note", "Record a short message"),
         ]
         latest_note = None
-        if self.voip_manager is not None and hasattr(self.voip_manager, "latest_voice_note_for_contact"):
+        if self.voip_manager is not None and hasattr(
+            self.voip_manager, "latest_voice_note_for_contact"
+        ):
             latest_note = self.voip_manager.latest_voice_note_for_contact(
                 self.current_contact_address(),
             )
@@ -120,7 +124,11 @@ class TalkContactScreen(Screen):
         """Return visible action rows for the LVGL scene."""
 
         actions = self.actions()
-        return [action.title for action in actions], [action.subtitle for action in actions], self.selected_index
+        return (
+            [action.title for action in actions],
+            [action.subtitle for action in actions],
+            self.selected_index,
+        )
 
     def get_visible_action_icons(self) -> list[str]:
         """Return the visible icon key for each action row."""

--- a/yoyopy/ui/screens/voip/voice_note.py
+++ b/yoyopy/ui/screens/voip/voice_note.py
@@ -78,7 +78,9 @@ class VoiceNoteScreen(Screen):
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
             return None
 
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
             return None
 
@@ -96,14 +98,18 @@ class VoiceNoteScreen(Screen):
 
         if self.context is None:
             return "Friend"
-        return self.context.voice_note_recipient_name or self.context.talk_contact_name or "Friend"
+        voice_note = self.context.talk.active_voice_note
+        selected_contact = self.context.talk
+        return voice_note.recipient_name or selected_contact.selected_contact_name or "Friend"
 
     def recipient_address(self) -> str:
         """Return the selected recipient SIP address."""
 
         if self.context is None:
             return ""
-        return self.context.voice_note_recipient_address or self.context.talk_contact_address
+        voice_note = self.context.talk.active_voice_note
+        selected_contact = self.context.talk
+        return voice_note.recipient_address or selected_contact.selected_contact_address
 
     def recipient_monogram(self) -> str:
         """Return a compact label for the active recipient."""
@@ -173,9 +179,9 @@ class VoiceNoteScreen(Screen):
     def _duration_label(self) -> str:
         """Return a compact duration label for the active draft."""
 
-        if self.context is None or self.context.voice_note_duration_ms <= 0:
+        if self.context is None or self.context.talk.active_voice_note.duration_ms <= 0:
             return ""
-        seconds = max(1, round(self.context.voice_note_duration_ms / 1000))
+        seconds = max(1, round(self.context.talk.active_voice_note.duration_ms / 1000))
         return f"{seconds}s"
 
     def actions(self) -> list[VoiceNoteAction]:
@@ -352,28 +358,31 @@ class VoiceNoteScreen(Screen):
         if self._state == "review":
             return (
                 "Review",
-                self.context.voice_note_status_text or f"Listen, send, or record again for {recipient}.",
+                self.context.talk.active_voice_note.status_text
+                or f"Listen, send, or record again for {recipient}.",
                 "Tap next / Double choose" if self.is_one_button_mode() else "Select choose / Back",
                 "voice_note",
             )
         if self._state == "sending":
             return (
                 "Sending",
-                self.context.voice_note_status_text or f"Sending your note to {recipient}.",
+                self.context.talk.active_voice_note.status_text
+                or f"Sending your note to {recipient}.",
                 "Please wait",
                 "voice_note",
             )
         if self._state == "sent":
             return (
                 "Sent",
-                self.context.voice_note_status_text or f"Your note reached {recipient}.",
+                self.context.talk.active_voice_note.status_text
+                or f"Your note reached {recipient}.",
                 "Double done / Hold back" if self.is_one_button_mode() else "Back",
                 "voice_note",
             )
         if self._state == "failed":
             return (
                 "Couldn't Send",
-                self.context.voice_note_status_text or f"Try {recipient}'s note again.",
+                self.context.talk.active_voice_note.status_text or f"Try {recipient}'s note again.",
                 "Tap next / Double choose" if self.is_one_button_mode() else "Select retry / Back",
                 "voice_note",
             )
@@ -491,7 +500,7 @@ class VoiceNoteScreen(Screen):
         if self.voip_manager is None or self.context is None:
             return
 
-        file_path = self.context.voice_note_file_path
+        file_path = self.context.talk.active_voice_note.file_path
         if not file_path:
             return
 
@@ -503,7 +512,7 @@ class VoiceNoteScreen(Screen):
                 send_state="review",
                 status_text="Playing preview",
                 file_path=file_path,
-                duration_ms=self.context.voice_note_duration_ms,
+                duration_ms=self.context.talk.active_voice_note.duration_ms,
             )
             return
 
@@ -514,7 +523,7 @@ class VoiceNoteScreen(Screen):
             send_state="review",
             status_text="Couldn't play note",
             file_path=file_path,
-            duration_ms=self.context.voice_note_duration_ms,
+            duration_ms=self.context.talk.active_voice_note.duration_ms,
         )
 
     def on_select(self, data=None) -> None:


### PR DESCRIPTION
## Summary
- extract focused runtime state objects for media, power, network, screen, VoIP, Talk, and active voice-note ownership
- thin `AppContext` into a compatibility wrapper with delegated update methods and property aliases for existing callers
- migrate shared chrome and Talk screen callers to the new ownership paths and document the updated runtime-state shape

## Why
`AppContext` had become a broad shared mutable bag spanning unrelated concerns. This change keeps current behavior while creating clearer responsibility boundaries and reducing the amount of code that has to treat `AppContext` as the direct home for every runtime field.

Addresses #90.

## Impact
- runtime state ownership is easier to reason about for follow-up cleanup work
- existing callers keep working through compatibility aliases while new code can target focused state objects directly
- tests now cover both the focused state grouping and compatibility behavior

## Validation
- `uv sync --extra dev`
- `uv run black yoyopy/runtime_state.py yoyopy/app_context.py yoyopy/app.py yoyopy/ui/screens/lvgl_status.py yoyopy/ui/screens/navigation/hub.py yoyopy/ui/screens/system/power.py yoyopy/ui/screens/theme.py yoyopy/ui/screens/voip/quick_call.py yoyopy/ui/screens/voip/talk_contact.py yoyopy/ui/screens/voip/voice_note.py tests/test_app_context_runtime_state.py tests/test_network_status_sync.py`
- `uv run ruff check yoyopy/runtime_state.py yoyopy/app_context.py yoyopy/app.py yoyopy/ui/screens/lvgl_status.py yoyopy/ui/screens/navigation/hub.py yoyopy/ui/screens/system/power.py yoyopy/ui/screens/theme.py yoyopy/ui/screens/voip/quick_call.py yoyopy/ui/screens/voip/talk_contact.py yoyopy/ui/screens/voip/voice_note.py tests/test_app_context_runtime_state.py tests/test_network_status_sync.py`
- `uv run pytest -q tests/test_app_context_runtime_state.py tests/test_app_context_voice.py tests/test_network_status_sync.py`
- `uv run pytest -q tests/test_app_context_runtime_state.py tests/test_app_context_voice.py tests/test_network_status_sync.py tests/test_call_screen.py tests/test_power_screen.py tests/test_screen_routing.py tests/test_app_orchestration.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`