### PR TITLE
tooling: add a local CI-mirroring quality command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ When asked to deploy, sync, restart, check status, view logs, or take a screensh
 - Whisplay now runs on the LVGL rendering path in production under `yoyopy/ui/lvgl_binding/`.
 - Production local music now runs through the app-managed mpv backend under `yoyopy/audio/music/`.
 - Production VoIP now runs through Liblinphone under `yoyopy/voip/liblinphone_binding/` and `yoyopy/voip/backend.py`.
-- CI validates the Python test suite with `uv sync --extra dev` and `uv run pytest -q`.
+- CI validates the staged quality gate plus Python test suite; the local mirror is `uv run python scripts/quality.py ci`.
 - Raspberry Pi validation has a defined path through `yoyoctl pi smoke` and `yoyoctl remote`.
 
 This file should reflect the repo as it exists on `main`. Older milestone notes are useful for history, but they are not the source of truth anymore.
@@ -272,8 +272,7 @@ uv sync --extra dev
 ### Validate Locally
 
 ```bash
-python -m compileall yoyopy tests demos
-uv run pytest -q
+uv run python scripts/quality.py ci
 ```
 
 ### Run The Production App

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Supported display/input modes:
 uv run yoyoctl setup host
 uv run yoyoctl setup verify-host
 python yoyopod.py --simulate
-uv run python scripts/quality.py gate
-uv run pytest -q
+uv run python scripts/quality.py ci
 ```
 
 For the full setup, validation, and Pi workflow, start with:

--- a/docs/CONTRIBUTOR_WORKFLOW.md
+++ b/docs/CONTRIBUTOR_WORKFLOW.md
@@ -42,8 +42,7 @@ python yoyopod.py --simulate
 Core validation loop:
 
 ```bash
-uv run python scripts/quality.py gate
-uv run pytest -q
+uv run python scripts/quality.py ci
 ```
 
 Full quality debt audit:
@@ -115,8 +114,7 @@ When updating docs:
 At minimum, run:
 
 ```bash
-uv run python scripts/quality.py gate
-uv run pytest -q
+uv run python scripts/quality.py ci
 ```
 
 Then add any focused commands relevant to your area, for example:

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -123,9 +123,13 @@ python demos/demo_runtime_state.py --simulate
 Local validation:
 
 ```bash
+uv run python scripts/quality.py ci
+```
+
+Optional extra syntax/import smoke for broad tree changes:
+
+```bash
 python -m compileall yoyopy tests demos scripts
-uv run python scripts/quality.py gate
-uv run pytest -q
 ```
 
 Full quality audit of the current repo debt:

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -234,7 +234,7 @@ If you use it, say clearly that the board is running a dirty-tree override inste
 
 1. Run local checks as needed:
    ```bash
-   uv run pytest -q
+   uv run python scripts/quality.py ci
    ```
 2. Commit the intended change.
 3. Push the branch.
@@ -250,7 +250,7 @@ If you use it, say clearly that the board is running a dirty-tree override inste
 
 ## Release / Pre-Merge Checklist
 
-- local branch is green with `uv run pytest -q`
+- local branch is green with `uv run python scripts/quality.py ci`
 - branch is pushed and reviewed
 - `yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak` passes
 - the app starts cleanly and stays running for manual hardware testing

--- a/docs/QUALITY_GATES.md
+++ b/docs/QUALITY_GATES.md
@@ -1,14 +1,23 @@
 # Quality Gates
 
-This repo now owns one executable quality contract instead of relying on tribal knowledge:
+This repo now owns one obvious local command that mirrors current CI expectations:
 
 ```bash
-uv run python scripts/quality.py gate
+uv run python scripts/quality.py ci
 ```
 
-CI runs that exact command.
+That command runs:
 
-## Gated now
+- the staged quality gate: `uv run python scripts/quality.py gate`
+- the Python test suite: `uv run pytest -q`
+
+CI currently runs those same two steps in separate jobs.
+
+## Local CI mirror
+
+Use `ci` as the default local before-PR command when you want the same gate-plus-tests contract CI expects.
+
+## Staged gate
 
 The staged gate currently covers the developer-workflow surface tracked in `[tool.yoyopod_quality]` inside `pyproject.toml`:
 

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -12,10 +12,10 @@ Run these anywhere:
 
 ```bash
 uv sync --extra dev
