### PR TITLE
[codex] Make target-hardware validation branch-driven and agent-safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,8 @@ Workflow instructions for deploying and debugging on Raspberry Pi are in canonic
 
 | Skill | File | Purpose |
 |---|---|---|
-| yoyopod-deploy | `skills/yoyopod-deploy/SKILL.md` | Git push, remote branch sync, restart, verify |
-| yoyopod-sync | `skills/yoyopod-sync/SKILL.md` | Rsync dirty tree (no commit), restart |
+| yoyopod-deploy | `skills/yoyopod-deploy/SKILL.md` | Commit-safe branch/SHA validation on the Pi |
+| yoyopod-sync | `skills/yoyopod-sync/SKILL.md` | Rare-case dirty-tree sync escape hatch |
 | yoyopod-logs | `skills/yoyopod-logs/SKILL.md` | Tail app logs with filtering |
 | yoyopod-restart | `skills/yoyopod-restart/SKILL.md` | Kill processes and relaunch |
 | yoyopod-status | `skills/yoyopod-status/SKILL.md` | Health check dashboard |
@@ -300,8 +300,8 @@ Preferred remote helper:
 ```bash
 yoyoctl remote status --host rpi-zero
 yoyoctl remote preflight --host rpi-zero --with-music --with-voip --with-lvgl-soak
-yoyoctl remote sync --host rpi-zero --branch main
-yoyoctl remote smoke --host rpi-zero --with-music --with-voip --with-lvgl-soak
+git rev-parse HEAD
+yoyoctl remote validate --host rpi-zero --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak
 yoyoctl remote lvgl-soak --host rpi-zero --cycles 2
 yoyoctl remote power --host rpi-zero
 yoyoctl remote service install --host rpi-zero

--- a/deploy/pi-deploy.yaml
+++ b/deploy/pi-deploy.yaml
@@ -1,9 +1,15 @@
 # Raspberry Pi deploy contract for YoyoPod.
-# This is the shared source of truth for yoyoctl remote and Pi skills.
+# This is the shared source of truth for `yoyoctl remote` and the Pi skills.
+# The board should reuse one stable checkout path at `project_dir`.
 # Machine-specific connection overrides belong in deploy/pi-deploy.local.yaml.
 # Leave host/user blank in the tracked file; do not commit personal Pi values here.
 # Create or edit that file with:
-#   uv run yoyoctl remote config edit
+#   yoyoctl remote config edit
+# Default board validation flow:
+#   git branch --show-current
+#   git rev-parse HEAD
+#   yoyoctl remote validate --branch <branch> --sha <commit>
+# Dirty-tree `yoyoctl remote rsync` is a rare debugging escape hatch only.
 
 host: ""
 user: ""

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -154,9 +154,10 @@ yoyoctl remote config show
 uv run yoyoctl remote setup
 uv run yoyoctl remote verify-setup
 yoyoctl remote status
-yoyoctl remote preflight --branch main --with-music --with-voip --with-lvgl-soak
-yoyoctl remote sync --branch main
-yoyoctl remote smoke --with-music --with-voip
+git branch --show-current
+git rev-parse HEAD
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak
+yoyoctl remote preflight --branch <branch> --with-music --with-voip --with-lvgl-soak
 yoyoctl remote service status
 yoyoctl remote logs --lines 200
 ```

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -1,20 +1,29 @@
 # Raspberry Pi Dev Workflow
 
-This guide gives the day-to-day remote workflow for YoyoPod development once code is already in Git.
+This guide covers the normal dev-machine-to-board loop for YoyoPod.
 
-## What This Solves
+The default contract is:
 
-The repo now has a clear hardware smoke path, but developers still need a quick way to:
+1. finish the implementation locally
+2. commit the intended changes
+3. push the branch
+4. validate that committed branch and exact SHA on the Pi
+5. leave the app running for manual hardware testing
 
-- sync a branch onto the Raspberry Pi
-- inspect remote status
-- run one combined preflight before manual app startup
-- run the Pi smoke checks
-- launch the production app
-- install and inspect the production systemd unit
-- tail the structured file logs with subsystem/error filtering
+Dirty-tree sync still exists, but only as a rare debugging override.
 
-Use `yoyoctl remote` for that loop.
+## Stable Board Checkout
+
+The Raspberry Pi should reuse one stable checkout path, configured by `project_dir` in `deploy/pi-deploy.yaml`.
+
+Why this is the default:
+
+- `uv sync` is expensive on Pi Zero hardware
+- native LVGL and Liblinphone rebuilds can be expensive
+- repeated fresh copies waste time
+- the service unit, logs, PID file, and restart flow all assume one stable path
+
+Do not normalize ad hoc per-branch checkout directories on the board.
 
 ## Setup
 
@@ -23,7 +32,8 @@ Make sure your dev machine can SSH into the Raspberry Pi with an alias or reacha
 The repo-tracked deploy contract lives in `deploy/pi-deploy.yaml`.
 
 - keep `host` and `user` blank there
-- put your real machine-specific values in `deploy/pi-deploy.local.yaml`
+- keep the shared `project_dir` stable there
+- put machine-specific values in `deploy/pi-deploy.local.yaml`
 - create or update that file with:
 
 ```bash
@@ -42,7 +52,6 @@ Optional environment defaults:
 ```bash
 export YOYOPOD_PI_HOST=rpi-zero
 export YOYOPOD_PI_PROJECT_DIR=~/YoyoPod_Core
-export YOYOPOD_PI_BRANCH=main
 ```
 
 On Windows PowerShell:
@@ -50,10 +59,56 @@ On Windows PowerShell:
 ```powershell
 $env:YOYOPOD_PI_HOST="rpi-zero"
 $env:YOYOPOD_PI_PROJECT_DIR="~/YoyoPod_Core"
-$env:YOYOPOD_PI_BRANCH="main"
 ```
 
-## Common Commands
+## Default Validate-On-Board Flow
+
+Use this when validating a feature branch or PR on target hardware.
+
+1. Confirm the local tree is committed:
+   ```bash
+   git status --short
+   ```
+2. Resolve the branch and exact commit:
+   ```bash
+   git branch --show-current
+   git rev-parse HEAD
+   ```
+3. Push the branch:
+   ```bash
+   git push
+   ```
+   If the branch has no upstream yet:
+   ```bash
+   git push -u origin <branch>
+   ```
+4. Run the repo-owned hardware validation flow:
+   ```bash
+   yoyoctl remote validate --branch <branch> --sha <commit>
+   ```
+
+Useful variations:
+
+```bash
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip
+yoyoctl remote validate --branch <branch> --sha <commit> --with-power --with-rtc
+yoyoctl remote validate --branch <branch> --sha <commit> --with-lvgl-soak
+yoyoctl remote validate --branch <branch> --sha <commit> --skip-uv-sync
+```
+
+`yoyoctl remote validate` does all of this:
+
+1. stops if the local worktree is dirty
+2. verifies the requested branch is pushed
+3. syncs the stable Pi checkout to the branch and exact SHA
+4. runs `uv sync --extra dev` unless skipped
+5. runs the requested smoke checks
+6. restarts the app
+7. verifies startup with the PID file and startup marker
+8. prints the latest startup marker and recent logs
+9. leaves the app running for manual testing
+
+## Lower-Level Commands
 
 ### Check remote status
 
@@ -63,33 +118,24 @@ yoyoctl remote status
 
 Shows:
 
-- remote branch and commit
-- dirty working tree state
+- remote branch or `DETACHED`
+- remote commit
+- dirty working tree state on the Pi checkout
 - music backend process state
 - tracked PID file state
 - latest startup marker from the file log
 - top memory processes
 
-### Sync branch to the Raspberry Pi
+### Sync committed code without launching the app
 
 ```bash
