### PR TITLE
docs: label generated planning workspace

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,13 @@ These are useful when you need to understand how the repo got here, but they are
 - [`UI_RESTRUCTURE_PROPOSAL.md`](UI_RESTRUCTURE_PROPOSAL.md), refactor status record for the UI split and remaining cleanup
 - [`PHASE2_SUMMARY.md`](PHASE2_SUMMARY.md), milestone summary for early screen integration
 
+## Generated planning workspace
+
+- [`superpowers/README.md`](superpowers/README.md), status and usage notes for generated plan/spec workspaces
+- [`superpowers/`](superpowers/), historical agent-generated plans and specs that may retain older repo names or environment-specific paths
+
+Treat this directory as preserved planning context, not as the current implementation contract.
+
 ## Archived history
 
 - [`archive/README.md`](archive/README.md), archive policy

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,22 @@
+# Superpowers Planning Workspace
+
+This directory holds generated plans and design specs from earlier agent-assisted work slices.
+
+## Status
+
+**Status:** Historical planning workspace, not the current implementation contract
+
+> Current note: files in this directory are useful for research context, prior design reasoning, and task history. They may still contain older repo names such as `yoyo-py`, machine-specific paths, or workflow assumptions that no longer match `main` exactly.
+
+For current truth, trust in this order:
+
+1. current code under `yoyopy/`
+2. top-level runtime/setup docs such as `docs/SYSTEM_ARCHITECTURE.md`, `docs/DEVELOPMENT_GUIDE.md`, and `docs/SETUP_CONTRACT.md`
+3. current repo guidance in `AGENTS.md` and `rules/`
+
+## What is here
+
+- `plans/` for agent-generated execution plans and task breakdowns
+- `specs/` for paired design/spec documents created during those work slices
+
+These files are preserved because they still contain useful rationale and discovery, but they should be read as historical planning material unless a newer top-level doc explicitly adopts them.


### PR DESCRIPTION
## What changed
- add a README for `docs/superpowers/` explaining that it is a historical generated planning workspace, not the current implementation contract
- add that directory to the main docs index with explicit framing about older repo names and environment-specific paths

## Why
There is still useful context in `docs/superpowers/`, but without framing it looks more current than it is. That is how stale repo names and machine-specific paths keep misleading people.

## Validation
- `git diff --check`
- `rg -n "Historical planning workspace|older repo names|generated planning workspace|superpowers/README" docs/README.md docs/superpowers/README.md`

Related to #95