-uv run pytest -q
+uv run python scripts/quality.py ci
 ```
 
-This covers the pure-Python and simulation-mode regression suite.
+This mirrors the same staged gate plus pure-Python regression suite CI expects.
 
 ### 2. Default dev-machine-to-board validation
 
@@ -186,7 +186,7 @@ Use this when you want a focused battery, charging, RTC, shutdown-threshold, and
 ## Suggested Order On Hardware
 
 1. `uv sync --extra dev`
-2. `uv run pytest -q`
+2. `uv run python scripts/quality.py ci`
 3. `git push`
 4. `git rev-parse HEAD`
 5. `yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip`

--- a/rules/code-style.md
+++ b/rules/code-style.md
@@ -4,5 +4,6 @@
 - Black formatting, 100 char line length
 - Logging via `loguru` (not stdlib logging) -- see `rules/logging.md`
 - Build system: hatchling
+- Local CI mirror: `uv run python scripts/quality.py ci`
 - Repo-owned staged quality gate: `uv run python scripts/quality.py gate`
 - Full quality debt audit: `uv run python scripts/quality.py audit`

--- a/rules/design-fidelity.md
+++ b/rules/design-fidelity.md
@@ -67,8 +67,7 @@ For Whisplay UI work, the standard loop is:
 
 1. Validate locally:
    ```bash
-   python -m compileall yoyopy tests
-   uv run pytest -q
+   uv run python scripts/quality.py ci
    ```
    For iterative UI work, run the most relevant focused tests if the full suite is unnecessary.
 2. Commit and push the branch you want to validate:

--- a/rules/project.md
+++ b/rules/project.md
@@ -15,6 +15,9 @@ uv run yoyoctl setup verify-host
 python yoyopod.py
 python yoyopod.py --simulate
 
+# Local CI mirror
+uv run python scripts/quality.py ci
+
 # Tests
 uv run pytest -q
 uv run pytest -q tests/test_fsm_runtime.py

--- a/scripts/quality.py
+++ b/scripts/quality.py
@@ -104,6 +104,18 @@ def build_gate_steps(config: QualityConfig) -> tuple[QualityStep, ...]:
     )
 
 
+def build_ci_steps(config: QualityConfig) -> tuple[QualityStep, ...]:
+    """Build the local command that mirrors current CI expectations."""
+
+    return (
+        *build_gate_steps(config),
+        QualityStep(
+            label="pytest -q (CI test suite)",
+            command=_python_module_command("pytest", "-q"),
+        ),
+    )
+
+
 def build_audit_steps(config: QualityConfig) -> tuple[QualityStep, ...]:
     """Build the non-gating full-repo audit commands."""
 
@@ -170,6 +182,10 @@ def build_parser() -> argparse.ArgumentParser:
         description="Run repo-owned quality commands for YoyoPod Core."
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser(
+        "ci",
+        help="Run the local command that mirrors CI: staged gate plus pytest.",
+    )
     subparsers.add_parser("gate", help="Run the staged CI-gated workflow checks.")
     subparsers.add_parser("audit", help="Run the non-gating full-repo quality audit.")
     subparsers.add_parser("targets", help="Print the tracked gate and audit target sets.")
@@ -182,6 +198,8 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     config = load_quality_config()
 
+    if args.command == "ci":
+        return run_steps(build_ci_steps(config))
     if args.command == "gate":
         return run_steps(build_gate_steps(config))
     if args.command == "audit":

--- a/tests/test_quality_script.py
+++ b/tests/test_quality_script.py
@@ -1,0 +1,29 @@
+"""Tests for the repo-owned quality command wrapper."""
+
+from __future__ import annotations
+
+import runpy
+import sys
+from pathlib import Path
+
+QUALITY_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "quality.py"
+QUALITY = runpy.run_path(str(QUALITY_SCRIPT))
+
+
+def test_ci_steps_wrap_gate_plus_pytest() -> None:
+    config = QUALITY["load_quality_config"]()
+
+    gate_steps = QUALITY["build_gate_steps"](config)
+    ci_steps = QUALITY["build_ci_steps"](config)
+
+    assert ci_steps[:-1] == gate_steps
+    assert ci_steps[-1].label == "pytest -q (CI test suite)"
+    assert ci_steps[-1].command == (sys.executable, "-m", "pytest", "-q")
+
+
+def test_parser_accepts_ci_command() -> None:
+    parser = QUALITY["build_parser"]()
+
+    args = parser.parse_args(["ci"])
+
+    assert args.command == "ci"


### PR DESCRIPTION
## Summary
- add a `ci` subcommand to `scripts/quality.py` that runs the staged quality gate and `pytest -q`
- add a focused regression test for the new quality wrapper contract
- update the active contributor and agent guidance to point to the same local validation command

## Validation
- `PYTHONPATH=.venv/lib/python3.12/site-packages python3 -m pytest -q tests/test_quality_script.py`
- `PYTHONPATH=.venv/lib/python3.12/site-packages python3 -m black --check --fast scripts/quality.py tests/test_quality_script.py`
- `PYTHONPATH=.venv/lib/python3.12/site-packages python3 -m ruff check scripts/quality.py tests/test_quality_script.py`
- `python3 -m compileall scripts/quality.py tests/test_quality_script.py`

## Notes
- I attempted to run the new full `scripts/quality.py ci` command in this workspace, but the checked-in `.venv` points at a missing uv-managed Python 3.12 interpreter, so the environment here cannot run the full repo gate end-to-end.