-yoyoctl remote sync --branch main
+yoyoctl remote sync --branch <branch>
+yoyoctl remote sync --branch <branch> --sha <commit>
 ```
 
-By default this will:
+Use this when you want the stable checkout updated but do not want the full validate flow yet.
 
-1. `git fetch origin`
-2. `git checkout <branch>`
-3. `git pull --ff-only origin <branch>`
-4. `uv sync --extra dev`
-
-Skip dependency refresh if you only need the Git update:
-
-```bash
-yoyoctl remote sync --branch main --skip-uv-sync
-```
-
-### Run smoke validation remotely
+### Run smoke validation only
 
 ```bash
 yoyoctl remote smoke
@@ -105,52 +151,13 @@ yoyoctl remote smoke --with-music --music-timeout 10
 yoyoctl remote smoke --with-voip --voip-timeout 15 --verbose
 ```
 
-### Run Whisplay gesture tuning remotely
+### Restart the already-synced app
 
 ```bash
-yoyoctl remote whisplay
-yoyoctl remote whisplay --duration-seconds 45 --double-tap-ms 240 --long-hold-ms 900
+yoyoctl remote restart
 ```
 
-### Run the LVGL Whisplay soak remotely
-
-```bash
-yoyoctl remote lvgl-soak
-yoyoctl remote lvgl-soak --cycles 3 --hold-seconds 0.3
-```
-
-Use this when you want a focused hardware-in-the-loop pass for:
-
-- repeated LVGL screen transitions
-- sleep/wake recovery
-- Whisplay-only rendering regressions
-
-### PiSugar RTC helpers
-
-```bash
-yoyoctl remote rtc status
-yoyoctl remote rtc sync-to
-```
-
-### PiSugar power helper
-
-```bash
-yoyoctl remote power
-```
-
-Use this when you want a focused battery, charging, and watchdog snapshot without the full smoke pass.
-
-### Production systemd service
-
-```bash
-yoyoctl remote service status
-yoyoctl remote service install
-yoyoctl remote service restart
-yoyoctl remote service logs --lines 150
-```
-
-This installs `deploy/systemd/yoyopod@.service` onto the Pi as `yoyopod@<remote-user>.service`, enables it at boot, and keeps the app paired with the PiSugar watchdog recovery loop. `service install`, `start`, and `restart` now wait for the file-log startup marker and verify that it matches the PID file before returning success.
-The install step also records the merged `project_dir` in `/etc/default/yoyopod`, so the service keeps following your configured checkout path after the repo rename.
+This waits for the startup marker and matching PID before returning success.
 
 ### Structured file logs
 
@@ -167,17 +174,33 @@ This tails the file sinks declared in `deploy/pi-deploy.yaml`, which is the stab
 - `<project-dir>/logs/yoyopod_errors.log`
 - `/tmp/yoyopod.pid`
 
-Use this during on-device tuning when the Whisplay button feels too eager or too sluggish. The helper runs interactively over SSH, prints every semantic gesture event, and accepts temporary timing overrides without modifying the tracked config file.
-
-Liblinphone note:
-
-- keep `config/liblinphone_factory.conf` tracked and synced with the branch when debugging outbound-call negotiation on the Pi
-- if registration works but calls fail during setup, compare the active branch's factory config before changing SIP credentials
-
-### Run the full preflight in one command
+### Production systemd service
 
 ```bash
-yoyoctl remote preflight --branch main --with-music --with-voip --with-lvgl-soak
+yoyoctl remote service status
+yoyoctl remote service install
+yoyoctl remote service restart
+yoyoctl remote service logs --lines 150
+```
+
+This installs `deploy/systemd/yoyopod@.service` onto the Pi as `yoyopod@<remote-user>.service`, enables it at boot, and records the merged `project_dir` in `/etc/default/yoyopod` so the service follows the same stable checkout path.
+
+### Whisplay and PiSugar helpers
+
+```bash
+yoyoctl remote whisplay
+yoyoctl remote whisplay --duration-seconds 45 --double-tap-ms 240 --long-hold-ms 900
+yoyoctl remote lvgl-soak
+yoyoctl remote rtc status
+yoyoctl remote power
+```
+
+## Preflight
+
+`yoyoctl remote preflight` is still useful, but it is a preparation step, not the full hardware-validation finish line.
+
+```bash
+yoyoctl remote preflight --branch <branch> --with-music --with-voip --with-lvgl-soak
 ```
 
 What it does:
@@ -187,51 +210,56 @@ What it does:
 3. syncs the chosen branch to the Raspberry Pi
 4. runs the Raspberry Pi smoke pass
 
-Useful variations:
+Use it before commit when you want an extra sanity pass, or before `yoyoctl remote validate` when you want a stricter gate.
+
+## Dirty-Tree Escape Hatch
+
+`yoyoctl remote rsync` still exists, but it is not the normal validation path.
+
+Use it only when:
+
+- the user explicitly wants to validate uncommitted local changes
+- you are doing a one-off debugging session and have called out that the Pi is not running committed code
+
+Commands:
 
 ```bash
