### PR TITLE
[codex] Canonicalize music track and playlist models

### DIFF
--- a/docs/AUDIO_STACK.md
+++ b/docs/AUDIO_STACK.md
@@ -58,6 +58,16 @@ audio:
   default_volume: 100
 ```
 
+## Music Domain Models
+
+`yoyopy/audio/music/models.py` is the canonical ownership point for shared music-domain data.
+
+- `Track` is the shared track model used by mpv metadata, recent-history persistence, and UI playback reads.
+- `Playlist` is the discovered local-playlist summary returned by library scans.
+- `PlaybackQueue` is the runtime ordered track queue used when the app needs selected-track state.
+
+`AppContext` and demo helpers should reference these models instead of defining parallel `Track` or `Playlist` dataclasses.
+
 ## Music Control Path
 
 ### 1. Local library selection

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -85,7 +85,7 @@ yoyopod.py / yoyopy.main
 - `yoyopy/audio/music/backend.py`: `MusicBackend`, `MpvBackend`, `MockMusicBackend`
 - `yoyopy/audio/music/process.py`: app-managed mpv process lifecycle
 - `yoyopy/audio/music/ipc.py`: low-level mpv JSON IPC client
-- `yoyopy/audio/music/models.py`: `Track`, `Playlist`, `MusicConfig`
+- `yoyopy/audio/music/models.py`: `Track`, `Playlist`, `PlaybackQueue`, `MusicConfig`
 - `yoyopy/audio/volume.py`: shared ALSA and mpv output-volume coordination
 - `yoyopy/voip/manager.py`: call, message, and voice-note facade
 - `yoyopy/voip/liblinphone_binding/`: native Liblinphone shim and CPython binding
@@ -205,6 +205,8 @@ and updates:
 3. `LocalMusicService` handles local playlist and filesystem browse concerns
 4. callbacks refresh `NowPlayingScreen`
 5. the derived runtime state stays synchronized with actual playback state
+
+Shared music-domain model ownership lives in `yoyopy/audio/music/models.py`. `Track` is the canonical track shape, `Playlist` is the local-library playlist summary, and `PlaybackQueue` is the runtime ordered queue used when the app needs selected-track state.
 
 ### 4G / GPS Bringup
 

--- a/tests/test_music_models.py
+++ b/tests/test_music_models.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from yoyopy.audio.music.models import MusicConfig, Playlist, Track
+from yoyopy.app_context import AppContext
+from yoyopy.audio.music.models import MusicConfig, PlaybackQueue, Playlist, Track
 
 
 def test_track_get_artist_string_with_artists() -> None:
@@ -93,9 +94,49 @@ def test_playlist_dataclass() -> None:
     assert pl.track_count == 5
 
 
+def test_playback_queue_tracks_current_selection() -> None:
+    queue = PlaybackQueue(
+        name="Road Trip",
+        tracks=[
+            Track(uri="demo://golden-hour", name="Golden Hour", artists=["Kacey Musgraves"]),
+            Track(uri="demo://midnight-train", name="Midnight Train", artists=["Sam Smith"]),
+        ],
+    )
+
+    assert queue.track_count == 2
+    assert queue.current_track() == queue.tracks[0]
+    assert queue.has_previous() is False
+    assert queue.has_next() is True
+
+    assert queue.next_track() == queue.tracks[1]
+    assert queue.current_track() == queue.tracks[1]
+    assert queue.has_previous() is True
+    assert queue.has_next() is False
+
+    assert queue.previous_track() == queue.tracks[0]
+    assert queue.current_track() == queue.tracks[0]
+
+
+def test_app_context_demo_playlist_uses_canonical_track_model() -> None:
+    context = AppContext()
+    playlist = context.create_demo_playlist()
+    context.set_playlist(playlist)
+    context.playback.position = 45.0
+
+    track = context.get_current_track()
+
+    assert isinstance(track, Track)
+    assert track is not None
+    assert track.name == "The Adventure Begins"
+    assert track.length == 180_000
+    assert context.get_playback_progress() == 0.25
+
+
 def test_music_config_defaults() -> None:
     cfg = MusicConfig(music_dir=Path("/home/pi/Music"))
-    expected_socket = r"\\.\pipe\yoyopod-mpv" if sys.platform == "win32" else "/tmp/yoyopod-mpv.sock"
+    expected_socket = (
+        r"\\.\pipe\yoyopod-mpv" if sys.platform == "win32" else "/tmp/yoyopod-mpv.sock"
+    )
     assert cfg.mpv_socket == expected_socket
     assert cfg.mpv_binary == "mpv"
     assert cfg.alsa_device == "default"

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -1307,11 +1307,11 @@ class YoyoPodApp:
             current_screen = self.screen_manager.get_current_screen().route_name
 
         current_track = None
-        if self.context is not None and self.context.get_current_track() is not None:
-            track = self.context.get_current_track()
+        track = self.context.get_current_track() if self.context is not None else None
+        if track is not None:
             current_track = {
-                "title": track.title,
-                "artist": track.artist,
+                "title": track.name,
+                "artist": track.get_artist_string(),
             }
 
         payload = {

--- a/yoyopy/app_context.py
+++ b/yoyopy/app_context.py
@@ -7,11 +7,12 @@ current playlist, playback status, volume, and user settings.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, List, Dict, Any, TYPE_CHECKING
-from pathlib import Path
+
 from loguru import logger
 
+from yoyopy.audio.music.models import PlaybackQueue, Track
 from yoyopy.ui.input.hal import InteractionProfile
 
 if TYPE_CHECKING:
@@ -20,56 +21,9 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class Track:
-    """Represents a single audio track."""
-    title: str
-    artist: str
-    duration: float = 0.0  # Duration in seconds
-    file_path: Optional[Path] = None
-    stream_url: Optional[str] = None
-    album: Optional[str] = None
-    artwork_url: Optional[str] = None
-
-
-@dataclass
-class Playlist:
-    """Represents a playlist of tracks."""
-    name: str
-    tracks: List[Track] = field(default_factory=list)
-    current_index: int = 0
-
-    def current_track(self) -> Optional[Track]:
-        """Get the currently playing track."""
-        if 0 <= self.current_index < len(self.tracks):
-            return self.tracks[self.current_index]
-        return None
-
-    def next_track(self) -> Optional[Track]:
-        """Move to next track and return it."""
-        if self.current_index < len(self.tracks) - 1:
-            self.current_index += 1
-            return self.current_track()
-        return None
-
-    def previous_track(self) -> Optional[Track]:
-        """Move to previous track and return it."""
-        if self.current_index > 0:
-            self.current_index -= 1
-            return self.current_track()
-        return None
-
-    def has_next(self) -> bool:
-        """Check if there's a next track."""
-        return self.current_index < len(self.tracks) - 1
-
-    def has_previous(self) -> bool:
-        """Check if there's a previous track."""
-        return self.current_index > 0
-
-
-@dataclass
 class PlaybackState:
     """Current playback state."""
+
     is_playing: bool = False
     is_paused: bool = False
     is_stopped: bool = True
@@ -111,7 +65,7 @@ class AppContext:
 
     def __init__(
         self,
-        audio_manager: Optional['AudioManager'] = None,
+        audio_manager: Optional["AudioManager"] = None,
         interaction_profile: InteractionProfile = InteractionProfile.STANDARD,
     ) -> None:
         """
@@ -128,10 +82,10 @@ class AppContext:
         self.interaction_profile = interaction_profile
 
         # Current playlist
-        self.current_playlist: Optional[Playlist] = None
+        self.current_playlist: Optional[PlaybackQueue] = None
 
         # Available playlists
-        self.playlists: Dict[str, Playlist] = {}
+        self.playlists: Dict[str, PlaybackQueue] = {}
 
         # User settings
         self.settings = {
@@ -177,7 +131,7 @@ class AppContext:
 
         logger.info("AppContext initialized")
 
-    def set_playlist(self, playlist: Playlist) -> None:
+    def set_playlist(self, playlist: PlaybackQueue) -> None:
         """
         Set the current playlist.
 
@@ -200,14 +154,15 @@ class AppContext:
         Returns:
             True if playback started, False otherwise
         """
-        if not self.current_playlist or not self.current_playlist.current_track():
+        track = self.get_current_track()
+        if track is None:
             logger.warning("Cannot play: no track selected")
             return False
 
         self.playback.is_playing = True
         self.playback.is_paused = False
         self.playback.is_stopped = False
-        logger.info(f"Playing: {self.get_current_track().title}")
+        logger.info(f"Playing: {track.name}")
         return True
 
     def pause(self) -> None:
@@ -301,7 +256,7 @@ class AppContext:
         if self.current_playlist:
             track = self.current_playlist.next_track()
             if track:
-                logger.info(f"Next track: {track.title}")
+                logger.info(f"Next track: {track.name}")
                 if self.playback.is_playing:
                     self.play()
             return track
@@ -312,38 +267,42 @@ class AppContext:
         if self.current_playlist:
             track = self.current_playlist.previous_track()
             if track:
-                logger.info(f"Previous track: {track.title}")
+                logger.info(f"Previous track: {track.name}")
                 if self.playback.is_playing:
                     self.play()
             return track
         return None
 
-    def create_demo_playlist(self) -> Playlist:
+    def create_demo_playlist(self) -> PlaybackQueue:
         """Create a demo playlist for testing."""
         demo_tracks = [
             Track(
-                title="The Adventure Begins",
-                artist="Story Time Stories",
-                duration=180.0,
+                uri="demo://the-adventure-begins",
+                name="The Adventure Begins",
+                artists=["Story Time Stories"],
+                length=180_000,
             ),
             Track(
-                title="Journey to the Mountains",
-                artist="Story Time Stories",
-                duration=240.0,
+                uri="demo://journey-to-the-mountains",
+                name="Journey to the Mountains",
+                artists=["Story Time Stories"],
+                length=240_000,
             ),
             Track(
-                title="The Magic Forest",
-                artist="Bedtime Tales",
-                duration=200.0,
+                uri="demo://the-magic-forest",
+                name="The Magic Forest",
+                artists=["Bedtime Tales"],
+                length=200_000,
             ),
             Track(
-                title="Ocean Waves & Dreams",
-                artist="Relaxing Sounds",
-                duration=300.0,
+                uri="demo://ocean-waves-and-dreams",
+                name="Ocean Waves & Dreams",
+                artists=["Relaxing Sounds"],
+                length=300_000,
             ),
         ]
 
-        playlist = Playlist(name="Demo Playlist", tracks=demo_tracks)
+        playlist = PlaybackQueue(name="Demo Playlist", tracks=demo_tracks)
         self.playlists["demo"] = playlist
         logger.info(f"Created demo playlist with {len(demo_tracks)} tracks")
         return playlist
@@ -356,15 +315,15 @@ class AppContext:
             Progress from 0.0 to 1.0
         """
         track = self.get_current_track()
-        if track and track.duration > 0:
-            return min(1.0, self.playback.position / track.duration)
+        if track and track.length > 0:
+            return min(1.0, self.playback.position / (track.length / 1000))
         return 0.0
 
     def update_system_status(
         self,
         battery: Optional[int] = None,
         signal: Optional[int] = None,
-        connected: Optional[bool] = None
+        connected: Optional[bool] = None,
     ) -> None:
         """
         Update system status information.

--- a/yoyopy/audio/__init__.py
+++ b/yoyopy/audio/__init__.py
@@ -7,21 +7,30 @@ Provides audio playback, volume control, and device management.
 from yoyopy.audio.history import RecentTrackEntry, RecentTrackHistoryStore
 from yoyopy.audio.local_service import LocalLibraryItem, LocalMusicService
 from yoyopy.audio.manager import AudioManager, AudioDevice
-from yoyopy.audio.music import MusicBackend, MockMusicBackend, MpvBackend, Track, Playlist, MusicConfig
+from yoyopy.audio.music import (
+    MusicBackend,
+    MockMusicBackend,
+    MpvBackend,
+    MusicConfig,
+    PlaybackQueue,
+    Playlist,
+    Track,
+)
 from yoyopy.audio.volume import OutputVolumeController
 
 __all__ = [
-    'AudioDevice',
-    'AudioManager',
-    'LocalLibraryItem',
-    'LocalMusicService',
-    'MockMusicBackend',
-    'MpvBackend',
-    'MusicBackend',
-    'MusicConfig',
-    'OutputVolumeController',
-    'Playlist',
-    'RecentTrackEntry',
-    'RecentTrackHistoryStore',
-    'Track',
+    "AudioDevice",
+    "AudioManager",
+    "LocalLibraryItem",
+    "LocalMusicService",
+    "MockMusicBackend",
+    "MpvBackend",
+    "MusicBackend",
+    "MusicConfig",
+    "PlaybackQueue",
+    "OutputVolumeController",
+    "Playlist",
+    "RecentTrackEntry",
+    "RecentTrackHistoryStore",
+    "Track",
 ]

--- a/yoyopy/audio/music/__init__.py
+++ b/yoyopy/audio/music/__init__.py
@@ -1,13 +1,14 @@
 """Music backend subpackage for YoyoPod."""
 
 from yoyopy.audio.music.backend import MockMusicBackend, MpvBackend, MusicBackend
-from yoyopy.audio.music.models import MusicConfig, Playlist, Track
+from yoyopy.audio.music.models import MusicConfig, PlaybackQueue, Playlist, Track
 
 __all__ = [
     "MockMusicBackend",
     "MpvBackend",
     "MusicBackend",
     "MusicConfig",
+    "PlaybackQueue",
     "Playlist",
     "Track",
 ]

--- a/yoyopy/audio/music/models.py
+++ b/yoyopy/audio/music/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +25,14 @@ def _artist_list(value: object) -> list[str]:
 def _track_number(value: object) -> int | None:
     """Coerce one runtime track-number field into an integer when possible."""
     if value in (None, ""):
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if not isinstance(value, str):
         return None
     try:
         return int(value)
@@ -71,9 +79,7 @@ class Track:
         )
 
         file_track: Track | None = None
-        if path_obj.exists() and (
-            not title or not artists or not album_name or track_no is None
-        ):
+        if path_obj.exists() and (not title or not artists or not album_name or track_no is None):
             file_track = cls.from_file_tags(path_obj)
 
         return cls(
@@ -82,7 +88,11 @@ class Track:
             artists=artists or (file_track.artists if file_track is not None else ["Unknown"]),
             album=album_name or (file_track.album if file_track is not None else ""),
             length=duration_ms or (file_track.length if file_track is not None else 0),
-            track_no=track_no if track_no is not None else (file_track.track_no if file_track is not None else None),
+            track_no=(
+                track_no
+                if track_no is not None
+                else (file_track.track_no if file_track is not None else None)
+            ),
         )
 
     @classmethod
@@ -116,6 +126,55 @@ class Playlist:
     uri: str
     name: str
     track_count: int = 0
+
+
+@dataclass(slots=True)
+class PlaybackQueue:
+    """Runtime ordered track queue and current selection state."""
+
+    name: str
+    tracks: list[Track] = field(default_factory=list)
+    source_uri: str | None = None
+    current_index: int = 0
+
+    @property
+    def track_count(self) -> int:
+        """Return the number of tracks currently loaded into the queue."""
+
+        return len(self.tracks)
+
+    def current_track(self) -> Track | None:
+        """Return the selected track when the queue is not empty."""
+
+        if 0 <= self.current_index < len(self.tracks):
+            return self.tracks[self.current_index]
+        return None
+
+    def next_track(self) -> Track | None:
+        """Advance to the next track and return it when available."""
+
+        if self.current_index < len(self.tracks) - 1:
+            self.current_index += 1
+            return self.current_track()
+        return None
+
+    def previous_track(self) -> Track | None:
+        """Move back to the previous track and return it when available."""
+
+        if self.current_index > 0:
+            self.current_index -= 1
+            return self.current_track()
+        return None
+
+    def has_next(self) -> bool:
+        """Return True when the queue can advance to another track."""
+
+        return self.current_index < len(self.tracks) - 1
+
+    def has_previous(self) -> bool:
+        """Return True when the queue can move back to an earlier track."""
+
+        return self.current_index > 0
 
 
 def _default_mpv_socket() -> str:

--- a/yoyopy/cli/pi/gallery.py
+++ b/yoyopy/cli/pi/gallery.py
@@ -359,7 +359,8 @@ def _capture_screen(
 
 def _build_context() -> object:
     """Create one stable one-button app context."""
-    from yoyopy.app_context import AppContext, Playlist, Track as ContextTrack
+    from yoyopy.app_context import AppContext
+    from yoyopy.audio.music.models import PlaybackQueue, Track
     from yoyopy.ui.input import InteractionProfile
 
     context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
@@ -391,11 +392,21 @@ def _build_context() -> object:
         },
     )
 
-    demo_playlist = Playlist(
+    demo_playlist = PlaybackQueue(
         name="Road Trip",
         tracks=[
-            ContextTrack(title="Golden Hour", artist="Kacey Musgraves", duration=214.0),
-            ContextTrack(title="Midnight Train", artist="Sam Smith", duration=198.0),
+            Track(
+                uri="demo://golden-hour",
+                name="Golden Hour",
+                artists=["Kacey Musgraves"],
+                length=214_000,
+            ),
+            Track(
+                uri="demo://midnight-train",
+                name="Midnight Train",
+                artists=["Sam Smith"],
+                length=198_000,
+            ),
         ],
     )
     context.set_playlist(demo_playlist)

--- a/yoyopy/ui/screens/music/now_playing.py
+++ b/yoyopy/ui/screens/music/now_playing.py
@@ -64,7 +64,9 @@ class NowPlayingScreen(Screen):
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
             return None
 
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
             return None
 
@@ -133,7 +135,13 @@ class NowPlayingScreen(Screen):
         artist_y = title_bottom + 8
         artist_text = text_fit(self.display, artist, self.display.WIDTH - 36, 11)
         artist_width, _ = self.display.get_text_size(artist_text, 11)
-        self.display.text(artist_text, (self.display.WIDTH - artist_width) // 2, artist_y, color=MUTED, font_size=11)
+        self.display.text(
+            artist_text,
+            (self.display.WIDTH - artist_width) // 2,
+            artist_y,
+            color=MUTED,
+            font_size=11,
+        )
 
         state_width, state_height = self.display.get_text_size(state_text, 10)
         chip_width = state_width + 26
@@ -258,8 +266,8 @@ class NowPlayingScreen(Screen):
             return ("No Track Yet", "Pick local music to begin", 0.0, "READY", False)
 
         return (
-            track.title,
-            track.artist,
+            track.name,
+            track.get_artist_string(),
             self.context.get_playback_progress() if self.context else 0.0,
             "PLAYING" if self.context and self.context.playback.is_playing else "PAUSED",
             bool(self.context and self.context.playback.is_playing),
@@ -298,34 +306,34 @@ class NowPlayingScreen(Screen):
         if self.context:
             self.context.next_track()
 
-    def on_select(self, data=None) -> None:
+    def on_select(self, data: object | None = None) -> None:
         """Toggle play/pause."""
         self._toggle_playback()
 
-    def on_play_pause(self, data=None) -> None:
+    def on_play_pause(self, data: object | None = None) -> None:
         """Toggle play/pause from a dedicated action."""
         self._toggle_playback()
 
-    def on_back(self, data=None) -> None:
+    def on_back(self, data: object | None = None) -> None:
         """Go back."""
         self.request_route("back")
 
-    def on_advance(self, data=None) -> None:
+    def on_advance(self, data: object | None = None) -> None:
         """Advance to the next track in one-button mode."""
         self._next_track()
 
-    def on_up(self, data=None) -> None:
+    def on_up(self, data: object | None = None) -> None:
         """Go to the previous track."""
         self._previous_track()
 
-    def on_prev_track(self, data=None) -> None:
+    def on_prev_track(self, data: object | None = None) -> None:
         """Go to the previous track from a dedicated media action."""
         self._previous_track()
 
-    def on_down(self, data=None) -> None:
+    def on_down(self, data: object | None = None) -> None:
         """Go to the next track."""
         self._next_track()
 
-    def on_next_track(self, data=None) -> None:
+    def on_next_track(self, data: object | None = None) -> None:
         """Go to the next track from a dedicated media action."""
         self._next_track()


### PR DESCRIPTION
## What changed
- made `yoyopy/audio/music/models.py` the canonical home for shared music-domain models
- kept `Track` as the shared track shape, kept `Playlist` as the local-library playlist summary, and added `PlaybackQueue` for runtime ordered track selection state
- removed the duplicate `Track`/`Playlist` dataclasses from `yoyopy/app_context.py`
- updated fallback/demo callers to use canonical track fields instead of the old parallel shape
- documented the ownership boundary in the audio and system architecture docs
- added tests covering `PlaybackQueue` behavior and `AppContext`'s use of canonical `Track`

## Why
Issue #89 called out drift between multiple `Track`/`Playlist` representations. The app context had a second music model hierarchy with different field names and semantics from the audio-domain models, which increased conversion noise and made the ownership boundary unclear.

This change keeps the cleanup tight: shared music data now lives in one place, while runtime queue state is represented explicitly instead of via another conflicting `Playlist` type.

## Validation
Passed locally:
- `uv run --extra dev pytest -q tests\test_music_models.py tests\test_local_music_service.py`
- `uv run --extra dev pytest -q tests\test_music_backend.py tests\test_music_models.py tests\test_local_music_service.py tests\test_display.py tests\test_input_navigation.py tests\test_now_playing_lvgl_view.py tests\test_playlist_lvgl_view.py tests\test_whisplay_one_button.py`
- `python -m compileall yoyopy tests demos`
- `uv run --extra dev black --check yoyopy\audio\music\models.py yoyopy\audio\music\__init__.py yoyopy\audio\__init__.py yoyopy\app_context.py yoyopy\ui\screens\music\now_playing.py yoyopy\app.py yoyopy\cli\pi\gallery.py tests\test_music_models.py`
- `uv run --extra dev ruff check yoyopy\audio\music\models.py yoyopy\audio\music\__init__.py yoyopy\audio\__init__.py yoyopy\app_context.py yoyopy\ui\screens\music\now_playing.py yoyopy\app.py yoyopy\cli\pi\gallery.py tests\test_music_models.py`
- `uv run --extra dev mypy yoyopy\audio\music\models.py yoyopy\app_context.py yoyopy\ui\screens\music\now_playing.py`

Repo-wide audit was also attempted:
- `uv run --extra dev python scripts\quality.py audit`

That audit still fails because of pre-existing repo-wide formatting, lint, and mypy debt outside this diff.

## Raspberry Pi validation
Attempted on `rpi-zero` against `/home/tifo/yoyo-py`:
- `uv run yoyoctl remote status --host rpi-zero --project-dir /home/tifo/yoyo-py`
- `uv run yoyoctl remote rsync --host rpi-zero --project-dir /home/tifo/yoyo-py`
- `uv run yoyoctl remote smoke --host rpi-zero --project-dir /home/tifo/yoyo-py --with-music --with-voip --with-lvgl-soak`

The Pi smoke did not pass cleanly. The observed blockers were environmental/runtime issues on the device rather than obvious regressions from this diff:
- Whisplay hardware init fell back with `A PWM object already exists for this GPIO channel`
- Liblinphone emitted LIME/database corruption errors (`database disk image is malformed`) during VoIP validation
- the remote helper config in the tracked deploy contract did not match the active Pi checkout path and had to be overridden to `/home/tifo/yoyo-py`

Leaving this as a draft PR so the code review can proceed while the Pi environment issues are sorted out.