### PR TITLE
[codex] add yoyoctl target validation suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ When asked to deploy, sync, restart, check status, view logs, or take a screensh
 - Production local music now runs through the app-managed mpv backend under `src/yoyopod/audio/music/`.
 - Production VoIP now runs through Liblinphone under `src/yoyopod/voip/liblinphone_binding/` and `src/yoyopod/voip/backend.py`.
 - CI validates the staged quality gate plus Python test suite; the local mirror is `uv run python scripts/quality.py ci`.
-- Raspberry Pi validation has a defined path through `yoyoctl pi smoke` and `yoyoctl remote`.
+- Raspberry Pi validation has a defined path through the `yoyoctl pi validate` suite and `yoyoctl remote`.
 
 This file should reflect the repo as it exists on `main`. Older milestone notes are useful for history, but they are not the source of truth anymore.
 
@@ -306,12 +306,14 @@ yoyoctl remote power --host rpi-zero
 yoyoctl remote service install --host rpi-zero
 ```
 
-Direct smoke helper on the Pi:
+Direct target validation helpers on the Pi:
 
 ```bash
-yoyoctl pi smoke
-yoyoctl pi smoke --with-music --with-voip
-yoyoctl pi lvgl soak
+yoyoctl pi validate deploy
+yoyoctl pi validate smoke
+yoyoctl pi validate music
+yoyoctl pi validate voip
+yoyoctl pi validate stability
 ```
 
 If the Pi seems to keep old Python state after a pull, restart the running app process before retesting.
@@ -377,7 +379,7 @@ These old names are no longer correct:
 - `tests/test_voip_registration.py` -> use `yoyoctl pi voip check`
 - `tests/test_incoming_call_debug.py` -> use `yoyoctl pi voip debug`
 - `scripts/pi_remote.py` -> use `yoyoctl remote`
-- `scripts/pi_smoke.py` -> use `yoyoctl pi smoke`
+- `scripts/pi_smoke.py` -> use `yoyoctl pi validate smoke` or the focused `yoyoctl pi validate` subcommands
 - `scripts/check_voip_registration.py` -> use `yoyoctl pi voip check`
 - `scripts/debug_incoming_call.py` -> use `yoyoctl pi voip debug`
 - `scripts/pisugar_power.py` -> use `yoyoctl pi power battery`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ uv run yoyoctl setup host
 uv run yoyoctl setup verify-host
 python yoyopod.py --simulate
 uv run python scripts/quality.py ci
+yoyoctl pi validate smoke
 ```
 
 For the full setup, validation, and Pi workflow, start with:

--- a/docs/CONTRIBUTOR_WORKFLOW.md
+++ b/docs/CONTRIBUTOR_WORKFLOW.md
@@ -86,6 +86,8 @@ Baseline commands:
 ```bash
 uv run yoyoctl setup pi
 uv run yoyoctl setup verify-pi
+yoyoctl pi validate deploy
+yoyoctl pi validate smoke
 uv run yoyoctl remote setup
 uv run yoyoctl remote verify-setup
 ```

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -140,13 +140,15 @@ uv run python scripts/quality.py audit
 
 The staged gate contract and exact target set live in [`QUALITY_GATES.md`](QUALITY_GATES.md).
 
-Pi smoke:
+Target-side validation suite:
 
 ```bash
-yoyoctl pi smoke
-yoyoctl pi smoke --with-music --with-voip
-yoyoctl pi smoke --with-power --with-rtc
-yoyoctl pi lvgl soak
+yoyoctl pi validate deploy
+yoyoctl pi validate smoke
+yoyoctl pi validate smoke --with-power --with-rtc
+yoyoctl pi validate music
+yoyoctl pi validate voip
+yoyoctl pi validate stability
 ```
 
 ## Raspberry Pi Workflow

--- a/docs/MPV_DEPENDENCIES.md
+++ b/docs/MPV_DEPENDENCIES.md
@@ -70,7 +70,7 @@ Notes:
 
 ```bash
 pgrep -af mpv
-yoyoctl pi smoke --with-music
+yoyoctl pi validate music
 yoyoctl remote smoke --with-music
 yoyoctl remote logs --filter music --lines 100
 ```

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -102,11 +102,12 @@ yoyoctl remote validate --branch <branch> --sha <commit> --skip-uv-sync
 2. verifies the requested branch is pushed
 3. syncs the stable Pi checkout to the branch and exact SHA
 4. runs `uv sync --extra dev` unless skipped