-yoyoctl remote preflight --branch main --skip-local
-yoyoctl remote preflight --branch main --skip-sync --with-voip
-yoyoctl remote preflight --branch main --skip-uv-sync --with-music --with-voip
+yoyoctl remote rsync
+yoyoctl remote rsync --skip-restart
 ```
 
-### Restart the production app remotely
-
-```bash
-yoyoctl remote restart
-```
+If you use it, say clearly that the board is running a dirty-tree override instead of the committed branch/SHA flow.
 
 ## Suggested Daily Loop
 
-1. Run local checks: `uv run pytest -q`
-2. Push your branch
-3. Run the combined preflight:
-   `yoyoctl remote preflight --branch <branch> --with-music --with-voip --with-lvgl-soak`
-4. Launch the app:
-   `yoyoctl remote restart`
-
-If you are validating the production boot path rather than an interactive SSH run, use:
-
-5. `yoyoctl remote service restart`
-6. `yoyoctl remote service status`
+1. Run local checks as needed:
+   ```bash
+   uv run pytest -q
+   ```
+2. Commit the intended change.
+3. Push the branch.
+4. Resolve the exact commit:
+   ```bash
+   git rev-parse HEAD
+   ```
+5. Validate on the Pi:
+   ```bash
+   yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak
+   ```
+6. Manually test on the target hardware while the app remains running.
 
 ## Release / Pre-Merge Checklist
 
-- Local branch is green with `uv run pytest -q`
-- Branch is pushed and reviewed
-- `yoyoctl remote preflight --branch <branch> --with-music --with-voip --with-lvgl-soak` passes
-- `yoyoctl remote restart` starts cleanly
-- Manual sanity:
-  - display renders correctly
-  - input works on target hardware
-  - music playback works
-  - SIP registration succeeds
-  - incoming/outgoing call flow still behaves correctly
+- local branch is green with `uv run pytest -q`
+- branch is pushed and reviewed
+- `yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak` passes
+- the app starts cleanly and stays running for manual hardware testing
+- manual sanity still passes for display, input, music, SIP registration, and call flow
 
 ## Notes
 
-- `pi_remote.py run` uses an interactive SSH session so you can stop the remote app with `Ctrl+C`.
-- `pi_remote.py preflight` is intentionally non-interactive. It validates but does not launch the app.
-- `pi_remote.py service install` expects passwordless `sudo` or an interactive sudo policy on the Pi.
-- The helper does not kill existing remote processes for you. If the Pi already has a stale YoyoPod process, stop it first.
+- `yoyoctl remote validate` is the default board-validation contract for branches and PRs.
+- `yoyoctl remote preflight` is intentionally non-launching.
+- `yoyoctl remote service install` expects passwordless `sudo` or an interactive sudo policy on the Pi.
+- `yoyoctl remote rsync` is a debugging escape hatch, not the normal deploy story.
 - For deeper hardware debugging, use `docs/RPI_SMOKE_VALIDATION.md`.

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -1,6 +1,8 @@
 # Raspberry Pi Smoke Validation
 
-This guide separates the validation work that is safe in CI from the checks that still require Raspberry Pi hardware, the mpv music backend, and a reachable SIP account.
+This guide separates CI-safe checks from the target-hardware checks that still require a Raspberry Pi, the mpv music backend, and a reachable SIP account.
+
+The default board-validation path from the dev machine is now committed-code validation through `yoyoctl remote validate`.
 
 ## Validation Layers
 
@@ -15,9 +17,45 @@ uv run pytest -q
 
 This covers the pure-Python and simulation-mode regression suite.
 
-### 2. Raspberry Pi core hardware smoke
+### 2. Default dev-machine-to-board validation
 
-Run this on the target Raspberry Pi after pulling the latest branch:
+Use this for feature branches and PR validation on target hardware:
+
+```bash
+git status --short
+git branch --show-current
+git rev-parse HEAD
+git push
+yoyoctl remote validate --branch <branch> --sha <commit>
+```
+
+Useful variations:
+
+```bash
+yoyoctl remote validate --branch <branch> --sha <commit> --with-power --with-rtc
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak
+```
+
+What it checks:
+
+- the branch is committed locally
+- the branch and exact SHA are pushed
+- the stable Pi checkout is synced to committed code only
+- the requested smoke checks pass
+- the app restarts cleanly
+- the PID file and startup marker agree
+- recent logs look sane before handoff
+
+Expected result:
+
+- the app stays running on the Pi after validation
+- the Pi reflects the requested committed branch/SHA, not dirty local state
+- the startup marker matches the active PID
+
+### 3. On-Pi core hardware smoke
+
+Run these directly on the target Raspberry Pi when you want the lower-level hardware checks without the remote orchestration layer:
 
 ```bash
 yoyoctl pi smoke
@@ -34,12 +72,12 @@ What it checks:
 
 Expected result:
 
-- `display` should report a real hardware adapter, not simulation
-- `input` should report the active interaction profile plus semantic capabilities for the attached hardware
+- `display` reports a real hardware adapter, not simulation
+- `input` reports the active interaction profile plus semantic capabilities for the attached hardware
 
-### 3. Raspberry Pi service smoke
+### 4. On-Pi service smoke
 
-Add music-backend and SIP checks when the services are expected to be available:
+Add music-backend and SIP checks when those services are expected to be available:
 
 ```bash
 yoyoctl pi smoke --with-music --with-voip
@@ -51,7 +89,7 @@ What it checks:
 - PiSugar battery telemetry and RTC state when requested
 - mpv music-backend startup using `config/yoyopod_config.yaml`
 - Liblinphone startup and SIP registration using `config/voip_config.yaml`
-- Liblinphone media/codec defaults from `config/liblinphone_factory.conf`
+- Liblinphone media and codec defaults from `config/liblinphone_factory.conf`
 
 Useful flags:
 
@@ -59,9 +97,9 @@ Useful flags:
 - `--voip-timeout 15`
 - `--verbose`
 
-## Manual Follow-up Checks
+## Manual Follow-Up Checks
 
-### Full application startup
+### Full application startup on the Pi
 
 ```bash
 uv run python yoyopod.py
@@ -69,7 +107,7 @@ uv run python yoyopod.py
 
 Verify:
 
-- the home/menu UI renders on the target display
+- the home and menu UI render on the target display
 - button input navigates screens correctly
 - the app returns cleanly on `Ctrl+C`
 
@@ -105,7 +143,7 @@ yoyoctl pi tune
 yoyoctl pi tune --double-tap-ms 240 --long-hold-ms 900
 ```
 
-Use this when button feel needs tuning on the real device. It listens for the semantic Whisplay gestures, prints every detected `advance` / `select` / `back` event with timing detail, and can apply temporary timing overrides without editing `config/yoyopod_config.yaml`.
+Use this when button feel needs tuning on the real device. It listens for the semantic Whisplay gestures, prints every detected `advance`, `select`, and `back` event with timing detail, and can apply temporary timing overrides without editing `config/yoyopod_config.yaml`.
 
 Useful flags:
 
@@ -135,7 +173,7 @@ yoyoctl pi power rtc status
 yoyoctl pi power rtc sync-to
 ```
 
-Use this when you want a focused RTC read/sync pass without running the full app.
+Use this when you want a focused RTC read or sync pass without running the full app.
 
 ### PiSugar power drill
 
@@ -149,20 +187,31 @@ Use this when you want a focused battery, charging, RTC, shutdown-threshold, and
 
 1. `uv sync --extra dev`
 2. `uv run pytest -q`
-3. `yoyoctl pi smoke`
-4. `yoyoctl pi smoke --with-music --with-voip`
-5. `yoyoctl pi lvgl soak`
-6. `uv run python yoyopod.py`
+3. `git push`
+4. `git rev-parse HEAD`
+5. `yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip`
+6. manual follow-up on the still-running app
+
+## Dirty-Tree Escape Hatch
+
+`yoyoctl remote rsync` still exists for rare debugging sessions, but it is not the default validation contract.
+
+Only use it when:
+
+- you explicitly need to validate uncommitted local state
+- you have called out that the board is not running committed branch/SHA code
 
 ## Failure Triage
 
-- `display` fails: check attached HAT, driver/library install, and `display.hardware` config
+- `display` fails: check attached HAT, driver and library install, and `display.hardware` config
 - `input` fails: check the matching display adapter initialized correctly first
 - `music` fails: verify `mpv` is installed, the configured socket path is writable, and the configured `audio.music_dir` exists
 - `voip` fails: verify the Liblinphone shim build, `config/liblinphone_factory.conf`, SIP credentials, network reachability, and audio device configuration
+- `validate` fails before launch: check whether the branch was actually pushed and whether the Pi checkout is reachable over SSH
 
 ## Notes
 
