### PR TITLE
[codex] Automate target test music provisioning

### DIFF
--- a/deploy/pi-deploy.yaml
+++ b/deploy/pi-deploy.yaml
@@ -25,6 +25,9 @@ error_log_file: logs/yoyopod_errors.log
 pid_file: /tmp/yoyopod.pid
 startup_marker: "YoyoPod starting"
 screenshot_path: /tmp/yoyopod_screenshot.png
+# Validation-only library seeded by `yoyoctl pi music provision-test-library`
+# and automatically used by `yoyoctl remote/pi smoke --with-music` unless disabled.
+test_music_target_dir: ~/YoyoPod_Test_Music
 rsync_exclude:
   - .git/
   - .cache/

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -96,6 +96,22 @@ yoyoctl remote validate --branch <branch> --sha <commit> --with-lvgl-soak
 yoyoctl remote validate --branch <branch> --sha <commit> --skip-uv-sync
 ```
 
+When `--with-music` is enabled, the Pi-side smoke flow seeds the deterministic validation library into the configured `test_music_target_dir` before it exercises the music backend.
+
+The seeded validation library is explicit and stable:
+
+- `yoyopod-validation-set.m3u`
+- `tracks/alpha-beacon.wav`
+- `tracks/bravo-lantern.wav`
+- `tracks/charlie-sundial.wav`
+
+Use the dedicated provisioning helper when you want the assets on the Pi without running the full smoke flow:
+
+```bash
+yoyoctl remote provision-test-music
+yoyoctl remote provision-test-music --target-dir ~/YoyoPod_Test_Music
+```
+
 `yoyoctl remote validate` does all of this:
 
 1. stops if the local worktree is dirty
@@ -157,6 +173,7 @@ Useful variations:
 ```bash
 yoyoctl remote smoke --with-music --music-timeout 10
 yoyoctl remote smoke --with-voip --voip-timeout 15 --verbose
+yoyoctl remote provision-test-music
 ```
 
 ### Restart the already-synced app

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -37,6 +37,15 @@ yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voi
 yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak
 ```
 
+When `--with-music` is enabled, the Pi smoke flow provisions a deterministic validation library under the configured `test_music_target_dir` before the mpv checks run.
+
+The seeded validation library is explicit and stable:
+
+- `yoyopod-validation-set.m3u`
+- `tracks/alpha-beacon.wav`
+- `tracks/bravo-lantern.wav`
+- `tracks/charlie-sundial.wav`
+
 What it checks:
 
 - the branch is committed locally
@@ -78,6 +87,9 @@ What each command checks:
 Useful flags:
 
 - `yoyoctl pi validate music --timeout 10`
+- `yoyoctl pi validate music --test-music-dir ~/YoyoPod_Test_Music`
+- `yoyoctl pi music provision-test-library --target-dir ~/YoyoPod_Test_Music`
+- `yoyoctl remote provision-test-music`
 - `yoyoctl pi validate voip --timeout 15`
 - `yoyoctl pi validate stability --cycles 3 --hold-seconds 0.3`
 - `--verbose` on any suite command
@@ -203,7 +215,7 @@ Only use it when:
 - `deploy` fails: verify the checkout still has `deploy/pi-deploy.yaml`, `deploy/systemd/yoyopod@.service`, the configured virtualenv, and writable runtime path parents
 - `display` fails: check attached HAT, driver and library install, and `display.hardware` config
 - `input` fails: check the matching display adapter initialized correctly first
-- `music` fails: verify `mpv` is installed, the configured socket path is writable, and the configured `audio.music_dir` exists
+- `music` fails: verify `mpv` is installed, the configured socket path is writable, and the provision target under `test_music_target_dir` is writable when deterministic seeding is enabled
 - `voip` fails: verify the Liblinphone shim build, `config/liblinphone_factory.conf`, SIP credentials, network reachability, and audio device configuration
 - `stability` fails: rerun `yoyoctl pi validate stability --verbose` or `yoyoctl pi lvgl soak` for a deeper LVGL-only pass
 - `validate` fails before launch: check whether the branch was actually pushed and whether the Pi checkout is reachable over SSH

