### PR TITLE
refactor: remove legacy screen button compatibility bridge

### DIFF
--- a/docs/INPUT_HAL_ARCHITECTURE.md
+++ b/docs/INPUT_HAL_ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # YoyoPod Input HAL Architecture
 
-**Last updated:** 2026-04-02
-**Status:** Implemented with compatibility layer
+**Last updated:** 2026-04-15
+**Status:** Implemented
 
 This document describes the input abstraction layer that now exists in the UI package.
 
@@ -65,24 +65,21 @@ This is the current call path:
 input adapter -> InputManager -> ScreenManager -> current screen handler
 ```
 
-## Compatibility Bridge
-
-The abstraction layer is present, but cleanup is not fully complete.
+## Screen Contract
 
 Current behavior:
 
 - `ScreenManager` registers semantic callbacks
-- `Screen` defines semantic methods like `on_select()`
-- those methods currently forward to legacy `on_button_*()` handlers when a screen has not been fully migrated yet
+- `Screen` defines semantic methods like `on_select()`, `on_back()`, `on_up()`, and `on_down()`
+- concrete screens implement those semantic handlers directly
 
-That means the input HAL is implemented, but many concrete screens still rely on old button-named methods internally.
+Legacy `on_button_*()` compatibility methods have been removed from `Screen`.
 
 ## Known Gaps
 
-- full migration of concrete screens to semantic handlers is still pending
 - some older demos and tests still import deleted pre-HAL input modules
 - `keyboard.py` still has small naming drift between `get_supported_actions()` and the manager's `get_capabilities()` convention
 
 ## Summary
 
-The input HAL is real and in use today. The remaining work is cleanup and removal of legacy screen handler names, not invention of the architecture itself.
+The input HAL is real and in use today. Screen input is now fully semantic end to end.

--- a/docs/INTEGRATION_PLAN.md
+++ b/docs/INTEGRATION_PLAN.md
@@ -117,5 +117,5 @@ The integration itself is done. Remaining repository work is separate:
 
 - continue reducing stale historical docs
 - migrate older demos and tests to current names and entry points
-- finish semantic input migration inside screen implementations
+- keep semantic input handling on the semantic `Screen` contract; do not reintroduce button-named handlers
 - reduce hardcoded hardware assumptions

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -166,13 +166,11 @@ Screen groups:
 - `yoyopy/ui/screens/music/`
 - `yoyopy/ui/screens/voip/`
 
-There is still a compatibility bridge in `Screen`:
+`Screen` now exposes semantic handlers only:
 
-- semantic handlers like `on_select()` exist
-- most concrete screens still implement legacy `on_button_*()` methods
-- `Screen` currently forwards semantic actions to those legacy methods
-
-That bridge is intentional but temporary.
+- semantic handlers like `on_select()`, `on_back()`, `on_up()`, and `on_down()` are the screen input contract
+- `ScreenManager` dispatches semantic actions directly to those handlers
+- legacy `on_button_*()` compatibility methods have been removed
 
 ## State Coordination
 

--- a/tests/test_input_navigation.py
+++ b/tests/test_input_navigation.py
@@ -55,6 +55,13 @@ class _SimpleSetupScreen(Screen):
         return True
 
 
+class _PassiveScreen(Screen):
+    """Minimal screen double that relies on the base semantic no-op handlers."""
+
+    def render(self) -> None:
+        return None
+
+
 def test_semantic_input_navigation() -> None:
     """Semantic actions should drive the registered screens correctly."""
     display = Display(simulate=True)
@@ -120,5 +127,24 @@ def test_screen_manager_configures_simple_one_button_navigation() -> None:
         screen_manager.replace_screen("simple")
         assert adapter.raw_ptt_passthrough is False
         assert adapter.double_tap_select_enabled is False
+    finally:
+        display.cleanup()
+
+
+def test_screen_base_requires_semantic_handlers_only() -> None:
+    """The base Screen contract should not expose legacy button-named handlers."""
+    display = Display(simulate=True)
+    screen = _PassiveScreen(display, AppContext())
+
+    try:
+        assert not hasattr(screen, "on_button_a")
+        assert not hasattr(screen, "on_button_b")
+        assert not hasattr(screen, "on_button_x")
+        assert not hasattr(screen, "on_button_y")
+
+        screen.handle_action(InputAction.SELECT)
+        screen.handle_action(InputAction.BACK)
+        screen.handle_action(InputAction.UP)
+        screen.handle_action(InputAction.DOWN)
     finally:
         display.cleanup()

--- a/yoyopy/ui/screens/base.py
+++ b/yoyopy/ui/screens/base.py
@@ -141,27 +141,19 @@ class Screen(ABC):
 
     def on_select(self, data: Optional[Any] = None) -> None:
         """Handle SELECT action (confirm/accept current item)."""
-        # Backward compatibility: delegate to on_button_a if not overridden
-        if hasattr(self, 'on_button_a') and self.on_select.__func__ is Screen.on_select:
-            self.on_button_a()
+        pass
 
     def on_back(self, data: Optional[Any] = None) -> None:
         """Handle BACK action (cancel/return to previous screen)."""
-        # Backward compatibility: delegate to on_button_b if not overridden
-        if hasattr(self, 'on_button_b') and self.on_back.__func__ is Screen.on_back:
-            self.on_button_b()
+        pass
 
     def on_up(self, data: Optional[Any] = None) -> None:
         """Handle UP action (navigate up in lists/menus)."""
-        # Backward compatibility: delegate to on_button_x if not overridden
-        if hasattr(self, 'on_button_x') and self.on_up.__func__ is Screen.on_up:
-            self.on_button_x()
+        pass
 
     def on_down(self, data: Optional[Any] = None) -> None:
         """Handle DOWN action (navigate down in lists/menus)."""
-        # Backward compatibility: delegate to on_button_y if not overridden
-        if hasattr(self, 'on_button_y') and self.on_down.__func__ is Screen.on_down:
-            self.on_button_y()
+        pass
 
     def on_left(self, data: Optional[Any] = None) -> None:
         """Handle LEFT action (navigate left/previous)."""
@@ -222,41 +214,5 @@ class Screen(ABC):
         Args:
             data: Dict containing voice command information:
                   {'command': str, 'confidence': float, ...}
-        """
-        pass
-
-    # ===== LEGACY BUTTON HANDLERS (for backward compatibility) =====
-    # These will be removed in a future version.
-    # Use semantic action handlers (on_select, on_back, etc.) instead.
-
-    def on_button_a(self) -> None:
-        """
-        DEPRECATED: Handle Button A press.
-
-        Use on_select() instead for hardware-independent input.
-        """
-        pass
-
-    def on_button_b(self) -> None:
-        """
-        DEPRECATED: Handle Button B press.
-
-        Use on_back() instead for hardware-independent input.
-        """
-        pass
-
-    def on_button_x(self) -> None:
-        """
-        DEPRECATED: Handle Button X press.
-
-        Use on_up() instead for hardware-independent input.
-        """
-        pass
-
-    def on_button_y(self) -> None:
-        """
-        DEPRECATED: Handle Button Y press.
-
-        Use on_down() instead for hardware-independent input.
         """
         pass


### PR DESCRIPTION
Closes #91

## Summary
- remove legacy on_button_* compatibility forwarding from the base Screen contract
- keep screen input semantic end to end and add a regression test for the base contract
- update input architecture docs to reflect the final semantic screen contract

## Validation
- uv run pytest tests/test_input_navigation.py -q