### PR TITLE
[codex] Add freeze diagnostics to screenshot capture path

### DIFF
--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -174,6 +174,34 @@ This tails the file sinks declared in `deploy/pi-deploy.yaml`, which is the stab
 - `<project-dir>/logs/yoyopod_errors.log`
 - `/tmp/yoyopod.pid`
 
+### Freeze investigation
+
+When the app looks stuck during idle navigation, use the screenshot signal path as the first
+evidence trigger:
+
+```bash
+yoyoctl remote logs --follow --filter ERROR
+yoyoctl remote screenshot --readback
+```
+
+What to expect:
+
+- `yoyoctl remote screenshot --readback` sends `SIGUSR1` to the app.
+- `SIGUSR1` now does two things:
+  - appends an all-thread traceback dump to `logs/yoyopod_errors.log`
+  - logs a structured runtime snapshot before trying the queued screenshot capture
+- if the main loop is still healthy enough, you also get the PNG
+- if the main loop is wedged and the PNG never appears, the error log is still the first place to inspect
+
+For shadow-buffer comparison, use:
+
+```bash
+yoyoctl remote screenshot
+```
+
+That uses `SIGUSR2`, which captures the same traceback + runtime evidence but prefers the legacy
+shadow-first screenshot path.
+
 ### Production systemd service
 
 ```bash

--- a/rules/lvgl.md
+++ b/rules/lvgl.md
@@ -56,6 +56,9 @@ Must rebuild on Pi after changing `lv_conf.h` or `lvgl_shim.c`.
 - `yoyoctl remote screenshot` defaults to the shadow-first path via `SIGUSR2`.
 - `yoyoctl remote screenshot --readback` requests LVGL readback via `SIGUSR1`.
 - The remote helper now clears the previous remote PNG before capture and waits for a fresh file.
+- Both screenshot signals also append freeze diagnostics to `logs/yoyopod_errors.log`:
+  - an all-thread traceback dump from `faulthandler`
+  - a structured runtime snapshot logged before the screenshot is queued
 - To confirm which path actually succeeded, check the app log:
   - `Saved screenshot via LVGL readback` means native LVGL snapshotting succeeded.
   - `Saved screenshot via shadow buffer` means the shadow path was used instead.

--- a/src/yoyopod/app.py
+++ b/src/yoyopod/app.py
@@ -82,6 +82,19 @@ from yoyopod.voice import VoiceDeviceCatalog
 from yoyopod.voip import CallHistoryStore, VoIPManager
 
 
+def _queue_depth(queue_obj: object) -> int | None:
+    """Return a best-effort queue depth for runtime diagnostics."""
+
+    qsize = getattr(queue_obj, "qsize", None)
+    if not callable(qsize):
+        return None
+
+    try:
+        return int(qsize())
+    except (NotImplementedError, TypeError, ValueError):
+        return None
+
+
 class YoyoPodApp:
     """
     Main YoyoPod application coordinator.
@@ -180,6 +193,7 @@ class YoyoPodApp:
         self._lvgl_backend: Optional[LvglDisplayBackend] = None
         self._lvgl_input_bridge: Optional[LvglInputBridge] = None
         self._last_lvgl_pump_at = 0.0
+        self._last_loop_heartbeat_at = 0.0
         self._next_voip_iterate_at = 0.0
         self._voip_iterate_interval_seconds = 0.02
 
@@ -717,15 +731,19 @@ class YoyoPodApp:
 
     def get_status(self) -> Dict[str, Any]:
         """Return the current application status."""
+        monotonic_now = time.monotonic()
         pending_shutdown_in_seconds = None
         if self._pending_shutdown is not None:
             pending_shutdown_in_seconds = max(
                 0.0,
-                self._pending_shutdown.execute_at - time.monotonic(),
+                self._pending_shutdown.execute_at - monotonic_now,
             )
 
         assert self.coordinator_runtime is not None
         assert self.call_interruption_policy is not None
+        current_screen = (
+            self.screen_manager.get_current_screen() if self.screen_manager is not None else None
+        )
         power_snapshot = (
             self.power_manager.get_snapshot() if self.power_manager is not None else None
         )
@@ -739,6 +757,12 @@ class YoyoPodApp:
             "music_available": self.music_backend is not None and self.music_backend.is_connected,
             "volume": self.get_output_volume(),
             "power_available": power_snapshot.available if power_snapshot is not None else False,
+            "current_screen": getattr(current_screen, "route_name", None),
+            "screen_stack_depth": (
+                len(self.screen_manager.screen_stack) if self.screen_manager is not None else 0
+            ),
+            "pending_main_thread_callbacks": _queue_depth(self._pending_main_thread_callbacks),
+            "pending_event_bus_events": self.event_bus.pending_count(),
             "battery_percent": self.context.battery_percent if self.context else None,
             "battery_charging": self.context.battery_charging if self.context else None,
             "external_power": self.context.external_power if self.context else None,
@@ -772,6 +796,28 @@ class YoyoPodApp:
                 getattr(self.display, "backend_kind", "pil")
                 if self.display is not None
                 else "unknown"
+            ),
+            "lvgl_initialized": bool(
+                self._lvgl_backend is not None and self._lvgl_backend.initialized
+            ),
+            "lvgl_pump_age_seconds": (
+                max(0.0, monotonic_now - self._last_lvgl_pump_at)
+                if self._last_lvgl_pump_at > 0.0
+                else None
+            ),
+            "loop_heartbeat_age_seconds": (
+                max(0.0, monotonic_now - self._last_loop_heartbeat_at)
+                if self._last_loop_heartbeat_at > 0.0
+                else None
+            ),
+            "next_voip_iterate_in_seconds": (
+                max(0.0, self._next_voip_iterate_at - monotonic_now)
+                if (
+                    self.voip_manager is not None
+                    and self.voip_manager.running
+                    and self._next_voip_iterate_at > 0.0
+                )
+                else None
             ),
             "power_model": power_snapshot.device.model if power_snapshot is not None else None,
             "power_error": power_snapshot.error if power_snapshot is not None else None,

--- a/src/yoyopod/cli/remote/ops.py
+++ b/src/yoyopod/cli/remote/ops.py
@@ -1560,7 +1560,9 @@ def run_screenshot(
     if verify_result.returncode != 0 or verify_result.stdout.strip() != "READY":
         print(
             "Screenshot was not created on the Raspberry Pi. "
-            "Confirm the app is running and screenshot handlers are installed."
+            "Confirm the app is running and screenshot handlers are installed. "
+            "If the app is wedged, inspect `yoyoctl remote logs --errors` for the "
+            "traceback dump and runtime snapshot triggered by the screenshot signal."
         )
         if verify_result.stderr.strip():
             print(verify_result.stderr.strip())

--- a/src/yoyopod/event_bus.py
+++ b/src/yoyopod/event_bus.py
@@ -66,6 +66,10 @@ class EventBus:
 
         return processed
 
+    def pending_count(self) -> int:
+        """Return the number of queued events waiting for the coordinator thread."""
+        return self._queue.qsize()
+
     def _dispatch(self, event: Any) -> None:
         """Dispatch an event to all compatible subscribers."""
         handlers: list[EventHandler] = []

--- a/src/yoyopod/main.py
+++ b/src/yoyopod/main.py
@@ -7,12 +7,15 @@ and keeps the installed entry point aligned with the top-level launcher.
 
 from __future__ import annotations
 
+import faulthandler
+import json
 import os
 import signal
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from types import FrameType
-from typing import Any
+from typing import Any, TextIO
 
 from loguru import logger
 
@@ -164,6 +167,120 @@ def configure_logger(config_dir: str = "config") -> LoggingRuntimeConfig:
     )
 
 
+def _signal_name(signum: int) -> str:
+    """Return a stable signal name for diagnostics."""
+
+    try:
+        return signal.Signals(signum).name
+    except ValueError:
+        return str(signum)
+
+
+def _json_safe(value: object) -> object:
+    """Normalize runtime state into JSON-safe values for log snapshots."""
+
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except TypeError:
+            pass
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
+def _log_signal_snapshot(
+    *,
+    app: object,
+    app_log: Any,
+    signal_name: str,
+    prefer_readback: bool,
+) -> None:
+    """Emit one structured runtime snapshot to the error log on demand."""
+
+    payload: dict[str, object] = {
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "capture_mode": "readback-first" if prefer_readback else "shadow-first",
+        "signal": signal_name,
+    }
+    get_status = getattr(app, "get_status", None)
+    if callable(get_status):
+        try:
+            payload["status"] = _json_safe(get_status())
+        except Exception as exc:
+            payload["status_error"] = str(exc)
+    else:
+        payload["status_error"] = "app does not expose get_status()"
+
+    app_log.error("Freeze diagnostics snapshot: {}", json.dumps(payload, sort_keys=True))
+
+
+def _install_traceback_dump_handlers(
+    *,
+    signals: tuple[int, ...],
+    dump_path: Path,
+    app_log: Any,
+) -> tuple[TextIO | None, tuple[int, ...]]:
+    """Chain all-thread traceback dumps onto the screenshot signals."""
+
+    if not signals:
+        return None, ()
+
+    dump_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        dump_stream = dump_path.open("a", encoding="utf-8", buffering=1)
+    except OSError as exc:
+        app_log.warning("Failed to open traceback dump log {}: {}", dump_path, exc)
+        return None, ()
+
+    installed: list[int] = []
+    for signum in signals:
+        try:
+            faulthandler.register(signum, file=dump_stream, all_threads=True, chain=True)
+        except (OSError, RuntimeError, ValueError) as exc:
+            app_log.warning(
+                "Failed to arm traceback dump for {}: {}",
+                _signal_name(signum),
+                exc,
+            )
+            continue
+        installed.append(signum)
+
+    if not installed:
+        dump_stream.close()
+        return None, ()
+
+    app_log.info(
+        "Freeze traceback dumps armed for {} -> {}",
+        ", ".join(_signal_name(signum) for signum in installed),
+        dump_path,
+    )
+    return dump_stream, tuple(installed)
+
+
+def _uninstall_traceback_dump_handlers(
+    *,
+    signals: tuple[int, ...],
+    dump_stream: TextIO | None,
+) -> None:
+    """Best-effort faulthandler cleanup on process exit."""
+
+    for signum in signals:
+        try:
+            faulthandler.unregister(signum)
+        except (OSError, RuntimeError, ValueError):
+            continue
+
+    if dump_stream is not None:
+        dump_stream.close()
+
+
 def main() -> int:
     """Run the integrated YoyoPod application."""
     logging_config = configure_logger()
@@ -172,6 +289,8 @@ def main() -> int:
     simulate = "--simulate" in sys.argv
     pid = os.getpid()
     startup_logged = False
+    traceback_dump_stream: TextIO | None = None
+    registered_traceback_signals: tuple[int, ...] = ()
 
     write_pid_file(logging_config.pid_file, pid)
 
@@ -240,6 +359,12 @@ def main() -> int:
 
             def handle_screenshot_default(_signum: int, _frame: FrameType | None) -> None:
                 """SIGUSR1: save a screenshot using readback-first capture."""
+                _log_signal_snapshot(
+                    app=app,
+                    app_log=app_log,
+                    signal_name=_signal_name(sigusr1),
+                    prefer_readback=True,
+                )
                 _request_screenshot_capture(
                     app=app,
                     screenshot_path=screenshot_path,
@@ -249,6 +374,12 @@ def main() -> int:
 
             def handle_screenshot_legacy_shadow(_signum: int, _frame: FrameType | None) -> None:
                 """SIGUSR2: save a screenshot using shadow-first capture for debugging."""
+                _log_signal_snapshot(
+                    app=app,
+                    app_log=app_log,
+                    signal_name=_signal_name(sigusr2),
+                    prefer_readback=False,
+                )
                 _request_screenshot_capture(
                     app=app,
                     screenshot_path=screenshot_path,
@@ -258,6 +389,11 @@ def main() -> int:
 
             signal.signal(sigusr1, handle_screenshot_default)
             signal.signal(sigusr2, handle_screenshot_legacy_shadow)
+            traceback_dump_stream, registered_traceback_signals = _install_traceback_dump_handlers(
+                signals=(sigusr1, sigusr2),
+                dump_path=logging_config.error_log_file,
+                app_log=app_log,
+            )
             app_log.info(
                 "Screenshot handlers installed (SIGUSR1=default/readback-first, SIGUSR2=legacy shadow-first) -> {}",
                 screenshot_path,
@@ -272,6 +408,10 @@ def main() -> int:
             logger.exception("Unhandled exception escaped the YoyoPod main loop")
             exit_code = 1
         finally:
+            _uninstall_traceback_dump_handlers(
+                signals=registered_traceback_signals,
+                dump_stream=traceback_dump_stream,
+            )
             signal.signal(signal.SIGTERM, previous_sigterm)
             app.stop()
 

--- a/src/yoyopod/runtime/loop.py
+++ b/src/yoyopod/runtime/loop.py
@@ -83,6 +83,7 @@ class RuntimeLoopService:
         screen_update_interval: float,
     ) -> float:
         """Run one coordinator-loop iteration and return the next screen refresh timestamp."""
+        self.app._last_loop_heartbeat_at = monotonic_now
         self.iterate_voip_backend_if_due(monotonic_now)
         self.process_pending_main_thread_actions()
         self.app.recovery_service.attempt_manager_recovery(now=monotonic_now)

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -42,7 +42,9 @@ def test_background_publish_is_queued_until_drain() -> None:
     worker.join()
 
     assert seen_thread_ids == []
+    assert bus.pending_count() == 1
     assert bus.drain() == 1
+    assert bus.pending_count() == 0
     assert seen_thread_ids == [bus.main_thread_id]
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,7 @@
+import json
+import signal
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -164,3 +167,85 @@ def test_request_screenshot_capture_queues_main_loop_callback(monkeypatch) -> No
     assert force_refresh_calls == ["force_refresh"]
     assert capture_calls == [(adapter, "/tmp/test.png", True, True)]
     assert adapter._force_shadow_buffer_sync is False
+
+
+def test_log_signal_snapshot_serializes_runtime_state() -> None:
+    """Signal-triggered diagnostics should emit JSON-safe runtime state."""
+
+    logs: list[tuple[object, ...]] = []
+    fake_log = SimpleNamespace(
+        error=lambda *args: logs.append(args),
+    )
+    app = SimpleNamespace(
+        get_status=lambda: {
+            "current_screen": "hub",
+            "rtc_time": datetime(2026, 4, 16, 0, 9, tzinfo=timezone.utc),
+            "recent_calls": [{"when": datetime(2026, 4, 15, 23, 59, tzinfo=timezone.utc)}],
+        }
+    )
+
+    main_module._log_signal_snapshot(
+        app=app,
+        app_log=fake_log,
+        signal_name="SIGUSR1",
+        prefer_readback=True,
+    )
+
+    assert len(logs) == 1
+    assert logs[0][0] == "Freeze diagnostics snapshot: {}"
+    payload = json.loads(logs[0][1])
+    assert payload["signal"] == "SIGUSR1"
+    assert payload["capture_mode"] == "readback-first"
+    assert payload["status"]["current_screen"] == "hub"
+    assert payload["status"]["rtc_time"] == "2026-04-16T00:09:00+00:00"
+    assert payload["status"]["recent_calls"][0]["when"] == "2026-04-15T23:59:00+00:00"
+
+
+def test_install_traceback_dump_handlers_registers_faulthandler_chain(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Traceback dumps should chain onto the existing screenshot signal handlers."""
+
+    register_calls: list[tuple[int, bool, bool]] = []
+    unregister_calls: list[int] = []
+    logs: list[tuple[str, tuple[object, ...]]] = []
+
+    monkeypatch.setattr(
+        main_module.faulthandler,
+        "register",
+        lambda signum, *, file, all_threads, chain: register_calls.append(
+            (signum, all_threads, chain)
+        ),
+    )
+    monkeypatch.setattr(
+        main_module.faulthandler,
+        "unregister",
+        lambda signum: unregister_calls.append(signum),
+    )
+    fake_log = SimpleNamespace(
+        info=lambda *args: logs.append(("info", args)),
+        warning=lambda *args: logs.append(("warning", args)),
+    )
+
+    dump_stream, installed = main_module._install_traceback_dump_handlers(
+        signals=(signal.SIGUSR1, signal.SIGUSR2),
+        dump_path=tmp_path / "yoyopod_errors.log",
+        app_log=fake_log,
+    )
+
+    assert installed == (signal.SIGUSR1, signal.SIGUSR2)
+    assert register_calls == [
+        (signal.SIGUSR1, True, True),
+        (signal.SIGUSR2, True, True),
+    ]
+    assert dump_stream is not None
+    assert dump_stream.closed is False
+
+    main_module._uninstall_traceback_dump_handlers(
+        signals=installed,
+        dump_stream=dump_stream,
+    )
+
+    assert unregister_calls == [signal.SIGUSR1, signal.SIGUSR2]
+    assert dump_stream.closed is True


### PR DESCRIPTION
## Summary
- chain `faulthandler` onto `SIGUSR1` and `SIGUSR2` so screenshot requests also dump all thread tracebacks into `logs/yoyopod_errors.log`
- log a structured runtime snapshot from the signal handler, including current screen, queue depth, LVGL pump age, loop heartbeat, and next VoIP iterate timing
- document the Pi freeze-investigation flow and point `yoyoctl remote screenshot` failures at `yoyoctl remote logs --errors`

## Why
Issue #127 needs evidence-first debugging for the idle navigation freeze on hardware. The existing screenshot signal queued work onto the app loop, so when the loop wedged we could lose the most useful evidence. This change makes the same signal path produce logs even when the PNG never lands.

## Impact
- Operators can use `yoyoctl remote screenshot --readback` or the default shadow path as a hang-evidence trigger.
- The change narrows diagnosis by showing whether the coordinator loop is stalled, what screen was active, and which threads were blocked.
- This does not claim the freeze is fixed; it improves the first-capture evidence.

## Testing
- `uv run pytest -q tests/test_main.py tests/test_event_bus.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`
