### PR TITLE
Instrument VoIP keep-alive and runtime blocking timings

### DIFF
--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -165,6 +165,7 @@ This waits for the startup marker and matching PID before returning success.
 yoyoctl remote logs --lines 200
 yoyoctl remote logs --errors
 yoyoctl remote logs --filter voip
+yoyoctl remote logs --filter coord
 yoyoctl remote logs --follow --filter ERROR
 ```
 
@@ -173,6 +174,12 @@ This tails the file sinks declared in `deploy/pi-deploy.yaml`, which is the stab
 - `<project-dir>/logs/yoyopod.log`
 - `<project-dir>/logs/yoyopod_errors.log`
 - `/tmp/yoyopod.pid`
+
+For keep-alive freeze triage, watch the `voip` and `coord` lines together:
+
+- `VoIP timing window`: rolling summary of keep-alive schedule delay, iterate duration, and the worst loop gap in that window
+- `VoIP iterate timing drift`: one-off warning when a keep-alive step ran late or took unusually long
+- `Runtime loop blocked`: one-off warning when some other coordinator work starved the loop enough to threaten VoIP cadence
 
 ### Freeze investigation
 
@@ -190,6 +197,11 @@ What to expect:
 - `SIGUSR1` now does two things:
   - appends an all-thread traceback dump to `logs/yoyopod_errors.log`
   - logs a structured runtime snapshot before trying the queued screenshot capture
+- recent runtime logs also expose VoIP keep-alive timing in three layers:
+  - `VoIP keep-alive native iterate slow` means the Liblinphone keep-alive call itself blocked
+  - `VoIP iterate timing drift` means the coordinator reached keep-alive late or the full iterate pass ran long
+  - `Coordinator blocking span` points at nearby coordinator work that may have delayed keep-alives
+- the periodic `VoIP timing window` summary rolls those samples up for hardware runs without logging every 20 ms iterate
 - if the main loop is still healthy enough, you also get the PNG
 - if the main loop is wedged and the PNG never appears, the error log is still the first place to inspect
 

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -119,6 +119,16 @@ yoyoctl pi voip check
 
 Use this when you want a registration-only pass with detailed logs.
 
+When the full app is running, the coordinator-thread timing signals land in
+`logs/yoyopod.log` and through `yoyoctl remote logs --follow`.
+
+- `VoIP iterate timing drift` is the per-keep-alive warning. `schedule_delay_ms` shows how late the iterate ran, `iterate_ms` shows how long the Liblinphone keep-alive took on the coordinator thread, and `native_events` shows how many backend events were drained during that pass.
+- `VoIP timing window` is the low-frequency summary for target-hardware runs. Use it to spot repeated delay or duration spikes without reading every keep-alive warning. `max_blocking_span` and `max_blocking_span_ms` point at the worst nearby coordinator step seen in that summary window.
+- `Runtime loop blocked` means the whole coordinator loop stalled between iterations.
+- `Coordinator blocking span` names the specific runtime step that blocked long enough to threaten keep-alive cadence or UI responsiveness.
+- `Runtime iteration slow` means the total loop iteration stayed on the coordinator thread too long even if the exact hot span was not obvious from a single callback.
+- Freeze snapshots also include `runtime_blocking_span_name`, `runtime_blocking_span_seconds`, and `runtime_blocking_span_age_seconds` so a `SIGUSR1` dump can tell you whether the last blocking span is still fresh or already stale.
+
 ### Incoming call debug drill
 
 ```bash

--- a/src/yoyopod/app.py
+++ b/src/yoyopod/app.py
@@ -849,4 +849,5 @@ class YoyoPodApp:
                 if self.power_manager is not None
                 else None
             ),
+            **self.runtime_loop.timing_snapshot(now=monotonic_now),
         }

--- a/src/yoyopod/runtime/loop.py
+++ b/src/yoyopod/runtime/loop.py
@@ -3,19 +3,151 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
 from loguru import logger
+
+from yoyopod.utils.logger import get_subsystem_logger
 
 if TYPE_CHECKING:
     from yoyopod.app import YoyoPodApp
 
 
+coord_logger = get_subsystem_logger("coord")
+voip_logger = get_subsystem_logger("voip")
+_T = TypeVar("_T")
+
+
+@dataclass(slots=True)
+class _VoipTimingWindow:
+    """Rolling aggregate used for low-noise VoIP timing summaries."""
+
+    started_at: float = 0.0
+    samples: int = 0
+    total_schedule_delay_seconds: float = 0.0
+    max_schedule_delay_seconds: float = 0.0
+    delayed_samples: int = 0
+    total_iterate_duration_seconds: float = 0.0
+    max_iterate_duration_seconds: float = 0.0
+    max_native_iterate_duration_seconds: float = 0.0
+    max_event_drain_duration_seconds: float = 0.0
+    max_drained_events: int = 0
+    slow_samples: int = 0
+    max_loop_gap_seconds: float = 0.0
+    max_blocking_span_name: str | None = None
+    max_blocking_span_seconds: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class _VoipIterateMetrics:
+    """Normalized keep-alive sub-span timings surfaced from the VoIP backend."""
+
+    native_duration_seconds: float = 0.0
+    event_drain_duration_seconds: float = 0.0
+
+
+def _queue_depth(queue_obj: object) -> int | None:
+    """Return a best-effort queue depth for runtime diagnostics."""
+
+    qsize = getattr(queue_obj, "qsize", None)
+    if not callable(qsize):
+        return None
+
+    try:
+        return int(qsize())
+    except (NotImplementedError, TypeError, ValueError):
+        return None
+
+
 class RuntimeLoopService:
     """Own the coordinator loop cadence and queued main-thread work."""
 
+    _VOIP_TIMING_SUMMARY_INTERVAL_SECONDS = 10.0
+    _MIN_RUNTIME_LOOP_GAP_WARNING_SECONDS = 0.2
+    _MIN_RUNTIME_BLOCKING_SPAN_WARNING_SECONDS = 0.2
+    _MIN_RUNTIME_ITERATION_WARNING_SECONDS = 0.2
+    _MIN_VOIP_SCHEDULE_DELAY_WARNING_SECONDS = 0.15
+    _MIN_VOIP_ITERATE_WARNING_SECONDS = 0.15
+
     def __init__(self, app: "YoyoPodApp") -> None:
         self.app = app
