### PR TITLE
docs: label historical implementation records

### DIFF
--- a/docs/INTEGRATION_PLAN.md
+++ b/docs/INTEGRATION_PLAN.md
@@ -1,7 +1,9 @@
 # YoyoPod VoIP + Local Music Integration Record
 
 **Last updated:** 2026-04-07
-**Status:** Implemented
+**Status:** Historical implementation record, implemented on `main`
+
+> Current note: this file explains the integration milestone that brought VoIP and local music into one app flow. It is useful for understanding how the current runtime came together, but it is not the primary source of truth for the current architecture. For current contracts, trust `docs/SYSTEM_ARCHITECTURE.md`, current subsystem docs, and the code under `yoyopy/`.
 
 This document started as a plan and now serves as the completion record for the VoIP + local music integration that ships on `main`.
 

--- a/docs/PHASE2_SUMMARY.md
+++ b/docs/PHASE2_SUMMARY.md
@@ -1,7 +1,9 @@
 # Phase 2 Summary: Screen Integration
 
 **Last updated:** 2026-04-02
-**Status:** Historical summary, corrected to current file paths
+**Status:** Historical milestone summary, corrected to current file paths
+
+> Current note: this file preserves a milestone summary for the screen-integration phase. It is useful for understanding why the current app wiring looks the way it does, but it should not outrank the current architecture docs or the code on `main`.
 
 Phase 2 was the point where the integrated application stopped being a set of separate demos and became one navigable app.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,11 +72,11 @@ If one of these conflicts with the current code or the current runtime docs abov
 
 ## Historical implementation records
 
-These are useful when you need to understand how the repo got here, but they are not the top-level source of truth for current architecture.
+These are useful when you need to understand how the repo got here, but they are not the top-level source of truth for current architecture. Each of these files should say that plainly at the top.
 
-- [`INTEGRATION_PLAN.md`](INTEGRATION_PLAN.md)
-- [`UI_RESTRUCTURE_PROPOSAL.md`](UI_RESTRUCTURE_PROPOSAL.md)
-- [`PHASE2_SUMMARY.md`](PHASE2_SUMMARY.md)
+- [`INTEGRATION_PLAN.md`](INTEGRATION_PLAN.md), implemented milestone record for VoIP + local music integration
+- [`UI_RESTRUCTURE_PROPOSAL.md`](UI_RESTRUCTURE_PROPOSAL.md), refactor status record for the UI split and remaining cleanup
+- [`PHASE2_SUMMARY.md`](PHASE2_SUMMARY.md), milestone summary for early screen integration
 
 ## Archived history
 

--- a/docs/UI_RESTRUCTURE_PROPOSAL.md
+++ b/docs/UI_RESTRUCTURE_PROPOSAL.md
@@ -1,7 +1,9 @@
 # YoyoPod UI Refactor Status
 
 **Last updated:** 2026-04-02
-**Status:** Mostly implemented
+**Status:** Historical implementation record, mostly implemented
+
+> Current note: this file records the UI refactor milestone and what it accomplished. It is useful for historical context and remaining cleanup notes, but it is not the top-level source of truth for the current runtime shape. For current behavior, trust `docs/SYSTEM_ARCHITECTURE.md`, UI subsystem docs, and the current code under `yoyopy/ui/`.
 
 This document replaces the old proposal-only version and records what the refactor actually accomplished.
 


### PR DESCRIPTION
## What changed
- add explicit top-of-file framing to the remaining historical implementation records in the top-level docs directory
- make it clear that these milestone records are useful context, but not the primary source of truth for current architecture
- tighten the docs index so those files are described as implementation-history records instead of ambiguous maybe-current docs

## Why
A few top-level docs were already mostly honest, but not consistently enough. This pass makes the remaining milestone/history docs say what they are right at the top.

## Validation
- `git diff --check`
- `rg -n "Current note:|Historical implementation record|Historical milestone summary|source of truth" docs/README.md docs/INTEGRATION_PLAN.md docs/UI_RESTRUCTURE_PROPOSAL.md docs/PHASE2_SUMMARY.md`

Related to #95