-- The smoke script exits non-zero if any requested check fails.
-- CI intentionally does not run hardware-in-the-loop checks.
-- The hardware smoke script is meant to be quick. Use the manual drills above when you need deeper debugging.
+- the smoke script exits non-zero if any requested check fails
+- CI intentionally does not run hardware-in-the-loop checks
+- `yoyoctl remote validate` is the normal branch and PR validation path
+- the hardware smoke script is meant to be quick; use the manual drills above when you need deeper debugging

--- a/rules/deploy.md
+++ b/rules/deploy.md
@@ -1,50 +1,98 @@
 # Deploy Workflow
 
-Applies to: `deploy/pi-deploy.yaml`, deployment and debugging on Raspberry Pi
+Applies to: `deploy/pi-deploy.yaml`, `yoyoctl remote`, Raspberry Pi validation, and Pi-facing agent skills
 
-## Manual Deploy
+## Default Contract
+
+The normal target-hardware workflow validates committed code only.
+
+Use this order:
+
+1. finish implementation locally
+2. run local checks as needed
+3. commit the intended changes
+4. push the branch
+5. deploy the committed branch and preferably the exact commit SHA to the Raspberry Pi
+6. run smoke validation
+7. launch or restart the app
+8. verify startup with the PID file, startup marker, and recent logs
+9. leave the app running for manual testing
+
+The repo-owned command for that flow is:
 
 ```bash
-# Local: commit and push
-git push
-
-# RPi: pull and run
-ssh rpi-zero "cd YoyoPod_Core && git pull origin main"
-ssh rpi-zero "cd YoyoPod_Core && source .venv/bin/activate && python yoyopod.py"
+git branch --show-current
+git rev-parse HEAD
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak
 ```
 
-Kill stuck processes before restarting:
+`yoyoctl remote validate` is the default because it:
 
-```bash
-ssh rpi-zero "killall -9 python"
-```
+- stops on uncommitted local changes
+- requires a pushed branch/SHA
+- syncs one stable checkout path on the board
+- runs smoke checks before launch
+- waits for the startup marker after restart
+- prints recent logs and leaves the app running
 
-## rpi-deploy Plugin
+## Stable Pi Checkout Path
 
-The `rpi-deploy` Claude Code plugin automates the deploy cycle with slash commands. In this repo, prefer `yoyoctl remote` as the executable implementation for these workflows and keep the skills as thin wrappers around it.
+The board must reuse one stable checkout path, configured by `project_dir` in `deploy/pi-deploy.yaml`.
+
+Why this is the normal contract:
+
+- dependency installs are expensive on Pi Zero hardware
+- native LVGL and Liblinphone rebuilds can be expensive
+- repeated fresh copies waste time and introduce drift
+- the fixed path is what the service unit, logs, PID file, and agent skills expect
+
+Do not normalize ad hoc per-branch directories on the board.
+
+## Command Map
+
+The `rpi-deploy` Claude Code plugin is still the high-level integration surface, but in this repo `yoyoctl remote` is the executable implementation and the skills should stay thin wrappers around it.
 
 | Command | Purpose |
 |---|---|
-| `/yoyopod-deploy` | Git push, SSH pull, kill, restart, verify |
-| `/yoyopod-sync` | Rsync dirty tree (no commit), kill, restart |
-| `/yoyopod-logs [N] [--errors] [--filter <sub>]` | Tail app logs from Pi |
-| `/yoyopod-restart` | Kill processes and relaunch |
-| `/yoyopod-status` | Health check dashboard (connectivity, memory, processes) |
+| `/yoyopod-deploy` | Commit-safe branch/SHA validation on the Pi |
+| `/yoyopod-sync` | Rare-case dirty-tree rsync escape hatch for debugging only |
+| `/yoyopod-logs [N] [--errors] [--filter <sub>]` | Tail app logs from the Pi |
+| `/yoyopod-restart` | Restart the already-synced app |
+| `/yoyopod-status` | Health check dashboard |
 | `/yoyopod-screenshot [--readback]` | Capture display output as PNG |
 
-Config: `deploy/pi-deploy.yaml` plus optional `deploy/pi-deploy.local.yaml` for machine-specific host/user overrides. Preferred edit flow:
+Lower-level `yoyoctl remote` commands:
+
+- `yoyoctl remote validate` is the default branch/SHA validation flow
+- `yoyoctl remote sync` is the committed-code sync primitive
+- `yoyoctl remote smoke` is the remote smoke primitive
+- `yoyoctl remote restart` restarts the synced app and verifies startup
+- `yoyoctl remote rsync` is not the default; use it only as an explicit debugging override
+
+Config lives in `deploy/pi-deploy.yaml` plus optional `deploy/pi-deploy.local.yaml` for machine-specific host and user overrides. Preferred edit flow:
 
 ```bash
 yoyoctl remote config show
-uv run yoyoctl remote config edit
+yoyoctl remote config edit
 uv run yoyoctl remote setup
 uv run yoyoctl remote verify-setup
 ```
 
-Plugin repo: https://github.com/moustafattia/rpi-deploy
+## Escape Hatch Only
+
+Dirty-tree deploys are still allowed as a rare debugging override, but they are not the default validation story.
+
+Use `yoyoctl remote rsync` only when:
+
+- the user explicitly asks to validate uncommitted local state
+- you are doing one-off hardware debugging and have called out that the Pi is not running committed code
+
+Do not present dirty-tree rsync as the normal way to validate a branch or PR.
 
 ## Target Hardware
 
 - Raspberry Pi Zero 2W (416 MB RAM)
-- SSH host, user, and project-dir defaults come from `deploy/pi-deploy.yaml` plus gitignored `deploy/pi-deploy.local.yaml`
+- SSH host, user, and stable project-dir defaults come from `deploy/pi-deploy.yaml` plus gitignored `deploy/pi-deploy.local.yaml`
 - Machine-local hostnames, usernames, and path overrides must stay out of tracked files
+- Default project dir on Pi: `/home/pi/YoyoPod_Core`
+- Default venv on Pi: `/home/pi/YoyoPod_Core/.venv`

--- a/rules/design-fidelity.md
+++ b/rules/design-fidelity.md
@@ -71,18 +71,21 @@ For Whisplay UI work, the standard loop is:
    uv run pytest -q
    ```
    For iterative UI work, run the most relevant focused tests if the full suite is unnecessary.
-2. Sync dirty local changes to the Pi:
+2. Commit and push the branch you want to validate:
    ```bash
-   yoyoctl remote rsync
+   git branch --show-current
+   git rev-parse HEAD
    ```
-3. Restart the app if needed:
+3. Validate the committed branch or exact SHA on the Pi:
    ```bash