+        self._last_loop_iteration_started_at = 0.0
+        self._last_runtime_loop_gap_seconds = 0.0
+        self._last_runtime_iteration_duration_seconds = 0.0
+        self._last_voip_iterate_started_at = 0.0
+        self._last_voip_schedule_delay_seconds = 0.0
+        self._last_voip_iterate_duration_seconds = 0.0
+        self._last_voip_native_events = 0
+        self._last_voip_native_iterate_duration_seconds = 0.0
+        self._last_voip_event_drain_duration_seconds = 0.0
+        self._last_runtime_blocking_span_name: str | None = None
+        self._last_runtime_blocking_span_seconds = 0.0
+        self._last_runtime_blocking_span_recorded_at = 0.0
+        self._voip_timing_window = _VoipTimingWindow()
+
+    def _record_blocking_span(self, span_name: str, duration_seconds: float) -> None:
+        """Persist and log one named coordinator-thread blocking span."""
+
+        self._last_runtime_blocking_span_name = span_name
+        self._last_runtime_blocking_span_seconds = duration_seconds
+        self._last_runtime_blocking_span_recorded_at = time.monotonic()
+        if (
+            self._voip_timing_window.started_at > 0.0
+            and duration_seconds >= self._voip_timing_window.max_blocking_span_seconds
+        ):
+            self._voip_timing_window.max_blocking_span_name = span_name
+            self._voip_timing_window.max_blocking_span_seconds = duration_seconds
+        coord_logger.warning(
+            "Coordinator blocking span: "
+            "span={} duration_ms={:.1f} pending_callbacks={} pending_events={} screen={} state={}",
+            span_name,
+            duration_seconds * 1000.0,
+            _queue_depth(self.app._pending_main_thread_callbacks),
+            self.app.event_bus.pending_count(),
+            self._current_screen_name(),
+            self._runtime_state_name(),
+        )
+
+    def _measure_blocking_span(
+        self,
+        span_name: str,
+        callback: Callable[[], _T],
+    ) -> _T:
+        """Run one coordinator step and surface unusually long blocking spans."""
+
+        started_at = time.monotonic()
+        try:
+            return callback()
+        finally:
+            duration_seconds = max(0.0, time.monotonic() - started_at)
+            if duration_seconds >= self._runtime_blocking_span_warning_seconds():
+                self._record_blocking_span(span_name, duration_seconds)
+
+    def _latest_voip_iterate_metrics(self) -> _VoipIterateMetrics | None:
+        """Return the latest backend-native keep-alive sub-span timings when available."""
+
+        if self.app.voip_manager is None:
+            return None
+
+        get_metrics = getattr(self.app.voip_manager, "get_iterate_metrics", None)
+        if not callable(get_metrics):
+            return None
+
+        metrics = get_metrics()
+        if metrics is None:
+            return None
+
+        return _VoipIterateMetrics(
+            native_duration_seconds=max(
+                0.0,
+                float(getattr(metrics, "native_duration_seconds", 0.0) or 0.0),
+            ),
+            event_drain_duration_seconds=max(
+                0.0,
+                float(getattr(metrics, "event_drain_duration_seconds", 0.0) or 0.0),
+            ),
+        )
 
     def process_pending_main_thread_actions(self, limit: Optional[int] = None) -> int:
         """Drain queued typed events scheduled by worker threads."""
@@ -68,11 +200,64 @@ class RuntimeLoopService:
         if self.app._next_voip_iterate_at <= 0.0:
             self.app._next_voip_iterate_at = monotonic_now
 
-        if monotonic_now < self.app._next_voip_iterate_at:
+        scheduled_for = self.app._next_voip_iterate_at
+        if monotonic_now < scheduled_for:
             return
 
-        self.app.voip_manager.iterate()
+        schedule_delay_seconds = max(0.0, monotonic_now - scheduled_for)
+        since_last_iterate_seconds = (
+            max(0.0, monotonic_now - self._last_voip_iterate_started_at)
+            if self._last_voip_iterate_started_at > 0.0
+            else 0.0
+        )
+        self._last_voip_iterate_started_at = monotonic_now
+        self._last_voip_schedule_delay_seconds = schedule_delay_seconds
+
+        started_at = time.monotonic()
+        native_events = self.app.voip_manager.iterate()
+        iterate_duration_seconds = time.monotonic() - started_at
+        iterate_metrics = self._latest_voip_iterate_metrics()
+        self._last_voip_iterate_duration_seconds = iterate_duration_seconds
+        self._last_voip_native_events = native_events
+        self._last_voip_native_iterate_duration_seconds = (
+            iterate_metrics.native_duration_seconds if iterate_metrics is not None else 0.0
+        )
+        self._last_voip_event_drain_duration_seconds = (
+            iterate_metrics.event_drain_duration_seconds if iterate_metrics is not None else 0.0
+        )
         self.app._next_voip_iterate_at = monotonic_now + self.app._voip_iterate_interval_seconds
+
+        delayed = schedule_delay_seconds >= self._voip_schedule_delay_warning_seconds()
+        slow = iterate_duration_seconds >= self._voip_iterate_warning_seconds()
+        self._record_voip_timing_sample(
+            monotonic_now=monotonic_now,
+            schedule_delay_seconds=schedule_delay_seconds,
+            iterate_duration_seconds=iterate_duration_seconds,
+            native_iterate_duration_seconds=self._last_voip_native_iterate_duration_seconds,
+            event_drain_duration_seconds=self._last_voip_event_drain_duration_seconds,
+            drained_events=native_events,
+            delayed=delayed,
+            slow=slow,
+        )
+
+        if delayed or slow:
+            voip_logger.warning(
+                "VoIP iterate timing drift: "
+                "schedule_delay_ms={:.1f} iterate_ms={:.1f} since_last_ms={:.1f} "
+                "interval_ms={:.1f} native_iterate_ms={:.1f} event_drain_ms={:.1f} "
+                "native_events={} pending_callbacks={} pending_events={} screen={} state={}",
+                schedule_delay_seconds * 1000.0,
+                iterate_duration_seconds * 1000.0,
+                since_last_iterate_seconds * 1000.0,
+                self.app._voip_iterate_interval_seconds * 1000.0,
+                self._last_voip_native_iterate_duration_seconds * 1000.0,
+                self._last_voip_event_drain_duration_seconds * 1000.0,
+                native_events,
+                _queue_depth(self.app._pending_main_thread_callbacks),
+                self.app.event_bus.pending_count(),
+                self._current_screen_name(),
+                self._runtime_state_name(),
+            )
 
     def run_iteration(
         self,
@@ -83,35 +268,89 @@ class RuntimeLoopService:
         screen_update_interval: float,
     ) -> float:
         """Run one coordinator-loop iteration and return the next screen refresh timestamp."""
+        iteration_started_at = time.monotonic()
+        self._observe_loop_gap(monotonic_now=monotonic_now)
         self.app._last_loop_heartbeat_at = monotonic_now