-5. runs the requested smoke checks
-6. restarts the app
-7. verifies startup with the PID file and startup marker
-8. prints the latest startup marker and recent logs
-9. leaves the app running for manual testing
+5. runs `yoyoctl pi validate deploy`
+6. runs the requested target-side validation checks
+7. restarts the app
+8. verifies startup with the PID file and startup marker
+9. prints the latest startup marker and recent logs
+10. leaves the app running for manual testing
 
 ## Lower-Level Commands
 
@@ -143,6 +144,13 @@ yoyoctl remote smoke --with-power --with-rtc
 yoyoctl remote smoke --with-music --with-voip --with-rtc
 yoyoctl remote smoke --with-lvgl-soak
 ```
+
+This composes the target-side suite:
+
+- `yoyoctl pi validate smoke`
+- `yoyoctl pi validate music`
+- `yoyoctl pi validate voip`
+- `yoyoctl pi validate stability`
 
 Useful variations:
 

--- a/docs/POWER_MODULE.md
+++ b/docs/POWER_MODULE.md
@@ -300,13 +300,13 @@ yoyoctl remote power --host rpi-zero
 Smoke validation:
 
 ```bash
-yoyoctl pi smoke --with-power
-yoyoctl pi smoke --with-power --with-rtc
+yoyoctl pi validate smoke --with-power
+yoyoctl pi validate smoke --with-power --with-rtc
 ```
 
 Recommended hardware sequence:
 1. `uv run pytest -q`
-2. `yoyoctl pi smoke --with-power --with-rtc`
+2. `yoyoctl pi validate smoke --with-power --with-rtc`
 3. `yoyoctl pi power battery`
 4. `yoyoctl pi power rtc status`
 

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -42,7 +42,8 @@ What it checks:
 - the branch is committed locally
 - the branch and exact SHA are pushed
 - the stable Pi checkout is synced to committed code only
-- the requested smoke checks pass
+- the target-side deploy validation passes
+- the requested target-side smoke, music, voip, and stability checks pass
 - the app restarts cleanly
 - the PID file and startup marker agree
 - recent logs look sane before handoff
@@ -53,49 +54,33 @@ Expected result:
 - the Pi reflects the requested committed branch/SHA, not dirty local state
 - the startup marker matches the active PID
 
-### 3. On-Pi core hardware smoke
+### 3. On-Pi target validation suite
 
-Run these directly on the target Raspberry Pi when you want the lower-level hardware checks without the remote orchestration layer:
-
-```bash
-yoyoctl pi smoke
-yoyoctl pi smoke --with-power --with-rtc
-yoyoctl pi lvgl soak
-```
-
-What it checks:
-
-- target environment information
-- display initialization on real hardware
-- matching input adapter construction and start/stop
-- optional LVGL transition and sleep/wake soak when requested
-
-Expected result:
-
-- `display` reports a real hardware adapter, not simulation
-- `input` reports the active interaction profile plus semantic capabilities for the attached hardware
-
-### 4. On-Pi service smoke
-
-Add music-backend and SIP checks when those services are expected to be available:
+Run these directly on the target Raspberry Pi when you want focused, repeated-safe validation without the remote orchestration layer:
 
 ```bash