-   yoyoctl remote restart
+   yoyoctl remote validate --branch <branch> --sha <commit>
    ```
 4. Capture output from the Pi:
    - single capture with `yoyoctl remote screenshot`
    - multi-screen capture with `yoyoctl pi gallery`
 5. Compare the captured result against Figma and adjust.
+
+Use `yoyoctl remote rsync` only if the user explicitly wants a dirty-tree hardware check as a one-off debugging override.
 
 ## Screenshot Interpretation
 
@@ -99,7 +102,7 @@ Use all three appropriately:
 ## Native Rebuild Rule
 
 - If `yoyopy/ui/lvgl_binding/native/lvgl_shim.c`, `lvgl_shim.h`, `binding.py`, or LVGL config changes, the native shim must be rebuilt on the Pi before judging the hardware result.
-- `yoyoctl remote rsync` may rebuild stale native shims automatically. Do not assume a stale Pi build reflects local code.
+- `yoyoctl remote validate` and `yoyoctl remote restart` may rebuild stale native shims automatically. Do not assume a stale Pi build reflects local code.
 
 ## Whisplay-Specific Acceptance Criteria
 

--- a/skills/yoyopod-deploy/SKILL.md
+++ b/skills/yoyopod-deploy/SKILL.md
@@ -1,43 +1,45 @@
 ---
 name: yoyopod-deploy
-description: Git-based deploy to Raspberry Pi (push, pull, restart)
+description: Commit-safe branch/SHA validation on Raspberry Pi
 disable-model-invocation: true
 allowed-tools:
   - Read
   - Bash(git status:*)
   - Bash(git branch --show-current:*)
+  - Bash(git rev-parse:*)
   - Bash(git push:*)
   - Bash(yoyoctl remote:*)
 ---
 
 ## Config
 
-Use `deploy/pi-deploy.yaml` as the shared deploy contract and `deploy/pi-deploy.local.yaml` for machine-specific overrides such as host, SSH user, project dir, and branch. `yoyoctl remote` merges them directly, and `yoyoctl remote config edit` is the preferred way to create or update the local override.
+Use `deploy/pi-deploy.yaml` as the shared deploy contract and `deploy/pi-deploy.local.yaml` for machine-specific overrides such as host, SSH user, and the stable Pi `project_dir`. `yoyoctl remote` merges them directly, and `yoyoctl remote config edit` is the preferred way to create or update the local override.
 
 If the file does not exist yet, run `yoyoctl remote config edit` first. That command creates `deploy/pi-deploy.local.yaml` automatically before opening it.
 
 ## Steps
 
-1. **Check local git status.** Run `git status --short`. If there are uncommitted or unstaged changes, stop and tell the user: "You have uncommitted changes. Use `/yoyopod-sync` for a dirty-tree deploy, or commit first."
+1. **Check local git status.** Run `git status --short`. If there are uncommitted or unstaged changes, stop and tell the user: "You have uncommitted changes. Commit and push first. `/yoyopod-sync` is a rare dirty-tree debugging override only."
 
-2. **Resolve the branch.** Run `git branch --show-current` and deploy that branch.
+2. **Resolve the branch and exact commit.** Run:
+   ```bash
+   git branch --show-current
+   git rev-parse HEAD
+   ```
+   If the branch is empty, stop and ask the user which branch should be validated.
 
 3. **Push the branch.** Run `git push`. If the branch has no upstream yet, run `git push -u origin <branch>`.
 
-4. **Sync the committed branch onto the Pi.** Run:
+4. **Validate the committed branch and exact SHA on the Pi.** Run:
    ```bash