-        self.iterate_voip_backend_if_due(monotonic_now)
-        self.process_pending_main_thread_actions()
-        self.app.recovery_service.attempt_manager_recovery(now=monotonic_now)
-        self.app.recovery_service.poll_power_status(now=monotonic_now)
-        self.pump_lvgl_backend(monotonic_now)
-        self.app.recovery_service.feed_watchdog_if_due(monotonic_now)
-        self.app.shutdown_service.process_pending_shutdown(monotonic_now)
-        if self.app._shutdown_completed:
+        try:
+            self._measure_blocking_span(
+                "voip_keepalive",
+                lambda: self.iterate_voip_backend_if_due(monotonic_now),
+            )
+            self._measure_blocking_span(
+                "main_thread_actions",
+                self.process_pending_main_thread_actions,
+            )
+            self._measure_blocking_span(
+                "manager_recovery",
+                lambda: self.app.recovery_service.attempt_manager_recovery(now=monotonic_now),
+            )
+            self._measure_blocking_span(
+                "power_poll",
+                lambda: self.app.recovery_service.poll_power_status(now=monotonic_now),
+            )
+            self._measure_blocking_span(
+                "lvgl_pump",
+                lambda: self.pump_lvgl_backend(monotonic_now),
+            )
+            self._measure_blocking_span(
+                "watchdog_feed",
+                lambda: self.app.recovery_service.feed_watchdog_if_due(monotonic_now),
+            )
+            self._measure_blocking_span(
+                "pending_shutdown",
+                lambda: self.app.shutdown_service.process_pending_shutdown(monotonic_now),
+            )
+            if self.app._shutdown_completed:
+                return last_screen_update
+
+            self._measure_blocking_span(
+                "screen_power",
+                lambda: self.app.screen_power_service.update_screen_power(monotonic_now),
+            )
+            overlay_active = self._measure_blocking_span(
+                "power_overlay",
+                lambda: self.app.screen_power_service.update_power_overlays(monotonic_now),
+            )
+            if overlay_active:
+                return current_time
+
+            if not self.app._screen_awake:
+                return current_time
+
+            if current_time - last_screen_update >= screen_update_interval:
+                self.app.boot_service.ensure_coordinators()
+                assert self.app.playback_coordinator is not None
+                assert self.app.screen_coordinator is not None
+                self._measure_blocking_span(
+                    "visible_screen_refresh",
+                    lambda: (
+                        self.app.playback_coordinator.update_now_playing_if_needed(),
+                        self.app.screen_coordinator.update_in_call_if_needed(),
+                        self.app.screen_coordinator.update_power_screen_if_needed(),
+                    ),
+                )
+                return current_time
+
             return last_screen_update
-
-        self.app.screen_power_service.update_screen_power(monotonic_now)
-        overlay_active = self.app.screen_power_service.update_power_overlays(monotonic_now)
-        if overlay_active:
-            return current_time
-
-        if not self.app._screen_awake:
-            return current_time
-
-        if current_time - last_screen_update >= screen_update_interval:
-            self.app.boot_service.ensure_coordinators()
-            assert self.app.playback_coordinator is not None
-            assert self.app.screen_coordinator is not None
-            self.app.playback_coordinator.update_now_playing_if_needed()
-            self.app.screen_coordinator.update_in_call_if_needed()
-            self.app.screen_coordinator.update_power_screen_if_needed()
-            return current_time
-
-        return last_screen_update
+        finally:
+            iteration_finished_at = time.monotonic()
+            self._last_runtime_iteration_duration_seconds = (
+                iteration_finished_at - iteration_started_at
+            )
+            self._maybe_log_voip_timing_summary(monotonic_now=iteration_finished_at)
+            if (
+                self._last_runtime_iteration_duration_seconds
+                >= self._runtime_iteration_warning_seconds()
+            ):
+                coord_logger.warning(
+                    "Runtime iteration slow: "
+                    "iteration_ms={:.1f} pending_callbacks={} pending_events={} screen={} state={}",
+                    self._last_runtime_iteration_duration_seconds * 1000.0,
+                    _queue_depth(self.app._pending_main_thread_callbacks),
+                    self.app.event_bus.pending_count(),
+                    self._current_screen_name(),
+                    self._runtime_state_name(),
+                )
 
     def log_startup_status(self) -> None:
         """Emit the current runtime snapshot before entering the main loop."""
@@ -210,3 +449,241 @@ class RuntimeLoopService:
         finally:
             if not self.app._shutdown_completed and not self.app._stopping:
                 self.app.stop()
