### PR TITLE
docs: clarify doc status and design history

### DIFF
--- a/docs/ASK_SCREEN_DESIGN_SPEC.md
+++ b/docs/ASK_SCREEN_DESIGN_SPEC.md
@@ -1,9 +1,12 @@
 # Ask Screen Design Specification
 
+**Status:** Design target for the unified `Ask` experience, not the standalone current implementation contract
 **Source:** Figma YoyoPod-Design, node `43:4677` (Ask section)
 **Extracted:** 2026-04-10
 **Target:** 240x280 Whisplay portrait display
 **Rendering path:** PIL fallback in `yoyopy/ui/screens/navigation/ask.py`
+
+> Current note: use this file for intended interaction and visual design. For what actually exists on `main`, trust `docs/SYSTEM_ARCHITECTURE.md`, the current `AskScreen` implementation, and the current router/screen registration code.
 
 ---
 

--- a/docs/LVGL_MIGRATION_PLAN.md
+++ b/docs/LVGL_MIGRATION_PLAN.md
@@ -6,6 +6,8 @@
 
 > Current note: Whisplay now runs on the LVGL path in the current runtime. This document is still useful for migration context and rationale, but it is not the primary source of truth for current behavior. For current implementation details, trust `AGENTS.md`, `docs/SYSTEM_ARCHITECTURE.md`, and the code under `yoyopy/ui/lvgl_binding/`.
 
+> Read this as migration history plus remaining rationale, not as proof that every phase item below is still pending.
+
 ---
 
 ## Summary

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,17 +53,30 @@ Plan docs are useful, but they are not automatically the current implementation 
 
 ## Plans, specs, and design work
 
-These files are useful for context, but they may describe work in progress, transitional architecture, or older intended behavior.
+These files are useful for context, but they are not all the same kind of document.
 
-- [`LVGL_MIGRATION_PLAN.md`](LVGL_MIGRATION_PLAN.md)
-- [`VOICE_COMMAND_PLAN.md`](VOICE_COMMAND_PLAN.md)
-- [`VOICE_COMMAND_CHECKLIST.md`](VOICE_COMMAND_CHECKLIST.md)
-- [`ASK_SCREEN_DESIGN_SPEC.md`](ASK_SCREEN_DESIGN_SPEC.md)
+### Transitional or partly historical design docs
+
+- [`LVGL_MIGRATION_PLAN.md`](LVGL_MIGRATION_PLAN.md), historical migration record with some still-relevant rationale
+- [`VOICE_COMMAND_PLAN.md`](VOICE_COMMAND_PLAN.md), transitional design record, not the current `Ask` implementation contract
+- [`VOICE_COMMAND_CHECKLIST.md`](VOICE_COMMAND_CHECKLIST.md), historical implementation checklist from an older branch snapshot
+- [`ASK_SCREEN_DESIGN_SPEC.md`](ASK_SCREEN_DESIGN_SPEC.md), design target for the unified `Ask` screen, not automatic proof of implementation
+
+### Active design or contract docs
+
 - [`GLOBAL_AUDIO_DEVICE_FACADE_CONTRACT.md`](GLOBAL_AUDIO_DEVICE_FACADE_CONTRACT.md)
 - [`WHISPLAY_SIMULATION_PARITY_CONTRACT.md`](WHISPLAY_SIMULATION_PARITY_CONTRACT.md)
 - [`design-previews/`](design-previews/)
 
-If one of these conflicts with the current code or the current runtime docs above, treat it as design history unless it is explicitly updated.
+If one of these conflicts with the current code or the current runtime docs above, trust the current code and the current runtime docs.
+
+## Historical implementation records
+
+These are useful when you need to understand how the repo got here, but they are not the top-level source of truth for current architecture.
+
+- [`INTEGRATION_PLAN.md`](INTEGRATION_PLAN.md)
+- [`UI_RESTRUCTURE_PROPOSAL.md`](UI_RESTRUCTURE_PROPOSAL.md)
+- [`PHASE2_SUMMARY.md`](PHASE2_SUMMARY.md)
 
 ## Archived history
 

--- a/docs/VOICE_COMMAND_CHECKLIST.md
+++ b/docs/VOICE_COMMAND_CHECKLIST.md
@@ -1,13 +1,16 @@
 # Voice Command Implementation Checklist
 
+**Status:** Historical implementation checklist, not the current implementation contract
+
+> Current note: this file preserves a working checklist from an earlier branch snapshot. It still contains old branch naming and some stale absolute file paths from a previous local workspace. Use it for implementation context only, not as the authoritative map of current files on `main`.
+
 ## Branch
 
-Current feature branch:
+Historical feature branch at the time this checklist was written:
 
 - `feat/ask-voice-local`
 
-This branch was created from the current working state and already includes the
-simulation/input fixes that were in progress before voice work started.
+That branch note is preserved for context only.
 
 ## Goal
 
@@ -20,6 +23,8 @@ Keep conversational AI responses out of scope for now. The `AI Requests` path
 should exist in the UI, but only return a placeholder spoken response.
 
 ## Actual Integration Points
+
+The file references below were captured at the time of writing. Some absolute paths are now stale and should be interpreted as historical pointers to the equivalent files in the current repo.
 
 ### Ask Navigation and Rendering
 

--- a/docs/VOICE_COMMAND_PLAN.md
+++ b/docs/VOICE_COMMAND_PLAN.md
@@ -1,8 +1,10 @@
 # Voice Command Plan
 
-**Status:** Transitional design record, not the full current implementation contract
+**Status:** Transitional design record, partly stale relative to the current `Ask` flow
 
 > Current note: this document captures the original design direction for local voice control. The current codebase now uses a unified `AskScreen` instead of the earlier split `Voice Commands` and `AI Requests` menu shape described below. Keep using this file for design context and future direction, but trust the current code and `docs/SYSTEM_ARCHITECTURE.md` for what exists on `main`.
+
+> Read this as a direction and constraint document, not as proof that every flow, menu shape, or setting below is what ships today.
 
 ## Goal
 


### PR DESCRIPTION
## What changed
- label the most ambiguous plan/spec docs more clearly so contributors can tell current contracts from design history
- make the docs index distinguish transitional design docs from active contract docs and historical implementation records
- add explicit warnings where voice docs still reflect older branch snapshots, stale absolute paths, or older menu shapes
- clarify that the Ask design spec is a design target, not automatic proof of current implementation

## Why
The repo docs are in better shape now, but some plan/spec files still read too much like current truth. That is exactly how contributors get misled.

## Validation
- `git diff --check`
- `rg -n "Status:|Current note:|historical|stale absolute|source of truth" docs/README.md docs/LVGL_MIGRATION_PLAN.md docs/VOICE_COMMAND_PLAN.md docs/VOICE_COMMAND_CHECKLIST.md docs/ASK_SCREEN_DESIGN_SPEC.md`

Related to #95