### PR TITLE
fix: handle stop/play crash in music backend

### DIFF
--- a/src/yoyopod/audio/music/backend.py
+++ b/src/yoyopod/audio/music/backend.py
@@ -12,6 +12,17 @@ from yoyopod.audio.music.models import MusicConfig, Track
 from yoyopod.audio.music.process import MpvProcess
 
 
+def _coerce_time_position_ms(value: object) -> int:
+    """Coerce mpv's time-pos seconds value into milliseconds."""
+    if value in (None, "") or isinstance(value, bool):
+        return 0
+
+    try:
+        return max(0, int(float(value) * 1000))
+    except (TypeError, ValueError):
+        return 0
+
+
 @runtime_checkable
 class MusicBackend(Protocol):
     """Backend contract for music playback. Mirrors VoIPBackend pattern."""
@@ -161,10 +172,7 @@ class MpvBackend:
         return self._playback_state
 
     def get_time_position(self) -> int:
-        pos = self._get_property("time-pos")
-        if pos is not None:
-            return int(float(pos) * 1000)
-        return 0
+        return _coerce_time_position_ms(self._get_property("time-pos"))
 
     def load_tracks(self, uris: list[str]) -> bool:
         if not uris:
@@ -228,6 +236,7 @@ class MpvBackend:
                 pass
             else:
                 self._update_playback_state("stopped")
+                self._clear_track_cache()
                 self._update_track(None)
         elif event_name == "property-change":
             prop_name = event.get("name", "")

--- a/src/yoyopod/audio/music/models.py
+++ b/src/yoyopod/audio/music/models.py
@@ -40,6 +40,17 @@ def _track_number(value: object) -> int | None:
         return None
 
 
+def _duration_ms(value: object) -> int:
+    """Coerce one mpv duration value in seconds into milliseconds."""
+    if value in (None, "") or isinstance(value, bool):
+        return 0
+
+    try:
+        return max(0, int(float(value) * 1000))
+    except (TypeError, ValueError):
+        return 0
+
+
 @dataclass(frozen=True, slots=True)
 class Track:
     """One music track."""
@@ -61,8 +72,7 @@ class Track:
         metadata_map = _normalized_metadata(metadata)
         path_obj = Path(path)
 
-        raw_duration = metadata_map.get("duration", 0)
-        duration_ms = int(float(raw_duration) * 1000) if raw_duration else 0
+        duration_ms = _duration_ms(metadata_map.get("duration", 0))
 
         runtime_title = metadata_map.get("title")
         title = runtime_title if isinstance(runtime_title, str) else ""

--- a/tests/test_music_backend.py
+++ b/tests/test_music_backend.py
@@ -244,6 +244,47 @@ def test_mpv_backend_builds_track_from_property_events() -> None:
     assert track.length == 12500
 
 
+def test_mpv_backend_ignores_stale_metadata_after_stop_end_file() -> None:
+    backend = MpvBackend(MusicConfig())
+
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "path",
+            "data": "/music/alpha.ogg",
+        }
+    )
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "metadata",
+            "data": {
+                "title": "Alpha",
+                "artist": "Artist",
+            },
+        }
+    )
+
+    assert backend.get_current_track() is not None
+
+    backend._handle_mpv_event({"event": "end-file", "reason": "stop"})
+    assert backend.get_current_track() is None
+
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "metadata",
+            "data": {
+                "title": "Stale Alpha",
+                "artist": "Artist",
+            },
+        }
+    )
+
+    assert backend.get_playback_state() == "stopped"
+    assert backend.get_current_track() is None
+
+
 def test_mpv_backend_get_current_track_refreshes_snapshot_when_cache_empty() -> None:
     class FakeIpc:
         connected = True
@@ -280,6 +321,55 @@ def test_mpv_backend_get_current_track_refreshes_snapshot_when_cache_empty() -> 
     assert track.name == "Beta"
     assert track.artists == ["Composer"]
     assert track.length == 9000
+
+
+def test_mpv_backend_get_current_track_tolerates_non_numeric_duration_snapshot() -> None:
+    class FakeIpc:
+        connected = True
+
+        def __init__(self) -> None:
+            self.responses = {
+                "path": "/music/beta.ogg",
+                "metadata": {"artist": "Composer"},
+                "duration": "N/A",
+                "media-title": "Beta",
+            }
+
+        def send_command(self, args: list[object]) -> dict[str, object]:
+            return {"error": "success", "data": self.responses[str(args[1])]}
+
+        def disconnect(self) -> None:
+            return None
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+        def kill(self) -> None:
+            return None
+
+    backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
+
+    track = backend.get_current_track()
+
+    assert track is not None
+    assert track.name == "Beta"
+    assert track.artists == ["Composer"]
+    assert track.length == 0
+
+
+def test_mpv_backend_get_time_position_returns_zero_for_non_numeric_value() -> None:
+    class FakeIpc:
+        def send_command(self, args: list[object]) -> dict[str, object]:
+            return {"error": "success", "data": "N/A"}
+
+    backend = MpvBackend(MusicConfig())
+    backend._ipc = FakeIpc()
+
+    assert backend.get_time_position() == 0
 
 
 def test_mpv_backend_registers_mpv_event_handler_only_once_across_restarts() -> None:

--- a/tests/test_music_models.py
+++ b/tests/test_music_models.py
@@ -39,6 +39,16 @@ def test_track_from_mpv_metadata_missing_fields() -> None:
     assert track.length == 0
 
 
+def test_track_from_mpv_metadata_ignores_non_numeric_duration() -> None:
+    track = Track.from_mpv_metadata(
+        "/music/noisy.mp3",
+        {"title": "Noisy", "artist": "Alice", "duration": "N/A"},
+    )
+    assert track.name == "Noisy"
+    assert track.artists == ["Alice"]
+    assert track.length == 0
+
+
 def test_track_from_mpv_metadata_strips_file_extension_from_runtime_title() -> None:
     track = Track.from_mpv_metadata(
         "/music/OpenSampler/02-Moonlight-Sonata.ogg",


### PR DESCRIPTION
## Summary
- clear cached track metadata when mpv reports a stop end-file event so late property updates cannot resurrect stale now-playing state
- coerce transient non-numeric mpv `time-pos` and `duration` values to zero instead of crashing playback reads during stop/play transitions
- add regression coverage for stale stop metadata plus invalid duration and time-position payloads

Closes #73

## Validation
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_music_backend.py`
- `PYTHONDONTWRITEBYTECODE=1 uv run python scripts/quality.py gate`
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q`