+
+    def timing_snapshot(self, *, now: float | None = None) -> dict[str, float | int | None]:
+        """Expose the latest loop timing markers for snapshots and diagnostics."""
+
+        monotonic_now = time.monotonic() if now is None else now
+        return {
+            "runtime_loop_gap_seconds": (
+                self._last_runtime_loop_gap_seconds
+                if self._last_loop_iteration_started_at > 0.0
+                else None
+            ),
+            "runtime_iteration_seconds": (
+                self._last_runtime_iteration_duration_seconds
+                if self._last_loop_iteration_started_at > 0.0
+                else None
+            ),
+            "voip_schedule_delay_seconds": (
+                self._last_voip_schedule_delay_seconds
+                if self._last_voip_iterate_started_at > 0.0
+                else None
+            ),
+            "voip_iterate_duration_seconds": (
+                self._last_voip_iterate_duration_seconds
+                if self._last_voip_iterate_started_at > 0.0
+                else None
+            ),
+            "voip_native_iterate_duration_seconds": (
+                self._last_voip_native_iterate_duration_seconds
+                if self._last_voip_iterate_started_at > 0.0
+                else None
+            ),
+            "voip_event_drain_duration_seconds": (
+                self._last_voip_event_drain_duration_seconds
+                if self._last_voip_iterate_started_at > 0.0
+                else None
+            ),
+            "voip_iterate_native_events": (
+                self._last_voip_native_events if self._last_voip_iterate_started_at > 0.0 else None
+            ),
+            "voip_iterate_age_seconds": (
+                max(0.0, monotonic_now - self._last_voip_iterate_started_at)
+                if self._last_voip_iterate_started_at > 0.0
+                else None
+            ),
+            "voip_iterate_interval_seconds": self.app._voip_iterate_interval_seconds,
+            "runtime_blocking_span_name": self._last_runtime_blocking_span_name,
+            "runtime_blocking_span_seconds": (
+                self._last_runtime_blocking_span_seconds
+                if self._last_runtime_blocking_span_name is not None
+                else None
+            ),
+            "runtime_blocking_span_age_seconds": (
+                max(0.0, monotonic_now - self._last_runtime_blocking_span_recorded_at)
+                if self._last_runtime_blocking_span_recorded_at > 0.0
+                else None
+            ),
+            "voip_timing_window_samples": self._voip_timing_window.samples,
+        }
+
+    def _observe_loop_gap(self, *, monotonic_now: float) -> None:
+        """Track coordinator-loop gaps so starvation shows up in logs and snapshots."""
+
+        if self._last_loop_iteration_started_at <= 0.0:
+            self._last_loop_iteration_started_at = monotonic_now
+            self._last_runtime_loop_gap_seconds = 0.0
+            return
+
+        loop_gap_seconds = max(0.0, monotonic_now - self._last_loop_iteration_started_at)
+        self._last_loop_iteration_started_at = monotonic_now
+        self._last_runtime_loop_gap_seconds = loop_gap_seconds
+        self._voip_timing_window.max_loop_gap_seconds = max(
+            self._voip_timing_window.max_loop_gap_seconds,
+            loop_gap_seconds,
+        )
+
+        if loop_gap_seconds < self._runtime_loop_gap_warning_seconds():
+            return
+
+        coord_logger.warning(
+            "Runtime loop blocked: "
+            "gap_ms={:.1f} interval_ms={:.1f} pending_callbacks={} pending_events={} screen={} state={}",
+            loop_gap_seconds * 1000.0,
+            self.app._voip_iterate_interval_seconds * 1000.0,
+            _queue_depth(self.app._pending_main_thread_callbacks),
+            self.app.event_bus.pending_count(),
+            self._current_screen_name(),
+            self._runtime_state_name(),
+        )
+
+    def _record_voip_timing_sample(
+        self,
+        *,
+        monotonic_now: float,
+        schedule_delay_seconds: float,
+        iterate_duration_seconds: float,
+        native_iterate_duration_seconds: float,
+        event_drain_duration_seconds: float,
+        drained_events: int,
+        delayed: bool,
+        slow: bool,
+    ) -> None:
+        """Accumulate one VoIP iterate sample for the next summary window."""
+
+        if self._voip_timing_window.started_at <= 0.0:
+            self._voip_timing_window.started_at = monotonic_now
+
+        self._voip_timing_window.samples += 1
+        self._voip_timing_window.total_schedule_delay_seconds += schedule_delay_seconds
+        self._voip_timing_window.max_schedule_delay_seconds = max(
+            self._voip_timing_window.max_schedule_delay_seconds,
+            schedule_delay_seconds,
+        )
+        self._voip_timing_window.total_iterate_duration_seconds += iterate_duration_seconds
+        self._voip_timing_window.max_iterate_duration_seconds = max(
+            self._voip_timing_window.max_iterate_duration_seconds,
+            iterate_duration_seconds,
+        )
+        self._voip_timing_window.max_native_iterate_duration_seconds = max(
+            self._voip_timing_window.max_native_iterate_duration_seconds,
+            native_iterate_duration_seconds,
+        )
+        self._voip_timing_window.max_event_drain_duration_seconds = max(
+            self._voip_timing_window.max_event_drain_duration_seconds,
+            event_drain_duration_seconds,
+        )
+        self._voip_timing_window.max_drained_events = max(
+            self._voip_timing_window.max_drained_events,
+            drained_events,
+        )
+        self._voip_timing_window.max_loop_gap_seconds = max(
+            self._voip_timing_window.max_loop_gap_seconds,
+            self._last_runtime_loop_gap_seconds,
+        )
+        if delayed:
+            self._voip_timing_window.delayed_samples += 1
+        if slow:
+            self._voip_timing_window.slow_samples += 1
+
+    def _maybe_log_voip_timing_summary(self, *, monotonic_now: float) -> None:
+        """Emit a low-frequency summary of keep-alive timing behavior."""
+
+        window = self._voip_timing_window
+        if window.started_at <= 0.0 or window.samples <= 0:
+            return
+
+        if (
+            self._VOIP_TIMING_SUMMARY_INTERVAL_SECONDS > 0.0
+            and (monotonic_now - window.started_at) < self._VOIP_TIMING_SUMMARY_INTERVAL_SECONDS
+        ):
+            return
+
+        average_schedule_delay_ms = (window.total_schedule_delay_seconds / window.samples) * 1000.0
+        average_iterate_duration_ms = (
+            window.total_iterate_duration_seconds / window.samples
+        ) * 1000.0
+        voip_logger.info(
+            "VoIP timing window: "
+            "samples={} avg_schedule_delay_ms={:.1f} max_schedule_delay_ms={:.1f} "
+            "avg_iterate_ms={:.1f} max_iterate_ms={:.1f} max_loop_gap_ms={:.1f} "
+            "delayed_samples={} slow_samples={} max_native_iterate_ms={:.1f} "
+            "max_event_drain_ms={:.1f} max_native_events={} "
+            "max_blocking_span={} max_blocking_span_ms={:.1f} "
+            "interval_ms={:.1f} screen={} state={}",
+            window.samples,
+            average_schedule_delay_ms,
+            window.max_schedule_delay_seconds * 1000.0,
+            average_iterate_duration_ms,
+            window.max_iterate_duration_seconds * 1000.0,
+            window.max_loop_gap_seconds * 1000.0,
+            window.delayed_samples,
+            window.slow_samples,
+            window.max_native_iterate_duration_seconds * 1000.0,
+            window.max_event_drain_duration_seconds * 1000.0,
+            window.max_drained_events,
+            window.max_blocking_span_name or "none",
+            window.max_blocking_span_seconds * 1000.0,
+            self.app._voip_iterate_interval_seconds * 1000.0,
+            self._current_screen_name(),
+            self._runtime_state_name(),
+        )
+        self._voip_timing_window = _VoipTimingWindow(started_at=monotonic_now)
+
+    def _runtime_loop_gap_warning_seconds(self) -> float:
+        """Return the loop-gap threshold that is worth surfacing on hardware."""
+
+        return max(
+            self._MIN_RUNTIME_LOOP_GAP_WARNING_SECONDS,
+            self.app._voip_iterate_interval_seconds * 6.0,
+        )
+
+    def _runtime_iteration_warning_seconds(self) -> float:
+        """Return the total iteration duration threshold for broad blocking work."""
+
+        return max(
+            self._MIN_RUNTIME_ITERATION_WARNING_SECONDS,
+            self.app._voip_iterate_interval_seconds * 6.0,
+        )
+
+    def _runtime_blocking_span_warning_seconds(self) -> float:
+        """Return the per-step blocking threshold for coordinator runtime spans."""
+
+        return max(
+            self._MIN_RUNTIME_BLOCKING_SPAN_WARNING_SECONDS,
+            self.app._voip_iterate_interval_seconds * 6.0,
+        )
+
+    def _voip_schedule_delay_warning_seconds(self) -> float:
+        """Return the schedule-drift threshold for VoIP iterate warnings."""
+
+        return max(
+            self._MIN_VOIP_SCHEDULE_DELAY_WARNING_SECONDS,
+            self.app._voip_iterate_interval_seconds * 4.0,
+        )
+
+    def _voip_iterate_warning_seconds(self) -> float:
+        """Return the per-iterate duration threshold for VoIP keep-alive warnings."""
+
+        return max(
+            self._MIN_VOIP_ITERATE_WARNING_SECONDS,
+            self.app._voip_iterate_interval_seconds * 4.0,
+        )
+
+    def _current_screen_name(self) -> str:
+        """Return the active route name for diagnostic log context."""
+
+        if self.app.screen_manager is None:
+            return "none"
+
+        current_screen = self.app.screen_manager.get_current_screen()
+        return str(getattr(current_screen, "route_name", None) or "none")
+
+    def _runtime_state_name(self) -> str:
+        """Return the current derived app state for diagnostic log context."""
+
+        if self.app.coordinator_runtime is not None:
+            return str(self.app.coordinator_runtime.get_state_name())
+
+        return str(getattr(self.app._ui_state, "value", self.app._ui_state))