--- a/src/yoyopod/audio/test_music.py
+++ b/src/yoyopod/audio/test_music.py
@@ -1,0 +1,243 @@
+"""Deterministic test-music library provisioning for Pi-side validation."""
+
+from __future__ import annotations
+
+import json
+import math
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_TEST_MUSIC_TARGET_DIR = "~/YoyoPod_Test_Music"
+TEST_MUSIC_MANIFEST_FILENAME = ".yoyopod_test_music_manifest.json"
+TEST_MUSIC_LIBRARY_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class TestToneSpec:
+    """One generated WAV track for playback validation."""
+
+    relative_path: str
+    title: str
+    frequency_hz: float
+    duration_seconds: float
+
+
+@dataclass(frozen=True, slots=True)
+class TestPlaylistSpec:
+    """One generated M3U playlist for playback validation."""
+
+    relative_path: str
+    title: str
+    tracks: tuple[TestToneSpec, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ProvisionedTestMusicLibrary:
+    """Concrete target paths for one provisioned validation library."""
+
+    target_dir: Path
+    track_paths: tuple[Path, ...]
+    playlist_paths: tuple[Path, ...]
+    manifest_path: Path
+
+    @property
+    def default_playlist_path(self) -> Path:
+        """Return the primary validation playlist."""
+
+        return self.playlist_paths[0]
+
+    @property
+    def expected_asset_paths(self) -> tuple[Path, ...]:
+        """Return the managed files that should exist after provisioning."""
+
+        return (*self.track_paths, *self.playlist_paths, self.manifest_path)
+
+
+TEST_TONE_SPECS: tuple[TestToneSpec, ...] = (
+    TestToneSpec(
+        relative_path="tracks/alpha-beacon.wav",
+        title="Alpha Beacon",
+        frequency_hz=440.0,
+        duration_seconds=1.10,
+    ),
+    TestToneSpec(
+        relative_path="tracks/bravo-lantern.wav",
+        title="Bravo Lantern",
+        frequency_hz=554.37,
+        duration_seconds=1.25,
+    ),
+    TestToneSpec(
+        relative_path="tracks/charlie-sundial.wav",
+        title="Charlie Sundial",
+        frequency_hz=659.25,
+        duration_seconds=0.95,
+    ),
+)
+
+TEST_PLAYLIST_SPECS: tuple[TestPlaylistSpec, ...] = (
+    TestPlaylistSpec(
+        relative_path="yoyopod-validation-set.m3u",
+        title="YoyoPod Validation Set",
+        tracks=TEST_TONE_SPECS,
+    ),
+)
+
+
+def expected_test_music_relative_paths() -> tuple[str, ...]:
+    """Return the tracked asset set for the validation library."""
+
+    return tuple(
+        [*(spec.relative_path for spec in TEST_TONE_SPECS), *(spec.relative_path for spec in TEST_PLAYLIST_SPECS)]
+    )
+
+
+def provision_test_music_library(target_dir: Path) -> ProvisionedTestMusicLibrary:
+    """Provision the known-good validation music set into one dedicated directory."""
+
+    resolved_target_dir = target_dir.expanduser().resolve()
+    resolved_target_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = resolved_target_dir / TEST_MUSIC_MANIFEST_FILENAME
+    _remove_previously_managed_assets(resolved_target_dir, manifest_path)
+
+    track_paths = tuple(
+        _write_tone_track(resolved_target_dir, spec)
+        for spec in TEST_TONE_SPECS
+    )
+    playlist_paths = tuple(
+        _write_playlist(resolved_target_dir, spec)
+        for spec in TEST_PLAYLIST_SPECS
+    )
+
+    manifest_payload = {
+        "version": TEST_MUSIC_LIBRARY_VERSION,
+        "target_dir": str(resolved_target_dir),
+        "managed_paths": list(expected_test_music_relative_paths()),
+        "tracks": [
+            {
+                "path": spec.relative_path,
+                "title": spec.title,
+                "frequency_hz": spec.frequency_hz,
+                "duration_seconds": spec.duration_seconds,
+            }
+            for spec in TEST_TONE_SPECS
+        ],
+        "playlists": [
+            {
+                "path": spec.relative_path,
+                "title": spec.title,
+                "tracks": [track.relative_path for track in spec.tracks],
+            }
+            for spec in TEST_PLAYLIST_SPECS
+        ],
+    }
+    manifest_path.write_text(
+        json.dumps(manifest_payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    return ProvisionedTestMusicLibrary(
+        target_dir=resolved_target_dir,
+        track_paths=track_paths,
+        playlist_paths=playlist_paths,
+        manifest_path=manifest_path,
+    )
+
+
+def _write_tone_track(target_dir: Path, spec: TestToneSpec) -> Path:
+    """Write one deterministic mono PCM WAV test tone."""
+
+    path = _resolve_relative_asset_path(target_dir, spec.relative_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    sample_rate = 22050
+    amplitude = 12000
+    frame_count = int(sample_rate * spec.duration_seconds)
+
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+
+        frames = bytearray()
+        for index in range(frame_count):
+            attack = min(1.0, index / max(1, sample_rate // 50))
+            release = min(1.0, (frame_count - index) / max(1, sample_rate // 20))
+            envelope = min(attack, release)
+            sample = int(
+                amplitude
+                * envelope
+                * math.sin((2.0 * math.pi * spec.frequency_hz * index) / sample_rate)
+            )
+            frames.extend(sample.to_bytes(2, byteorder="little", signed=True))
+        handle.writeframes(bytes(frames))
+
+    return path
+
+
+def _write_playlist(target_dir: Path, spec: TestPlaylistSpec) -> Path:
+    """Write one deterministic M3U playlist that references the generated tracks."""
+
+    path = _resolve_relative_asset_path(target_dir, spec.relative_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = ["#EXTM3U"]
+    for track in spec.tracks:
+        track_path = _resolve_relative_asset_path(target_dir, track.relative_path)
+        lines.append(f"#EXTINF:{round(track.duration_seconds)}, {track.title}")
+        lines.append(str(track_path.relative_to(path.parent)))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _remove_previously_managed_assets(target_dir: Path, manifest_path: Path) -> None:
+    """Delete only the previously managed validation assets for repeatable reprovisioning."""
+
+    managed_paths = _load_managed_paths_from_manifest(manifest_path)
+    for relative_path in managed_paths:
+        asset_path = _resolve_relative_asset_path(target_dir, relative_path)
+        if asset_path.is_file() or asset_path.is_symlink():
+            asset_path.unlink()
+
+    if manifest_path.exists():
+        manifest_path.unlink()
+
+    for current_path in sorted(target_dir.rglob("*"), key=lambda item: len(item.parts), reverse=True):
+        if current_path.is_dir():
+            try:
+                current_path.rmdir()
+            except OSError:
+                continue
+
+
+def _load_managed_paths_from_manifest(manifest_path: Path) -> tuple[str, ...]:
+    """Load the previous managed relative-path list when a manifest exists."""
+
+    if not manifest_path.exists():
+        return ()
+
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return ()
+
+    raw_paths = payload.get("managed_paths", [])
+    if not isinstance(raw_paths, list):
+        return ()
+
+    managed_paths: list[str] = []
+    for candidate in raw_paths:
+        text = str(candidate).strip()
+        if text:
+            managed_paths.append(text)
+    return tuple(managed_paths)
+
+
+def _resolve_relative_asset_path(target_dir: Path, relative_path: str) -> Path:
+    """Resolve one managed asset path and reject unsafe values."""
+
+    relative = Path(relative_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(f"Unsafe test-music asset path: {relative_path}")
+    return target_dir / relative

--- a/src/yoyopod/cli/pi/__init__.py
+++ b/src/yoyopod/cli/pi/__init__.py
@@ -6,6 +6,7 @@ import typer
 
 from yoyopod.cli.pi.gallery import gallery_app
 from yoyopod.cli.pi.lvgl import lvgl_app
+from yoyopod.cli.pi.music import music_app
 from yoyopod.cli.pi.network import network_app
 from yoyopod.cli.pi.power import power_app
 from yoyopod.cli.pi.smoke import smoke_app
@@ -18,6 +19,7 @@ pi_app.add_typer(validate_app)
 pi_app.add_typer(voip_app)
 pi_app.add_typer(power_app)
 pi_app.add_typer(network_app)
+pi_app.add_typer(music_app)
 pi_app.add_typer(lvgl_app)
 pi_app.add_typer(smoke_app)
 pi_app.add_typer(tune_app)

--- a/src/yoyopod/cli/pi/music.py
+++ b/src/yoyopod/cli/pi/music.py
@@ -1,0 +1,47 @@
+"""On-device helpers for deterministic test-music provisioning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from yoyopod.audio.test_music import (
+    DEFAULT_TEST_MUSIC_TARGET_DIR,
+    provision_test_music_library,
+)
+from yoyopod.cli.common import configure_logging
+
+music_app = typer.Typer(
+    name="music",
+    help="Commands for deterministic local-music validation assets on the Pi.",
+    no_args_is_help=True,
+)
+
+
+@music_app.command("provision-test-library")
+def provision_test_library(
+    target_dir: Annotated[
+        str,
+        typer.Option(
+            "--target-dir",
+            help="Dedicated target directory for validation-only test music.",
+        ),
+    ] = DEFAULT_TEST_MUSIC_TARGET_DIR,
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", help="Enable DEBUG logging for provisioning."),
+    ] = False,
+) -> None:
+    """Generate the known-good validation music library into one dedicated target path."""
+
+    configure_logging(verbose)
+    library = provision_test_music_library(Path(target_dir))
+
+    print("Provisioned YoyoPod validation music")
+    print(f"target_dir: {library.target_dir}")
+    print(f"playlist: {library.default_playlist_path}")
+    for track_path in library.track_paths:
+        print(f"track: {track_path}")
+    print(f"manifest: {library.manifest_path}")

--- a/src/yoyopod/cli/pi/smoke.py
+++ b/src/yoyopod/cli/pi/smoke.py
@@ -10,6 +10,7 @@ from typing import Annotated, Any, Optional
 
 import typer
 
+from yoyopod.audio.test_music import DEFAULT_TEST_MUSIC_TARGET_DIR
 from yoyopod.cli.common import configure_logging, resolve_config_dir
 
 smoke_app = typer.Typer(
@@ -242,8 +243,35 @@ def _rtc_check(config_dir: Path) -> CheckResult:
     return CheckResult(name="rtc", status="pass", details=details)
 
 
-def _music_check(app_config: dict[str, Any], timeout_seconds: int) -> CheckResult:
+def _prepare_music_validation_library(
+    app_config: dict[str, Any],
+    *,
+    provision_test_music: bool,
+    test_music_dir: str,
+):
+    """Provision the deterministic validation music library and point smoke at it."""
+    from yoyopod.audio.test_music import provision_test_music_library
+
+    if not provision_test_music:
+        return None
+
+    library = provision_test_music_library(Path(test_music_dir))
+    audio_config = app_config.get("audio")
+    if not isinstance(audio_config, dict):
+        audio_config = {}
+        app_config["audio"] = audio_config
+    audio_config["music_dir"] = str(library.target_dir)
+    return library
+
+
+def _music_check(
+    app_config: dict[str, Any],
+    timeout_seconds: int,
+    *,
+    expected_library=None,
+) -> CheckResult:
     """Validate music-backend startup and basic state queries."""
+    from yoyopod.audio.local_service import LocalMusicService
     from yoyopod.audio.music import MpvBackend, MusicConfig
 
     audio_config = app_config.get("audio", {})
@@ -274,6 +302,69 @@ def _music_check(app_config: dict[str, Any], timeout_seconds: int) -> CheckResul
                 name="music",
                 status="fail",
                 details=f"music backend did not report ready within {timeout_seconds}s",
+            )
+
+        if expected_library is not None:
+            missing_assets = [
+                path
+                for path in expected_library.expected_asset_paths
+                if not path.exists()
+            ]
+            if missing_assets:
+                missing_list = ", ".join(str(path) for path in missing_assets)
+                return CheckResult(
+                    name="music",
+                    status="fail",
+                    details=f"missing provisioned test assets: {missing_list}",
+                )
+
+            music_service = LocalMusicService(backend, music_dir=expected_library.target_dir)
+            playlist_path = expected_library.default_playlist_path
+            playlists = music_service.list_playlists()
+            if str(playlist_path) not in {playlist.uri for playlist in playlists}:
+                return CheckResult(
+                    name="music",
+                    status="fail",
+                    details=f"provisioned playlist not discoverable under {expected_library.target_dir}",
+                )
+
+            if not music_service.load_playlist(str(playlist_path)):
+                return CheckResult(
+                    name="music",
+                    status="fail",
+                    details=f"mpv could not load the provisioned playlist {playlist_path}",
+                )
+
+            expected_track_uris = {str(path) for path in expected_library.track_paths}
+            loaded_track = None
+            while (time.monotonic() - started_at) < timeout_seconds:
+                loaded_track = backend.get_current_track()
+                if loaded_track is not None and loaded_track.uri in expected_track_uris:
+                    break
+                time.sleep(0.1)
+
+            if loaded_track is None or loaded_track.uri not in expected_track_uris:
+                current_uri = loaded_track.uri if loaded_track is not None else "none"
+                return CheckResult(
+                    name="music",
+                    status="fail",
+                    details=(
+                        "music backend started, but it did not load one of the "
+                        f"provisioned validation tracks from {expected_library.target_dir}; "
+                        f"current_track={current_uri}"
+                    ),
+                )
+
+            playback_state = backend.get_playback_state()
+            return CheckResult(
+                name="music",
+                status="pass",
+                details=(
+                    f"binary={config.mpv_binary}, socket={config.mpv_socket}, "
+                    f"music_dir={expected_library.target_dir}, "
+                    f"playlist={playlist_path.name}, state={playback_state}, "
+                    f"track={loaded_track.name}"
+                ),
             )
 
         playback_state = backend.get_playback_state()
@@ -450,6 +541,20 @@ def smoke(
     with_rtc: Annotated[bool, typer.Option("--with-rtc", help="Also validate PiSugar RTC state and alarm.")] = False,
     with_voip: Annotated[bool, typer.Option("--with-voip", help="Also validate Liblinphone startup and SIP registration.")] = False,
     with_lvgl_soak: Annotated[bool, typer.Option("--with-lvgl-soak", help="Also run a short LVGL transition and sleep/wake soak.")] = False,
+    provision_test_music: Annotated[
+        bool,
+        typer.Option(
+            "--provision-test-music/--no-provision-test-music",
+            help="Seed the deterministic validation music library before music checks.",
+        ),
+    ] = True,
+    test_music_dir: Annotated[
+        str,
+        typer.Option(
+            "--test-music-dir",
+            help="Dedicated target directory for validation-only test music assets.",
+        ),
+    ] = DEFAULT_TEST_MUSIC_TARGET_DIR,
     music_timeout: Annotated[int, typer.Option("--music-timeout", help="Startup timeout in seconds for music checks.")] = 5,
     voip_timeout: Annotated[float, typer.Option("--voip-timeout", help="Registration timeout in seconds for VoIP checks.")] = 90.0,
     display_hold_seconds: Annotated[float, typer.Option("--display-hold-seconds", help="How long to keep the display confirmation text visible.")] = 0.5,
@@ -465,6 +570,13 @@ def smoke(
     logger.info(f"Using config directory: {config_path}")
 
     app_config = _load_app_config(config_path)
+    expected_music_library = None
+    if with_music:
+        expected_music_library = _prepare_music_validation_library(
+            app_config,
+            provision_test_music=provision_test_music,
+            test_music_dir=test_music_dir,
+        )
     results: list[CheckResult] = [_environment_check()]
     display = None
 
@@ -482,7 +594,13 @@ def smoke(
             results.append(_rtc_check(config_path))
 
         if with_music:
-            results.append(_music_check(app_config, music_timeout))
+            results.append(
+                _music_check(
+                    app_config,
+                    music_timeout,
+                    expected_library=expected_music_library,
+                )
+            )
 
         if with_voip:
             results.append(_voip_check(config_path, voip_timeout))

--- a/src/yoyopod/cli/remote/__init__.py
+++ b/src/yoyopod/cli/remote/__init__.py
@@ -9,6 +9,7 @@ from yoyopod.cli.remote.lvgl import lvgl_soak
 from yoyopod.cli.remote.ops import (
     logs,
     preflight,
+    provision_test_music,
     restart,
     rsync,
     rtc,
@@ -31,6 +32,7 @@ remote_app.command()(status)
 remote_app.command()(sync)
 remote_app.command()(validate)
 remote_app.command()(smoke)
+remote_app.command(name="provision-test-music")(provision_test_music)
 remote_app.command()(preflight)
 remote_app.command()(restart)
 remote_app.command()(logs)

--- a/src/yoyopod/cli/remote/config.py
+++ b/src/yoyopod/cli/remote/config.py
@@ -9,6 +9,7 @@ from typing import Sequence
 
 import yaml
 
+from yoyopod.audio.test_music import DEFAULT_TEST_MUSIC_TARGET_DIR
 from yoyopod.cli.common import REPO_ROOT
 
 DEPLOY_CONFIG_PATH = REPO_ROOT / "deploy" / "pi-deploy.yaml"
@@ -50,6 +51,7 @@ class PiDeployConfig:
     pid_file: str = "/tmp/yoyopod.pid"
     startup_marker: str = "YoyoPod starting"
     screenshot_path: str = "/tmp/yoyopod_screenshot.png"
+    test_music_target_dir: str = DEFAULT_TEST_MUSIC_TARGET_DIR
     rsync_exclude: tuple[str, ...] = (
         ".git/",
         ".cache/",
@@ -122,6 +124,10 @@ def parse_pi_deploy_config(data: dict[str, object]) -> PiDeployConfig:
         startup_marker=str(data["startup_marker"]).strip(),
         screenshot_path=str(data.get("screenshot_path", "/tmp/yoyopod_screenshot.png")).strip()
         or "/tmp/yoyopod_screenshot.png",
+        test_music_target_dir=str(
+            data.get("test_music_target_dir", DEFAULT_TEST_MUSIC_TARGET_DIR)
+        ).strip()
+        or DEFAULT_TEST_MUSIC_TARGET_DIR,
         rsync_exclude=_as_string_tuple(
             data.get(
                 "rsync_exclude",
@@ -190,6 +196,7 @@ def pi_deploy_config_to_dict(config: PiDeployConfig) -> dict[str, object]:
         "pid_file": config.pid_file,
         "startup_marker": config.startup_marker,
         "screenshot_path": config.screenshot_path,
+        "test_music_target_dir": config.test_music_target_dir,
         "rsync_exclude": list(config.rsync_exclude),
     }
 

--- a/src/yoyopod/cli/remote/ops.py
+++ b/src/yoyopod/cli/remote/ops.py
@@ -45,6 +45,7 @@ __all__ = [
     "PiDeployConfig",
     "RemoteConfig",
     "_resolve_remote_config",
+    "build_provision_test_music_command",
     "load_pi_deploy_config",
     "pi_deploy_config_to_dict",
     "quote_remote_project_dir",
@@ -675,6 +676,8 @@ def build_smoke_command(
     with_music: bool = False,
     with_voip: bool = False,
     with_lvgl_soak: bool = False,
+    provision_test_music: bool = True,
+    test_music_target_dir: str | None = None,
     verbose: bool = False,
     music_timeout: int = 5,
     voip_timeout: float = 90.0,
@@ -694,8 +697,11 @@ def build_smoke_command(
             music_command += " --verbose"
         if music_timeout != 5:
             music_command += f" --timeout {music_timeout}"
+        if not provision_test_music:
+            music_command += " --no-provision-test-music"
+        elif test_music_target_dir:
+            music_command += f" --test-music-dir {shlex.quote(test_music_target_dir)}"
         commands.append(music_command)
-
     if with_voip:
         voip_command = "uv run yoyoctl pi validate voip"
         if verbose:
@@ -716,6 +722,22 @@ def build_smoke_command(
 def build_deploy_validation_command(*, verbose: bool = False) -> str:
     """Create the remote deploy-readiness validation command."""
     parts = ["uv run yoyoctl pi validate deploy"]
+    if verbose:
+        parts.append("--verbose")
+    return " ".join(parts)
+
+
+def build_provision_test_music_command(
+    *,
+    target_dir: str,
+    verbose: bool = False,
+) -> str:
+    """Create the remote command that seeds the deterministic test-music library."""
+    parts = [
+        "uv run yoyoctl pi music provision-test-library",
+        "--target-dir",
+        shlex.quote(target_dir),
+    ]
     if verbose:
         parts.append("--verbose")
     return " ".join(parts)
@@ -846,6 +868,20 @@ def validate(
     with_music: Annotated[
         bool, typer.Option("--with-music", help="Include music-backend startup checks.")
     ] = False,
+    provision_test_music: Annotated[
+        bool,
+        typer.Option(
+            "--provision-test-music/--no-provision-test-music",
+            help="Seed deterministic validation music before remote music smoke checks.",
+        ),
+    ] = True,
+    test_music_dir: Annotated[
+        str,
+        typer.Option(
+            "--test-music-dir",
+            help="Dedicated target directory for validation-only test music assets.",
+        ),
+    ] = "",
     with_voip: Annotated[
         bool, typer.Option("--with-voip", help="Include SIP registration checks.")
     ] = False,
@@ -874,6 +910,7 @@ def validate(
     config = resolve_remote_config(host, user, project_dir, resolved_branch)
     validate_config(config)
     deploy_config = load_pi_deploy_config()
+    resolved_test_music_dir = test_music_dir or deploy_config.test_music_target_dir
 
     sync_exit_code = run_remote(
         config,
@@ -895,6 +932,8 @@ def validate(
             with_power=with_power,
             with_rtc=with_rtc,
             with_music=with_music,
+            provision_test_music=provision_test_music,
+            test_music_target_dir=resolved_test_music_dir if with_music else None,
             with_voip=with_voip,
             with_lvgl_soak=with_lvgl_soak,
             verbose=verbose,
@@ -939,6 +978,20 @@ def smoke(
     with_music: Annotated[
         bool, typer.Option("--with-music", help="Include music-backend startup checks.")
     ] = False,
+    provision_test_music: Annotated[
+        bool,
+        typer.Option(
+            "--provision-test-music/--no-provision-test-music",
+            help="Seed deterministic validation music before remote music smoke checks.",
+        ),
+    ] = True,
+    test_music_dir: Annotated[
+        str,
+        typer.Option(
+            "--test-music-dir",
+            help="Dedicated target directory for validation-only test music assets.",
+        ),
+    ] = "",
     with_voip: Annotated[
         bool, typer.Option("--with-voip", help="Include SIP registration checks.")
     ] = False,
@@ -961,17 +1014,62 @@ def smoke(
     """Run the Raspberry Pi smoke validator remotely."""
     config = resolve_remote_config(host, user, project_dir, branch)
     validate_config(config)
+    deploy_config = load_pi_deploy_config()
+    resolved_test_music_dir = test_music_dir or deploy_config.test_music_target_dir
     rc = run_remote(
         config,
         build_smoke_command(
             with_power=with_power,
             with_rtc=with_rtc,
             with_music=with_music,
+            provision_test_music=provision_test_music,
+            test_music_target_dir=resolved_test_music_dir if with_music else None,
             with_voip=with_voip,
             with_lvgl_soak=with_lvgl_soak,
             verbose=verbose,
             music_timeout=music_timeout,
             voip_timeout=voip_timeout,
+        ),
+    )
+    if rc != 0:
+        raise typer.Exit(code=rc)
+
+
+def provision_test_music(
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    target_dir: Annotated[
+        str,
+        typer.Option(
+            "--target-dir",
+            help="Dedicated target directory for validation-only test music assets.",
+        ),
+    ] = "",
+    verbose: Annotated[
+        bool, typer.Option("--verbose", help="Enable verbose provisioning logging.")
+    ] = False,
+) -> None:
+    """Provision the deterministic validation music library on the Raspberry Pi."""
+
+    config = resolve_remote_config(host, user, project_dir, branch)
+    validate_config(config)
+    deploy_config = load_pi_deploy_config()
+    resolved_target_dir = target_dir or deploy_config.test_music_target_dir
+    rc = run_remote(
+        config,
+        build_provision_test_music_command(
+            target_dir=resolved_target_dir,
+            verbose=verbose,
         ),
     )
     if rc != 0:
@@ -1020,6 +1118,20 @@ def preflight(
             "--with-music", help="Include music-backend startup checks in the remote smoke pass."
         ),
     ] = False,
+    provision_test_music: Annotated[
+        bool,
+        typer.Option(
+            "--provision-test-music/--no-provision-test-music",
+            help="Seed deterministic validation music before remote music smoke checks.",
+        ),
+    ] = True,
+    test_music_dir: Annotated[
+        str,
+        typer.Option(
+            "--test-music-dir",
+            help="Dedicated target directory for validation-only test music assets.",
+        ),
+    ] = "",
     with_voip: Annotated[
         bool,
         typer.Option(
@@ -1045,6 +1157,8 @@ def preflight(
     """Run local checks, sync the Pi, and execute the Pi smoke pass."""
     config = resolve_remote_config(host, user, project_dir, branch)
     validate_config(config)
+    deploy_config = load_pi_deploy_config()
+    resolved_test_music_dir = test_music_dir or deploy_config.test_music_target_dir
 
     if not skip_local:
         for label, command in build_local_preflight_commands():
@@ -1066,6 +1180,8 @@ def preflight(
             with_power=with_power,
             with_rtc=with_rtc,
             with_music=with_music,
+            provision_test_music=provision_test_music,
+            test_music_target_dir=resolved_test_music_dir if with_music else None,
             with_voip=with_voip,
             with_lvgl_soak=with_lvgl_soak,
             verbose=verbose,
@@ -1427,6 +1543,11 @@ def build_parser(deploy_config: PiDeployConfig) -> argparse.ArgumentParser:
     validate_parser.add_argument("--with-power", action="store_true")
     validate_parser.add_argument("--with-rtc", action="store_true")
     validate_parser.add_argument("--with-music", action="store_true")
+    validate_parser.add_argument("--no-provision-test-music", action="store_true")
+    validate_parser.add_argument(
+        "--test-music-dir",
+        default=deploy_config.test_music_target_dir,
+    )
     validate_parser.add_argument("--with-voip", action="store_true")
     validate_parser.add_argument("--with-lvgl-soak", action="store_true")
     validate_parser.add_argument("--verbose", action="store_true")
@@ -1459,11 +1580,26 @@ def build_parser(deploy_config: PiDeployConfig) -> argparse.ArgumentParser:
     smoke_parser.add_argument("--with-power", action="store_true")
     smoke_parser.add_argument("--with-rtc", action="store_true")
     smoke_parser.add_argument("--with-music", action="store_true")
+    smoke_parser.add_argument("--no-provision-test-music", action="store_true")
+    smoke_parser.add_argument(
+        "--test-music-dir",
+        default=deploy_config.test_music_target_dir,
+    )
     smoke_parser.add_argument("--with-voip", action="store_true")
     smoke_parser.add_argument("--with-lvgl-soak", action="store_true")
     smoke_parser.add_argument("--verbose", action="store_true")
     smoke_parser.add_argument("--music-timeout", type=int, default=5)
     smoke_parser.add_argument("--voip-timeout", type=float, default=10.0)
+
+    provision_music_parser = subparsers.add_parser(
+        "provision-test-music",
+        help="Seed the deterministic validation music library on the Raspberry Pi",
+    )
+    provision_music_parser.add_argument(
+        "--target-dir",
+        default=deploy_config.test_music_target_dir,
+    )
+    provision_music_parser.add_argument("--verbose", action="store_true")
 
     whisplay_parser = subparsers.add_parser(
         "whisplay",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,6 +31,17 @@ def test_pi_help():
     assert "validate" in _plain(result.output)
 
 
+def test_pi_music_help():
+    result = runner.invoke(app, ["pi", "music", "--help"])
+    assert result.exit_code == 0
+
+
+def test_pi_music_provision_test_library_help():
+    result = runner.invoke(app, ["pi", "music", "provision-test-library", "--help"])
+    assert result.exit_code == 0
+    assert "--target-dir" in _plain(result.output)
+
+
 def test_remote_help():
     result = runner.invoke(app, ["remote", "--help"])
     assert result.exit_code == 0
@@ -134,6 +145,19 @@ def test_pi_smoke_help():
     assert "--with-voip" in _plain(result.output)
     assert "--with-power" in _plain(result.output)
     assert "--with-lvgl-soak" in _plain(result.output)
+    assert "--test-music-dir" in _plain(result.output)
+
+
+def test_pi_music_help():
+    result = runner.invoke(app, ["pi", "music", "--help"])
+    assert result.exit_code == 0
+    assert "provision-test-library" in _plain(result.output)
+
+
+def test_pi_music_provision_test_library_help():
+    result = runner.invoke(app, ["pi", "music", "provision-test-library", "--help"])
+    assert result.exit_code == 0
+    assert "--target-dir" in _plain(result.output)
 
 
 def test_pi_validate_help():
@@ -215,12 +239,20 @@ def test_remote_validate_help():
     assert "--branch" in _plain(result.output)
     assert "--sha" in _plain(result.output)
     assert "--with-music" in _plain(result.output)
+    assert "--test-music-dir" in _plain(result.output)
     assert "--lines" in _plain(result.output)
 
 
 def test_remote_smoke_help():
     result = runner.invoke(app, ["remote", "smoke", "--help"])
     assert result.exit_code == 0
+    assert "--test-music-dir" in _plain(result.output)
+
+
+def test_remote_provision_test_music_help():
+    result = runner.invoke(app, ["remote", "provision-test-music", "--help"])
+    assert result.exit_code == 0
+    assert "--target-dir" in _plain(result.output)
 
 
 def test_remote_preflight_help():

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -1,5 +1,7 @@
 """Tests for Raspberry Pi remote workflow helpers."""
 
+import shlex
+
 import pytest
 import yaml
 
@@ -13,6 +15,7 @@ from yoyopod.cli.remote.ops import (
     build_logs_command,
     build_native_shim_refresh_command,
     build_parser,
+    build_provision_test_music_command,
     build_restart_command,
     build_rsync_command,
     build_rtc_command,
@@ -66,6 +69,7 @@ DEPLOY_CONFIG = PiDeployConfig(
     pid_file="/tmp/yoyopod.pid",
     startup_marker="YoyoPod starting",
     screenshot_path="/tmp/yoyopod_screenshot.png",
+    test_music_target_dir="~/YoyoPod_Test_Music",
     rsync_exclude=(".git/", ".cache/", "build/", "logs/"),
 )
 
@@ -101,6 +105,7 @@ def test_load_pi_deploy_config_merges_local_override(tmp_path) -> None:
                 "pid_file: /tmp/yoyopod.pid",
                 'startup_marker: "YoyoPod starting"',
                 "screenshot_path: /tmp/yoyopod_screenshot.png",
+                "test_music_target_dir: ~/YoyoPod_Test_Music",
                 "rsync_exclude: [.git/, .cache/, build/, logs/]",
             ]
         ),
@@ -126,6 +131,7 @@ def test_load_pi_deploy_config_merges_local_override(tmp_path) -> None:
     assert config.user == "pi"
     assert config.project_dir == "~/custom-yoyo"
     assert config.branch == "main"
+    assert config.test_music_target_dir == "~/YoyoPod_Test_Music"
 
 
 def test_build_local_override_template_targets_machine_specific_fields() -> None:
@@ -349,6 +355,7 @@ def test_build_smoke_command_adds_optional_checks() -> None:
         with_power=True,
         with_rtc=True,
         with_music=True,
+        test_music_target_dir=DEPLOY_CONFIG.test_music_target_dir,
         with_voip=True,
         with_lvgl_soak=True,
         verbose=True,
@@ -360,6 +367,7 @@ def test_build_smoke_command_adds_optional_checks() -> None:
     assert "--with-power" in command
     assert "--with-rtc" in command
     assert "uv run yoyoctl pi validate music" in command
+    assert shlex.quote(DEPLOY_CONFIG.test_music_target_dir) in command
     assert "uv run yoyoctl pi validate voip" in command
     assert "uv run yoyoctl pi validate stability" in command
     assert "--verbose" in command
@@ -372,6 +380,34 @@ def test_build_deploy_validation_command_targets_pi_suite() -> None:
     command = build_deploy_validation_command(verbose=True)
 
     assert command == "uv run yoyoctl pi validate deploy --verbose"
+
+
+def test_build_smoke_command_supports_disabling_test_music_provisioning() -> None:
+    """Music smoke should be able to skip deterministic asset seeding when requested."""
+
+    command = build_smoke_command(
+        with_music=True,
+        provision_test_music=False,
+        test_music_target_dir=DEPLOY_CONFIG.test_music_target_dir,
+    )
+
+    assert "uv run yoyoctl pi validate music" in command
+    assert "--no-provision-test-music" in command
+    assert "--test-music-dir" not in command
+
+
+def test_build_provision_test_music_command_targets_the_dedicated_library_path() -> None:
+    """Remote provisioning should call the Pi-side test-music helper with the target dir."""
+
+    command = build_provision_test_music_command(
+        target_dir=DEPLOY_CONFIG.test_music_target_dir,
+        verbose=True,
+    )
+
+    assert command.startswith("uv run yoyoctl pi music provision-test-library")
+    assert "--target-dir" in command
+    assert shlex.quote(DEPLOY_CONFIG.test_music_target_dir) in command
+    assert command.endswith("--verbose")
 
 
 def test_build_validation_inspection_command_reports_marker_and_logs() -> None:

--- a/tests/test_remote_config_helpers.py
+++ b/tests/test_remote_config_helpers.py
@@ -2,7 +2,11 @@
 
 from pathlib import Path
 
-from yoyopod.cli.remote.config import load_pi_deploy_config, resolve_remote_config
+from yoyopod.cli.remote.config import (
+    DEFAULT_TEST_MUSIC_TARGET_DIR,
+    load_pi_deploy_config,
+    resolve_remote_config,
+)
 from yoyopod.cli.remote.transport import build_ssh_command
 
 
@@ -69,3 +73,4 @@ def test_load_pi_deploy_config_uses_tracked_defaults_without_local_override(tmp_
     assert config.host == "rpi-zero"
     assert config.user == "pi"
     assert config.project_dir == "~/YoyoPod_Core"
+    assert config.test_music_target_dir == DEFAULT_TEST_MUSIC_TARGET_DIR

--- a/tests/test_test_music_library.py
+++ b/tests/test_test_music_library.py
@@ -1,0 +1,49 @@
+"""Tests for deterministic playback-validation music provisioning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from yoyopod.audio.test_music import (
+    TEST_MUSIC_MANIFEST_FILENAME,
+    expected_test_music_relative_paths,
+    provision_test_music_library,
+)
+
+
+def test_provision_test_music_library_writes_expected_assets(tmp_path: Path) -> None:
+    """Provisioning should create the full known-good validation library."""
+
+    library = provision_test_music_library(tmp_path / "YoyoPod_Test_Music")
+
+    expected_relative = set(expected_test_music_relative_paths())
+    actual_relative = {
+        path.relative_to(library.target_dir).as_posix()
+        for path in (*library.track_paths, *library.playlist_paths)
+    }
+
+    assert actual_relative == expected_relative
+    assert library.manifest_path.name == TEST_MUSIC_MANIFEST_FILENAME
+    assert library.manifest_path.exists()
+
+    playlist_text = library.default_playlist_path.read_text(encoding="utf-8")
+    assert "#EXTM3U" in playlist_text
+    assert "tracks/alpha-beacon.wav" in playlist_text
+    assert "tracks/bravo-lantern.wav" in playlist_text
+
+
+def test_provision_test_music_library_replaces_managed_assets_only(tmp_path: Path) -> None:
+    """Reprovisioning should refresh managed files without deleting unrelated ones."""
+
+    library = provision_test_music_library(tmp_path / "YoyoPod_Test_Music")
+    extra_file = library.target_dir / "keep-me.txt"
+    extra_file.write_text("user-media-stays\n", encoding="utf-8")
+
+    first_track = library.track_paths[0]
+    first_track.write_bytes(b"bad")
+
+    reprovisioned = provision_test_music_library(library.target_dir)
+
+    assert extra_file.exists()
+    assert first_track.stat().st_size > 3
+    assert reprovisioned.default_playlist_path.exists()


### PR DESCRIPTION
## Summary
- add deterministic Pi-side test music provisioning helpers and CLI commands
- thread the dedicated test music target path through remote validation and smoke helpers
- document the playback-validation seeding flow and cover it with focused tests

## Testing
- uv run pytest -q
- uv run python scripts/quality.py gate

Closes #131