-   yoyoctl remote sync --branch <branch>
+   yoyoctl remote validate --branch <branch> --sha <commit>
    ```
+   Add smoke flags such as `--with-music`, `--with-voip`, `--with-power`, `--with-rtc`, or `--with-lvgl-soak` when the task calls for them.
 
-5. **Restart and verify the app.** Run:
-   ```bash
-   yoyoctl remote restart
-   ```
-
-6. **Handle failures.** If either command fails, run:
+5. **Handle failures.** If validation fails, run:
    ```bash
    yoyoctl remote logs --lines 20
    ```
    Include the relevant error output in your response.
 
-Report the deployed branch and whether the final restart succeeded.
+6. **Report the result.** Include the deployed branch, exact SHA, whether validation passed, and that the app was left running for manual testing when the flow succeeded.

--- a/skills/yoyopod-sync/SKILL.md
+++ b/skills/yoyopod-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoyopod-sync
-description: Quick rsync deploy to Raspberry Pi (no commit needed)
+description: Rare-case dirty-tree sync escape hatch for Raspberry Pi debugging
 disable-model-invocation: true
 allowed-tools:
   - Read
@@ -9,26 +9,28 @@ allowed-tools:
 
 ## Config
 
-Use `deploy/pi-deploy.yaml` as the shared deploy contract and `deploy/pi-deploy.local.yaml` for machine-specific overrides such as host, SSH user, project dir, and branch. `yoyoctl remote` merges them directly, and `yoyoctl remote config edit` is the preferred way to create or update the local override.
+Use `deploy/pi-deploy.yaml` as the shared deploy contract and `deploy/pi-deploy.local.yaml` for machine-specific overrides such as host, SSH user, and the stable Pi `project_dir`. `yoyoctl remote` merges them directly, and `yoyoctl remote config edit` is the preferred way to create or update the local override.
 
 If the file does not exist yet, run `yoyoctl remote config edit` first. That command creates `deploy/pi-deploy.local.yaml` automatically before opening it.
 
 ## Steps
 
-1. **Sync the dirty working tree and restart.** Run:
+1. **Confirm this is really a dirty-tree override.** Only use this skill if the user explicitly wants to validate uncommitted local state or asks for a dirty-tree debugging shortcut. Otherwise stop and recommend `/yoyopod-deploy`.
+
+2. **Sync the dirty working tree.** Run:
    ```bash
    yoyoctl remote rsync
    ```
 
-2. **If the user explicitly wants sync without restart,** run:
+3. **If the user explicitly wants sync without restart,** run:
    ```bash
    yoyoctl remote rsync --skip-restart
    ```
 
-3. **Handle failures.** If the rsync or restart step fails, run:
+4. **Handle failures.** If the rsync or restart step fails, run:
    ```bash
    yoyoctl remote logs --lines 20
    ```
    Include the relevant error output in your response.
 
-Report whether the dirty-tree sync and restart succeeded.
+5. **Report the result clearly.** Say that this was a dirty-tree validation override, not the normal committed branch/SHA workflow.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,16 @@ def test_remote_sync_help():
     assert result.exit_code == 0
     assert "--host" in _plain(result.output)
     assert "--branch" in _plain(result.output)
+    assert "--sha" in _plain(result.output)
+
+
+def test_remote_validate_help():
+    result = runner.invoke(app, ["remote", "validate", "--help"])
+    assert result.exit_code == 0
+    assert "--branch" in _plain(result.output)
+    assert "--sha" in _plain(result.output)
+    assert "--with-music" in _plain(result.output)
+    assert "--lines" in _plain(result.output)
 
 
 def test_remote_smoke_help():
@@ -210,6 +220,7 @@ def test_remote_screenshot_help():
 def test_remote_rsync_help():
     result = runner.invoke(app, ["remote", "rsync", "--help"])
     assert result.exit_code == 0
+    assert "escape hatch" in _plain(result.output).lower()
 
 
 def test_remote_whisplay_help():

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -1,5 +1,6 @@
 """Tests for Raspberry Pi remote workflow helpers."""
 
+import pytest
 import yaml
 
 from yoyopy.cli.remote.ops import (
@@ -19,10 +20,12 @@ from yoyopy.cli.remote.ops import (
     build_status_command,
     build_sync_command,
     build_sync_file_manifest,
+    build_validation_inspection_command,
     build_whisplay_command,
     load_pi_deploy_config,
     quote_remote_project_dir,
     resolve_local_executable,
+    resolve_local_validation_target,
     run_screenshot,
     should_use_direct_rsync,
     sync_path_is_excluded,
@@ -154,8 +157,41 @@ def test_build_sync_command_includes_uv_sync_by_default() -> None:
         branch="main",
     )
 
-    assert "uv sync --extra dev" in build_sync_command(config, skip_uv_sync=False)
-    assert "uv sync --extra dev" not in build_sync_command(config, skip_uv_sync=True)
+    command_with_uv = build_sync_command(config, skip_uv_sync=False)
+    command_without_uv = build_sync_command(config, skip_uv_sync=True)
+
+    assert "git fetch --prune origin" in command_with_uv
+    assert "git checkout --force -B main origin/main" in command_with_uv
+    assert "git clean -fd" in command_with_uv
+    assert "uv sync --extra dev" in command_with_uv
+    assert "uv sync --extra dev" not in command_without_uv
+
+
+def test_build_sync_command_supports_exact_sha_checkout() -> None:
+    """Exact-SHA sync should verify ancestry and detach to the requested commit."""
+
+    config = RemoteConfig(
+        host="rpi-zero",
+        user="pi",
+        project_dir=DEFAULT_PROJECT_DIR,
+        branch="feature/hardware-validate",
+    )
+
+    command = build_sync_command(
+        config,
+        skip_uv_sync=False,
+        target_sha="1234567890abcdef1234567890abcdef12345678",
+    )
+
+    assert (
+        "git checkout --force -B feature/hardware-validate origin/feature/hardware-validate"
+        in command
+    )
+    assert (
+        "git merge-base --is-ancestor 1234567890abcdef1234567890abcdef12345678 "
+        "origin/feature/hardware-validate"
+    ) in command
+    assert "git checkout --force --detach 1234567890abcdef1234567890abcdef12345678" in command
 
 
 def test_build_rsync_command_uses_excludes_and_remote_target() -> None:
@@ -330,6 +366,17 @@ def test_build_smoke_command_adds_optional_checks() -> None:
     assert "--voip-timeout 15.0" in command
 
 
+def test_build_validation_inspection_command_reports_marker_and_logs() -> None:
+    """Post-validate inspection should show the startup marker and recent file logs."""
+
+    command = build_validation_inspection_command(DEPLOY_CONFIG, lines=25)
+
+    assert "== Latest Startup Marker ==" in command
+    assert "grep -F 'YoyoPod starting' logs/yoyopod.log | tail -n 1" in command
+    assert "== Recent Logs ==" in command
+    assert "tail -n 25 logs/yoyopod.log" in command
+
+
 def test_build_local_preflight_commands_cover_compile_and_pytest() -> None:
     """Preflight should run both compileall and pytest locally."""
     commands = build_local_preflight_commands()
@@ -432,6 +479,51 @@ def test_build_verify_setup_command_supports_feature_flags() -> None:
     assert "--with-voice" in command
     assert "--with-pisugar" in command
     assert "--with-network" not in command
+
+
+def test_resolve_local_validation_target_uses_clean_head_and_remote_branch(monkeypatch) -> None:
+    """Committed board validation should resolve the current branch and exact pushed HEAD."""
+
+    responses = {
+        ("git", "status", "--short"): SimpleNamespace(returncode=0, stdout="", stderr=""),
+        ("git", "branch", "--show-current"): SimpleNamespace(
+            returncode=0,
+            stdout="feature/117\n",
+            stderr="",
+        ),
+        ("git", "ls-remote", "--exit-code", "origin", "refs/heads/feature/117"): SimpleNamespace(
+            returncode=0,
+            stdout="abc1234567890abc1234567890abc1234567890\trefs/heads/feature/117\n",
+            stderr="",
+        ),
+        ("git", "rev-parse", "HEAD"): SimpleNamespace(
+            returncode=0,
+            stdout="abc1234567890abc1234567890abc1234567890\n",
+            stderr="",
+        ),
+    }
+
+    def fake_run_local_capture(command):
+        return responses[tuple(command)]
+
+    monkeypatch.setattr("yoyopy.cli.remote.ops.run_local_capture", fake_run_local_capture)
+
+    assert resolve_local_validation_target(branch="", sha=None) == (
+        "feature/117",
+        "abc1234567890abc1234567890abc1234567890",
+    )
+
+
+def test_resolve_local_validation_target_rejects_dirty_worktree(monkeypatch) -> None:
+    """Dirty local state should stop the committed validation flow immediately."""
+
+    def fake_run_local_capture(_command):
+        return SimpleNamespace(returncode=0, stdout=" M yoyopy/app.py\n", stderr="")
+
+    monkeypatch.setattr("yoyopy.cli.remote.ops.run_local_capture", fake_run_local_capture)
+
+    with pytest.raises(SystemExit, match="Commit and push before `yoyoctl remote validate`"):
+        resolve_local_validation_target(branch="", sha=None)
 
 
 def test_build_lvgl_soak_command_supports_cycles_and_sleep_toggle() -> None:

--- a/yoyopy/cli/remote/__init__.py
+++ b/yoyopy/cli/remote/__init__.py
@@ -16,6 +16,7 @@ from yoyopy.cli.remote.ops import (
     smoke,
     status,
     sync,
+    validate,
     whisplay,
 )
 from yoyopy.cli.remote.setup import setup, verify_setup
@@ -28,6 +29,7 @@ remote_app = typer.Typer(
 
 remote_app.command()(status)
 remote_app.command()(sync)
+remote_app.command()(validate)
 remote_app.command()(smoke)
 remote_app.command()(preflight)
 remote_app.command()(restart)

--- a/yoyopy/cli/remote/ops.py
+++ b/yoyopy/cli/remote/ops.py
@@ -325,6 +325,73 @@ def _resolve_remote_config(
     )
 
 
+def _capture_local_git(command: Sequence[str], *, action: str) -> str:
+    """Run one local git command and return its trimmed stdout."""
+    completed = run_local_capture(command)
+    if completed.returncode != 0:
+        details = completed.stderr.strip() or completed.stdout.strip() or "unknown git failure"
+        raise SystemExit(f"Failed to {action}: {details}")
+    return completed.stdout.strip()
+
+
+def resolve_local_validation_target(
+    *,
+    branch: str,
+    sha: str | None,
+) -> tuple[str, str]:
+    """Resolve the branch/SHA pair for committed on-board validation."""
+    status_output = _capture_local_git(
+        ["git", "status", "--short"],
+        action="check the local git status",
+    )
+    if status_output:
+        raise SystemExit(
+            "Local working tree has uncommitted changes. Commit and push before "
+            "`yoyoctl remote validate`. Rare-case escape hatch: `yoyoctl remote rsync`."
+        )
+
+    current_branch = _capture_local_git(
+        ["git", "branch", "--show-current"],
+        action="resolve the current branch",
+    )
+    resolved_branch = branch.strip() or current_branch
+    if not resolved_branch:
+        raise SystemExit(
+            "Could not resolve a validation branch from the local checkout. "
+            "Pass `--branch <name>` when validating from a detached HEAD."
+        )
+
+    remote_branch_lookup = run_local_capture(
+        ["git", "ls-remote", "--exit-code", "origin", f"refs/heads/{resolved_branch}"]
+    )
+    if remote_branch_lookup.returncode != 0 or not remote_branch_lookup.stdout.strip():
+        raise SystemExit(
+            f"origin/{resolved_branch} is not pushed yet. Push the branch before board validation."
+        )
+    remote_branch_head = remote_branch_lookup.stdout.split()[0]
+
+    if sha:
+        resolved_sha = _capture_local_git(
+            ["git", "rev-parse", "--verify", f"{sha}^{{commit}}"],
+            action=f"resolve commit {sha}",
+        )
+    elif current_branch == resolved_branch:
+        resolved_sha = _capture_local_git(
+            ["git", "rev-parse", "HEAD"],
+            action="resolve HEAD",
+        )
+    else:
+        resolved_sha = remote_branch_head
+
+    if resolved_sha != remote_branch_head:
+        raise SystemExit(
+            f"origin/{resolved_branch} is at {remote_branch_head[:12]}, but the requested "
+            f"validation commit is {resolved_sha[:12]}. Push the branch before board validation."
+        )
+
+    return resolved_branch, resolved_sha
+
+
 # ---------------------------------------------------------------------------
 # Startup verification and native shim helpers
 # ---------------------------------------------------------------------------
@@ -454,6 +521,34 @@ def build_restart_command(deploy_config: PiDeployConfig) -> str:
             build_native_shim_refresh_command(deploy_config),
             managed_restart,
             build_startup_verification_command(deploy_config),
+        ]
+    )
+
+
+def build_validation_inspection_command(
+    deploy_config: PiDeployConfig | None = None,
+    *,
+    lines: int = 20,
+) -> str:
+    """Inspect the latest startup marker and recent logs after validation."""
+    deploy = deploy_config or load_pi_deploy_config()
+    log_file = shell_quote(deploy.log_file)
+    startup_marker = shell_quote(deploy.startup_marker)
+    return " && ".join(
+        [
+            "echo '== Latest Startup Marker ==' ",
+            (
+                f"if test -f {log_file}; "
+                f"then grep -F {startup_marker} {log_file} | tail -n 1 || true; "
+                "else echo 'missing'; fi"
+            ),
+            "echo",
+            "echo '== Recent Logs ==' ",
+            (
+                f"if test -f {log_file}; "
+                f"then tail -n {lines} {log_file}; "
+                "else echo 'missing'; fi"
+            ),
         ]
     )
 
@@ -764,7 +859,8 @@ def build_status_command(deploy_config: PiDeployConfig | None = None) -> str:
     return " && ".join(
         [
             "echo '== Git ==' ",
-            "git branch --show-current",
+            'branch="$(git branch --show-current)"',
+            'if test -n "$branch"; then echo "$branch"; else echo DETACHED; fi',
             "git rev-parse --short HEAD",
             "git status --short",
             "echo",
@@ -797,13 +893,30 @@ def build_status_command(deploy_config: PiDeployConfig | None = None) -> str:
     )
 
 
-def build_sync_command(config: RemoteConfig, skip_uv_sync: bool) -> str:
-    """Create the remote sync command."""
+def build_sync_command(
+    config: RemoteConfig,
+    skip_uv_sync: bool,
+    *,
+    target_sha: str | None = None,
+) -> str:
+    """Create the remote committed-code sync command."""
+    branch_literal = shlex.quote(config.branch)
+    origin_branch_literal = shlex.quote(f"origin/{config.branch}")
     commands = [
-        "git fetch origin",
-        f"git checkout {shlex.quote(config.branch)}",
-        f"git pull --ff-only origin {shlex.quote(config.branch)}",
+        "git fetch --prune origin",
+        "git clean -fd",
+        f"git checkout --force -B {branch_literal} {origin_branch_literal}",
+        "git clean -fd",
     ]
+    if target_sha:
+        target_sha_literal = shlex.quote(target_sha)
+        commands.extend(
+            [
+                f"git rev-parse --verify {target_sha_literal}^{{commit}} >/dev/null",
+                f"git merge-base --is-ancestor {target_sha_literal} {origin_branch_literal}",
+                f"git checkout --force --detach {target_sha_literal}",
+            ]
+        )
     if not skip_uv_sync:
         commands.append("uv sync --extra dev")
     return " && ".join(commands)
@@ -907,16 +1020,126 @@ def sync(
     branch: Annotated[
         str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
     ] = "",
+    sha: Annotated[
+        Optional[str],
+        typer.Option(
+            "--sha",
+            help="Exact commit SHA to check out after syncing the branch onto the Raspberry Pi.",
+        ),
+    ] = None,
     skip_uv_sync: Annotated[
         bool, typer.Option("--skip-uv-sync", help="Skip `uv sync --extra dev` after pulling.")
     ] = False,
 ) -> None:
-    """Fetch, checkout, pull, and optionally run uv sync on the Raspberry Pi."""
+    """Sync the stable Pi checkout to one committed branch or exact commit."""
     config = _resolve_remote_config(host, user, project_dir, branch)
     validate_config(config)
-    rc = run_remote(config, build_sync_command(config, skip_uv_sync))
+    rc = run_remote(config, build_sync_command(config, skip_uv_sync, target_sha=sha))
     if rc != 0:
         raise typer.Exit(code=rc)
+
+
+def validate(
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str,
+        typer.Option(
+            "--branch",
+            help="Git branch to validate on the Raspberry Pi. Defaults to the current local branch.",
+        ),
+    ] = "",
+    sha: Annotated[
+        Optional[str],
+        typer.Option(
+            "--sha",
+            help="Exact commit SHA to validate. Defaults to local HEAD when validating the current branch.",
+        ),
+    ] = None,
+    skip_uv_sync: Annotated[
+        bool,
+        typer.Option(
+            "--skip-uv-sync", help="Skip `uv sync --extra dev` during the remote sync step."
+        ),
+    ] = False,
+    with_power: Annotated[
+        bool, typer.Option("--with-power", help="Include PiSugar power checks.")
+    ] = False,
+    with_rtc: Annotated[
+        bool, typer.Option("--with-rtc", help="Include PiSugar RTC checks.")
+    ] = False,
+    with_music: Annotated[
+        bool, typer.Option("--with-music", help="Include music-backend startup checks.")
+    ] = False,
+    with_voip: Annotated[
+        bool, typer.Option("--with-voip", help="Include SIP registration checks.")
+    ] = False,
+    with_lvgl_soak: Annotated[
+        bool,
+        typer.Option(
+            "--with-lvgl-soak", help="Include a short LVGL transition and sleep/wake soak."
+        ),
+    ] = False,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", help="Enable verbose smoke-script logging.")
+    ] = False,
+    music_timeout: Annotated[
+        int, typer.Option("--music-timeout", help="Music-backend startup timeout in seconds.")
+    ] = 5,
+    voip_timeout: Annotated[
+        float, typer.Option("--voip-timeout", help="VoIP registration timeout in seconds.")
+    ] = 90.0,
+    lines: Annotated[
+        int,
+        typer.Option("--lines", help="Number of recent startup log lines to show after launch."),
+    ] = 20,
+) -> None:
+    """Validate a committed branch/SHA on the Pi, then leave the app running."""
+    resolved_branch, resolved_sha = resolve_local_validation_target(branch=branch, sha=sha)
+    config = _resolve_remote_config(host, user, project_dir, resolved_branch)
+    validate_config(config)
+    deploy_config = load_pi_deploy_config()
+
+    sync_exit_code = run_remote(
+        config,
+        build_sync_command(config, skip_uv_sync, target_sha=resolved_sha),
+    )
+    if sync_exit_code != 0:
+        raise typer.Exit(code=sync_exit_code)
+
+    smoke_exit_code = run_remote(
+        config,
+        build_smoke_command(
+            with_power=with_power,
+            with_rtc=with_rtc,
+            with_music=with_music,
+            with_voip=with_voip,
+            with_lvgl_soak=with_lvgl_soak,
+            verbose=verbose,
+            music_timeout=music_timeout,
+            voip_timeout=voip_timeout,
+        ),
+    )
+    if smoke_exit_code != 0:
+        raise typer.Exit(code=smoke_exit_code)
+
+    restart_exit_code = run_remote(config, build_restart_command(deploy_config))
+    if restart_exit_code != 0:
+        raise typer.Exit(code=restart_exit_code)
+
+    inspect_exit_code = run_remote(
+        config,
+        build_validation_inspection_command(deploy_config, lines=lines),
+    )
+    if inspect_exit_code != 0:
+        raise typer.Exit(code=inspect_exit_code)
 
 
 def smoke(
@@ -1193,10 +1416,13 @@ def rsync(
     ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable debug logging.")] = False,
 ) -> None:
-    """Rsync the local working tree to the Pi (no git commit needed)."""
+    """Rare-case escape hatch: mirror the local dirty working tree to the Pi."""
     config = _resolve_remote_config(host, user, project_dir, branch)
     validate_config(config)
     deploy_config = load_pi_deploy_config()
+    print(
+        "[pi-remote] warning=dirty-tree rsync is a debugging escape hatch; prefer `yoyoctl remote validate` for committed branch/SHA validation"
+    )
     rc = run_rsync_deploy(config, deploy_config, skip_restart=skip_restart)
     if rc != 0:
         raise typer.Exit(code=rc)
@@ -1402,13 +1628,36 @@ def build_parser(deploy_config: PiDeployConfig) -> argparse.ArgumentParser:
 
     sync_parser = subparsers.add_parser(
         "sync",
-        help="Fetch, checkout, pull, and optionally run uv sync on the Raspberry Pi",
+        help="Sync the stable Pi checkout to one committed branch or exact commit",
+    )
+    sync_parser.add_argument(
+        "--sha",
+        help="Exact commit SHA to check out after syncing the branch",
     )
     sync_parser.add_argument(
         "--skip-uv-sync",
         action="store_true",
-        help="Skip `uv sync --extra dev` after pulling",
+        help="Skip `uv sync --extra dev` after syncing the requested revision",
     )
+
+    validate_parser = subparsers.add_parser(
+        "validate",
+        help="Validate one committed branch/SHA on the Pi and leave the app running",
+    )
+    validate_parser.add_argument(
+        "--sha",
+        help="Exact commit SHA to validate (defaults to local HEAD for the current branch)",
+    )
+    validate_parser.add_argument("--skip-uv-sync", action="store_true")
+    validate_parser.add_argument("--with-power", action="store_true")
+    validate_parser.add_argument("--with-rtc", action="store_true")
+    validate_parser.add_argument("--with-music", action="store_true")
+    validate_parser.add_argument("--with-voip", action="store_true")
+    validate_parser.add_argument("--with-lvgl-soak", action="store_true")
+    validate_parser.add_argument("--verbose", action="store_true")
+    validate_parser.add_argument("--music-timeout", type=int, default=5)
+    validate_parser.add_argument("--voip-timeout", type=float, default=90.0)
+    validate_parser.add_argument("--lines", type=int, default=20)
 
     screenshot_parser = subparsers.add_parser(
         "screenshot",
@@ -1501,6 +1750,12 @@ def build_parser(deploy_config: PiDeployConfig) -> argparse.ArgumentParser:
         choices=["status", "install", "start", "stop", "restart", "logs"],
     )
     service_parser.add_argument("--lines", type=int, default=100)
+
+    rsync_parser = subparsers.add_parser(
+        "rsync",
+        help="Rare-case escape hatch: mirror the local dirty working tree to the Pi",
+    )
+    rsync_parser.add_argument("--skip-restart", action="store_true")
 
     return parser
 


### PR DESCRIPTION
## Summary

Closes #117.

This changes the default target-hardware workflow from a loose mix of `sync`, `smoke`, `restart`, and dirty-tree deploy habits into one repo-owned committed-code validation path.

The new default is:

1. finish implementation locally
2. commit intended changes
3. push branch / PR head
4. deploy the committed branch and exact SHA to the board
5. reuse one stable checkout path on the board
6. run smoke checks
7. launch or restart the app
8. verify startup from PID plus startup marker plus recent logs
9. leave the app running for manual testing

## What Changed

- added `yoyoctl remote validate` as the default validate-on-board flow
- tightened `yoyoctl remote sync` so it can target a committed branch or exact SHA on the stable Pi checkout
- made the stable `project_dir` contract explicit in tooling and docs
- updated status and sync behavior around detached exact-SHA validation on the board
- rewrote the Pi deploy docs, rules, and skills around the branch/SHA flow
- kept dirty-tree `yoyoctl remote rsync`, but documented it as a rare debugging escape hatch only

## Old Flow

The old flow had most of the building blocks, but the story was scattered:

- `remote sync` updated the Pi checkout
- `remote smoke` validated separately
- `remote restart` verified startup separately
- docs and skills still made dirty-tree rsync feel normal
- branch-vs-SHA validation and stable-path expectations were not one obvious contract

## New Default Flow

The new default is one clear repo-owned path:

```bash
git status --short
git branch --show-current
git rev-parse HEAD
git push
yoyoctl remote validate --branch <branch> --sha <commit>
```

`yoyoctl remote validate` now:

- stops on uncommitted local changes
- requires a pushed branch / exact SHA
- syncs committed code only to the stable board checkout
- runs the requested smoke checks
- restarts the app
- verifies startup using PID and startup marker
- prints recent logs
- leaves the app running for manual testing

## Escape Hatch Only

Dirty-tree deploys are still available through:

```bash
yoyoctl remote rsync
yoyoctl remote rsync --skip-restart
```

That path is now explicitly documented as a rare debugging override, not the normal branch or PR validation workflow.

## Validation

Commands run locally:

```bash
uv sync --extra dev
uv run black yoyopy/cli/remote/ops.py yoyopy/cli/remote/__init__.py tests/test_pi_remote.py tests/test_cli.py
python -m compileall yoyopy tests
uv run pytest tests/test_pi_remote.py tests/test_cli.py -q
uv run pytest -q
uv run yoyoctl remote --help
uv run yoyoctl remote validate --help
```

Results:

- `python -m compileall yoyopy tests` passed
- focused remote CLI tests passed
- full test suite passed (`444 passed`)
- help output now shows `remote validate` as the committed-code path and `remote rsync` as the escape hatch

## Notes

I did not run the real Raspberry Pi validation flow from this workstation session, so the on-device branch/SHA deploy, smoke pass, startup verification, and leave-running behavior were validated through command builders, CLI tests, and docs alignment rather than an actual Pi run in this PR.