--- a/src/yoyopod/voip/backend.py
+++ b/src/yoyopod/voip/backend.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional, Protocol
+from typing import Callable, Protocol
 
 from loguru import logger
 
@@ -43,8 +44,8 @@ class VoIPBackend(Protocol):
     def stop(self) -> None:
         """Stop the backend and release resources."""
 
-    def iterate(self) -> None:
-        """Advance the backend once on the coordinator thread."""
+    def iterate(self) -> int:
+        """Advance the backend once on the coordinator thread and return drained event count."""
 
     def make_call(self, sip_address: str) -> bool:
         """Initiate an outgoing call."""
@@ -95,8 +96,21 @@ class _AlsaCaptureConfig:
     capture_raw: int
 
 
+@dataclass(frozen=True, slots=True)
+class VoIPIterateMetrics:
+    """Most recent keep-alive timing captured around one backend iterate."""
+
+    native_duration_seconds: float = 0.0
+    event_drain_duration_seconds: float = 0.0
+    total_duration_seconds: float = 0.0
+    drained_events: int = 0
+
+
 class LiblinphoneBackend:
     """Production VoIP backend driven by the native Liblinphone shim."""
+
+    _MIN_NATIVE_ITERATE_WARNING_SECONDS = 0.15
+    _MIN_EVENT_DRAIN_WARNING_SECONDS = 0.1
 
     def __init__(
         self,
@@ -108,6 +122,7 @@ class LiblinphoneBackend:
         self.binding = binding or LiblinphoneBinding.try_load()
         self.running = False
         self.event_callbacks: list[Callable[[VoIPEvent], None]] = []
+        self._last_iterate_metrics: VoIPIterateMetrics | None = None
 
     def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
         self.event_callbacks.append(callback)
@@ -204,21 +219,45 @@ class LiblinphoneBackend:
             self.binding.shutdown()
             self.running = False
 
-    def iterate(self) -> None:
-        if not self.running or self.binding is None:
-            return
+    def get_iterate_metrics(self) -> VoIPIterateMetrics | None:
+        """Return the latest native keep-alive timing sample."""
 
+        return self._last_iterate_metrics
+
+    def iterate(self) -> int:
+        if not self.running or self.binding is None:
+            return 0
+
+        drained_events = 0
+        started_at = time.monotonic()
+        native_duration_seconds = 0.0
+        event_drain_started_at = started_at
         try:
+            native_started_at = time.monotonic()
             self.binding.iterate()
+            native_duration_seconds = max(0.0, time.monotonic() - native_started_at)
+            event_drain_started_at = time.monotonic()
             while True:
                 event = self.binding.poll_event()
                 if event is None:
                     break
+                drained_events += 1
                 self._emit_native_event(event)
         except Exception as exc:
             logger.error("Liblinphone iterate failed: {}", exc)
             self.running = False
             self._emit(BackendStopped(reason=str(exc)))
+        finally:
+            event_drain_duration_seconds = max(0.0, time.monotonic() - event_drain_started_at)
+            total_duration_seconds = max(0.0, time.monotonic() - started_at)
+            self._last_iterate_metrics = VoIPIterateMetrics(
+                native_duration_seconds=native_duration_seconds,
+                event_drain_duration_seconds=event_drain_duration_seconds,
+                total_duration_seconds=total_duration_seconds,
+                drained_events=drained_events,
+            )
+            self._log_iterate_warning_if_needed()
+        return drained_events
 
     def make_call(self, sip_address: str) -> bool:
         return self._call_binding(lambda: self.binding.make_call(sip_address))
@@ -294,6 +333,36 @@ class LiblinphoneBackend:
             logger.error("Liblinphone operation failed: {}", exc)
             return False
 
+    def _log_iterate_warning_if_needed(self) -> None:
+        """Surface backend-native keep-alive work when it blocks unusually long."""
+
+        if self._last_iterate_metrics is None:
+            return
+
+        if (
+            self._last_iterate_metrics.native_duration_seconds
+            >= self._MIN_NATIVE_ITERATE_WARNING_SECONDS
+        ):
+            logger.warning(
+                "VoIP keep-alive native iterate slow: native_ms={:.1f} "
+                "total_ms={:.1f} drained_events={}",
+                self._last_iterate_metrics.native_duration_seconds * 1000.0,
+                self._last_iterate_metrics.total_duration_seconds * 1000.0,
+                self._last_iterate_metrics.drained_events,
+            )
+
+        if (
+            self._last_iterate_metrics.event_drain_duration_seconds
+            >= self._MIN_EVENT_DRAIN_WARNING_SECONDS
+        ):
+            logger.warning(
+                "VoIP keep-alive event drain slow: drain_ms={:.1f} "
+                "total_ms={:.1f} drained_events={}",
+                self._last_iterate_metrics.event_drain_duration_seconds * 1000.0,
+                self._last_iterate_metrics.total_duration_seconds * 1000.0,
+                self._last_iterate_metrics.drained_events,
+            )
+
     def _emit(self, event: VoIPEvent) -> None:
         for callback in self.event_callbacks:
             try:
@@ -303,7 +372,9 @@ class LiblinphoneBackend:
 
     def _emit_native_event(self, event: LiblinphoneNativeEvent) -> None:
         if event.type == 1:
-            self._emit(RegistrationStateChanged(state=self._registration_state(event.registration_state)))
+            self._emit(
+                RegistrationStateChanged(state=self._registration_state(event.registration_state))
+            )
             return
 
         if event.type == 2:
@@ -552,8 +623,11 @@ class MockVoIPBackend:
         self.running = False
         self.recording_active = False
 
-    def iterate(self) -> None:
-        return
+    def iterate(self) -> int:
+        return 0
+
+    def get_iterate_metrics(self) -> VoIPIterateMetrics | None:
+        return None
 
     def make_call(self, sip_address: str) -> bool:
         self.commands.append(f"call {sip_address}")
@@ -609,5 +683,7 @@ class MockVoIPBackend:
         duration_ms: int,
         mime_type: str,
     ) -> str | None:
