### PR TITLE
feat: add responsiveness watchdog capture

### DIFF
--- a/config/yoyopod_config.yaml
+++ b/config/yoyopod_config.yaml
@@ -105,6 +105,15 @@ logging:
   backtrace: true
   diagnose: true
 
+# Investigation-only diagnostics
+diagnostics:
+  responsiveness_watchdog_enabled: false              # Opt-in loop-stall evidence capture for Pi investigations
+  responsiveness_watchdog_poll_interval_seconds: 1.0  # Background watchdog cadence
+  responsiveness_stall_threshold_seconds: 5.0         # Emit evidence when the app loop stops advancing this long
+  responsiveness_capture_cooldown_seconds: 30.0      # Do not recapture repeatedly while a single stall persists
+  responsiveness_recent_input_window_seconds: 3.0    # Treat very recent input as evidence the input side is still alive
+  responsiveness_capture_dir: "logs/responsiveness"  # JSON + traceback artifacts for automatic captures
+
 # 4G Cellular Network Settings
 network:
   enabled: false

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -214,6 +214,37 @@ yoyoctl remote screenshot
 That uses `SIGUSR2`, which captures the same traceback + runtime evidence but prefers the legacy
 shadow-first screenshot path.
 
+### Automatic responsiveness watchdog
+
+For validation runs where you want the app to capture evidence on its own, enable the
+opt-in responsiveness watchdog in `config/yoyopod_config.yaml` or via env vars:
+
+```yaml
+diagnostics:
+  responsiveness_watchdog_enabled: true
+  responsiveness_stall_threshold_seconds: 5.0
+```
+
+What it does:
+
+- watches `loop_heartbeat_age_seconds` in the running app status
+- captures one evidence bundle when the coordinator loop stops advancing past the threshold
+- writes:
+  - `logs/responsiveness/<timestamp>-<reason>.json`
+  - `logs/responsiveness/<timestamp>-<reason>.traceback.txt`
+- logs one summary line to `logs/yoyopod_errors.log` pointing at those artifacts
+
+How to interpret the extra status markers in the JSON bundle:
+
+- `input_activity_age_seconds`: raw or semantic input activity seen by the input side
+- `handled_input_activity_age_seconds`: last input activity the coordinator actually drained
+- `last_input_action` / `last_handled_input_action`: the latest action names on each side
+
+If `input_activity_age_seconds` is fresh but `handled_input_activity_age_seconds` is stale, the
+input side is still alive and the stall is likely between input delivery and the coordinator/UI
+thread. If both are stale and `loop_heartbeat_age_seconds` is also stale, treat it as a broader
+runtime stall.
+
 ### Production systemd service
 
 ```bash

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -128,6 +128,8 @@ When the full app is running, the coordinator-thread timing signals land in
 - `Coordinator blocking span` names the specific runtime step that blocked long enough to threaten keep-alive cadence or UI responsiveness.
 - `Runtime iteration slow` means the total loop iteration stayed on the coordinator thread too long even if the exact hot span was not obvious from a single callback.
 - Freeze snapshots also include `runtime_blocking_span_name`, `runtime_blocking_span_seconds`, and `runtime_blocking_span_age_seconds` so a `SIGUSR1` dump can tell you whether the last blocking span is still fresh or already stale.
+- When `diagnostics.responsiveness_watchdog_enabled=true`, the app also writes automatic evidence bundles under `logs/responsiveness/` once the loop heartbeat stops advancing past the configured threshold.
+- Those bundles include `input_activity_age_seconds` and `handled_input_activity_age_seconds` so you can tell whether input was still arriving while the coordinator/UI side stopped responding.
 
 ### Incoming call debug drill
 

--- a/src/yoyopod/app.py
+++ b/src/yoyopod/app.py
@@ -181,6 +181,10 @@ class YoyoPodApp:
         self._stopping = False
         self._app_started_at = 0.0
         self._last_user_activity_at = 0.0
+        self._last_input_activity_at = 0.0
+        self._last_input_activity_action_name: str | None = None
+        self._last_input_handled_at = 0.0
+        self._last_input_handled_action_name: str | None = None
         self._screen_on_started_at: float | None = 0.0
         self._screen_on_accumulated_seconds = 0.0
         self._screen_timeout_seconds = 0.0
@@ -194,6 +198,11 @@ class YoyoPodApp:
         self._lvgl_input_bridge: Optional[LvglInputBridge] = None
         self._last_lvgl_pump_at = 0.0
         self._last_loop_heartbeat_at = 0.0
+        self._last_responsiveness_capture_at = 0.0
+        self._last_responsiveness_capture_reason: str | None = None
+        self._last_responsiveness_capture_scope: str | None = None
+        self._last_responsiveness_capture_summary: str | None = None
+        self._last_responsiveness_capture_artifacts: dict[str, str] = {}
         self._next_voip_iterate_at = 0.0
         self._voip_iterate_interval_seconds = 0.02
 
@@ -618,6 +627,29 @@ class YoyoPodApp:
         """Marshal screen-state sync work onto the coordinator thread."""
         self.event_bus.publish(ScreenChangedEvent(screen_name=screen_name))
 
+    def note_input_activity(self, action: object, _data: Any | None = None) -> None:
+        """Record raw or semantic input activity before the coordinator drains it."""
+
+        self._last_input_activity_at = time.monotonic()
+        self._last_input_activity_action_name = getattr(action, "value", None)
+
+    def record_responsiveness_capture(
+        self,
+        *,
+        captured_at: float,
+        reason: str,
+        suspected_scope: str,
+        summary: str,
+        artifacts: dict[str, str] | None = None,
+    ) -> None:
+        """Persist the latest automatic hang-evidence capture metadata."""
+
+        self._last_responsiveness_capture_at = captured_at
+        self._last_responsiveness_capture_reason = reason
+        self._last_responsiveness_capture_scope = suspected_scope
+        self._last_responsiveness_capture_summary = summary
+        self._last_responsiveness_capture_artifacts = dict(artifacts or {})
+
     def _sync_screen_changed(self, screen_name: str | None) -> None:
         """Keep the derived base UI state aligned with the active screen."""
         self._ensure_coordinators()
@@ -761,8 +793,23 @@ class YoyoPodApp:
             "screen_stack_depth": (
                 len(self.screen_manager.screen_stack) if self.screen_manager is not None else 0
             ),
+            "input_manager_running": (
+                self.input_manager.running if self.input_manager is not None else False
+            ),
             "pending_main_thread_callbacks": _queue_depth(self._pending_main_thread_callbacks),
             "pending_event_bus_events": self.event_bus.pending_count(),
+            "input_activity_age_seconds": (
+                max(0.0, monotonic_now - self._last_input_activity_at)
+                if self._last_input_activity_at > 0.0
+                else None
+            ),
+            "last_input_action": self._last_input_activity_action_name,
+            "handled_input_activity_age_seconds": (
+                max(0.0, monotonic_now - self._last_input_handled_at)
+                if self._last_input_handled_at > 0.0
+                else None
+            ),
+            "last_handled_input_action": self._last_input_handled_action_name,
             "battery_percent": self.context.battery_percent if self.context else None,
             "battery_charging": self.context.battery_charging if self.context else None,
             "external_power": self.context.external_power if self.context else None,
@@ -848,6 +895,23 @@ class YoyoPodApp:
                 self.power_manager.config.watchdog_feed_interval_seconds
                 if self.power_manager is not None
                 else None
+            ),
+            "responsiveness_watchdog_enabled": bool(
+                getattr(getattr(self.app_settings, "diagnostics", None), "responsiveness_watchdog_enabled", False)
+            ),
+            "responsiveness_capture_dir": (
+                getattr(getattr(self.app_settings, "diagnostics", None), "responsiveness_capture_dir", None)
+            ),
+            "responsiveness_last_capture_age_seconds": (
+                max(0.0, monotonic_now - self._last_responsiveness_capture_at)
+                if self._last_responsiveness_capture_at > 0.0
+                else None
+            ),
+            "responsiveness_last_capture_reason": self._last_responsiveness_capture_reason,
+            "responsiveness_last_capture_scope": self._last_responsiveness_capture_scope,
+            "responsiveness_last_capture_summary": self._last_responsiveness_capture_summary,
+            "responsiveness_last_capture_artifacts": dict(
+                self._last_responsiveness_capture_artifacts
             ),
             **self.runtime_loop.timing_snapshot(now=monotonic_now),
         }

--- a/src/yoyopod/config/models.py
+++ b/src/yoyopod/config/models.py
@@ -387,6 +387,36 @@ class AppLoggingConfig:
 
 
 @dataclass(slots=True)
+class AppDiagnosticsConfig:
+    """Investigation-only runtime diagnostics for target-hardware runs."""
+
+    responsiveness_watchdog_enabled: bool = config_value(
+        default=False,
+        env="YOYOPOD_RESPONSIVENESS_WATCHDOG_ENABLED",
+    )
+    responsiveness_watchdog_poll_interval_seconds: float = config_value(
+        default=1.0,
+        env="YOYOPOD_RESPONSIVENESS_WATCHDOG_POLL_INTERVAL_SECONDS",
+    )
+    responsiveness_stall_threshold_seconds: float = config_value(
+        default=5.0,
+        env="YOYOPOD_RESPONSIVENESS_STALL_THRESHOLD_SECONDS",
+    )
+    responsiveness_capture_cooldown_seconds: float = config_value(
+        default=30.0,
+        env="YOYOPOD_RESPONSIVENESS_CAPTURE_COOLDOWN_SECONDS",
+    )
+    responsiveness_recent_input_window_seconds: float = config_value(
+        default=3.0,
+        env="YOYOPOD_RESPONSIVENESS_RECENT_INPUT_WINDOW_SECONDS",
+    )
+    responsiveness_capture_dir: str = config_value(
+        default="logs/responsiveness",
+        env="YOYOPOD_RESPONSIVENESS_CAPTURE_DIR",
+    )
+
+
+@dataclass(slots=True)
 class YoyoPodConfig:
     """Root application configuration model loaded from yoyopod_config.yaml."""
 
@@ -399,6 +429,7 @@ class YoyoPodConfig:
     power: AppPowerConfig = config_value(default_factory=AppPowerConfig)
     display: AppDisplayConfig = config_value(default_factory=AppDisplayConfig)
     logging: AppLoggingConfig = config_value(default_factory=AppLoggingConfig)
+    diagnostics: AppDiagnosticsConfig = config_value(default_factory=AppDiagnosticsConfig)
     network: AppNetworkConfig = config_value(default_factory=AppNetworkConfig)
 
 

--- a/src/yoyopod/main.py
+++ b/src/yoyopod/main.py
@@ -12,16 +12,18 @@ import json
 import os
 import signal
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from types import FrameType
-from typing import Any, TextIO
+from typing import Any, Mapping, TextIO
 
 from loguru import logger
 
 from yoyopod import __version__
 from yoyopod.app import YoyoPodApp
 from yoyopod.config.models import YoyoPodConfig, load_config_model_from_yaml
+from yoyopod.runtime import ResponsivenessWatchdog, ResponsivenessWatchdogDecision
 from yoyopod.utils.logger import (
     LoggingRuntimeConfig,
     build_logging_runtime_config,
@@ -195,6 +197,50 @@ def _json_safe(value: object) -> object:
     return str(value)
 
 
+def _build_runtime_snapshot_payload(
+    *,
+    app: object,
+    source: str,
+    trigger: str,
+    capture_mode: str | None = None,
+    reason: str | None = None,
+    suspected_scope: str | None = None,
+    summary: str | None = None,
+    status: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Build one JSON-safe runtime snapshot payload for logs or evidence files."""
+
+    payload: dict[str, object] = {
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "source": source,
+        "trigger": trigger,
+    }
+    if capture_mode is not None:
+        payload["capture_mode"] = capture_mode
+    if reason is not None:
+        payload["reason"] = reason
+    if suspected_scope is not None:
+        payload["suspected_scope"] = suspected_scope
+    if summary is not None:
+        payload["summary"] = summary
+
+    snapshot_status = status
+    if snapshot_status is None:
+        get_status = getattr(app, "get_status", None)
+        if callable(get_status):
+            try:
+                snapshot_status = get_status()
+            except Exception as exc:
+                payload["status_error"] = str(exc)
+        else:
+            payload["status_error"] = "app does not expose get_status()"
+
+    if snapshot_status is not None:
+        payload["status"] = _json_safe(snapshot_status)
+
+    return payload
+
+
 def _log_signal_snapshot(
     *,
     app: object,
@@ -204,21 +250,126 @@ def _log_signal_snapshot(
 ) -> None:
     """Emit one structured runtime snapshot to the error log on demand."""
 
-    payload: dict[str, object] = {
-        "captured_at": datetime.now(timezone.utc).isoformat(),
-        "capture_mode": "readback-first" if prefer_readback else "shadow-first",
-        "signal": signal_name,
-    }
-    get_status = getattr(app, "get_status", None)
-    if callable(get_status):
-        try:
-            payload["status"] = _json_safe(get_status())
-        except Exception as exc:
-            payload["status_error"] = str(exc)
-    else:
-        payload["status_error"] = "app does not expose get_status()"
-
+    payload = _build_runtime_snapshot_payload(
+        app=app,
+        source="signal_snapshot",
+        trigger=signal_name,
+        capture_mode="readback-first" if prefer_readback else "shadow-first",
+        status=None,
+    )
+    payload["signal"] = signal_name
     app_log.error("Freeze diagnostics snapshot: {}", json.dumps(payload, sort_keys=True))
+
+
+def _resolve_responsiveness_capture_dir(app: object) -> Path:
+    """Resolve the configured directory for automatic watchdog evidence files."""
+
+    app_settings = getattr(app, "app_settings", None)
+    diagnostics = getattr(app_settings, "diagnostics", None)
+    raw_capture_dir = getattr(diagnostics, "responsiveness_capture_dir", "logs/responsiveness")
+    capture_dir = Path(str(raw_capture_dir))
+    if not capture_dir.is_absolute():
+        capture_dir = Path.cwd() / capture_dir
+    return capture_dir
+
+
+def _append_traceback_dump(
+    *,
+    dump_path: Path,
+    app_log: Any,
+    header: str,
+) -> bool:
+    """Write one all-thread traceback dump to the provided file path."""
+
+    dump_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with dump_path.open("a", encoding="utf-8", buffering=1) as dump_stream:
+            dump_stream.write(f"{header}\n")
+            faulthandler.dump_traceback(file=dump_stream, all_threads=True)
+            dump_stream.write("\n")
+    except OSError as exc:
+        app_log.warning("Failed to write traceback dump {}: {}", dump_path, exc)
+        return False
+    return True
+
+
+def _capture_responsiveness_watchdog_evidence(
+    *,
+    app: object,
+    app_log: Any,
+    error_log_path: Path,
+    decision: ResponsivenessWatchdogDecision,
+    status: Mapping[str, object],
+) -> None:
+    """Persist one automatic responsiveness capture and announce where it landed."""
+
+    payload = _build_runtime_snapshot_payload(
+        app=app,
+        source="responsiveness_watchdog",
+        trigger=decision.reason,
+        reason=decision.reason,
+        suspected_scope=decision.suspected_scope,
+        summary=decision.summary,
+        status=status,
+    )
+    capture_dir = _resolve_responsiveness_capture_dir(app)
+    capture_dir.mkdir(parents=True, exist_ok=True)
+
+    captured_at = payload["captured_at"]
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    stem = f"{timestamp}-{decision.reason}"
+    snapshot_path = capture_dir / f"{stem}.json"
+    snapshot_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    traceback_path = capture_dir / f"{stem}.traceback.txt"
+    _append_traceback_dump(
+        dump_path=traceback_path,
+        app_log=app_log,
+        header=(
+            f"=== Responsiveness watchdog capture at {captured_at} "
+            f"reason={decision.reason} scope={decision.suspected_scope} ==="
+        ),
+    )
+
+    record_capture = getattr(app, "record_responsiveness_capture", None)
+    artifacts = {
+        "snapshot": str(snapshot_path),
+        "traceback": str(traceback_path),
+        "error_log": str(error_log_path),
+    }
+    if callable(record_capture):
+        record_capture(
+            captured_at=time.monotonic(),
+            reason=decision.reason,
+            suspected_scope=decision.suspected_scope,
+            summary=decision.summary,
+            artifacts=artifacts,
+        )
+
+    app_log.error(
+        "Responsiveness watchdog captured evidence: {}",
+        json.dumps(
+            {
+                "captured_at": captured_at,
+                "reason": decision.reason,
+                "suspected_scope": decision.suspected_scope,
+                "summary": decision.summary,
+                "snapshot_path": str(snapshot_path),
+                "traceback_path": str(traceback_path),
+                "loop_heartbeat_age_seconds": status.get("loop_heartbeat_age_seconds"),
+                "input_activity_age_seconds": status.get("input_activity_age_seconds"),
+                "handled_input_activity_age_seconds": status.get(
+                    "handled_input_activity_age_seconds"
+                ),
+                "current_screen": status.get("current_screen"),
+                "state": status.get("state"),
+            },
+            sort_keys=True,
+        ),
+    )
 
 
 def _install_traceback_dump_handlers(
@@ -291,6 +442,7 @@ def main() -> int:
     startup_logged = False
     traceback_dump_stream: TextIO | None = None
     registered_traceback_signals: tuple[int, ...] = ()
+    responsiveness_watchdog: ResponsivenessWatchdog | None = None
 
     write_pid_file(logging_config.pid_file, pid)
 
@@ -399,6 +551,26 @@ def main() -> int:
                 screenshot_path,
             )
 
+        diagnostics = app.app_settings.diagnostics if app.app_settings is not None else None
+        if diagnostics is not None and diagnostics.responsiveness_watchdog_enabled and not simulate:
+            responsiveness_watchdog = ResponsivenessWatchdog(
+                status_provider=app.get_status,
+                capture_callback=lambda decision, status: _capture_responsiveness_watchdog_evidence(
+                    app=app,
+                    app_log=app_log,
+                    error_log_path=logging_config.error_log_file,
+                    decision=decision,
+                    status=status,
+                ),
+                stall_threshold_seconds=diagnostics.responsiveness_stall_threshold_seconds,
+                recent_input_window_seconds=(
+                    diagnostics.responsiveness_recent_input_window_seconds
+                ),
+                poll_interval_seconds=(diagnostics.responsiveness_watchdog_poll_interval_seconds),
+                capture_cooldown_seconds=(diagnostics.responsiveness_capture_cooldown_seconds),
+            )
+            responsiveness_watchdog.start()
+
         exit_code = 0
         try:
             app.run()
@@ -408,6 +580,8 @@ def main() -> int:
             logger.exception("Unhandled exception escaped the YoyoPod main loop")
             exit_code = 1
         finally:
+            if responsiveness_watchdog is not None:
+                responsiveness_watchdog.stop()
             _uninstall_traceback_dump_handlers(
                 signals=registered_traceback_signals,
                 dump_stream=traceback_dump_stream,

--- a/src/yoyopod/runtime/__init__.py
+++ b/src/yoyopod/runtime/__init__.py
@@ -3,6 +3,11 @@
 from yoyopod.runtime.loop import RuntimeLoopService
 from yoyopod.runtime.models import PendingShutdown, PowerAlert, RecoveryState
 from yoyopod.runtime.recovery import RecoverySupervisor
+from yoyopod.runtime.responsiveness import (
+    ResponsivenessWatchdog,
+    ResponsivenessWatchdogDecision,
+    evaluate_responsiveness_status,
+)
 from yoyopod.runtime.screen_power import ScreenPowerService
 from yoyopod.runtime.shutdown import ShutdownLifecycleService
 from yoyopod.runtime.voice import (
@@ -17,6 +22,8 @@ __all__ = [
     "PowerAlert",
     "RecoveryState",
     "RecoverySupervisor",
+    "ResponsivenessWatchdog",
+    "ResponsivenessWatchdogDecision",
     "RuntimeBootService",
     "RuntimeLoopService",
     "ScreenPowerService",
@@ -25,6 +32,7 @@ __all__ = [
     "VoiceCommandOutcome",
     "VoiceRuntimeCoordinator",
     "VoiceSettingsResolver",
+    "evaluate_responsiveness_status",
 ]
 
 

--- a/src/yoyopod/runtime/boot.py
+++ b/src/yoyopod/runtime/boot.py
@@ -233,6 +233,7 @@ class RuntimeBootService:
             )
             if self.app.input_manager:
                 self.app.context.interaction_profile = self.app.input_manager.interaction_profile
+                self.app.input_manager.on_activity(self.app.note_input_activity)
                 self.app.input_manager.on_activity(
                     self.app.screen_power_service.queue_user_activity_event
                 )

--- a/src/yoyopod/runtime/responsiveness.py
+++ b/src/yoyopod/runtime/responsiveness.py
@@ -1,0 +1,228 @@
+"""Opt-in responsiveness watchdog for target-hardware investigations."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Mapping
+
+from yoyopod.utils.logger import get_subsystem_logger
+
+app_logger = get_subsystem_logger("app")
+
+StatusProvider = Callable[[], Mapping[str, object]]
+CaptureCallback = Callable[["ResponsivenessWatchdogDecision", Mapping[str, object]], None]
+TimeProvider = Callable[[], float]
+
+
+@dataclass(frozen=True, slots=True)
+class ResponsivenessWatchdogDecision:
+    """Normalized watchdog decision describing why evidence should be captured."""
+
+    reason: str
+    suspected_scope: str
+    summary: str
+
+
+def evaluate_responsiveness_status(
+    status: Mapping[str, object],
+    *,
+    stall_threshold_seconds: float,
+    recent_input_window_seconds: float,
+) -> ResponsivenessWatchdogDecision | None:
+    """Return one capture decision when the runtime looks unresponsive."""
+
+    loop_age = _coerce_float(status.get("loop_heartbeat_age_seconds"))
+    if loop_age is None or loop_age < max(0.1, stall_threshold_seconds):
+        return None
+
+    input_age = _coerce_float(status.get("input_activity_age_seconds"))
+    handled_input_age = _coerce_float(status.get("handled_input_activity_age_seconds"))
+    lvgl_age = _coerce_float(status.get("lvgl_pump_age_seconds"))
+    pending_callbacks = max(0, _coerce_int(status.get("pending_main_thread_callbacks")) or 0)
+    pending_events = max(0, _coerce_int(status.get("pending_event_bus_events")) or 0)
+    last_input_action = str(status.get("last_input_action") or "none")
+    last_handled_input_action = str(status.get("last_handled_input_action") or "none")
+    current_screen = str(status.get("current_screen") or "none")
+    current_state = str(status.get("state") or "unknown")
+    display_backend = str(status.get("display_backend") or "unknown")
+
+    recent_input = input_age is not None and input_age <= max(0.1, recent_input_window_seconds)
+    handled_input_lagging = recent_input and (
+        handled_input_age is None
+        or handled_input_age >= stall_threshold_seconds
+        or handled_input_age > (input_age + 0.5)
+    )
+    if handled_input_lagging:
+        handled_text = "never" if handled_input_age is None else f"{handled_input_age:.1f}s"
+        return ResponsivenessWatchdogDecision(
+            reason="coordinator_stall_after_input",
+            suspected_scope="input_to_runtime_handoff",
+            summary=(
+                "Loop heartbeat stalled at "
+                f"{loop_age:.1f}s while input stayed alive (input_age={input_age:.1f}s, "
+                f"handled_input_age={handled_text}, last_input={last_input_action}, "
+                f"last_handled_input={last_handled_input_action}, "
+                f"pending_callbacks={pending_callbacks}, pending_events={pending_events}, "
+                f"screen={current_screen}, state={current_state})"
+            ),
+        )
+
+    if pending_callbacks > 0 or pending_events > 0:
+        return ResponsivenessWatchdogDecision(
+            reason="coordinator_stall_with_pending_work",
+            suspected_scope="runtime",
+            summary=(
+                "Loop heartbeat stalled at "
+                f"{loop_age:.1f}s with queued work pending "
+                f"(callbacks={pending_callbacks}, events={pending_events}, "
+                f"screen={current_screen}, state={current_state})"
+            ),
+        )
+
+    if (
+        display_backend == "lvgl"
+        and lvgl_age is not None
+        and lvgl_age >= stall_threshold_seconds
+    ):
+        return ResponsivenessWatchdogDecision(
+            reason="ui_and_runtime_stall",
+            suspected_scope="ui_and_runtime",
+            summary=(
+                "Loop and LVGL pump both stopped advancing "
+                f"(loop_age={loop_age:.1f}s, lvgl_age={lvgl_age:.1f}s, "
+                f"screen={current_screen}, state={current_state})"
+            ),
+        )
+
+    return ResponsivenessWatchdogDecision(
+        reason="broad_runtime_stall",
+        suspected_scope="runtime",
+        summary=(
+            "Loop heartbeat stalled without fresh input evidence "
+            f"(loop_age={loop_age:.1f}s, screen={current_screen}, state={current_state})"
+        ),
+    )
+
+
+class ResponsivenessWatchdog:
+    """Background observer that captures evidence when the app loop stops advancing."""
+
+    def __init__(
+        self,
+        *,
+        status_provider: StatusProvider,
+        capture_callback: CaptureCallback,
+        stall_threshold_seconds: float,
+        recent_input_window_seconds: float,
+        poll_interval_seconds: float,
+        capture_cooldown_seconds: float,
+        time_provider: TimeProvider | None = None,
+    ) -> None:
+        self._status_provider = status_provider
+        self._capture_callback = capture_callback
+        self._stall_threshold_seconds = max(0.1, float(stall_threshold_seconds))
+        self._recent_input_window_seconds = max(
+            0.1,
+            float(recent_input_window_seconds),
+        )
+        self._poll_interval_seconds = max(0.1, float(poll_interval_seconds))
+        self._capture_cooldown_seconds = max(0.0, float(capture_cooldown_seconds))
+        self._time_provider = time.monotonic if time_provider is None else time_provider
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._stall_active = False
+        self._last_capture_at = 0.0
+
+    def start(self) -> None:
+        """Start the background watchdog thread once."""
+        if self._thread is not None:
+            return
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name="responsiveness-watchdog",
+        )
+        self._thread.start()
+        app_logger.info(
+            "Responsiveness watchdog armed (threshold={}s, poll={}s)",
+            self._stall_threshold_seconds,
+            self._poll_interval_seconds,
+        )
+
+    def stop(self, *, timeout_seconds: float = 2.0) -> None:
+        """Stop the background watchdog thread."""
+        thread = self._thread
+        if thread is None:
+            return
+
+        self._stop_event.set()
+        thread.join(timeout=max(0.1, timeout_seconds))
+        self._thread = None
+        app_logger.info("Responsiveness watchdog stopped")
+
+    def poll_once(self) -> ResponsivenessWatchdogDecision | None:
+        """Run one check cycle and capture evidence when needed."""
+
+        try:
+            status = self._status_provider()
+        except Exception:
+            app_logger.exception("Responsiveness watchdog failed to collect status")
+            return None
+
+        decision = evaluate_responsiveness_status(
+            status,
+            stall_threshold_seconds=self._stall_threshold_seconds,
+            recent_input_window_seconds=self._recent_input_window_seconds,
+        )
+        if decision is None:
+            self._stall_active = False
+            return None
+
+        now = self._time_provider()
+        if self._stall_active:
+            return None
+        if (
+            self._last_capture_at > 0.0
+            and (now - self._last_capture_at) < self._capture_cooldown_seconds
+        ):
+            self._stall_active = True
+            return None
+
+        self._stall_active = True
+        self._last_capture_at = now
+        try:
+            self._capture_callback(decision, status)
+        except Exception:
+            app_logger.exception("Responsiveness watchdog capture failed")
+        return decision
+
+    def _run(self) -> None:
+        """Background watchdog loop."""
+        while not self._stop_event.wait(self._poll_interval_seconds):
+            self.poll_once()
+
+
+def _coerce_float(value: object) -> float | None:
+    """Best-effort float conversion for status values."""
+
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: object) -> int | None:
+    """Best-effort integer conversion for status values."""
+
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/yoyopod/runtime/screen_power.py
+++ b/src/yoyopod/runtime/screen_power.py
@@ -70,8 +70,11 @@ class ScreenPowerService:
     def handle_user_activity_event(self, event: UserActivityEvent) -> None:
         """Wake the display and reset the inactivity timer on user activity."""
         logger.debug(f"User activity received: {event.action_name or 'unknown'}")
+        handled_now = time.monotonic()
+        self.app._last_input_handled_at = handled_now
+        self.app._last_input_handled_action_name = event.action_name
         self.mark_user_activity(
-            now=time.monotonic(),
+            now=handled_now,
             render_on_wake=event.action_name is not None,
         )
 

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -1027,6 +1027,35 @@ def test_user_activity_event_wakes_screen_and_refreshes_current_screen() -> None
     assert app.menu_screen.render_calls == render_calls_before + 1
 
 
+def test_status_exposes_input_and_responsiveness_markers() -> None:
+    """Diagnostics status should distinguish raw input liveness from handled input."""
+
+    app, _, _ = _build_app(playback_state="stopped")
+
+    app.note_input_activity(SimpleNamespace(value="select"))
+    _publish_from_worker(app, UserActivityEvent(action_name="select"))
+
+    assert app.event_bus.drain() == 1
+
+    app.record_responsiveness_capture(
+        captured_at=time.monotonic(),
+        reason="coordinator_stall_after_input",
+        suspected_scope="input_to_runtime_handoff",
+        summary="test capture",
+        artifacts={"snapshot": "/tmp/test.json"},
+    )
+
+    status = app.get_status()
+
+    assert status["input_activity_age_seconds"] is not None
+    assert status["last_input_action"] == "select"
+    assert status["handled_input_activity_age_seconds"] is not None
+    assert status["last_handled_input_action"] == "select"
+    assert status["responsiveness_last_capture_reason"] == "coordinator_stall_after_input"
+    assert status["responsiveness_last_capture_scope"] == "input_to_runtime_handoff"
+    assert status["responsiveness_last_capture_artifacts"] == {"snapshot": "/tmp/test.json"}
+
+
 def test_raw_user_activity_wakes_screen_without_rerendering_current_pil_screen() -> None:
     """Raw button activity should wake the screen without flashing the current view."""
 

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -74,6 +74,12 @@ def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> Non
     assert settings.logging.enqueue is False
     assert settings.logging.backtrace is True
     assert settings.logging.diagnose is True
+    assert settings.diagnostics.responsiveness_watchdog_enabled is False
+    assert settings.diagnostics.responsiveness_watchdog_poll_interval_seconds == 1.0
+    assert settings.diagnostics.responsiveness_stall_threshold_seconds == 5.0
+    assert settings.diagnostics.responsiveness_capture_cooldown_seconds == 30.0
+    assert settings.diagnostics.responsiveness_recent_input_window_seconds == 3.0
+    assert settings.diagnostics.responsiveness_capture_dir == "logs/responsiveness"
 
 
 def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) -> None:
@@ -125,6 +131,9 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     monkeypatch.setenv("YOYOPOD_ERROR_LOG_FILE", "/var/log/yoyopod_errors.log")
     monkeypatch.setenv("YOYOPOD_PID_FILE", "/run/yoyopod.pid")
     monkeypatch.setenv("YOYOPOD_LOG_ENQUEUE", "true")
+    monkeypatch.setenv("YOYOPOD_RESPONSIVENESS_WATCHDOG_ENABLED", "true")
+    monkeypatch.setenv("YOYOPOD_RESPONSIVENESS_STALL_THRESHOLD_SECONDS", "8.0")
+    monkeypatch.setenv("YOYOPOD_RESPONSIVENESS_CAPTURE_DIR", "/tmp/yoyopod-watchdog")
 
     config_manager = ConfigManager(config_dir=str(tmp_path))
     settings = config_manager.get_app_settings()
@@ -160,6 +169,9 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     assert settings.logging.error_file == "/var/log/yoyopod_errors.log"
     assert settings.logging.pid_file == "/run/yoyopod.pid"
     assert settings.logging.enqueue is True
+    assert settings.diagnostics.responsiveness_watchdog_enabled is True
+    assert settings.diagnostics.responsiveness_stall_threshold_seconds == 8.0
+    assert settings.diagnostics.responsiveness_capture_dir == "/tmp/yoyopod-watchdog"
     assert config_dict["audio"]["music_dir"] == "/srv/music"
     assert config_dict["audio"]["mpv_socket"] == "/tmp/test-mpv.sock"
     assert "listen_sources" not in config_dict["audio"]
@@ -170,6 +182,7 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     assert config_dict["voice"]["screen_read_enabled"] is True
     assert config_dict["voice"]["vosk_model_path"] == "/srv/models/vosk-small"
     assert config_dict["logging"]["file"] == "/var/log/yoyopod.log"
+    assert config_dict["diagnostics"]["responsiveness_watchdog_enabled"] is True
 
 
 def test_config_manager_keeps_typed_voip_audio_settings(tmp_path, monkeypatch) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -201,6 +201,72 @@ def test_log_signal_snapshot_serializes_runtime_state() -> None:
     assert payload["status"]["recent_calls"][0]["when"] == "2026-04-15T23:59:00+00:00"
 
 
+def test_capture_responsiveness_watchdog_evidence_writes_artifacts(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Automatic watchdog captures should write a JSON snapshot and traceback artifact."""
+
+    logs: list[tuple[object, ...]] = []
+    fake_log = SimpleNamespace(
+        error=lambda *args: logs.append(args),
+        warning=lambda *args: logs.append(args),
+    )
+    capture_dir = tmp_path / "captures"
+    recorded: list[dict[str, object]] = []
+
+    class App:
+        app_settings = SimpleNamespace(
+            diagnostics=SimpleNamespace(responsiveness_capture_dir=str(capture_dir))
+        )
+
+        def record_responsiveness_capture(self, **kwargs) -> None:
+            recorded.append(kwargs)
+
+    monkeypatch.setattr(
+        main_module.faulthandler,
+        "dump_traceback",
+        lambda *, file, all_threads: file.write(
+            f"TRACEBACK all_threads={all_threads}\n"
+        ),
+    )
+
+    decision = main_module.ResponsivenessWatchdogDecision(
+        reason="coordinator_stall_after_input",
+        suspected_scope="input_to_runtime_handoff",
+        summary="input kept moving but the coordinator stalled",
+    )
+    status = {
+        "state": "menu",
+        "current_screen": "menu",
+        "loop_heartbeat_age_seconds": 6.0,
+        "input_activity_age_seconds": 0.4,
+        "handled_input_activity_age_seconds": 6.2,
+    }
+
+    main_module._capture_responsiveness_watchdog_evidence(
+        app=App(),
+        app_log=fake_log,
+        error_log_path=tmp_path / "yoyopod_errors.log",
+        decision=decision,
+        status=status,
+    )
+
+    snapshot_files = sorted(capture_dir.glob("*.json"))
+    traceback_files = sorted(capture_dir.glob("*.traceback.txt"))
+
+    assert len(snapshot_files) == 1
+    assert len(traceback_files) == 1
+    snapshot_payload = json.loads(snapshot_files[0].read_text(encoding="utf-8"))
+    assert snapshot_payload["source"] == "responsiveness_watchdog"
+    assert snapshot_payload["reason"] == "coordinator_stall_after_input"
+    assert snapshot_payload["status"]["loop_heartbeat_age_seconds"] == 6.0
+    assert "TRACEBACK all_threads=True" in traceback_files[0].read_text(encoding="utf-8")
+    assert recorded[0]["reason"] == "coordinator_stall_after_input"
+    assert recorded[0]["artifacts"]["snapshot"] == str(snapshot_files[0])
+    assert logs[-1][0] == "Responsiveness watchdog captured evidence: {}"
+
+
 def test_install_traceback_dump_handlers_registers_faulthandler_chain(
     monkeypatch,
     tmp_path,

--- a/tests/test_responsiveness_watchdog.py
+++ b/tests/test_responsiveness_watchdog.py
@@ -1,0 +1,120 @@
+"""Tests for the opt-in responsiveness watchdog."""
+
+from __future__ import annotations
+
+from yoyopod.runtime.responsiveness import (
+    ResponsivenessWatchdog,
+    evaluate_responsiveness_status,
+)
+
+
+def _status(**overrides: object) -> dict[str, object]:
+    status = {
+        "state": "menu",
+        "current_screen": "menu",
+        "display_backend": "lvgl",
+        "loop_heartbeat_age_seconds": 0.1,
+        "lvgl_pump_age_seconds": 0.1,
+        "pending_main_thread_callbacks": 0,
+        "pending_event_bus_events": 0,
+        "input_activity_age_seconds": None,
+        "handled_input_activity_age_seconds": None,
+        "last_input_action": None,
+        "last_handled_input_action": None,
+    }
+    status.update(overrides)
+    return status
+
+
+def test_evaluate_responsiveness_status_ignores_healthy_loop() -> None:
+    """Healthy loop heartbeats should not trigger automatic evidence capture."""
+
+    decision = evaluate_responsiveness_status(
+        _status(loop_heartbeat_age_seconds=0.8),
+        stall_threshold_seconds=5.0,
+        recent_input_window_seconds=3.0,
+    )
+
+    assert decision is None
+
+
+def test_evaluate_responsiveness_status_flags_recent_input_handoff_stall() -> None:
+    """Recent raw input with a stale coordinator heartbeat should point at the handoff seam."""
+
+    decision = evaluate_responsiveness_status(
+        _status(
+            loop_heartbeat_age_seconds=6.5,
+            input_activity_age_seconds=0.4,
+            handled_input_activity_age_seconds=7.1,
+            last_input_action="select",
+            last_handled_input_action="back",
+        ),
+        stall_threshold_seconds=5.0,
+        recent_input_window_seconds=3.0,
+    )
+
+    assert decision is not None
+    assert decision.reason == "coordinator_stall_after_input"
+    assert decision.suspected_scope == "input_to_runtime_handoff"
+    assert "last_input=select" in decision.summary
+
+
+def test_evaluate_responsiveness_status_flags_pending_work_stall() -> None:
+    """Queued callbacks or events should be surfaced as broader runtime stalls."""
+
+    decision = evaluate_responsiveness_status(
+        _status(
+            loop_heartbeat_age_seconds=5.5,
+            pending_main_thread_callbacks=2,
+            pending_event_bus_events=1,
+        ),
+        stall_threshold_seconds=5.0,
+        recent_input_window_seconds=3.0,
+    )
+
+    assert decision is not None
+    assert decision.reason == "coordinator_stall_with_pending_work"
+    assert decision.suspected_scope == "runtime"
+
+
+def test_watchdog_captures_once_per_stall_until_recovery() -> None:
+    """A persistent stall should capture once, then arm again only after recovery."""
+
+    current_status = _status(
+        loop_heartbeat_age_seconds=6.0,
+        pending_main_thread_callbacks=1,
+    )
+    captures: list[str] = []
+    now = [0.0]
+
+    watchdog = ResponsivenessWatchdog(
+        status_provider=lambda: current_status,
+        capture_callback=lambda decision, status: captures.append(
+            f"{decision.reason}:{status['loop_heartbeat_age_seconds']}"
+        ),
+        stall_threshold_seconds=5.0,
+        recent_input_window_seconds=3.0,
+        poll_interval_seconds=1.0,
+        capture_cooldown_seconds=10.0,
+        time_provider=lambda: now[0],
+    )
+
+    first = watchdog.poll_once()
+    second = watchdog.poll_once()
+
+    assert first is not None
+    assert second is None
+    assert captures == ["coordinator_stall_with_pending_work:6.0"]
+
+    current_status["loop_heartbeat_age_seconds"] = 0.2
+    assert watchdog.poll_once() is None
+
+    current_status["loop_heartbeat_age_seconds"] = 6.0
+    now[0] = 20.0
+    third = watchdog.poll_once()
+
+    assert third is not None
+    assert captures == [
+        "coordinator_stall_with_pending_work:6.0",
+        "coordinator_stall_with_pending_work:6.0",
+    ]


### PR DESCRIPTION
## Summary
- add a configurable responsiveness watchdog with evidence capture hooks for app stalls
- surface watchdog configuration in runtime settings and document how to use it during Pi validation
- cover the watchdog flow with focused runtime and orchestration tests

## Validation
- uv run pytest -q tests/test_responsiveness_watchdog.py tests/test_app_orchestration.py tests/test_config_models.py tests/test_main.py
- uv run python scripts/quality.py gate
- uv run pytest -q

Closes #129