-yoyoctl pi smoke --with-music --with-voip
-yoyoctl pi smoke --with-power --with-rtc --with-music --with-voip
+yoyoctl pi validate deploy
+yoyoctl pi validate smoke
+yoyoctl pi validate smoke --with-power --with-rtc
+yoyoctl pi validate music
+yoyoctl pi validate voip
+yoyoctl pi validate stability
 ```
 
-What it checks:
+What each command checks:
 
-- PiSugar battery telemetry and RTC state when requested
-- mpv music-backend startup using `config/yoyopod_config.yaml`
-- Liblinphone startup and SIP registration using `config/voip_config.yaml`
-- Liblinphone media and codec defaults from `config/liblinphone_factory.conf`
+- `deploy`: deploy contract files, tracked runtime config, runtime path parents, and app entrypoints without launching the app
+- `smoke`: target environment, display initialization on real hardware, matching input adapter construction and start/stop, plus optional PiSugar power and RTC checks
+- `music`: mpv music-backend startup using `config/yoyopod_config.yaml`
+- `voip`: Liblinphone startup and SIP registration using `config/voip_config.yaml`
+- `stability`: repeated LVGL transition plus sleep/wake recovery on the active app path
 
 Useful flags:
 
-- `--music-timeout 10`
-- `--voip-timeout 15`
-- `--verbose`
+- `yoyoctl pi validate music --timeout 10`
+- `yoyoctl pi validate voip --timeout 15`
+- `yoyoctl pi validate stability --cycles 3 --hold-seconds 0.3`
+- `--verbose` on any suite command
 
 ## Manual Follow-Up Checks
 
@@ -215,15 +200,17 @@ Only use it when:
 
 ## Failure Triage
 
+- `deploy` fails: verify the checkout still has `deploy/pi-deploy.yaml`, `deploy/systemd/yoyopod@.service`, the configured virtualenv, and writable runtime path parents
 - `display` fails: check attached HAT, driver and library install, and `display.hardware` config
 - `input` fails: check the matching display adapter initialized correctly first
 - `music` fails: verify `mpv` is installed, the configured socket path is writable, and the configured `audio.music_dir` exists
 - `voip` fails: verify the Liblinphone shim build, `config/liblinphone_factory.conf`, SIP credentials, network reachability, and audio device configuration
+- `stability` fails: rerun `yoyoctl pi validate stability --verbose` or `yoyoctl pi lvgl soak` for a deeper LVGL-only pass
 - `validate` fails before launch: check whether the branch was actually pushed and whether the Pi checkout is reachable over SSH
 
 ## Notes
 
-- the smoke script exits non-zero if any requested check fails
+- each `yoyoctl pi validate <command>` exits non-zero if its requested check fails
 - CI intentionally does not run hardware-in-the-loop checks
 - `yoyoctl remote validate` is the normal branch and PR validation path
-- the hardware smoke script is meant to be quick; use the manual drills above when you need deeper debugging
+- the target validation suite is meant to stay small and composable; use the manual drills above when you need deeper debugging

--- a/docs/SETUP_CONTRACT.md
+++ b/docs/SETUP_CONTRACT.md
@@ -172,8 +172,9 @@ hardware-specific extras still need follow-through when the feature requires the
 ```bash
 uv run yoyoctl setup pi
 uv run yoyoctl setup verify-pi
-yoyoctl pi smoke
-yoyoctl pi smoke --with-power --with-rtc
+yoyoctl pi validate deploy
+yoyoctl pi validate smoke
+yoyoctl pi validate smoke --with-power --with-rtc
 uv run python yoyopod.py
 ```
 
@@ -206,7 +207,7 @@ Checklist:
 - tracked config files are present under `config/`
 - required system packages are verified with `uv run yoyoctl setup verify-pi`
 - native shims have been built when the feature requires them
-- `yoyoctl pi smoke` passes for the requested hardware path
+- `yoyoctl pi validate smoke` passes for the requested hardware path
 - remote config values come from `deploy/pi-deploy.yaml` plus local overrides, not tribal knowledge
 
 ## Current gaps

--- a/rules/deploy.md
+++ b/rules/deploy.md
@@ -31,7 +31,7 @@ yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voi
 - stops on uncommitted local changes
 - requires a pushed branch/SHA
 - syncs one stable checkout path on the board
-- runs smoke checks before launch
+- runs the target-side deploy, smoke, and requested service/stability checks before launch
 - waits for the startup marker after restart
 - prints recent logs and leaves the app running
 
@@ -68,6 +68,14 @@ Lower-level `yoyoctl remote` commands:
 - `yoyoctl remote smoke` is the remote smoke primitive
 - `yoyoctl remote restart` restarts the synced app and verifies startup
 - `yoyoctl remote rsync` is not the default; use it only as an explicit debugging override
+
+Target-side `yoyoctl pi validate` commands:
+
+- `yoyoctl pi validate deploy` checks the deploy contract, config files, runtime paths, and entrypoints without launching the app
+- `yoyoctl pi validate smoke` checks environment, display, input, and optional PiSugar telemetry
+- `yoyoctl pi validate music` checks the mpv backend in isolation
+- `yoyoctl pi validate voip` checks Liblinphone startup and SIP registration in isolation
+- `yoyoctl pi validate stability` runs the repeated LVGL transition and sleep/wake stability pass
 
 Config lives in `deploy/pi-deploy.yaml` plus optional `deploy/pi-deploy.local.yaml` for machine-specific host and user overrides. Preferred edit flow:
 

--- a/rules/project.md
+++ b/rules/project.md
@@ -31,6 +31,13 @@ uv run python scripts/quality.py audit
 # Baseline Pi setup contract
 uv run yoyoctl setup pi
 uv run yoyoctl setup verify-pi
+
+# Focused target-side validation
+yoyoctl pi validate deploy
+yoyoctl pi validate smoke
+yoyoctl pi validate music
+yoyoctl pi validate voip
+yoyoctl pi validate stability
 ```
 
 `yoyoctl setup *` is the baseline executable contract, not the finished setup story.