-        self.commands.append(f"voice-note {sip_address} {Path(file_path).name} {duration_ms} {mime_type}")
+        self.commands.append(
+            f"voice-note {sip_address} {Path(file_path).name} {duration_ms} {mime_type}"
+        )
         return self.next_voice_note_id

--- a/src/yoyopod/voip/manager.py
+++ b/src/yoyopod/voip/manager.py
@@ -134,10 +134,12 @@ class VoIPManager:
             self._stopping = False
         logger.info("VoIP manager stopped")
 
-    def iterate(self) -> None:
+    def iterate(self) -> int:
+        drained_events = 0
         if self.running:
-            self.backend.iterate()
+            drained_events = self.backend.iterate()
         self._check_active_voice_note_timeout()
+        return drained_events
 
     def make_call(self, sip_address: str, contact_name: str | None = None) -> bool:
         if not self.registered:
@@ -383,6 +385,14 @@ class VoIPManager:
             "sip_identity": self.config.sip_identity,
             "unread_voice_notes": self.unread_voice_note_count(),
         }
+
+    def get_iterate_metrics(self) -> object | None:
+        """Return the latest backend-native keep-alive timing sample when available."""
+
+        get_metrics = getattr(self.backend, "get_iterate_metrics", None)
+        if not callable(get_metrics):
+            return None
+        return get_metrics()
 
     def get_call_duration(self) -> int:
         if self.call_start_time and self.call_state in (

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 import threading
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from types import SimpleNamespace
 from typing import Protocol
 
 import pytest
+from loguru import logger
 
 from yoyopod.app import YoyoPodApp
 from yoyopod.app_context import AppContext
@@ -36,6 +38,7 @@ from yoyopod.fsm import (
     MusicState,
 )
 from yoyopod.power import BatteryState, PowerSnapshot
+from yoyopod.runtime.loop import RuntimeLoopService
 from yoyopod.ui.input import InputManager, InteractionProfile
 
 
@@ -198,6 +201,35 @@ class FakeStoppingVoIPManager:
 
     def stop(self, notify_events: bool = True) -> None:
         self.stop_notify_events.append(notify_events)
+
+
+class FakeRuntimeLoopVoIPManager:
+    """Minimal running VoIP manager double for loop timing diagnostics."""
+
+    def __init__(
+        self,
+        *,
+        native_events: int = 0,
+        native_iterate_seconds: float = 0.0,
+        event_drain_seconds: float = 0.0,
+    ) -> None:
+        self.running = True
+        self.iterate_calls = 0
+        self.native_events = native_events
+        self.native_iterate_seconds = native_iterate_seconds
+        self.event_drain_seconds = event_drain_seconds
+
+    def iterate(self) -> int:
+        self.iterate_calls += 1
+        return self.native_events
+
+    def get_iterate_metrics(self) -> object:
+        return SimpleNamespace(
+            native_duration_seconds=self.native_iterate_seconds,
+            event_drain_duration_seconds=self.event_drain_seconds,
+            total_duration_seconds=self.native_iterate_seconds + self.event_drain_seconds,
+            drained_events=self.native_events,
+        )
 
 
 class FakePowerManager:
@@ -437,9 +469,7 @@ class OrchestrationHarness:
         if call_state is not None:
             self.call_fsm.sync(call_state)
         if music_interrupted_by_call is not None:
-            self.call_interruption_policy.music_interrupted_by_call = (
-                music_interrupted_by_call
-            )
+            self.call_interruption_policy.music_interrupted_by_call = music_interrupted_by_call
         self.runtime.sync_app_state(trigger)
 
     def push_screens(self, *screen_names: str) -> None:
@@ -1324,3 +1354,118 @@ def test_runtime_loop_service_refreshes_visible_power_screen() -> None:
 
     assert updated_at == 1.0
     assert app.power_screen.render_calls > render_calls_before
+
+
+def test_runtime_loop_logs_voip_timing_drift_and_exposes_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """VoIP keep-alive timing should surface in logs and freeze snapshots."""
+
+    app, _, _ = _build_app_with_power(
+        FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+    voip_manager = FakeRuntimeLoopVoIPManager(
+        native_events=3,
+        native_iterate_seconds=0.08,
+        event_drain_seconds=0.03,
+    )
+    app.voip_manager = voip_manager
+    app._voip_iterate_interval_seconds = 0.02
+
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(
+            f"{message.record['extra'].get('subsystem', '')}|{message.record['message']}"
+        ),
+        format="{message}",
+        level="INFO",
+    )
+    monkeypatch.setattr(RuntimeLoopService, "_VOIP_TIMING_SUMMARY_INTERVAL_SECONDS", 0.0)
+    try:
+        app.runtime_loop.run_iteration(
+            monotonic_now=1.0,
+            current_time=1.0,
+            last_screen_update=0.0,
+            screen_update_interval=10.0,
+        )
+        app.runtime_loop.run_iteration(
+            monotonic_now=1.25,
+            current_time=1.25,
+            last_screen_update=1.0,
+            screen_update_interval=10.0,
+        )
+    finally:
+        logger.remove(sink_id)
+
+    log_text = "\n".join(messages)
+    assert "coord|Runtime loop blocked:" in log_text
+    assert "voip|VoIP iterate timing drift:" in log_text
+    assert "voip|VoIP timing window:" in log_text
+    assert "native_iterate_ms=80.0" in log_text
+    assert "event_drain_ms=30.0" in log_text
+    assert "max_native_iterate_ms=80.0" in log_text
+    assert "max_event_drain_ms=30.0" in log_text
+    assert "native_events=3" in log_text
+    assert voip_manager.iterate_calls == 2
+
+    status = app.get_status()
+    assert status["runtime_loop_gap_seconds"] == pytest.approx(0.25)
+    assert status["voip_schedule_delay_seconds"] == pytest.approx(0.23)
+    assert status["voip_iterate_duration_seconds"] is not None
+    assert status["voip_native_iterate_duration_seconds"] == pytest.approx(0.08)
+    assert status["voip_event_drain_duration_seconds"] == pytest.approx(0.03)
+    assert status["voip_iterate_native_events"] == 3
+    assert status["voip_iterate_interval_seconds"] == pytest.approx(0.02)
+
+
+def test_runtime_loop_logs_named_blocking_spans(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Long coordinator steps should identify the blocking span in the logs and status."""
+
+    app, _, _ = _build_app_with_power(
+        FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+    app.voip_manager = FakeRuntimeLoopVoIPManager()
+    app._voip_iterate_interval_seconds = 0.02
+
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(
+            f"{message.record['extra'].get('subsystem', '')}|{message.record['message']}"
+        ),
+        format="{message}",
+        level="INFO",
+    )
+    monkeypatch.setattr(
+        RuntimeLoopService,
+        "_runtime_blocking_span_warning_seconds",
+        lambda self: 0.01,
+    )
+    monkeypatch.setattr(RuntimeLoopService, "_VOIP_TIMING_SUMMARY_INTERVAL_SECONDS", 0.0)
+    original_poll_power_status = app.recovery_service.poll_power_status
+
+    def slow_poll_power_status(*, now: float | None = None, force: bool = False) -> None:
+        time.sleep(0.02)
+        original_poll_power_status(now=now, force=force)
+
+    app.recovery_service.poll_power_status = slow_poll_power_status
+    try:
+        app.runtime_loop.run_iteration(
+            monotonic_now=1.0,
+            current_time=1.0,
+            last_screen_update=0.0,
+            screen_update_interval=10.0,
+        )
+    finally:
+        logger.remove(sink_id)
+
+    log_text = "\n".join(messages)
+    assert "coord|Coordinator blocking span: span=power_poll" in log_text
+    assert "voip|VoIP timing window:" in log_text
+    assert "max_blocking_span=power_poll" in log_text
+
+    status = app.get_status()
+    assert status["runtime_blocking_span_name"] == "power_poll"
+    assert status["runtime_blocking_span_seconds"] is not None
+    assert status["runtime_blocking_span_age_seconds"] is not None

--- a/tests/test_voip_backend.py
+++ b/tests/test_voip_backend.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from cffi import FFI
 
 from yoyopod.voip import (
@@ -93,7 +94,9 @@ class FakeBinding:
     def cancel_voice_recording(self) -> None:
         self.calls.append("cancel-record")
 
-    def send_voice_note(self, sip_address: str, *, file_path: str, duration_ms: int, mime_type: str) -> str:
+    def send_voice_note(
+        self, sip_address: str, *, file_path: str, duration_ms: int, mime_type: str
+    ) -> str:
         self.calls.append(f"voice {sip_address} {file_path} {duration_ms} {mime_type}")
         return "voice-1"
 
@@ -178,7 +181,7 @@ def test_liblinphone_backend_starts_and_drains_native_events() -> None:
             unread=1,
         ),
     ]
-    backend.iterate()
+    drained_events = backend.iterate()
 
     assert isinstance(events[0], RegistrationStateChanged)
     assert events[0].state == RegistrationState.OK
@@ -188,14 +191,15 @@ def test_liblinphone_backend_starts_and_drains_native_events() -> None:
     assert isinstance(events[3], MessageReceived)
     assert events[3].message.kind == MessageKind.VOICE_NOTE
     assert events[3].message.unread is True
+    assert drained_events == 4
     assert binding.start_kwargs["conference_factory_uri"] == ""
     assert binding.start_kwargs["file_transfer_server_url"] == "https://transfer.example.com"
     assert binding.start_kwargs["lime_server_url"] == ""
     assert binding.start_kwargs["mic_gain"] == 0
     assert binding.start_kwargs["output_volume"] == 100
-    assert binding.start_kwargs["factory_config_path"].endswith("config\\liblinphone_factory.conf") or binding.start_kwargs[
-        "factory_config_path"
-    ].endswith("config/liblinphone_factory.conf")
+    assert binding.start_kwargs["factory_config_path"].endswith(
+        "config\\liblinphone_factory.conf"
+    ) or binding.start_kwargs["factory_config_path"].endswith("config/liblinphone_factory.conf")
 
 
 def test_liblinphone_backend_infers_linphone_hosted_servers() -> None:
@@ -210,14 +214,40 @@ def test_liblinphone_backend_infers_linphone_hosted_servers() -> None:
 
     assert backend.start()
     assert (
-        binding.start_kwargs["conference_factory_uri"]
-        == "sip:conference-factory@sip.linphone.org"
+        binding.start_kwargs["conference_factory_uri"] == "sip:conference-factory@sip.linphone.org"
     )
     assert binding.start_kwargs["file_transfer_server_url"] == "https://files.linphone.org/lft.php"
     assert (
         binding.start_kwargs["lime_server_url"]
         == "https://lime.linphone.org/lime-server/lime-server.php"
     )
+
+
+def test_liblinphone_backend_records_native_iterate_timings(monkeypatch) -> None:
+    """Keep-alive diagnostics should separate native iterate time from event-drain time."""
+
+    binding = FakeBinding()
+    binding.events = [native_event(type=1, registration_state=2)]
+    backend = LiblinphoneBackend(build_config(), binding=binding)
+    warnings: list[tuple[object, ...]] = []
+    monotonic_values = iter([10.0, 10.0, 10.18, 10.18, 10.29, 10.31])
+
+    monkeypatch.setattr("yoyopod.voip.backend.time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr("yoyopod.voip.backend.logger.warning", lambda *args: warnings.append(args))
+
+    assert backend.start()
+
+    drained_events = backend.iterate()
+    metrics = backend.get_iterate_metrics()
+
+    assert drained_events == 1
+    assert metrics is not None
+    assert metrics.native_duration_seconds == pytest.approx(0.18)
+    assert metrics.event_drain_duration_seconds == pytest.approx(0.11)
+    assert metrics.total_duration_seconds == pytest.approx(0.31)
+    assert metrics.drained_events == 1
+    assert warnings[0][0].startswith("VoIP keep-alive native iterate slow:")
+    assert warnings[1][0].startswith("VoIP keep-alive event drain slow:")
 
 
 def test_liblinphone_backend_uses_shared_output_volume_and_capture_only_alsa(monkeypatch) -> None:
@@ -376,7 +406,9 @@ def test_voip_manager_fails_voice_note_send_without_transfer_server() -> None:
     assert manager.get_active_voice_note().status_text == "Voice notes unavailable"
 
 
-def test_voip_manager_allows_voice_note_send_for_hosted_linphone_account_without_explicit_url() -> None:
+def test_voip_manager_allows_voice_note_send_for_hosted_linphone_account_without_explicit_url() -> (
+    None
+):
     """Hosted Linphone accounts should use inferred upload settings instead of failing immediately."""
 
     backend = MockVoIPBackend()
@@ -406,10 +438,11 @@ def test_voip_manager_times_out_stuck_voice_note_send() -> None:
     assert manager.send_active_voice_note() is True
 
     manager.get_active_voice_note().send_started_at = time.monotonic() - 30.0
-    manager.iterate()
+    drained_events = manager.iterate()
 
     assert manager.get_active_voice_note().send_state == "failed"
     assert manager.get_active_voice_note().status_text == "Send timed out"
+    assert drained_events == 0
 
 
 def test_voip_manager_surfaces_voice_note_failure_reason() -> None:
@@ -437,7 +470,9 @@ def test_voip_manager_receives_incoming_voice_note_and_updates_summary(tmp_path:
     config.message_store_dir = str(tmp_path / "messages")
     manager = VoIPManager(config, backend=backend)
     summary_events: list[tuple[int, dict[str, dict[str, str]]]] = []
-    manager.on_message_summary_change(lambda unread, summary: summary_events.append((unread, summary)))
+    manager.on_message_summary_change(
+        lambda unread, summary: summary_events.append((unread, summary))
+    )
 
     assert manager.start()
 
@@ -487,7 +522,9 @@ def test_voip_manager_uses_ffplay_for_containerized_voice_notes() -> None:
     ]
 
 
-def test_voip_manager_coerces_rcs_voice_note_envelope_into_voice_note_record(tmp_path: Path) -> None:
+def test_voip_manager_coerces_rcs_voice_note_envelope_into_voice_note_record(
+    tmp_path: Path,
+) -> None:
     """Incoming GSMA file-transfer envelopes for voice recordings should not be stored as plain text."""
 
     backend = MockVoIPBackend()
@@ -513,7 +550,7 @@ def test_voip_manager_coerces_rcs_voice_note_envelope_into_voice_note_record(tmp
                     '<?xml version="1.0" encoding="UTF-8"?>'
                     '<file xmlns="urn:gsma:params:xml:ns:rcs:rcs:fthttp" '
                     'xmlns:am="urn:gsma:params:xml:ns:rcs:rcs:rram">'
-                    "<file-info type=\"file\">"
+                    '<file-info type="file">'
                     "<content-type>audio/wav;voice-recording=yes</content-type>"
                     "<am:playing-length>4046</am:playing-length>"
                     "</file-info>"
@@ -554,7 +591,10 @@ def test_liblinphone_shim_records_voice_notes_as_wav() -> None:
         encoding="utf-8"
     )
 
-    assert "linphone_recorder_params_set_file_format(params, LinphoneRecorderFileFormatWav);" in shim_source
+    assert (
+        "linphone_recorder_params_set_file_format(params, LinphoneRecorderFileFormatWav);"
+        in shim_source
+    )
 
 
 def test_liblinphone_shim_wires_incoming_message_debug_paths() -> None:
@@ -564,24 +604,43 @@ def test_liblinphone_shim_wires_incoming_message_debug_paths() -> None:
         encoding="utf-8"
     )
 
-    assert "linphone_core_cbs_set_messages_received(g_state.core_cbs, yoyopod_on_messages_received);" in shim_source
-    assert "linphone_core_set_chat_messages_aggregation_enabled(g_state.core, FALSE);" in shim_source
+    assert (
+        "linphone_core_cbs_set_messages_received(g_state.core_cbs, yoyopod_on_messages_received);"
+        in shim_source
+    )
+    assert (
+        "linphone_core_set_chat_messages_aggregation_enabled(g_state.core, FALSE);" in shim_source
+    )
     assert "linphone_core_cbs_set_message_received_unable_decrypt(" in shim_source
     assert "linphone_account_params_enable_cpim_in_basic_chat_room(params, TRUE);" in shim_source
-    assert "linphone_account_params_set_conference_factory_address(params, conference_factory_address);" in shim_source
+    assert (
+        "linphone_account_params_set_conference_factory_address(params, conference_factory_address);"
+        in shim_source
+    )
     assert "linphone_account_params_set_lime_server_url(params, lime_server_url);" in shim_source
     assert "linphone_factory_create_chat_room_cbs(g_state.factory);" in shim_source
     assert "linphone_chat_room_add_callbacks(chat_room, g_state.chat_room_cbs);" in shim_source
-    assert "linphone_chat_room_cbs_set_message_received(g_state.chat_room_cbs, yoyopod_on_chat_room_message_received);" in shim_source
+    assert (
+        "linphone_chat_room_cbs_set_message_received(g_state.chat_room_cbs, yoyopod_on_chat_room_message_received);"
+        in shim_source
+    )
     assert "linphone_logging_service_set_log_level_mask(" in shim_source
-    assert "yoyopod_log_account_diagnostics(\"registration_ok\");" in shim_source
+    assert 'yoyopod_log_account_diagnostics("registration_ok");' in shim_source
     assert "linphone_core_search_chat_room(" in shim_source
     assert "linphone_core_create_chat_room_6(" in shim_source
-    assert "linphone_chat_room_params_set_backend(params, LinphoneChatRoomBackendFlexisipChat);" in shim_source
-    assert "linphone_chat_room_params_set_backend(params, LinphoneChatRoomBackendBasic);" in shim_source
+    assert (
+        "linphone_chat_room_params_set_backend(params, LinphoneChatRoomBackendFlexisipChat);"
+        in shim_source
+    )
+    assert (
+        "linphone_chat_room_params_set_backend(params, LinphoneChatRoomBackendBasic);"
+        in shim_source
+    )
     assert "linphone_chat_room_params_enable_encryption(params, FALSE);" in shim_source
-    assert 'voice-recording=yes' in shim_source
-    assert "linphone_core_enable_auto_download_voice_recordings(g_state.core, FALSE);" in shim_source
+    assert "voice-recording=yes" in shim_source
+    assert (
+        "linphone_core_enable_auto_download_voice_recordings(g_state.core, FALSE);" in shim_source
+    )
     assert 'linphone_chat_room_params_set_subject(params, "YoyoPod");' in shim_source
     assert "linphone_core_delete_chat_room(g_state.core, chat_room);" in shim_source
     assert shim_source.count("chat_room = yoyopod_get_direct_chat_room(sip_address);") >= 2


### PR DESCRIPTION
## Summary
- instrument coordinator-side VoIP keep-alive timing drift, native iterate time, event-drain time, and named blocking spans
- expose the new runtime timing snapshot fields for freeze triage and document how to read them on Pi runs
- add focused backend and orchestration coverage for the new diagnostics

Closes #128