### PR TITLE
[codex] Promote voice orchestration into a shared runtime service

### DIFF
--- a/tests/test_runtime_voice.py
+++ b/tests/test_runtime_voice.py
@@ -1,0 +1,261 @@
+"""Direct tests for the shared runtime-owned voice orchestration seam."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from types import SimpleNamespace
+
+from yoyopy.app_context import AppContext
+from yoyopy.runtime.voice import (
+    VoiceCommandExecutor,
+    VoiceCommandOutcome,
+    VoiceRuntimeCoordinator,
+    VoiceSettingsResolver,
+)
+from yoyopy.voice import VoiceCaptureResult, VoiceSettings, VoiceTranscript
+
+
+class _FakeContact:
+    def __init__(self, name: str, sip_address: str, notes: str = "") -> None:
+        self.name = name
+        self.display_name = notes or name
+        self.sip_address = sip_address
+        self.notes = notes
+
+
+class _FakeConfigManager:
+    def __init__(self, contacts: list[_FakeContact]) -> None:
+        self._contacts = contacts
+
+    def get_contacts(self) -> list[_FakeContact]:
+        return list(self._contacts)
+
+    def get_capture_device_id(self) -> str | None:
+        return None
+
+    def get_ring_output_device(self) -> str | None:
+        return None
+
+    def get_default_output_volume(self) -> int:
+        return 61
+
+    def get_app_settings(self):
+        return SimpleNamespace(
+            voice=SimpleNamespace(
+                commands_enabled=True,
+                ai_requests_enabled=True,
+                screen_read_enabled=False,
+                stt_enabled=True,
+                tts_enabled=True,
+                stt_backend="dummy-stt",
+                tts_backend="dummy-tts",
+                vosk_model_path="models/custom-model",
+                speaker_device_id="",
+                capture_device_id="",
+                sample_rate_hz=22050,
+                record_seconds=6,
+                tts_rate_wpm=180,
+                tts_voice="en-us",
+            )
+        )
+
+
+class _FakeVoipManager:
+    def __init__(self) -> None:
+        self.make_calls: list[tuple[str, str]] = []
+        self.mute_calls = 0
+        self.unmute_calls = 0
+
+    def make_call(self, sip_address: str, contact_name: str = "") -> bool:
+        self.make_calls.append((sip_address, contact_name))
+        return True
+
+    def mute(self) -> bool:
+        self.mute_calls += 1
+        return True
+
+    def unmute(self) -> bool:
+        self.unmute_calls += 1
+        return True
+
+
+class _FakeVoiceService:
+    def __init__(self, transcript: str) -> None:
+        self.settings: VoiceSettings | None = None
+        self.transcript = transcript
+        self.capture_calls = 0
+        self.speak_calls: list[str] = []
+
+    def capture_available(self) -> bool:
+        return True
+
+    def stt_available(self) -> bool:
+        return True
+
+    def tts_available(self) -> bool:
+        return True
+
+    def capture_audio(self, request) -> VoiceCaptureResult:
+        self.capture_calls += 1
+        with NamedTemporaryFile(
+            prefix="voice-runtime-test-",
+            suffix=".wav",
+            delete=False,
+        ) as handle:
+            path = Path(handle.name)
+        path.write_bytes(b"RIFF")
+        return VoiceCaptureResult(audio_path=path, recorded=True)
+
+    def transcribe(self, audio_path: Path) -> VoiceTranscript:
+        return VoiceTranscript(text=self.transcript, confidence=0.91)
+
+    def speak(self, text: str) -> bool:
+        self.speak_calls.append(text)
+        return True
+
+
+class _NoAudioVoiceService(_FakeVoiceService):
+    def __init__(self) -> None:
+        super().__init__("")
+
+    def capture_audio(self, request) -> VoiceCaptureResult:
+        self.capture_calls += 1
+        return VoiceCaptureResult(audio_path=None, recorded=False)
+
+
+class _FakeOutputPlayer:
+    def play_wav(self, path: Path, **kwargs) -> None:
+        return None
+
+
+def _build_executor(
+    *,
+    context: AppContext,
+    config_manager: _FakeConfigManager | None = None,
+    voip_manager: _FakeVoipManager | None = None,
+    play_music_action=None,
+) -> VoiceCommandExecutor:
+    return VoiceCommandExecutor(
+        context=context,
+        config_manager=config_manager,
+        voip_manager=voip_manager,
+        volume_up_action=lambda step: 55,
+        volume_down_action=lambda step: 45,
+        mute_action=voip_manager.mute if voip_manager is not None else None,
+        unmute_action=voip_manager.unmute if voip_manager is not None else None,
+        play_music_action=play_music_action,
+        screen_summary_provider=lambda: "You are on Ask. Say a direct command now.",
+    )
+
+
+def test_voice_command_executor_routes_call_and_updates_context() -> None:
+    context = AppContext()
+    voip_manager = _FakeVoipManager()
+    executor = _build_executor(
+        context=context,
+        config_manager=_FakeConfigManager(
+            [_FakeContact("Hagar", "sip:mama@example.com", notes="Mama")]
+        ),
+        voip_manager=voip_manager,
+    )
+
+    outcome = executor.execute("call mom")
+
+    assert outcome == VoiceCommandOutcome(
+        "Calling",
+        "Calling Mama.",
+        route_name="call_started",
+    )
+    assert context.talk_contact_name == "Mama"
+    assert voip_manager.make_calls == [("sip:mama@example.com", "Mama")]
+    assert context.voice.last_transcript == "call mom"
+
+
+def test_voice_command_executor_handles_local_device_actions() -> None:
+    context = AppContext()
+    voip_manager = _FakeVoipManager()
+    executor = _build_executor(context=context, voip_manager=voip_manager)
+
+    mute_outcome = executor.execute("mute mic")
+    volume_outcome = executor.execute("volume up")
+
+    assert mute_outcome.body == "Voice commands mic is muted."
+    assert context.voice.mic_muted is True
+    assert voip_manager.mute_calls == 1
+    assert volume_outcome.body == "Volume is 55."
+    assert context.voice.output_volume == 55
+
+
+def test_voice_runtime_coordinator_runs_capture_and_emits_route() -> None:
+    context = AppContext()
+    service = _FakeVoiceService("play music")
+    outcomes: list[VoiceCommandOutcome] = []
+    coordinator = VoiceRuntimeCoordinator(
+        context=context,
+        settings_resolver=VoiceSettingsResolver(context=context),
+        command_executor=_build_executor(context=context, play_music_action=lambda: True),
+        voice_service_factory=lambda settings: service,
+        output_player=_FakeOutputPlayer(),
+    )
+    coordinator.bind(state_listener=lambda state: None, outcome_listener=outcomes.append)
+
+    coordinator.begin_listening(async_capture=False)
+
+    assert service.capture_calls == 1
+    assert service.speak_calls == ["Starting local music."]
+    assert outcomes == [
+        VoiceCommandOutcome(
+            "Playing",
+            "Starting local music.",
+            route_name="shuffle_started",
+        )
+    ]
+    assert context.voice.last_transcript == "play music"
+    assert context.voice.last_spoken_text == "Starting local music."
+    assert context.voice.interaction.phase == "reply"
+    assert context.voice.interaction.headline == "Playing"
+
+
+def test_voice_runtime_coordinator_handles_disabled_voice_without_capture() -> None:
+    context = AppContext()
+    context.configure_voice(commands_enabled=False)
+    service = _FakeVoiceService("volume up")
+    coordinator = VoiceRuntimeCoordinator(
+        context=context,
+        settings_resolver=VoiceSettingsResolver(context=context),
+        command_executor=_build_executor(context=context),
+        voice_service_factory=lambda settings: service,
+        output_player=_FakeOutputPlayer(),
+    )
+
+    coordinator.begin_listening(async_capture=False)
+
+    assert service.capture_calls == 0
+    assert context.voice.interaction.phase == "reply"
+    assert context.voice.interaction.headline == "Voice Off"
+
+
+def test_voice_runtime_coordinator_ptt_no_audio_resolves_to_no_speech() -> None:
+    context = AppContext()
+    service = _NoAudioVoiceService()
+    coordinator = VoiceRuntimeCoordinator(
+        context=context,
+        settings_resolver=VoiceSettingsResolver(context=context),
+        command_executor=_build_executor(context=context),
+        voice_service_factory=lambda settings: service,
+        output_player=_FakeOutputPlayer(),
+    )
+
+    coordinator.state.generation = 7
+    coordinator.state.capture_in_flight = True
+    coordinator.state.ptt_active = False
+    coordinator._run_ptt_listening_cycle(
+        service,
+        7,
+        None,
+    )
+
+    assert context.voice.interaction.phase == "reply"
+    assert context.voice.interaction.headline == "No Speech"
+    assert context.voice.interaction.capture_in_flight is False

--- a/yoyopy/app.py
+++ b/yoyopy/app.py
@@ -53,6 +53,7 @@ from yoyopy.runtime import (
     RuntimeLoopService,
     ScreenPowerService,
     ShutdownLifecycleService,
+    VoiceRuntimeCoordinator,
 )
 from yoyopy.ui.display import Display
 from yoyopy.ui.input import InputManager, InteractionProfile
@@ -114,6 +115,7 @@ class YoyoPodApp:
         self.call_history_store: Optional[CallHistoryStore] = None
         self.recent_track_store: Optional[RecentTrackHistoryStore] = None
         self.voice_device_catalog: Optional[VoiceDeviceCatalog] = None
+        self.voice_runtime: Optional[VoiceRuntimeCoordinator] = None
 
         # Screen instances
         self.hub_screen: Optional[HubScreen] = None

--- a/yoyopy/app_context.py
+++ b/yoyopy/app_context.py
@@ -17,6 +17,7 @@ from yoyopy.runtime_state import (
     PowerRuntimeState,
     ScreenRuntimeState,
     TalkRuntimeState,
+    VoiceInteractionState,
     VoiceState,
     VoipRuntimeState,
 )
@@ -35,6 +36,7 @@ __all__ = [
     "PowerRuntimeState",
     "ScreenRuntimeState",
     "TalkRuntimeState",
+    "VoiceInteractionState",
     "VoiceState",
     "VoipRuntimeState",
 ]
@@ -648,3 +650,26 @@ class AppContext:
         """Cache the latest spoken response text."""
 
         self.voice.last_spoken_text = text.strip()
+
+    def update_voice_interaction(
+        self,
+        *,
+        phase: str,
+        headline: str,
+        body: str,
+        capture_in_flight: bool | None = None,
+        ptt_active: bool | None = None,
+        generation: int | None = None,
+    ) -> None:
+        """Cache the current shared voice interaction state."""
+
+        interaction = self.voice.interaction
+        interaction.phase = phase
+        interaction.headline = headline
+        interaction.body = body
+        if capture_in_flight is not None:
+            interaction.capture_in_flight = capture_in_flight
+        if ptt_active is not None:
+            interaction.ptt_active = ptt_active
+        if generation is not None:
+            interaction.generation = generation

--- a/yoyopy/runtime/__init__.py
+++ b/yoyopy/runtime/__init__.py
@@ -1,11 +1,16 @@
 """Runtime services that keep ``YoyoPodApp`` thin and compositional."""
 
-from yoyopy.runtime.boot import RuntimeBootService
 from yoyopy.runtime.loop import RuntimeLoopService
 from yoyopy.runtime.models import PendingShutdown, PowerAlert, RecoveryState
 from yoyopy.runtime.recovery import RecoverySupervisor
 from yoyopy.runtime.screen_power import ScreenPowerService
 from yoyopy.runtime.shutdown import ShutdownLifecycleService
+from yoyopy.runtime.voice import (
+    VoiceCommandExecutor,
+    VoiceCommandOutcome,
+    VoiceRuntimeCoordinator,
+    VoiceSettingsResolver,
+)
 
 __all__ = [
     "PendingShutdown",
@@ -16,4 +21,18 @@ __all__ = [
     "RuntimeLoopService",
     "ScreenPowerService",
     "ShutdownLifecycleService",
+    "VoiceCommandExecutor",
+    "VoiceCommandOutcome",
+    "VoiceRuntimeCoordinator",
+    "VoiceSettingsResolver",
 ]
+
+
+def __getattr__(name: str):
+    """Load heavyweight runtime services lazily to avoid package import cycles."""
+
+    if name == "RuntimeBootService":
+        from yoyopy.runtime.boot import RuntimeBootService
+
+        return RuntimeBootService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/yoyopy/runtime/boot.py
+++ b/yoyopy/runtime/boot.py
@@ -23,6 +23,11 @@ from yoyopy.coordinators import (
 from yoyopy.fsm import CallFSM, CallInterruptionPolicy, MusicFSM
 from yoyopy.network import NetworkManager
 from yoyopy.power import PowerManager
+from yoyopy.runtime.voice import (
+    VoiceCommandExecutor,
+    VoiceRuntimeCoordinator,
+    VoiceSettingsResolver,
+)
 from yoyopy.ui.display import Display
 from yoyopy.ui.input import InteractionProfile, get_input_manager
 from yoyopy.ui.lvgl_binding import LvglInputBridge
@@ -402,6 +407,102 @@ class RuntimeBootService:
                 music_service=self.app.local_music_service,
             )
             voice_cfg = self.app.app_settings.voice if self.app.app_settings is not None else None
+            self.app.voice_runtime = VoiceRuntimeCoordinator(
+                context=context,
+                settings_resolver=VoiceSettingsResolver(
+                    context=context,
+                    config_manager=self.app.config_manager,
+                    settings_provider=lambda: VoiceSettings(
+                        commands_enabled=(
+                            self.app.context.voice.commands_enabled
+                            if self.app.context is not None
+                            else True
+                        ),
+                        ai_requests_enabled=(
+                            self.app.context.voice.ai_requests_enabled
+                            if self.app.context is not None
+                            else True
+                        ),
+                        screen_read_enabled=(
+                            self.app.context.voice.screen_read_enabled
+                            if self.app.context is not None
+                            else False
+                        ),
+                        stt_enabled=(
+                            self.app.context.voice.stt_enabled
+                            if self.app.context is not None
+                            else True
+                        ),
+                        tts_enabled=(
+                            self.app.context.voice.tts_enabled
+                            if self.app.context is not None
+                            else True
+                        ),
+                        mic_muted=(
+                            self.app.context.voice.mic_muted
+                            if self.app.context is not None
+                            else False
+                        ),
+                        output_volume=self.app.get_output_volume()
+                        or (
+                            self.app.context.voice.output_volume
+                            if self.app.context is not None
+                            else 50
+                        ),
+                        stt_backend=voice_cfg.stt_backend if voice_cfg is not None else "vosk",
+                        tts_backend=voice_cfg.tts_backend if voice_cfg is not None else "espeak-ng",
+                        vosk_model_path=(
+                            voice_cfg.vosk_model_path
+                            if voice_cfg is not None
+                            else "models/vosk-model-small-en-us"
+                        ),
+                        speaker_device_id=(
+                            self.app.context.voice.speaker_device_id
+                            if self.app.context is not None
+                            and self.app.context.voice.speaker_device_id is not None
+                            else (
+                                self.app.config_manager.get_ring_output_device()
+                                if self.app.config_manager is not None
+                                else None
+                            )
+                        ),
+                        capture_device_id=(
+                            self.app.context.voice.capture_device_id
+                            if self.app.context is not None
+                            and self.app.context.voice.capture_device_id is not None
+                            else (
+                                self.app.config_manager.get_capture_device_id()
+                                if self.app.config_manager is not None
+                                else None
+                            )
+                        ),
+                        sample_rate_hz=voice_cfg.sample_rate_hz if voice_cfg is not None else 16000,
+                        record_seconds=voice_cfg.record_seconds if voice_cfg is not None else 4,
+                        tts_rate_wpm=voice_cfg.tts_rate_wpm if voice_cfg is not None else 155,
+                        tts_voice=voice_cfg.tts_voice if voice_cfg is not None else "en",
+                    ),
+                ),
+                command_executor=VoiceCommandExecutor(
+                    context=context,
+                    config_manager=self.app.config_manager,
+                    voip_manager=self.app.voip_manager,
+                    volume_up_action=self.app.volume_up,
+                    volume_down_action=self.app.volume_down,
+                    mute_action=(
+                        self.app.voip_manager.mute if self.app.voip_manager is not None else None
+                    ),
+                    unmute_action=(
+                        self.app.voip_manager.unmute
+                        if self.app.voip_manager is not None
+                        else None
+                    ),
+                    play_music_action=(
+                        self.app.local_music_service.shuffle_all
+                        if self.app.local_music_service is not None
+                        else None
+                    ),
+                ),
+            )
             self.app.ask_screen = AskScreen(
                 display,
                 context,
@@ -420,67 +521,7 @@ class RuntimeBootService:
                     if self.app.local_music_service is not None
                     else None
                 ),
-                voice_settings_provider=lambda: VoiceSettings(
-                    commands_enabled=(
-                        self.app.context.voice.commands_enabled
-                        if self.app.context is not None
-                        else True
-                    ),
-                    ai_requests_enabled=(
-                        self.app.context.voice.ai_requests_enabled
-                        if self.app.context is not None
-                        else True
-                    ),
-                    screen_read_enabled=(
-                        self.app.context.voice.screen_read_enabled
-                        if self.app.context is not None
-                        else False
-                    ),
-                    stt_enabled=(
-                        self.app.context.voice.stt_enabled if self.app.context is not None else True
-                    ),
-                    tts_enabled=(
-                        self.app.context.voice.tts_enabled if self.app.context is not None else True
-                    ),
-                    mic_muted=(
-                        self.app.context.voice.mic_muted if self.app.context is not None else False
-                    ),
-                    output_volume=self.app.get_output_volume()
-                    or (
-                        self.app.context.voice.output_volume if self.app.context is not None else 50
-                    ),
-                    stt_backend=voice_cfg.stt_backend if voice_cfg is not None else "vosk",
-                    tts_backend=voice_cfg.tts_backend if voice_cfg is not None else "espeak-ng",
-                    vosk_model_path=(
-                        voice_cfg.vosk_model_path
-                        if voice_cfg is not None
-                        else "models/vosk-model-small-en-us"
-                    ),
-                    speaker_device_id=(
-                        self.app.context.voice.speaker_device_id
-                        if self.app.context is not None
-                        and self.app.context.voice.speaker_device_id is not None
-                        else (
-                            self.app.config_manager.get_ring_output_device()
-                            if self.app.config_manager is not None
-                            else None
-                        )
-                    ),
-                    capture_device_id=(
-                        self.app.context.voice.capture_device_id
-                        if self.app.context is not None
-                        and self.app.context.voice.capture_device_id is not None
-                        else (
-                            self.app.config_manager.get_capture_device_id()
-                            if self.app.config_manager is not None
-                            else None
-                        )
-                    ),
-                    sample_rate_hz=voice_cfg.sample_rate_hz if voice_cfg is not None else 16000,
-                    record_seconds=voice_cfg.record_seconds if voice_cfg is not None else 4,
-                    tts_rate_wpm=voice_cfg.tts_rate_wpm if voice_cfg is not None else 155,
-                    tts_voice=voice_cfg.tts_voice if voice_cfg is not None else "en",
-                ),
+                voice_runtime=self.app.voice_runtime,
             )
             self.app.power_screen = PowerScreen(
                 display,

--- a/yoyopy/runtime/voice.py
+++ b/yoyopy/runtime/voice.py
@@ -1,0 +1,761 @@
+"""Shared runtime-owned voice orchestration for Ask and future voice contexts."""
+
+from __future__ import annotations
+
+import math
+import threading
+import wave
+from dataclasses import dataclass, replace
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING, Callable
+
+from loguru import logger
+
+from yoyopy.runtime_state import VoiceInteractionState
+from yoyopy.voice import VoiceCaptureRequest, VoiceCommandIntent, VoiceService, VoiceSettings
+from yoyopy.voice.commands import match_voice_command
+from yoyopy.voice.output import AlsaOutputPlayer
+
+if TYPE_CHECKING:
+    from yoyopy.app_context import AppContext
+    from yoyopy.config import ConfigManager, Contact
+    from yoyopy.voip import VoIPManager
+
+
+@dataclass(slots=True, frozen=True)
+class VoiceCommandOutcome:
+    """Result returned by the shared voice command executor."""
+
+    headline: str
+    body: str
+    should_speak: bool = True
+    route_name: str | None = None
+
+
+class VoiceSettingsResolver:
+    """Resolve current voice settings from the app runtime and config layer."""
+
+    def __init__(
+        self,
+        *,
+        context: "AppContext | None",
+        config_manager: "ConfigManager | None" = None,
+        settings_provider: Callable[[], VoiceSettings] | None = None,
+    ) -> None:
+        self._context = context
+        self._config_manager = config_manager
+        self._settings_provider = settings_provider
+
+    def current(self) -> VoiceSettings:
+        """Return the latest runtime voice settings."""
+
+        if self._settings_provider is not None:
+            return self._settings_provider()
+        defaults = self.defaults()
+        if self._context is None:
+            return defaults
+
+        voice = self._context.voice
+        capture_device_id = (
+            voice.capture_device_id
+            if voice.capture_device_id is not None
+            else defaults.capture_device_id
+        )
+        speaker_device_id = (
+            voice.speaker_device_id
+            if voice.speaker_device_id is not None
+            else defaults.speaker_device_id
+        )
+        return replace(
+            defaults,
+            commands_enabled=voice.commands_enabled,
+            ai_requests_enabled=voice.ai_requests_enabled,
+            screen_read_enabled=voice.screen_read_enabled,
+            stt_enabled=voice.stt_enabled,
+            tts_enabled=voice.tts_enabled,
+            mic_muted=voice.mic_muted,
+            output_volume=voice.output_volume,
+            capture_device_id=capture_device_id,
+            speaker_device_id=speaker_device_id,
+        )
+
+    def defaults(self) -> VoiceSettings:
+        """Return configured voice defaults when no provider is supplied."""
+
+        capture_device_id = None
+        speaker_device_id = None
+        if self._config_manager is not None:
+            voice_cfg = getattr(self._config_manager.get_app_settings(), "voice", None)
+            if voice_cfg is not None:
+                capture_device_id = getattr(voice_cfg, "capture_device_id", "").strip() or None
+                speaker_device_id = getattr(voice_cfg, "speaker_device_id", "").strip() or None
+            if capture_device_id is None:
+                capture_device_id = self._config_manager.get_capture_device_id()
+            if speaker_device_id is None:
+                speaker_device_id = getattr(
+                    self._config_manager,
+                    "get_ring_output_device",
+                    lambda: None,
+                )()
+
+        defaults = VoiceSettings(
+            capture_device_id=capture_device_id,
+            speaker_device_id=speaker_device_id or None,
+        )
+        if self._config_manager is None:
+            return defaults
+
+        get_app_settings = getattr(self._config_manager, "get_app_settings", None)
+        if not callable(get_app_settings):
+            return defaults
+
+        app_settings = get_app_settings()
+        voice_cfg = getattr(app_settings, "voice", None)
+        if voice_cfg is None:
+            return defaults
+
+        get_default_output_volume = getattr(self._config_manager, "get_default_output_volume", None)
+        output_volume = defaults.output_volume
+        if callable(get_default_output_volume):
+            output_volume = int(get_default_output_volume())
+
+        return VoiceSettings(
+            commands_enabled=voice_cfg.commands_enabled,
+            ai_requests_enabled=voice_cfg.ai_requests_enabled,
+            screen_read_enabled=voice_cfg.screen_read_enabled,
+            stt_enabled=voice_cfg.stt_enabled,
+            tts_enabled=voice_cfg.tts_enabled,
+            output_volume=output_volume,
+            stt_backend=voice_cfg.stt_backend,
+            tts_backend=voice_cfg.tts_backend,
+            vosk_model_path=voice_cfg.vosk_model_path,
+            speaker_device_id=speaker_device_id,
+            capture_device_id=capture_device_id,
+            sample_rate_hz=voice_cfg.sample_rate_hz,
+            record_seconds=voice_cfg.record_seconds,
+            tts_rate_wpm=voice_cfg.tts_rate_wpm,
+            tts_voice=voice_cfg.tts_voice,
+        )
+
+
+class VoiceCommandExecutor:
+    """Execute deterministic voice commands against app runtime seams."""
+
+    _FAMILY_ALIAS_GROUPS: tuple[tuple[str, ...], ...] = (
+        ("mom", "mama", "mum", "mommy", "mother"),
+        ("dad", "dada", "daddy", "papa", "father"),
+    )
+
+    def __init__(
+        self,
+        *,
+        context: "AppContext | None",
+        config_manager: "ConfigManager | None" = None,
+        voip_manager: "VoIPManager | None" = None,
+        volume_up_action: Callable[[int], int | None] | None = None,
+        volume_down_action: Callable[[int], int | None] | None = None,
+        mute_action: Callable[[], bool] | None = None,
+        unmute_action: Callable[[], bool] | None = None,
+        play_music_action: Callable[[], bool] | None = None,
+        screen_summary_provider: Callable[[], str] | None = None,
+    ) -> None:
+        self._context = context
+        self._config_manager = config_manager
+        self._voip_manager = voip_manager
+        self._volume_up_action = volume_up_action
+        self._volume_down_action = volume_down_action
+        self._mute_action = mute_action
+        self._unmute_action = unmute_action
+        self._play_music_action = play_music_action
+        self._screen_summary_provider = screen_summary_provider or self._default_screen_summary
+
+    def execute(self, transcript: str) -> VoiceCommandOutcome:
+        """Parse and execute one local deterministic voice command."""
+
+        normalized = transcript.strip()
+        if not normalized:
+            return VoiceCommandOutcome("No Speech", "I did not catch a command.", should_speak=False)
+
+        if self._context is not None:
+            self._context.record_voice_transcript(normalized, mode="voice_commands")
+
+        command = match_voice_command(normalized)
+        if not command.is_command:
+            return VoiceCommandOutcome(
+                "Not Recognized",
+                "I heard "
+                f"'{normalized}'"
+                " but that is not a voice command. Try: call mom, play music, or volume up.",
+            )
+
+        if command.intent is VoiceCommandIntent.CALL_CONTACT:
+            return self._handle_call_command(command.contact_name)
+        if command.intent is VoiceCommandIntent.VOLUME_UP:
+            return self._handle_volume_change(+5)
+        if command.intent is VoiceCommandIntent.VOLUME_DOWN:
+            return self._handle_volume_change(-5)
+        if command.intent is VoiceCommandIntent.PLAY_MUSIC:
+            return self._handle_play_music_command()
+        if command.intent is VoiceCommandIntent.MUTE_MIC:
+            self._apply_mic_state(muted=True)
+            return VoiceCommandOutcome("Mic Muted", "Voice commands mic is muted.")
+        if command.intent is VoiceCommandIntent.UNMUTE_MIC:
+            self._apply_mic_state(muted=False)
+            return VoiceCommandOutcome("Mic Live", "Voice commands mic is live.")
+        if command.intent is VoiceCommandIntent.READ_SCREEN:
+            return VoiceCommandOutcome("Screen Read", self._screen_summary_provider())
+
+        return VoiceCommandOutcome("Not Ready", "That command is recognized but not wired yet.")
+
+    def _handle_volume_change(self, delta: int) -> VoiceCommandOutcome:
+        current = None
+        if delta > 0 and self._volume_up_action is not None:
+            current = self._volume_up_action(abs(delta))
+        elif delta < 0 and self._volume_down_action is not None:
+            current = self._volume_down_action(abs(delta))
+        elif self._context is not None:
+            current = (
+                self._context.volume_up(abs(delta))
+                if delta > 0
+                else self._context.volume_down(abs(delta))
+            )
+
+        self._sync_context_output_volume(current)
+        if current is None and self._context is not None:
+            current = self._context.voice.output_volume
+        return VoiceCommandOutcome(
+            "Volume",
+            f"Volume is {current if current is not None else 'updated'}.",
+        )
+
+    def _handle_play_music_command(self) -> VoiceCommandOutcome:
+        if self._play_music_action is None:
+            return VoiceCommandOutcome("Music Off", "Local music playback is not ready yet.")
+        if not self._play_music_action():
+            return VoiceCommandOutcome("Music Empty", "I could not find any local music to play.")
+        return VoiceCommandOutcome("Playing", "Starting local music.", route_name="shuffle_started")
+
+    def _handle_call_command(self, spoken_name: str) -> VoiceCommandOutcome:
+        contact = self._find_contact(spoken_name)
+        if contact is None:
+            return VoiceCommandOutcome("No Match", f"I could not find {spoken_name}.")
+
+        display_name = contact.display_name
+        if self._context is not None:
+            self._context.set_talk_contact(name=display_name, sip_address=contact.sip_address)
+
+        if self._voip_manager is None:
+            return VoiceCommandOutcome(
+                "Call Ready",
+                f"I found {display_name}, but calling is not ready.",
+            )
+
+        if self._voip_manager.make_call(contact.sip_address, contact_name=display_name):
+            return VoiceCommandOutcome(
+                "Calling",
+                f"Calling {display_name}.",
+                route_name="call_started",
+            )
+
+        return VoiceCommandOutcome("Call Failed", f"I could not call {display_name}.")
+
+    def _find_contact(self, spoken_name: str) -> "Contact | None":
+        if self._config_manager is None:
+            return None
+
+        normalized = self._normalize_label(spoken_name)
+        if not normalized:
+            return None
+
+        for contact in self._config_manager.get_contacts():
+            if normalized in self._contact_labels(contact):
+                return contact
+        return None
+
+    @classmethod
+    def _normalize_label(cls, value: str) -> str:
+        return " ".join(value.strip().lower().split())
+
+    @classmethod
+    def _contact_labels(cls, contact: "Contact") -> set[str]:
+        labels = {
+            cls._normalize_label(contact.name),
+            cls._normalize_label(contact.display_name),
+            cls._normalize_label(getattr(contact, "notes", "")),
+        }
+        labels.discard("")
+
+        expanded = set(labels)
+        for group in cls._FAMILY_ALIAS_GROUPS:
+            if any(label in group for label in labels):
+                expanded.update(group)
+        return expanded
+
+    def _default_screen_summary(self) -> str:
+        if self._context is not None and self._context.voice.screen_read_enabled:
+            return "You are on Ask. Say a direct command now."
+        return "Screen read is off. Turn it on in Setup to auto-read screens."
+
+    def _apply_mic_state(self, *, muted: bool) -> None:
+        if self._context is not None:
+            self._context.set_mic_muted(muted)
+        action = self._mute_action if muted else self._unmute_action
+        if action is not None:
+            try:
+                action()
+            except Exception as exc:
+                logger.warning("Voice mic state update failed: {}", exc)
+
+    def _sync_context_output_volume(self, volume: int | None) -> None:
+        if volume is None or self._context is None:
+            return
+        self._context.playback.volume = volume
+        self._context.voice.output_volume = volume
+
+
+class VoiceRuntimeCoordinator:
+    """Own one reusable voice interaction session outside the screen layer."""
+
+    def __init__(
+        self,
+        *,
+        context: "AppContext | None",
+        settings_resolver: VoiceSettingsResolver,
+        command_executor: VoiceCommandExecutor,
+        voice_service_factory: Callable[[VoiceSettings], VoiceService] | None = None,
+        output_player: AlsaOutputPlayer | None = None,
+    ) -> None:
+        self._context = context
+        self._settings_resolver = settings_resolver
+        self._command_executor = command_executor
+        self._voice_service_factory = voice_service_factory
+        self._output_player = output_player or AlsaOutputPlayer()
+        self._cached_voice_service: VoiceService | None = None
+        self._state = VoiceInteractionState()
+        self._active_capture_cancel: threading.Event | None = None
+        self._state_listener: Callable[[VoiceInteractionState], None] | None = None
+        self._outcome_listener: Callable[[VoiceCommandOutcome], None] | None = None
+        self._dispatcher: Callable[[Callable[[], None]], None] | None = None
+
+    @property
+    def state(self) -> VoiceInteractionState:
+        """Return the current interaction snapshot."""
+
+        return self._state
+
+    def bind(
+        self,
+        *,
+        state_listener: Callable[[VoiceInteractionState], None] | None,
+        outcome_listener: Callable[[VoiceCommandOutcome], None] | None = None,
+        dispatcher: Callable[[Callable[[], None]], None] | None = None,
+    ) -> None:
+        """Bind optional UI consumers for voice state and outcomes."""
+
+        self._state_listener = state_listener
+        self._outcome_listener = outcome_listener
+        self._dispatcher = dispatcher
+
+    def defaults(self) -> VoiceSettings:
+        """Expose default settings for compatibility callers."""
+
+        return self._settings_resolver.defaults()
+
+    def settings(self) -> VoiceSettings:
+        """Expose current settings for compatibility callers."""
+
+        return self._settings_resolver.current()
+
+    def reset_to_idle(self) -> None:
+        """Return the interaction to its ready state."""
+
+        self.cancel()
+        self._set_state("idle", "Ask", "Ask me anything...")
+
+    def begin_entry_cycle(self, *, quick_command: bool, async_capture: bool) -> None:
+        """Start the default Ask entry behavior for the current mode."""
+
+        self.reset_to_idle()
+        if quick_command:
+            self.begin_ptt_capture()
+            return
+        self.begin_listening(async_capture=async_capture)
+
+    def begin_listening(self, *, async_capture: bool) -> None:
+        """Start one record-transcribe-command cycle."""
+
+        if self._state.capture_in_flight:
+            return
+        voice_service = self._voice_service()
+        readiness_error = self._prepare_capture(voice_service=voice_service)
+        if readiness_error is not None:
+            self._apply_outcome(readiness_error)
+            return
+
+        generation = self._next_generation()
+        cancel_event = threading.Event()
+        self._active_capture_cancel = cancel_event
+        self._set_state(
+            "listening",
+            "Listening",
+            "Speak now...",
+            capture_in_flight=True,
+            generation=generation,
+        )
+        if async_capture:
+            threading.Thread(
+                target=self._run_listening_cycle,
+                args=(voice_service, generation, cancel_event),
+                daemon=True,
+                name="VoiceRuntimeCapture",
+            ).start()
+            return
+        self._run_listening_cycle(voice_service, generation, cancel_event)
+
+    def begin_ptt_capture(self) -> None:
+        """Start an open-ended PTT capture that ends on release."""
+
+        voice_service = self._voice_service()
+        readiness_error = self._prepare_capture(voice_service=voice_service, ptt_mode=True)
+        if readiness_error is not None:
+            self._apply_outcome(readiness_error)
+            return
+
+        generation = self._next_generation()
+        cancel_event = threading.Event()
+        self._active_capture_cancel = cancel_event
+        self._set_state(
+            "listening",
+            "Listening",
+            "Speak now...",
+            capture_in_flight=True,
+            ptt_active=True,
+            generation=generation,
+        )
+        logger.info("PTT capture started (generation={})", generation)
+        self._play_attention_tone()
+        threading.Thread(
+            target=self._run_ptt_listening_cycle,
+            args=(voice_service, generation, cancel_event),
+            daemon=True,
+            name="VoiceRuntimePTT",
+        ).start()
+
+    def finish_ptt_capture(self) -> None:
+        """Stop an active PTT capture and transition to thinking."""
+
+        if not self._state.ptt_active or self._active_capture_cancel is None:
+            return
+        logger.info("PTT release received (generation={})", self._state.generation)
+        self._set_state(
+            "thinking",
+            "Thinking",
+            "Just a moment...",
+            capture_in_flight=True,
+            ptt_active=False,
+        )
+        self._active_capture_cancel.set()
+
+    def cancel(self) -> None:
+        """Cancel any in-flight capture without mutating navigation."""
+
+        self._next_generation()
+        if self._active_capture_cancel is not None:
+            self._active_capture_cancel.set()
+            self._active_capture_cancel = None
+        self._set_state(
+            self._state.phase,
+            self._state.headline,
+            self._state.body,
+            capture_in_flight=False,
+            ptt_active=False,
+        )
+
+    def handle_transcript(self, transcript: str) -> VoiceCommandOutcome:
+        """Execute one already-captured transcript through the shared command seam."""
+
+        self._set_state("thinking", "Thinking", "Just a moment...")
+        outcome = self._command_executor.execute(transcript)
+        self._apply_outcome(outcome)
+        return outcome
+
+    def dispatch_listen_result(
+        self,
+        transcript: str,
+        *,
+        capture_failed: bool,
+        generation: int,
+    ) -> None:
+        """Apply one listen result, scheduling onto the bound dispatcher when needed."""
+
+        def apply_result() -> None:
+            if generation != self._state.generation:
+                return
+            self._active_capture_cancel = None
+            if capture_failed:
+                self._apply_outcome(
+                    VoiceCommandOutcome(
+                        "Mic Unavailable",
+                        "The Pi microphone input is busy or unavailable.",
+                        should_speak=False,
+                    )
+                )
+                return
+            if transcript:
+                self.handle_transcript(transcript)
+                return
+            self._apply_outcome(
+                VoiceCommandOutcome("No Speech", "I did not catch a command.", should_speak=False)
+            )
+
+        self._dispatch(apply_result)
+
+    def _prepare_capture(
+        self,
+        *,
+        voice_service: VoiceService,
+        ptt_mode: bool = False,
+    ) -> VoiceCommandOutcome | None:
+        if self._context is not None and not self._context.voice.commands_enabled:
+            body = (
+                "Turn voice commands on in Setup first."
+                if not ptt_mode
+                else "Turn voice commands on in Setup first."
+            )
+            return VoiceCommandOutcome("Voice Off", body, should_speak=False)
+        if self._context is not None and self._context.voice.mic_muted:
+            body = (
+                "Unmute the microphone in Setup or by voice first."
+                if not ptt_mode
+                else "Unmute the microphone first."
+            )
+            return VoiceCommandOutcome("Mic Muted", body, should_speak=False)
+
+        if self._context is not None:
+            self._context.update_voice_backend_status(
+                stt_available=voice_service.capture_available() and voice_service.stt_available(),
+                tts_available=voice_service.tts_available(),
+            )
+        if not voice_service.capture_available():
+            body = (
+                "Local recording is not ready on this device yet."
+                if not ptt_mode
+                else "Voice capture is not ready on this device."
+            )
+            return VoiceCommandOutcome("Mic Unavailable", body, should_speak=False)
+        if not voice_service.stt_available():
+            return VoiceCommandOutcome(
+                "Speech Offline",
+                "The offline speech model is not installed yet.",
+                should_speak=False,
+            )
+        return None
+
+    def _voice_service(self) -> VoiceService:
+        settings = self._settings_resolver.current()
+        if self._voice_service_factory is not None:
+            return self._voice_service_factory(settings)
+        if self._cached_voice_service is None or self._cached_voice_service.settings != settings:
+            self._cached_voice_service = VoiceService(settings=settings)
+        return self._cached_voice_service
+
+    def _next_generation(self) -> int:
+        self._state.generation += 1
+        return self._state.generation
+
+    def _run_listening_cycle(
+        self,
+        voice_service: VoiceService,
+        generation: int,
+        cancel_event: threading.Event,
+    ) -> None:
+        self._play_attention_tone()
+        request = VoiceCaptureRequest(
+            mode="voice_commands",
+            timeout_seconds=4.0,
+            cancel_event=cancel_event,
+        )
+        capture_result = voice_service.capture_audio(request)
+        if cancel_event.is_set():
+            if capture_result.audio_path is not None:
+                capture_result.audio_path.unlink(missing_ok=True)
+            return
+        if capture_result.audio_path is None:
+            self.dispatch_listen_result("", capture_failed=True, generation=generation)
+            return
+
+        try:
+            transcript = voice_service.transcribe(capture_result.audio_path)
+        except Exception as exc:
+            logger.warning("Voice command transcription failed: {}", exc)
+            self.dispatch_listen_result("", capture_failed=True, generation=generation)
+            return
+        finally:
+            capture_result.audio_path.unlink(missing_ok=True)
+
+        if cancel_event.is_set():
+            return
+        self.dispatch_listen_result(
+            transcript.text.strip(),
+            capture_failed=False,
+            generation=generation,
+        )
+
+    def _run_ptt_listening_cycle(
+        self,
+        voice_service: VoiceService,
+        generation: int,
+        cancel_event: threading.Event,
+    ) -> None:
+        request = VoiceCaptureRequest(
+            mode="voice_commands_ptt",
+            timeout_seconds=30.0,
+            cancel_event=cancel_event,
+        )
+        capture_result = voice_service.capture_audio(request)
+        logger.info(
+            "PTT capture finished (generation={}, recorded={}, audio_path={})",
+            generation,
+            capture_result.recorded,
+            capture_result.audio_path is not None,
+        )
+
+        if generation != self._state.generation:
+            if capture_result.audio_path is not None:
+                capture_result.audio_path.unlink(missing_ok=True)
+            return
+
+        if capture_result.audio_path is None:
+            if not self._state.ptt_active:
+                logger.info("PTT capture ended without audio; treating the release as no speech")
+                self.dispatch_listen_result("", capture_failed=False, generation=generation)
+            else:
+                logger.warning("PTT capture ended without audio while hold was still active")
+                self.dispatch_listen_result("", capture_failed=True, generation=generation)
+            return
+
+        if not self._state.ptt_active:
+            logger.info(
+                "PTT release finalized capture; starting transcription (generation={})",
+                generation,
+            )
+            try:
+                transcript = voice_service.transcribe(capture_result.audio_path)
+            except Exception as exc:
+                logger.warning("PTT transcription failed: {}", exc)
+                self.dispatch_listen_result("", capture_failed=True, generation=generation)
+                return
+            finally:
+                capture_result.audio_path.unlink(missing_ok=True)
+
+            self.dispatch_listen_result(
+                transcript.text.strip(),
+                capture_failed=False,
+                generation=generation,
+            )
+            logger.info(
+                "PTT transcription complete (generation={}, transcript_chars={})",
+                generation,
+                len(transcript.text.strip()),
+            )
+            return
+
+        capture_result.audio_path.unlink(missing_ok=True)
+
+    def _apply_outcome(self, outcome: VoiceCommandOutcome) -> None:
+        self._set_state(
+            "reply",
+            outcome.headline,
+            outcome.body,
+            capture_in_flight=False,
+            ptt_active=False,
+        )
+        if self._context is not None and outcome.should_speak:
+            self._context.record_voice_response(outcome.body)
+        if outcome.should_speak and not self._voice_service().speak(outcome.body):
+            logger.debug("Voice response not spoken: {}", outcome.body)
+        if self._outcome_listener is not None:
+            self._dispatch(lambda: self._outcome_listener(outcome))
+
+    def _set_state(
+        self,
+        phase: str,
+        headline: str,
+        body: str,
+        *,
+        capture_in_flight: bool | None = None,
+        ptt_active: bool | None = None,
+        generation: int | None = None,
+    ) -> None:
+        if capture_in_flight is None:
+            capture_in_flight = self._state.capture_in_flight
+        if ptt_active is None:
+            ptt_active = self._state.ptt_active
+        if generation is None:
+            generation = self._state.generation
+
+        self._state.phase = phase
+        self._state.headline = headline
+        self._state.body = body
+        self._state.capture_in_flight = capture_in_flight
+        self._state.ptt_active = ptt_active
+        self._state.generation = generation
+        if self._context is not None:
+            self._context.update_voice_interaction(
+                phase=phase,
+                headline=headline,
+                body=body,
+                capture_in_flight=capture_in_flight,
+                ptt_active=ptt_active,
+                generation=generation,
+            )
+        if self._state_listener is not None:
+            snapshot = replace(self._state)
+            self._dispatch(lambda: self._state_listener(snapshot))
+
+    def _dispatch(self, callback: Callable[[], None]) -> None:
+        if self._dispatcher is not None:
+            self._dispatcher(callback)
+            return
+        callback()
+
+    def _play_attention_tone(self) -> None:
+        beep_path: Path | None = None
+        try:
+            with NamedTemporaryFile(prefix="yoyopy-beep-", suffix=".wav", delete=False) as handle:
+                beep_path = Path(handle.name)
+            self._write_beep_wav(beep_path)
+            device_id = self._context.voice.speaker_device_id if self._context is not None else None
+            play_kwargs: dict[str, object] = {"timeout_seconds": 2.0}
+            if device_id:
+                play_kwargs["device_id"] = device_id
+            self._output_player.play_wav(beep_path, **play_kwargs)
+        except Exception:
+            logger.debug("Voice attention tone unavailable")
+        finally:
+            if beep_path is not None:
+                beep_path.unlink(missing_ok=True)
+
+    @staticmethod
+    def _write_beep_wav(path: Path) -> None:
+        sample_rate = 16000
+        duration_seconds = 0.18
+        frequency_hz = 1046.0
+        amplitude = 12000
+        frame_count = int(sample_rate * duration_seconds)
+
+        with wave.open(str(path), "wb") as handle:
+            handle.setnchannels(1)
+            handle.setsampwidth(2)
+            handle.setframerate(sample_rate)
+            frames = bytearray()
+            for index in range(frame_count):
+                envelope = 1.0 - (index / frame_count)
+                sample = int(
+                    amplitude
+                    * envelope
+                    * math.sin((2.0 * math.pi * frequency_hz * index) / sample_rate)
+                )
+                frames.extend(sample.to_bytes(2, byteorder="little", signed=True))
+            handle.writeframes(bytes(frames))

--- a/yoyopy/runtime_state.py
+++ b/yoyopy/runtime_state.py
@@ -209,6 +209,18 @@ class VoipRuntimeState:
 
 
 @dataclass(slots=True)
+class VoiceInteractionState:
+    """Shared state for the active voice interaction session."""
+
+    phase: str = "idle"
+    headline: str = "Ask"
+    body: str = "Ask me anything..."
+    capture_in_flight: bool = False
+    ptt_active: bool = False
+    generation: int = 0
+
+
+@dataclass(slots=True)
 class VoiceState:
     """Runtime voice settings and recent voice activity."""
 
@@ -226,6 +238,7 @@ class VoiceState:
     last_spoken_text: str = ""
     last_mode: str = ""
     output_volume: int = 50
+    interaction: VoiceInteractionState = field(default_factory=VoiceInteractionState)
 
 
 @dataclass(slots=True)

--- a/yoyopy/ui/screens/navigation/ask.py
+++ b/yoyopy/ui/screens/navigation/ask.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, Optional
 
+from yoyopy.runtime.voice import (
+    VoiceCommandExecutor,
+    VoiceRuntimeCoordinator,
+    VoiceSettingsResolver,
+)
 from yoyopy.ui.display import Display
 from yoyopy.ui.screens.base import Screen
 from yoyopy.ui.screens.navigation.ask_rendering import AskScreenRenderingMixin
 from yoyopy.ui.screens.navigation.ask_voice import AskScreenVoiceMixin
 from yoyopy.voice import VoiceService, VoiceSettings
-from yoyopy.voice.output import AlsaOutputPlayer
 
 if TYPE_CHECKING:
     from yoyopy.app_context import AppContext
@@ -41,58 +45,70 @@ class AskScreen(AskScreenVoiceMixin, AskScreenRenderingMixin, Screen):
         play_music_action: Optional[Callable[[], bool]] = None,
         voice_settings_provider: Optional[Callable[[], VoiceSettings]] = None,
         voice_service_factory: Optional[Callable[[VoiceSettings], VoiceService]] = None,
+        voice_runtime: Optional["VoiceRuntimeCoordinator"] = None,
     ) -> None:
         super().__init__(display, context, "Ask")
         self.config_manager = config_manager
         self.voip_manager = voip_manager
-        self.volume_up_action = volume_up_action
-        self.volume_down_action = volume_down_action
-        self.mute_action = mute_action
-        self.unmute_action = unmute_action
-        self.play_music_action = play_music_action
-        self.voice_settings_provider = voice_settings_provider
-        self.voice_service_factory = voice_service_factory
-        self._cached_voice_service: VoiceService | None = None
+        self.voice_runtime = voice_runtime or VoiceRuntimeCoordinator(
+            context=context,
+            settings_resolver=VoiceSettingsResolver(
+                context=context,
+                config_manager=config_manager,
+                settings_provider=voice_settings_provider,
+            ),
+            command_executor=VoiceCommandExecutor(
+                context=context,
+                config_manager=config_manager,
+                voip_manager=voip_manager,
+                volume_up_action=volume_up_action,
+                volume_down_action=volume_down_action,
+                mute_action=mute_action,
+                unmute_action=unmute_action,
+                play_music_action=play_music_action,
+                screen_summary_provider=self._screen_summary,
+            ),
+            voice_service_factory=voice_service_factory,
+        )
+        self._async_voice_capture = voice_runtime is not None or voice_service_factory is None
         self._state: str = "idle"
         self._headline: str = "Ask"
         self._body: str = "Ask me anything..."
-        self._auto_listen_started = False
         self._capture_in_flight = False
         self._listen_generation = 0
-        self._active_capture_cancel = None
-        self._output_player = AlsaOutputPlayer()
         self._quick_command = False
         self._ptt_active = False
         self._auto_return_timer = None
         self._lvgl_view: "ScreenView | None" = None
+        self._bind_voice_runtime()
 
     def enter(self) -> None:
         """Reset to a ready state when entering the Ask screen."""
 
         super().enter()
-        self._cancel_listening_cycle()
-        self._auto_listen_started = False
-        self._capture_in_flight = False
-
-        self._state = "idle"
-        self._headline = "Ask"
-        self._body = "Ask me anything..."
-        if self._quick_command:
-            self._start_ptt_capture()
-        else:
-            self._begin_listening_on_entry()
+        self._cancel_auto_return()
+        self.voice_runtime.begin_entry_cycle(
+            quick_command=self._quick_command,
+            async_capture=self._async_voice_capture,
+        )
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
         """Invalidate any in-flight result before leaving the screen."""
 
-        self._cancel_listening_cycle()
+        self.voice_runtime.cancel()
         self._cancel_auto_return()
         self._quick_command = False
         if self._lvgl_view is not None:
             self._lvgl_view.destroy()
             self._lvgl_view = None
         super().exit()
+
+    def set_screen_manager(self, manager) -> None:
+        """Bind screen-manager scheduling to the shared voice runtime."""
+
+        super().set_screen_manager(manager)
+        self._bind_voice_runtime()
 
     def set_quick_command(self, enabled: bool) -> None:
         """Enable or disable quick-command mode for one-shot entry."""
@@ -103,3 +119,10 @@ class AskScreen(AskScreenVoiceMixin, AskScreenRenderingMixin, Screen):
         """Return True when Ask should receive raw PTT release events."""
 
         return self.is_one_button_mode() and self._quick_command
+
+    def _screen_summary(self) -> str:
+        """Return the current screen summary for spoken playback."""
+
+        if self.context is not None and self.context.voice.screen_read_enabled:
+            return "You are on Ask. Say a direct command now."
+        return "Screen read is off. Turn it on in Setup to auto-read screens."

--- a/yoyopy/ui/screens/navigation/ask_rendering.py
+++ b/yoyopy/ui/screens/navigation/ask_rendering.py
@@ -194,8 +194,13 @@ class AskScreenRenderingMixin:
     def _refresh_after_state_change(self) -> None:
         """Refresh the screen after updating the voice UI state."""
 
-        if self.screen_manager is not None and self.screen_manager.get_current_screen() is self:
-            self.screen_manager.refresh_current_screen()
+        if self.screen_manager is None:
+            return
+        get_current_screen = getattr(self.screen_manager, "get_current_screen", None)
+        refresh_current_screen = getattr(self.screen_manager, "refresh_current_screen", None)
+        if callable(get_current_screen) and callable(refresh_current_screen):
+            if get_current_screen() is self:
+                refresh_current_screen()
 
     def _icon_circle_fill(self) -> tuple[int, int, int]:
         """Return the blended icon halo color for the current state."""

--- a/yoyopy/ui/screens/navigation/ask_voice.py
+++ b/yoyopy/ui/screens/navigation/ask_voice.py
@@ -1,285 +1,93 @@
-"""Voice wiring and screen-local command helpers for the Ask screen."""
+"""Thin Ask screen hooks over the shared runtime-owned voice coordinator."""
 
 from __future__ import annotations
 
-import math
 import threading
-import wave
-from dataclasses import replace
-from pathlib import Path
-from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
-from loguru import logger
-
-from yoyopy.voice import VoiceCaptureRequest, VoiceCommandIntent, VoiceService, VoiceSettings
+from yoyopy.runtime.voice import VoiceCommandOutcome, VoiceRuntimeCoordinator
 
 if TYPE_CHECKING:
-    from yoyopy.config import Contact
+    from yoyopy.runtime_state import VoiceInteractionState
+    from yoyopy.voice import VoiceService, VoiceSettings
 
 
 class AskScreenVoiceMixin:
-    """Keep voice-session handling separate from Ask presentation state."""
+    """Keep Ask focused on interaction hooks while runtime owns orchestration."""
+
+    voice_runtime: VoiceRuntimeCoordinator
 
     def on_select(self, data=None) -> None:
         """Start listening, or ask again from the reply state."""
 
-        if self._capture_in_flight:
-            return
-        self._start_listening_cycle(async_capture=self.voice_service_factory is None)
+        self.voice_runtime.begin_listening(async_capture=self._async_voice_capture)
 
     def on_back(self, data=None) -> None:
         """Cancel any in-flight capture and pop the screen."""
 
-        self._cancel_listening_cycle()
+        self.voice_runtime.cancel()
         self._cancel_auto_return()
         self.request_route("back")
 
     def on_voice_command(self, data=None) -> None:
-        """Parse and execute a deterministic local voice command."""
+        """Execute a supplied transcript through the shared runtime seam."""
 
         transcript = self._extract_transcript(data)
-        if not transcript:
-            self._set_response("No Speech", "I did not catch a command.")
-            return
+        self.voice_runtime.handle_transcript(transcript)
 
-        if self.context is not None:
-            self.context.record_voice_transcript(transcript, mode="voice_commands")
+    def on_ptt_release(self, data=None) -> None:
+        """Stop PTT recording when the button is released after a hold."""
 
-        command = self._voice_service().match_command(transcript)
-        if not command.is_command:
-            self._speak_response(
-                "Not Recognized",
-                "I heard "
-                f"'{transcript}'"
-                " but that is not a voice command. Try: call mom, play music, or volume up.",
-            )
-            return
+        self.voice_runtime.finish_ptt_capture()
 
-        if command.intent is VoiceCommandIntent.CALL_CONTACT:
-            self._handle_call_command(command.contact_name)
-            return
-        if command.intent is VoiceCommandIntent.VOLUME_UP:
-            self._handle_volume_change(+5)
-            return
-        if command.intent is VoiceCommandIntent.VOLUME_DOWN:
-            self._handle_volume_change(-5)
-            return
-        if command.intent is VoiceCommandIntent.PLAY_MUSIC:
-            self._handle_play_music_command()
-            return
-        if command.intent is VoiceCommandIntent.MUTE_MIC:
-            self._apply_mic_state(muted=True)
-            self._speak_response("Mic Muted", "Voice commands mic is muted.")
-            return
-        if command.intent is VoiceCommandIntent.UNMUTE_MIC:
-            self._apply_mic_state(muted=False)
-            self._speak_response("Mic Live", "Voice commands mic is live.")
-            return
-        if command.intent is VoiceCommandIntent.READ_SCREEN:
-            self._speak_response("Screen Read", self._screen_summary())
-            return
+    def _bind_voice_runtime(self) -> None:
+        """Bind screen-local consumers to the shared voice runtime."""
 
-        self._set_response("Not Ready", "That command is recognized but not wired yet.")
-
-    def _voice_service(self) -> VoiceService:
-        """Return the cached VoiceService, rebuilding only when settings change."""
-
-        settings = self._voice_settings()
-        if self.voice_service_factory is not None:
-            return self.voice_service_factory(settings)
-        if self._cached_voice_service is None or self._cached_voice_service.settings != settings:
-            self._cached_voice_service = VoiceService(settings=settings)
-        return self._cached_voice_service
-
-    def _voice_settings(self) -> VoiceSettings:
-        """Return the latest runtime voice settings."""
-
-        if self.voice_settings_provider is not None:
-            return self.voice_settings_provider()
-        defaults = self._default_voice_settings()
-        if self.context is not None:
-            voice = self.context.voice
-            capture_device_id = (
-                voice.capture_device_id
-                if voice.capture_device_id is not None
-                else defaults.capture_device_id
-            )
-            speaker_device_id = (
-                voice.speaker_device_id
-                if voice.speaker_device_id is not None
-                else defaults.speaker_device_id
-            )
-            return replace(
-                defaults,
-                commands_enabled=voice.commands_enabled,
-                ai_requests_enabled=voice.ai_requests_enabled,
-                screen_read_enabled=voice.screen_read_enabled,
-                stt_enabled=voice.stt_enabled,
-                tts_enabled=voice.tts_enabled,
-                mic_muted=voice.mic_muted,
-                output_volume=voice.output_volume,
-                capture_device_id=capture_device_id,
-                speaker_device_id=speaker_device_id,
-            )
-        return defaults
-
-    def _default_voice_settings(self) -> VoiceSettings:
-        """Return configured voice defaults when a screen-level provider is absent."""
-
-        capture_device_id = None
-        speaker_device_id = None
-        if self.config_manager is not None:
-            voice_cfg = getattr(self.config_manager.get_app_settings(), "voice", None)
-            if voice_cfg is not None:
-                capture_device_id = getattr(voice_cfg, "capture_device_id", "").strip() or None
-                speaker_device_id = getattr(voice_cfg, "speaker_device_id", "").strip() or None
-            if capture_device_id is None:
-                capture_device_id = self.config_manager.get_capture_device_id()
-            if speaker_device_id is None:
-                speaker_device_id = getattr(
-                    self.config_manager,
-                    "get_ring_output_device",
-                    lambda: None,
-                )()
-
-        defaults = VoiceSettings(
-            capture_device_id=capture_device_id,
-            speaker_device_id=speaker_device_id or None,
+        dispatcher = None
+        if self.screen_manager is not None:
+            dispatcher = getattr(self.screen_manager, "action_scheduler", None)
+        self.voice_runtime.bind(
+            state_listener=self._on_voice_runtime_state_changed,
+            outcome_listener=self._on_voice_runtime_outcome,
+            dispatcher=dispatcher,
         )
-        if self.config_manager is None:
-            return defaults
+        self._on_voice_runtime_state_changed(self.voice_runtime.state)
 
-        get_app_settings = getattr(self.config_manager, "get_app_settings", None)
-        if not callable(get_app_settings):
-            return defaults
+    def _on_voice_runtime_state_changed(self, state: "VoiceInteractionState") -> None:
+        """Mirror shared voice runtime state into Ask presentation fields."""
 
-        app_settings = get_app_settings()
-        voice_cfg = getattr(app_settings, "voice", None)
-        if voice_cfg is None:
-            return defaults
-
-        get_default_output_volume = getattr(self.config_manager, "get_default_output_volume", None)
-        output_volume = defaults.output_volume
-        if callable(get_default_output_volume):
-            output_volume = int(get_default_output_volume())
-
-        return VoiceSettings(
-            commands_enabled=voice_cfg.commands_enabled,
-            ai_requests_enabled=voice_cfg.ai_requests_enabled,
-            screen_read_enabled=voice_cfg.screen_read_enabled,
-            stt_enabled=voice_cfg.stt_enabled,
-            tts_enabled=voice_cfg.tts_enabled,
-            output_volume=output_volume,
-            stt_backend=voice_cfg.stt_backend,
-            tts_backend=voice_cfg.tts_backend,
-            vosk_model_path=voice_cfg.vosk_model_path,
-            speaker_device_id=speaker_device_id,
-            capture_device_id=capture_device_id,
-            sample_rate_hz=voice_cfg.sample_rate_hz,
-            record_seconds=voice_cfg.record_seconds,
-            tts_rate_wpm=voice_cfg.tts_rate_wpm,
-            tts_voice=voice_cfg.tts_voice,
-        )
-
-    def _begin_listening_on_entry(self) -> None:
-        """Auto-start one listen cycle when the screen first opens."""
-
-        if self._auto_listen_started:
-            return
-        self._auto_listen_started = True
-        self._start_listening_cycle(async_capture=True)
-
-    def _start_listening_cycle(self, *, async_capture: bool) -> None:
-        """Kick off one voice-command capture cycle."""
-
-        if self._capture_in_flight:
-            return
-        if self.context is not None and not self.context.voice.commands_enabled:
-            self._set_response("Voice Off", "Turn voice commands on in Setup first.")
-            self._refresh_after_state_change()
-            return
-        if self.context is not None and self.context.voice.mic_muted:
-            self._set_response("Mic Muted", "Unmute the microphone in Setup or by voice first.")
-            self._refresh_after_state_change()
-            return
-
-        voice_service = self._voice_service()
-        if self.context is not None:
-            self.context.update_voice_backend_status(
-                stt_available=voice_service.capture_available() and voice_service.stt_available(),
-                tts_available=voice_service.tts_available(),
-            )
-        if not voice_service.capture_available():
-            self._set_response(
-                "Mic Unavailable", "Local recording is not ready on this device yet."
-            )
-            self._refresh_after_state_change()
-            return
-        if not voice_service.stt_available():
-            self._set_response("Speech Offline", "The offline speech model is not installed yet.")
-            self._refresh_after_state_change()
-            return
-
-        self._capture_in_flight = True
-        self._set_state("listening", "Listening", "Speak now...")
+        self._state = state.phase
+        self._headline = state.headline
+        self._body = state.body
+        self._capture_in_flight = state.capture_in_flight
+        self._ptt_active = state.ptt_active
+        self._listen_generation = state.generation
         self._refresh_after_state_change()
-        self._listen_generation += 1
-        generation = self._listen_generation
-        cancel_event = threading.Event()
-        self._active_capture_cancel = cancel_event
 
-        if async_capture:
-            threading.Thread(
-                target=self._run_listening_cycle,
-                args=(voice_service, generation, cancel_event),
-                daemon=True,
-                name="AskScreenCapture",
-            ).start()
-            return
+    def _on_voice_runtime_outcome(self, outcome: VoiceCommandOutcome) -> None:
+        """Handle navigation side effects emitted by the shared voice runtime."""
 
-        self._run_listening_cycle(voice_service, generation, cancel_event)
+        navigated = False
+        if outcome.route_name is not None:
+            self.request_route(outcome.route_name)
+            navigated = self._apply_pending_navigation_request()
+        if not navigated:
+            self._schedule_auto_return()
 
-    def _run_listening_cycle(
-        self,
-        voice_service: VoiceService,
-        generation: int,
-        cancel_event: threading.Event,
-    ) -> None:
-        """Record, transcribe, and apply one command cycle."""
+    def _voice_service(self) -> "VoiceService":
+        """Compatibility shim for tests that inspect the effective service."""
 
-        self._play_attention_tone()
-        request = VoiceCaptureRequest(
-            mode="voice_commands",
-            timeout_seconds=4.0,
-            cancel_event=cancel_event,
-        )
-        capture_result = voice_service.capture_audio(request)
-        if cancel_event.is_set():
-            if capture_result.audio_path is not None:
-                capture_result.audio_path.unlink(missing_ok=True)
-            return
-        if capture_result.audio_path is None:
-            self._dispatch_listen_result("", capture_failed=True, generation=generation)
-            return
+        return self.voice_runtime._voice_service()
 
-        try:
-            transcript = voice_service.transcribe(capture_result.audio_path)
-        except Exception as exc:
-            logger.warning("Voice command transcription failed: {}", exc)
-            self._dispatch_listen_result("", capture_failed=True, generation=generation)
-            return
-        finally:
-            capture_result.audio_path.unlink(missing_ok=True)
+    def _voice_settings(self) -> "VoiceSettings":
+        """Compatibility shim for tests that inspect the resolved settings."""
 
-        if cancel_event.is_set():
-            return
+        return self.voice_runtime.settings()
 
-        self._dispatch_listen_result(
-            transcript.text.strip(),
-            capture_failed=False,
-            generation=generation,
-        )
+    def _default_voice_settings(self) -> "VoiceSettings":
+        """Compatibility shim for tests that inspect config-derived defaults."""
+
+        return self.voice_runtime.defaults()
 
     def _dispatch_listen_result(
         self,
@@ -288,178 +96,38 @@ class AskScreenVoiceMixin:
         capture_failed: bool,
         generation: int,
     ) -> None:
-        """Apply one listen result, marshalled onto the UI thread when possible."""
+        """Compatibility shim around the shared listen-result dispatcher."""
 
-        def apply_result() -> None:
-            if generation != self._listen_generation:
-                return
-            self._active_capture_cancel = None
-            self._capture_in_flight = False
-            navigated = False
-            if capture_failed:
-                self._set_response(
-                    "Mic Unavailable", "The Pi microphone input is busy or unavailable."
-                )
-            elif transcript:
-                self._set_state("thinking", "Thinking", "Just a moment...")
-                self._refresh_after_state_change()
-                self.on_voice_command({"transcript": transcript})
-                navigated = self._apply_pending_navigation_request()
-            else:
-                self._set_response("No Speech", "I did not catch a command.")
-            if navigated:
-                return
-            self._refresh_after_state_change()
-            self._schedule_auto_return()
-
-        scheduler = (
-            getattr(self.screen_manager, "action_scheduler", None)
-            if self.screen_manager is not None
-            else None
+        self.voice_runtime.state.generation = self._listen_generation
+        self.voice_runtime.dispatch_listen_result(
+            transcript,
+            capture_failed=capture_failed,
+            generation=generation,
         )
-        if scheduler is not None:
-            scheduler(apply_result)
-            return
-        apply_result()
-
-    def _apply_pending_navigation_request(self) -> bool:
-        """Apply any queued navigation immediately when Ask triggers it off-input-path."""
-
-        if self.screen_manager is None:
-            return False
-        navigation_request = self.consume_navigation_request()
-        if navigation_request is None:
-            return False
-        return self.screen_manager.apply_navigation_request(
-            navigation_request,
-            source_screen=self,
-        )
-
-    def _cancel_listening_cycle(self) -> None:
-        """Invalidate the current listen cycle and request capture cancellation."""
-
-        self._listen_generation += 1
-        if self._active_capture_cancel is not None:
-            self._active_capture_cancel.set()
-            self._active_capture_cancel = None
-        self._capture_in_flight = False
-
-    def _start_ptt_capture(self) -> None:
-        """Begin open-ended recording that stops on PTT_RELEASE."""
-
-        if self.context is not None and not self.context.voice.commands_enabled:
-            self._set_response("Voice Off", "Turn voice commands on in Setup first.")
-            self._refresh_after_state_change()
-            self._schedule_auto_return()
-            return
-        if self.context is not None and self.context.voice.mic_muted:
-            self._set_response("Mic Muted", "Unmute the microphone first.")
-            self._refresh_after_state_change()
-            self._schedule_auto_return()
-            return
-
-        voice_service = self._voice_service()
-        if not voice_service.capture_available():
-            self._set_response("Mic Unavailable", "Voice capture is not ready on this device.")
-            self._refresh_after_state_change()
-            self._schedule_auto_return()
-            return
-        if not voice_service.stt_available():
-            self._set_response("Speech Offline", "The offline speech model is not installed yet.")
-            self._refresh_after_state_change()
-            self._schedule_auto_return()
-            return
-
-        self._capture_in_flight = True
-        self._ptt_active = True
-        self._set_state("listening", "Listening", "Speak now...")
-        self._refresh_after_state_change()
-        self._listen_generation += 1
-        generation = self._listen_generation
-        cancel_event = threading.Event()
-        self._active_capture_cancel = cancel_event
-        logger.info("PTT capture started (generation={})", generation)
-
-        self._play_attention_tone()
-
-        threading.Thread(
-            target=self._run_ptt_listening_cycle,
-            args=(voice_service, generation, cancel_event),
-            daemon=True,
-            name="AskPTTCapture",
-        ).start()
 
     def _run_ptt_listening_cycle(
         self,
-        voice_service: VoiceService,
+        voice_service: "VoiceService",
         generation: int,
-        cancel_event: threading.Event,
+        cancel_event,
     ) -> None:
-        """Record until cancel_event is set (by PTT_RELEASE), then transcribe."""
+        """Compatibility shim used by existing tests."""
 
-        request = VoiceCaptureRequest(
-            mode="voice_commands_ptt",
-            timeout_seconds=30.0,
-            cancel_event=cancel_event,
-        )
-        capture_result = voice_service.capture_audio(request)
-        logger.info(
-            "PTT capture finished (generation={}, recorded={}, audio_path={})",
-            generation,
-            capture_result.recorded,
-            capture_result.audio_path is not None,
-        )
+        self.voice_runtime.state.generation = self._listen_generation
+        self.voice_runtime.state.ptt_active = self._ptt_active
+        self.voice_runtime.state.capture_in_flight = self._capture_in_flight
+        self.voice_runtime._run_ptt_listening_cycle(voice_service, generation, cancel_event)
 
-        if generation != self._listen_generation:
-            if capture_result.audio_path is not None:
-                capture_result.audio_path.unlink(missing_ok=True)
-            return
+    def _extract_transcript(self, data: object) -> str:
+        """Return the transcript text from a voice-command event payload."""
 
-        if capture_result.audio_path is None:
-            if not self._ptt_active:
-                logger.info("PTT capture ended without audio; treating the release as no speech")
-                self._dispatch_listen_result("", capture_failed=False, generation=generation)
-            else:
-                logger.warning("PTT capture ended without audio while hold was still active")
-                self._dispatch_listen_result("", capture_failed=True, generation=generation)
-            return
-
-        if not self._ptt_active:
-            logger.info(
-                "PTT release finalized capture; starting transcription (generation={})",
-                generation,
-            )
-            try:
-                transcript = voice_service.transcribe(capture_result.audio_path)
-            except Exception as exc:
-                logger.warning("PTT transcription failed: {}", exc)
-                self._dispatch_listen_result("", capture_failed=True, generation=generation)
-                return
-            finally:
-                capture_result.audio_path.unlink(missing_ok=True)
-
-            self._dispatch_listen_result(
-                transcript.text.strip(),
-                capture_failed=False,
-                generation=generation,
-            )
-            logger.info(
-                "PTT transcription complete (generation={}, transcript_chars={})",
-                generation,
-                len(transcript.text.strip()),
-            )
-        elif capture_result.audio_path is not None:
-            capture_result.audio_path.unlink(missing_ok=True)
-
-    def on_ptt_release(self, data=None) -> None:
-        """Stop PTT recording when the button is released after a hold."""
-
-        if self._ptt_active and self._active_capture_cancel is not None:
-            self._ptt_active = False
-            logger.info("PTT release received (generation={})", self._listen_generation)
-            self._set_state("thinking", "Thinking", "Just a moment...")
-            self._refresh_after_state_change()
-            self._active_capture_cancel.set()
+        if isinstance(data, str):
+            return data.strip()
+        if isinstance(data, dict):
+            value = data.get("command") or data.get("transcript") or data.get("text")
+            if isinstance(value, str):
+                return value.strip()
+        return ""
 
     def _schedule_auto_return(self) -> None:
         """Pop back after 2 seconds in quick-command mode."""
@@ -497,189 +165,15 @@ class AskScreenVoiceMixin:
             self._auto_return_timer.cancel()
             self._auto_return_timer = None
 
-    def _extract_transcript(self, data: object) -> str:
-        """Return the transcript text from a voice-command event payload."""
+    def _apply_pending_navigation_request(self) -> bool:
+        """Apply any queued navigation immediately when Ask triggers it off-input-path."""
 
-        if isinstance(data, str):
-            return data.strip()
-        if isinstance(data, dict):
-            value = data.get("command") or data.get("transcript") or data.get("text")
-            if isinstance(value, str):
-                return value.strip()
-        return ""
-
-    def _handle_volume_change(self, delta: int) -> None:
-        """Apply a local volume adjustment and announce the result."""
-
-        current = None
-        if delta > 0 and self.volume_up_action is not None:
-            current = self.volume_up_action(abs(delta))
-        elif delta < 0 and self.volume_down_action is not None:
-            current = self.volume_down_action(abs(delta))
-        elif self.context is not None:
-            current = (
-                self.context.volume_up(abs(delta))
-                if delta > 0
-                else self.context.volume_down(abs(delta))
-            )
-
-        self._sync_context_output_volume(current)
-        if current is None and self.context is not None:
-            current = self.context.voice.output_volume
-        self._speak_response(
-            "Volume", f"Volume is {current if current is not None else 'updated'}."
+        if self.screen_manager is None:
+            return False
+        navigation_request = self.consume_navigation_request()
+        if navigation_request is None:
+            return False
+        return self.screen_manager.apply_navigation_request(
+            navigation_request,
+            source_screen=self,
         )
-
-    def _handle_play_music_command(self) -> None:
-        """Start local music playback when the app provides a playback hook."""
-
-        if self.play_music_action is None:
-            self._set_response("Music Off", "Local music playback is not ready yet.")
-            return
-        if not self.play_music_action():
-            self._set_response("Music Empty", "I could not find any local music to play.")
-            return
-        self._set_response("Playing", "Starting local music.")
-        self.request_route("shuffle_started")
-
-    def _handle_call_command(self, spoken_name: str) -> None:
-        """Resolve a contact and place a call when the VoIP manager is available."""
-
-        contact = self._find_contact(spoken_name)
-        if contact is None:
-            self._set_response("No Match", f"I could not find {spoken_name}.")
-            return
-
-        display_name = contact.display_name
-        if self.context is not None:
-            self.context.set_talk_contact(name=display_name, sip_address=contact.sip_address)
-
-        if self.voip_manager is None:
-            self._speak_response("Call Ready", f"I found {display_name}, but calling is not ready.")
-            return
-
-        self._speak_response("Calling", f"Calling {display_name}.")
-        if self.voip_manager.make_call(contact.sip_address, contact_name=display_name):
-            self.request_route("call_started")
-            return
-
-        self._speak_response("Call Failed", f"I could not call {display_name}.")
-
-    def _find_contact(self, spoken_name: str) -> "Contact | None":
-        """Return a contact matching the spoken name by child-facing label first."""
-
-        if self.config_manager is None:
-            return None
-
-        normalized = self._normalize_label(spoken_name)
-        if not normalized:
-            return None
-
-        for contact in self.config_manager.get_contacts():
-            labels = self._contact_labels(contact)
-            if normalized in labels:
-                return contact
-        return None
-
-    @classmethod
-    def _normalize_label(cls, value: str) -> str:
-        """Normalize spoken and configured labels for alias matching."""
-
-        return " ".join(value.strip().lower().split())
-
-    @classmethod
-    def _contact_labels(cls, contact: "Contact") -> set[str]:
-        """Return exact and family-alias labels for a contact."""
-
-        labels = {
-            cls._normalize_label(contact.name),
-            cls._normalize_label(contact.display_name),
-            cls._normalize_label(getattr(contact, "notes", "")),
-        }
-        labels.discard("")
-
-        expanded = set(labels)
-        for group in cls._FAMILY_ALIAS_GROUPS:
-            if any(label in group for label in labels):
-                expanded.update(group)
-        return expanded
-
-    def _screen_summary(self) -> str:
-        """Return the current screen summary for spoken playback."""
-
-        if self.context is not None and self.context.voice.screen_read_enabled:
-            return "You are on Ask. Say a direct command now."
-        return "Screen read is off. Turn it on in Setup to auto-read screens."
-
-    def _apply_mic_state(self, *, muted: bool) -> None:
-        """Keep local voice mute state in sync with the live VoIP mute path when available."""
-
-        if self.context is not None:
-            self.context.set_mic_muted(muted)
-        action = self.mute_action if muted else self.unmute_action
-        if action is not None:
-            try:
-                action()
-            except Exception as exc:
-                logger.warning("Voice mic state update failed: {}", exc)
-
-    def _speak_response(self, headline: str, body: str) -> None:
-        """Update the UI response and forward it to the TTS boundary."""
-
-        self._set_response(headline, body)
-        if self.context is not None:
-            self.context.record_voice_response(body)
-        if not self._voice_service().speak(body):
-            logger.debug("Voice response not spoken: {}", body)
-
-    def _sync_context_output_volume(self, volume: int | None) -> None:
-        """Refresh cached volume state after routing through the shared output path."""
-
-        if volume is None or self.context is None:
-            return
-        self.context.playback.volume = volume
-        self.context.voice.output_volume = volume
-
-    def _play_attention_tone(self) -> None:
-        """Play a short Pi-side tone before recording a command."""
-
-        beep_path: Path | None = None
-        try:
-            with NamedTemporaryFile(prefix="yoyopy-beep-", suffix=".wav", delete=False) as handle:
-                beep_path = Path(handle.name)
-            self._write_beep_wav(beep_path)
-            device_id = self.context.voice.speaker_device_id if self.context is not None else None
-            play_kwargs = {"timeout_seconds": 2.0}
-            if device_id:
-                play_kwargs["device_id"] = device_id
-            self._output_player.play_wav(beep_path, **play_kwargs)
-        except Exception:
-            logger.debug("Voice attention tone unavailable")
-        finally:
-            if beep_path is not None:
-                beep_path.unlink(missing_ok=True)
-
-    @staticmethod
-    def _write_beep_wav(path: Path) -> None:
-        """Write a short attention beep WAV for local playback."""
-
-        sample_rate = 16000
-        duration_seconds = 0.18
-        frequency_hz = 1046.0
-        amplitude = 12000
-        frame_count = int(sample_rate * duration_seconds)
-
-        with wave.open(str(path), "wb") as handle:
-            handle.setnchannels(1)
-            handle.setsampwidth(2)
-            handle.setframerate(sample_rate)
-            frames = bytearray()
-            for index in range(frame_count):
-                envelope = 1.0 - (index / frame_count)
-                sample = int(
-                    amplitude
-                    * envelope
-                    * math.sin((2.0 * math.pi * frequency_hz * index) / sample_rate)
-                )
-                frames.extend(sample.to_bytes(2, byteorder="little", signed=True))
-            handle.writeframes(bytes(frames))


### PR DESCRIPTION
## Summary
- extract a shared `VoiceRuntimeCoordinator` plus settings and command helpers from `AskScreen`
- keep `AskScreen` focused on presentation and interaction hooks while the runtime owns the voice session flow
- add direct tests for the new runtime seam and fix import-cycle and UI refresh regressions uncovered during host-side validation

## Testing
- uv run pytest -q tests/test_runtime_voice.py
- uv run python scripts/quality.py gate
- uv run pytest -q

Closes #92