--- a/src/yoyopod/cli/pi/__init__.py
+++ b/src/yoyopod/cli/pi/__init__.py
@@ -10,9 +10,11 @@ from yoyopod.cli.pi.network import network_app
 from yoyopod.cli.pi.power import power_app
 from yoyopod.cli.pi.smoke import smoke_app
 from yoyopod.cli.pi.tune import tune_app
+from yoyopod.cli.pi.validate import validate_app
 from yoyopod.cli.pi.voip import voip_app
 
 pi_app = typer.Typer(name="pi", help="Commands that run ON the Raspberry Pi.", no_args_is_help=True)
+pi_app.add_typer(validate_app)
 pi_app.add_typer(voip_app)
 pi_app.add_typer(power_app)
 pi_app.add_typer(network_app)

--- a/src/yoyopod/cli/pi/smoke.py
+++ b/src/yoyopod/cli/pi/smoke.py
@@ -14,7 +14,7 @@ from yoyopod.cli.common import configure_logging, resolve_config_dir
 
 smoke_app = typer.Typer(
     name="smoke",
-    help="Run Raspberry Pi hardware smoke validation.",
+    help="Run the legacy combined Raspberry Pi smoke validator. Prefer `yoyoctl pi validate` for focused target checks.",
     invoke_without_command=True,
     no_args_is_help=False,
 )
@@ -455,7 +455,7 @@ def smoke(
     display_hold_seconds: Annotated[float, typer.Option("--display-hold-seconds", help="How long to keep the display confirmation text visible.")] = 0.5,
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
 ) -> None:
-    """Run Raspberry Pi hardware smoke validation for YoyoPod."""
+    """Run the legacy combined Raspberry Pi smoke validation flow for YoyoPod."""
     from loguru import logger
 
     configure_logging(verbose)

--- a/src/yoyopod/cli/pi/validate.py
+++ b/src/yoyopod/cli/pi/validate.py
@@ -1,0 +1,349 @@
+"""src/yoyopod/cli/pi/validate.py — focused target-side validation suite."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from yoyopod.cli.common import REPO_ROOT, configure_logging, resolve_config_dir
+from yoyopod.cli.pi.lvgl import soak as run_lvgl_soak
+from yoyopod.cli.pi.smoke import (
+    CheckResult,
+    _display_check,
+    _environment_check,
+    _input_check,
+    _load_app_config,
+    _music_check,
+    _power_check,
+    _rtc_check,
+    _voip_check,
+)
+from yoyopod.cli.remote.config import PiDeployConfig, load_pi_deploy_config
+
+validate_app = typer.Typer(
+    name="validate",
+    help="Focused target-side validation suite for deploy, smoke, music, voip, and stability checks.",
+    no_args_is_help=True,
+)
+
+
+def _print_summary(name: str, results: list[CheckResult]) -> None:
+    """Print a compact summary table for one validation command."""
+    print("")
+    print(f"YoyoPod target validation summary: {name}")
+    print("=" * 48)
+    for result in results:
+        print(f"[{result.status.upper():4}] {result.name}: {result.details}")
+
+
+def _resolve_runtime_path(path_value: str) -> Path:
+    """Resolve one repo-relative or absolute runtime path."""
+    path = Path(path_value)
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def _nearest_existing_parent(path: Path) -> Path:
+    """Return the nearest existing parent for one path."""
+    candidate = path if path.exists() and path.is_dir() else path.parent
+    while not candidate.exists() and candidate != candidate.parent:
+        candidate = candidate.parent
+    return candidate
+
+
+def _config_files_check(config_path: Path) -> CheckResult:
+    """Validate that the tracked runtime config files are present."""
+    required_files = (
+        config_path / "yoyopod_config.yaml",
+        config_path / "voip_config.yaml",
+        config_path / "contacts.yaml",
+    )
+    missing = [str(path.relative_to(REPO_ROOT)) for path in required_files if not path.exists()]
+    if missing:
+        return CheckResult(
+            name="config",
+            status="fail",
+            details=f"missing required config files: {', '.join(missing)}",
+        )
+
+    return CheckResult(
+        name="config",
+        status="pass",
+        details=", ".join(str(path.relative_to(REPO_ROOT)) for path in required_files),
+    )
+
+
+def _deploy_contract_check() -> tuple[CheckResult, PiDeployConfig | None]:
+    """Validate that the tracked deploy contract is readable."""
+    try:
+        deploy_config = load_pi_deploy_config()
+    except Exception as exc:
+        return CheckResult(name="deploy_contract", status="fail", details=str(exc)), None
+
+    return (
+        CheckResult(
+            name="deploy_contract",
+            status="pass",
+            details=(
+                f"project_dir={deploy_config.project_dir}, "
+                f"venv={deploy_config.venv}, "
+                f"start_cmd={deploy_config.start_cmd}"
+            ),
+        ),
+        deploy_config,
+    )
+
+
+def _runtime_paths_check(deploy_config: PiDeployConfig) -> CheckResult:
+    """Validate that runtime file parents are reachable and writable."""
+    path_map = {
+        "log": _resolve_runtime_path(deploy_config.log_file),
+        "error_log": _resolve_runtime_path(deploy_config.error_log_file),
+        "pid": _resolve_runtime_path(deploy_config.pid_file),
+        "screenshot": _resolve_runtime_path(deploy_config.screenshot_path),
+    }
+
+    details: list[str] = []
+    failures: list[str] = []
+    for name, path in path_map.items():
+        parent = _nearest_existing_parent(path)
+        writable = os.access(parent, os.W_OK)
+        details.append(f"{name}_parent={parent}")
+        if not writable:
+            failures.append(f"{name}_parent_not_writable={parent}")
+
+    if failures:
+        return CheckResult(
+            name="runtime_paths",
+            status="fail",
+            details=", ".join(failures),
+        )
+
+    return CheckResult(
+        name="runtime_paths",
+        status="pass",
+        details=", ".join(details),
+    )
+
+
+def _entrypoint_check(deploy_config: PiDeployConfig) -> CheckResult:
+    """Validate repo entrypoints and the configured virtualenv activation path."""
+    required_paths = {
+        "app": REPO_ROOT / "yoyopod.py",
+        "systemd": REPO_ROOT / "deploy" / "systemd" / "yoyopod@.service",
+    }
+
+    normalized_venv = Path(deploy_config.venv.rstrip("/"))
+    if not normalized_venv.is_absolute():
+        normalized_venv = REPO_ROOT / normalized_venv
+    activate_path = (
+        normalized_venv
+        if normalized_venv.name == "activate"
+        else normalized_venv / "bin" / "activate"
+    )
+    required_paths["venv_activate"] = activate_path
+
+    missing = [
+        f"{name}={path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path}"
+        for name, path in required_paths.items()
+        if not path.exists()
+    ]
+    if missing:
+        return CheckResult(
+            name="entrypoints",
+            status="fail",
+            details=f"missing required paths: {', '.join(missing)}",
+        )
+
+    start_parts = shlex.split(deploy_config.start_cmd)
+    if not start_parts:
+        return CheckResult(
+            name="entrypoints",
+            status="fail",
+            details="start_cmd is empty in deploy/pi-deploy.yaml",
+        )
+
+    executable = start_parts[0]
+    resolved_executable = shutil.which(executable)
+    if resolved_executable is None:
+        return CheckResult(
+            name="entrypoints",
+            status="fail",
+            details=f"configured start executable is not on PATH: {executable}",
+        )
+
+    return CheckResult(
+        name="entrypoints",
+        status="pass",
+        details=(
+            f"start_executable={resolved_executable}, "
+            f"venv_activate={activate_path.relative_to(REPO_ROOT) if activate_path.is_relative_to(REPO_ROOT) else activate_path}"
+        ),
+    )
+
+
+@validate_app.command()
+def deploy(
+    config_dir: Annotated[
+        str, typer.Option("--config-dir", help="Configuration directory to validate.")
+    ] = "config",
+    verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
+) -> None:
+    """Validate deploy-readiness for the current target checkout without launching the app."""
+    from loguru import logger
+
+    configure_logging(verbose)
+    config_path = resolve_config_dir(config_dir)
+
+    logger.info("Running target deploy validation")
+
+    deploy_result, deploy_config = _deploy_contract_check()
+    results = [deploy_result, _config_files_check(config_path)]
+    if deploy_config is not None:
+        results.append(_runtime_paths_check(deploy_config))
+        results.append(_entrypoint_check(deploy_config))
+
+    _print_summary("deploy", results)
+    if any(result.status == "fail" for result in results):
+        raise typer.Exit(code=1)
+
+
+@validate_app.command()
+def smoke(
+    config_dir: Annotated[
+        str, typer.Option("--config-dir", help="Configuration directory to use.")
+    ] = "config",
+    with_power: Annotated[
+        bool, typer.Option("--with-power", help="Also validate PiSugar power telemetry.")
+    ] = False,
+    with_rtc: Annotated[
+        bool, typer.Option("--with-rtc", help="Also validate PiSugar RTC state and alarm.")
+    ] = False,
+    display_hold_seconds: Annotated[
+        float,
+        typer.Option(
+            "--display-hold-seconds",
+            help="How long to keep the display confirmation text visible.",
+        ),
+    ] = 0.5,
+    verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
+) -> None:
+    """Validate core target hardware paths: environment, display, input, and optional PiSugar state."""
+    from loguru import logger
+
+    configure_logging(verbose)
+    config_path = resolve_config_dir(config_dir)
+
+    logger.info("Running target smoke validation")
+
+    app_config = _load_app_config(config_path)
+    results: list[CheckResult] = [_environment_check()]
+    display = None
+
+    try:
+        display_result, display = _display_check(app_config, display_hold_seconds)
+        results.append(display_result)
+
+        if display_result.status == "pass" and display is not None:
+            results.append(_input_check(display, app_config))
+
+        if with_power:
+            results.append(_power_check(config_path))
+
+        if with_rtc:
+            results.append(_rtc_check(config_path))
+    finally:
+        if display is not None:
+            try:
+                display.cleanup()
+            except Exception as exc:
+                logger.warning(f"Display cleanup failed: {exc}")
+
+    _print_summary("smoke", results)
+    if any(result.status == "fail" for result in results):
+        raise typer.Exit(code=1)
+
+
+@validate_app.command()
+def music(
+    config_dir: Annotated[
+        str, typer.Option("--config-dir", help="Configuration directory to use.")
+    ] = "config",
+    timeout: Annotated[
+        int, typer.Option("--timeout", help="Startup timeout in seconds for the music backend.")
+    ] = 5,
+    verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
+) -> None:
+    """Validate the mpv music backend on the target without starting the full app."""
+    from loguru import logger
+
+    configure_logging(verbose)
+    config_path = resolve_config_dir(config_dir)
+
+    logger.info("Running target music validation")
+
+    app_config = _load_app_config(config_path)
+    results = [_music_check(app_config, timeout)]
+
+    _print_summary("music", results)
+    if any(result.status == "fail" for result in results):
+        raise typer.Exit(code=1)
+
+
+@validate_app.command()
+def voip(
+    config_dir: Annotated[
+        str, typer.Option("--config-dir", help="Configuration directory to use.")
+    ] = "config",
+    timeout: Annotated[
+        float, typer.Option("--timeout", help="Registration timeout in seconds.")
+    ] = 90.0,
+    verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
+) -> None:
+    """Validate Liblinphone startup and SIP registration on the target."""
+    from loguru import logger
+
+    configure_logging(verbose)
+    config_path = resolve_config_dir(config_dir)
+
+    logger.info("Running target VoIP validation")
+
+    results = [_voip_check(config_path, timeout)]
+
+    _print_summary("voip", results)
+    if any(result.status == "fail" for result in results):
+        raise typer.Exit(code=1)
+
+
+@validate_app.command()
+def stability(
+    config_dir: Annotated[
+        str, typer.Option("--config-dir", help="Configuration directory to use.")
+    ] = "config",
+    cycles: Annotated[
+        int, typer.Option("--cycles", help="How many full transition cycles to run.")
+    ] = 2,
+    hold_seconds: Annotated[
+        float,
+        typer.Option("--hold-seconds", help="How long to keep each screen active during the soak."),
+    ] = 0.2,
+    skip_sleep: Annotated[
+        bool, typer.Option("--skip-sleep", help="Skip the sleep and wake exercise.")
+    ] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
+) -> None:
+    """Run a repeated LVGL screen-transition stability pass on the target checkout."""
+    run_lvgl_soak(
+        config_dir=config_dir,
+        simulate=False,
+        cycles=cycles,
+        hold_seconds=hold_seconds,
+        skip_sleep=skip_sleep,
+        verbose=verbose,
+    )

--- a/src/yoyopod/cli/remote/ops.py
+++ b/src/yoyopod/cli/remote/ops.py
@@ -679,24 +679,45 @@ def build_smoke_command(
     music_timeout: int = 5,
     voip_timeout: float = 90.0,
 ) -> str:
-    """Create the remote smoke-validation command."""
-    parts = ["uv run yoyoctl pi smoke"]
+    """Create the remote target-validation command set."""
+    commands = ["uv run yoyoctl pi validate smoke"]
     if with_power:
-        parts.append("--with-power")
+        commands[-1] += " --with-power"
     if with_rtc:
-        parts.append("--with-rtc")
+        commands[-1] += " --with-rtc"
+    if verbose:
+        commands[-1] += " --verbose"
+
     if with_music:
-        parts.append("--with-music")
+        music_command = "uv run yoyoctl pi validate music"
+        if verbose:
+            music_command += " --verbose"
+        if music_timeout != 5:
+            music_command += f" --timeout {music_timeout}"
+        commands.append(music_command)
+
     if with_voip:
-        parts.append("--with-voip")
+        voip_command = "uv run yoyoctl pi validate voip"
+        if verbose:
+            voip_command += " --verbose"
+        if voip_timeout != 90.0:
+            voip_command += f" --timeout {voip_timeout}"
+        commands.append(voip_command)
+
     if with_lvgl_soak:
-        parts.append("--with-lvgl-soak")
+        stability_command = "uv run yoyoctl pi validate stability"
+        if verbose:
+            stability_command += " --verbose"
+        commands.append(stability_command)
+
+    return " && ".join(commands)
+
+
+def build_deploy_validation_command(*, verbose: bool = False) -> str:
+    """Create the remote deploy-readiness validation command."""
+    parts = ["uv run yoyoctl pi validate deploy"]
     if verbose:
         parts.append("--verbose")
-    if music_timeout != 5:
-        parts.extend(["--music-timeout", str(music_timeout)])
-    if voip_timeout != 90.0:
-        parts.extend(["--voip-timeout", str(voip_timeout)])
     return " ".join(parts)
 
 
@@ -712,6 +733,7 @@ def build_local_preflight_commands() -> list[tuple[str, list[str]]]:
                 "yoyopod",
                 "tests",
                 "src/yoyopod/cli/pi/smoke.py",
+                "src/yoyopod/cli/pi/validate.py",
                 "src/yoyopod/cli/pi/voip.py",
                 "src/yoyopod/power/backend.py",
                 "src/yoyopod/power/manager.py",
@@ -859,6 +881,13 @@ def validate(
     )
     if sync_exit_code != 0:
         raise typer.Exit(code=sync_exit_code)
+
+    deploy_exit_code = run_remote(
+        config,
+        build_deploy_validation_command(verbose=verbose),
+    )
+    if deploy_exit_code != 0:
+        raise typer.Exit(code=deploy_exit_code)
 
     smoke_exit_code = run_remote(
         config,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,7 @@ def test_root_help():
 def test_pi_help():
     result = runner.invoke(app, ["pi", "--help"])
     assert result.exit_code == 0
+    assert "validate" in _plain(result.output)
 
 
 def test_remote_help():
@@ -133,6 +134,51 @@ def test_pi_smoke_help():
     assert "--with-voip" in _plain(result.output)
     assert "--with-power" in _plain(result.output)
     assert "--with-lvgl-soak" in _plain(result.output)
+
+
+def test_pi_validate_help():
+    result = runner.invoke(app, ["pi", "validate", "--help"])
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "deploy" in output
+    assert "smoke" in output
+    assert "music" in output
+    assert "voip" in output
+    assert "stability" in output
+
+
+def test_pi_validate_deploy_help():
+    result = runner.invoke(app, ["pi", "validate", "deploy", "--help"])
+    assert result.exit_code == 0
+    assert "--config-dir" in _plain(result.output)
+
+
+def test_pi_validate_smoke_help():
+    result = runner.invoke(app, ["pi", "validate", "smoke", "--help"])
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "--with-power" in output
+    assert "--with-rtc" in output
+
+
+def test_pi_validate_music_help():
+    result = runner.invoke(app, ["pi", "validate", "music", "--help"])
+    assert result.exit_code == 0
+    assert "--timeout" in _plain(result.output)
+
+
+def test_pi_validate_voip_help():
+    result = runner.invoke(app, ["pi", "validate", "voip", "--help"])
+    assert result.exit_code == 0
+    assert "--timeout" in _plain(result.output)
+
+
+def test_pi_validate_stability_help():
+    result = runner.invoke(app, ["pi", "validate", "stability", "--help"])
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "--cycles" in output
+    assert "--hold-seconds" in output
 
 
 def test_pi_tune_help():

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -8,6 +8,7 @@ from yoyopod.cli.remote.ops import (
     PiDeployConfig,
     RemoteConfig,
     build_archive_sync_extract_command,
+    build_deploy_validation_command,
     build_local_preflight_commands,
     build_logs_command,
     build_native_shim_refresh_command,
@@ -355,15 +356,22 @@ def test_build_smoke_command_adds_optional_checks() -> None:
         voip_timeout=15.0,
     )
 
-    assert command.startswith("uv run yoyoctl pi smoke")
+    assert command.startswith("uv run yoyoctl pi validate smoke")
     assert "--with-power" in command
     assert "--with-rtc" in command
-    assert "--with-music" in command
-    assert "--with-voip" in command
-    assert "--with-lvgl-soak" in command
+    assert "uv run yoyoctl pi validate music" in command
+    assert "uv run yoyoctl pi validate voip" in command
+    assert "uv run yoyoctl pi validate stability" in command
     assert "--verbose" in command
-    assert "--music-timeout 10" in command
-    assert "--voip-timeout 15.0" in command
+    assert "--timeout 10" in command
+    assert "--timeout 15.0" in command
+
+
+def test_build_deploy_validation_command_targets_pi_suite() -> None:
+    """Deploy validation should call the focused target-side suite."""
+    command = build_deploy_validation_command(verbose=True)
+
+    assert command == "uv run yoyoctl pi validate deploy --verbose"
 
 
 def test_build_validation_inspection_command_reports_marker_and_logs() -> None:
@@ -384,6 +392,7 @@ def test_build_local_preflight_commands_cover_compile_and_pytest() -> None:
     assert commands[0][0] == "compileall"
     assert commands[0][1][1:3] == ["-m", "compileall"]
     assert "src/yoyopod/cli/pi/smoke.py" in commands[0][1]
+    assert "src/yoyopod/cli/pi/validate.py" in commands[0][1]
     assert "src/yoyopod/cli/pi/voip.py" in commands[0][1]
     assert "src/yoyopod/power/backend.py" in commands[0][1]
     assert commands[1] == ("pytest", ["uv", "run", "pytest", "-q"])


### PR DESCRIPTION
## Summary
- add a focused `yoyoctl pi validate` suite with `deploy`, `smoke`, `music`, `voip`, and `stability` commands
- wire `yoyoctl remote validate` and remote smoke helpers to compose that suite instead of one combined on-target command
- update contributor, deploy, and agent docs plus CLI/help coverage to point to the new command set

## Why
Alpha needs repeatable target-side validation that stays small, composable, and safe to rerun on-device.

## Impact
- contributors and agents get a clearer target-side validation contract
- deploy-readiness is checked explicitly before remote launch and restart
- service checks for music, VoIP, and LVGL stability can run independently

## Validation
- `uv run pytest -q tests/test_cli.py tests/test_pi_remote.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`

Closes #130
