### PR TITLE
feat: add target navigation soak validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ uv run yoyoctl setup verify-host
 python yoyopod.py --simulate
 uv run python scripts/quality.py ci
 yoyoctl pi validate smoke
+yoyoctl pi validate navigation --with-playback
 ```
 
 For the full setup, validation, and Pi workflow, start with:

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -148,6 +148,7 @@ yoyoctl pi validate smoke
 yoyoctl pi validate smoke --with-power --with-rtc
 yoyoctl pi validate music
 yoyoctl pi validate voip
+yoyoctl pi validate navigation
 yoyoctl pi validate stability
 ```
 
@@ -163,7 +164,9 @@ yoyoctl remote status
 git branch --show-current
 git rev-parse HEAD
 yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak
-yoyoctl remote preflight --branch <branch> --with-music --with-voip --with-lvgl-soak
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-navigation-soak
+yoyoctl remote navigation-soak --with-playback --idle-seconds 5 --tail-idle-seconds 20
+yoyoctl remote preflight --branch <branch> --with-music --with-voip --with-navigation-soak --with-lvgl-soak
 yoyoctl remote service status
 yoyoctl remote logs --lines 200
 ```

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -92,6 +92,8 @@ Useful variations:
 ```bash
 yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip
 yoyoctl remote validate --branch <branch> --sha <commit> --with-power --with-rtc
+yoyoctl remote validate --branch <branch> --sha <commit> --with-navigation-soak
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-navigation-soak
 yoyoctl remote validate --branch <branch> --sha <commit> --with-lvgl-soak
 yoyoctl remote validate --branch <branch> --sha <commit> --skip-uv-sync
 ```
@@ -158,6 +160,7 @@ Use this when you want the stable checkout updated but do not want the full vali
 yoyoctl remote smoke
 yoyoctl remote smoke --with-power --with-rtc
 yoyoctl remote smoke --with-music --with-voip --with-rtc
+yoyoctl remote smoke --with-navigation-soak
 yoyoctl remote smoke --with-lvgl-soak
 ```
 
@@ -166,6 +169,7 @@ This composes the target-side suite:
 - `yoyoctl pi validate smoke`
 - `yoyoctl pi validate music`
 - `yoyoctl pi validate voip`
+- `yoyoctl pi validate navigation`
 - `yoyoctl pi validate stability`
 
 Useful variations:
@@ -287,6 +291,8 @@ This installs `deploy/systemd/yoyopod@.service` onto the Pi as `yoyopod@<remote-
 yoyoctl remote whisplay
 yoyoctl remote whisplay --duration-seconds 45 --double-tap-ms 240 --long-hold-ms 900
 yoyoctl remote lvgl-soak
+yoyoctl remote navigation-soak
+yoyoctl remote navigation-soak --with-playback --idle-seconds 5 --tail-idle-seconds 20
 yoyoctl remote rtc status
 yoyoctl remote power
 ```
@@ -296,7 +302,7 @@ yoyoctl remote power
 `yoyoctl remote preflight` is still useful, but it is a preparation step, not the full hardware-validation finish line.
 
 ```bash
-yoyoctl remote preflight --branch <branch> --with-music --with-voip --with-lvgl-soak
+yoyoctl remote preflight --branch <branch> --with-music --with-voip --with-navigation-soak --with-lvgl-soak
 ```
 
 What it does:
@@ -340,15 +346,22 @@ If you use it, say clearly that the board is running a dirty-tree override inste
    ```
 5. Validate on the Pi:
    ```bash
-   yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak
+   yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip
    ```
 6. Manually test on the target hardware while the app remains running.
+
+When you are chasing idle freezes or routed-screen hangs, add the deterministic soak:
+
+```bash
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-navigation-soak
+```
 
 ## Release / Pre-Merge Checklist
 
 - local branch is green with `uv run python scripts/quality.py ci`
 - branch is pushed and reviewed
 - `yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak` passes
+- if you touched idle navigation, `yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-navigation-soak` passes
 - the app starts cleanly and stays running for manual hardware testing
 - manual sanity still passes for display, input, music, SIP registration, and call flow
 

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -34,6 +34,8 @@ Useful variations:
 ```bash
 yoyoctl remote validate --branch <branch> --sha <commit> --with-power --with-rtc
 yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip
+yoyoctl remote validate --branch <branch> --sha <commit> --with-navigation-soak
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-navigation-soak
 yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak
 ```
 
@@ -73,6 +75,7 @@ yoyoctl pi validate smoke
 yoyoctl pi validate smoke --with-power --with-rtc
 yoyoctl pi validate music
 yoyoctl pi validate voip
+yoyoctl pi validate navigation
 yoyoctl pi validate stability
 ```
 
@@ -82,6 +85,7 @@ What each command checks:
 - `smoke`: target environment, display initialization on real hardware, matching input adapter construction and start/stop, plus optional PiSugar power and RTC checks
 - `music`: mpv music-backend startup using `config/yoyopod_config.yaml`
 - `voip`: Liblinphone startup and SIP registration using `config/voip_config.yaml`
+- `navigation`: repeatable one-button routed navigation with explicit idle dwells, click-driven transitions, optional playlist/shuffle playback, and a final sleep/wake pass
 - `stability`: repeated LVGL transition plus sleep/wake recovery on the active app path
 
 Useful flags:
@@ -91,6 +95,9 @@ Useful flags:
 - `yoyoctl pi music provision-test-library --target-dir ~/YoyoPod_Test_Music`
 - `yoyoctl remote provision-test-music`
 - `yoyoctl pi validate voip --timeout 15`
+- `yoyoctl pi validate navigation --with-playback --test-music-dir ~/YoyoPod_Test_Music`
+- `yoyoctl pi validate navigation --cycles 3 --idle-seconds 5 --tail-idle-seconds 20`
+- `yoyoctl remote navigation-soak --with-playback --test-music-dir ~/YoyoPod_Test_Music`
 - `yoyoctl pi validate stability --cycles 3 --hold-seconds 0.3`
 - `--verbose` on any suite command
 
@@ -175,6 +182,22 @@ Use this when Whisplay rendering feels fast but you still want a hardware pass f
 - sleep/wake recovery
 - LVGL-only corruption or stuck redraw issues
 
+### Navigation and idle stability soak
+
+```bash
+yoyoctl pi validate navigation
+yoyoctl pi validate navigation --with-playback --test-music-dir ~/YoyoPod_Test_Music
+yoyoctl remote navigation-soak --with-playback --idle-seconds 5 --tail-idle-seconds 20
+```
+
+Use this when you want a reproducible freeze-repro path that keeps the app mostly idle but still exercises:
+
+- routed one-button navigation from the real input dispatcher
+- click-driven transitions into `Listen`, `Talk`, `Ask`, and `Setup`
+- playlist and shuffle playback navigation while mpv is active
+- explicit idle dwell windows between actions
+- a final tail-idle and sleep/wake pass on the hub
+
 ### PiSugar RTC drill
 
 ```bash
@@ -217,6 +240,7 @@ Only use it when:
 - `input` fails: check the matching display adapter initialized correctly first
 - `music` fails: verify `mpv` is installed, the configured socket path is writable, and the provision target under `test_music_target_dir` is writable when deterministic seeding is enabled
 - `voip` fails: verify the Liblinphone shim build, `config/liblinphone_factory.conf`, SIP credentials, network reachability, and audio device configuration
+- `navigation` fails: rerun `yoyoctl pi validate navigation --verbose` or `yoyoctl remote navigation-soak --verbose` and inspect which expected screen or playback transition stalled
 - `stability` fails: rerun `yoyoctl pi validate stability --verbose` or `yoyoctl pi lvgl soak` for a deeper LVGL-only pass
 - `validate` fails before launch: check whether the branch was actually pushed and whether the Pi checkout is reachable over SSH
 

--- a/rules/deploy.md
+++ b/rules/deploy.md
@@ -23,7 +23,7 @@ The repo-owned command for that flow is:
 ```bash
 git branch --show-current
 git rev-parse HEAD
-yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-lvgl-soak
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-navigation-soak
 ```
 
 `yoyoctl remote validate` is the default because it:
@@ -60,6 +60,7 @@ The `rpi-deploy` Claude Code plugin is still the high-level integration surface,
 | `/yoyopod-restart` | Restart the already-synced app |
 | `/yoyopod-status` | Health check dashboard |
 | `/yoyopod-screenshot [--readback]` | Capture display output as PNG |
+| `yoyoctl remote navigation-soak` | Run the target navigation and idle soak over SSH |
 
 Lower-level `yoyoctl remote` commands:
 
@@ -67,6 +68,7 @@ Lower-level `yoyoctl remote` commands:
 - `yoyoctl remote sync` is the committed-code sync primitive
 - `yoyoctl remote smoke` is the remote smoke primitive
 - `yoyoctl remote restart` restarts the synced app and verifies startup
+- `yoyoctl remote navigation-soak` runs the action-driven navigation and idle soak remotely
 - `yoyoctl remote rsync` is not the default; use it only as an explicit debugging override
 
 Target-side `yoyoctl pi validate` commands:
@@ -75,6 +77,7 @@ Target-side `yoyoctl pi validate` commands:
 - `yoyoctl pi validate smoke` checks environment, display, input, and optional PiSugar telemetry
 - `yoyoctl pi validate music` checks the mpv backend in isolation
 - `yoyoctl pi validate voip` checks Liblinphone startup and SIP registration in isolation
+- `yoyoctl pi validate navigation` runs the one-button navigation, idle, and playback stress path used for freeze repro
 - `yoyoctl pi validate stability` runs the repeated LVGL transition and sleep/wake stability pass
 
 Config lives in `deploy/pi-deploy.yaml` plus optional `deploy/pi-deploy.local.yaml` for machine-specific host and user overrides. Preferred edit flow:

--- a/rules/project.md
+++ b/rules/project.md
@@ -37,6 +37,7 @@ yoyoctl pi validate deploy
 yoyoctl pi validate smoke
 yoyoctl pi validate music
 yoyoctl pi validate voip
+yoyoctl pi validate navigation
 yoyoctl pi validate stability
 ```
 

--- a/src/yoyopod/cli/pi/lvgl.py
+++ b/src/yoyopod/cli/pi/lvgl.py
@@ -7,7 +7,9 @@ from typing import Annotated, Optional
 
 import typer
 
+from yoyopod.audio.test_music import DEFAULT_TEST_MUSIC_TARGET_DIR
 from yoyopod.cli.common import configure_logging
+from yoyopod.cli.pi.stability import NavigationSoakError, run_navigation_idle_soak
 
 lvgl_app = typer.Typer(name="lvgl", help="LVGL display stress-test and probe commands.", no_args_is_help=True)
 
@@ -18,110 +20,57 @@ def soak(
     simulate: Annotated[bool, typer.Option("--simulate", help="Run against simulation instead of hardware.")] = False,
     cycles: Annotated[int, typer.Option("--cycles", help="How many full transition cycles to run.")] = 2,
     hold_seconds: Annotated[float, typer.Option("--hold-seconds", help="How long to keep each screen active during the soak.")] = 0.2,
+    idle_seconds: Annotated[
+        float,
+        typer.Option(
+            "--idle-seconds",
+            help="How long to idle after each full navigation cycle.",
+        ),
+    ] = 1.0,
+    with_music: Annotated[
+        bool,
+        typer.Option(
+            "--with-music",
+            help="Exercise playlist loading and now-playing actions during the soak.",
+        ),
+    ] = False,
+    provision_test_music: Annotated[
+        bool,
+        typer.Option(
+            "--provision-test-music/--no-provision-test-music",
+            help="Seed the deterministic validation music library before playback soak steps.",
+        ),
+    ] = True,
+    test_music_dir: Annotated[
+        str,
+        typer.Option(
+            "--test-music-dir",
+            help="Dedicated target directory for validation-only test music assets.",
+        ),
+    ] = DEFAULT_TEST_MUSIC_TARGET_DIR,
     skip_sleep: Annotated[bool, typer.Option("--skip-sleep", help="Skip the sleep/wake exercise.")] = False,
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
 ) -> None:
-    """Run a deterministic LVGL screen-transition soak pass against YoyoPod."""
+    """Run a deterministic LVGL navigation and idle soak pass against YoyoPod."""
     from loguru import logger
 
-    from yoyopod.app import YoyoPodApp
-    from yoyopod.events import UserActivityEvent
-
     configure_logging(verbose)
-
-    def _pump_app(app: YoyoPodApp, duration_seconds: float) -> None:
-        """Pump the coordinator-thread services without entering the full app run loop."""
-        deadline = time.monotonic() + max(0.0, duration_seconds)
-        while time.monotonic() < deadline:
-            app._process_pending_main_thread_actions()
-            now = time.monotonic()
-            app._attempt_manager_recovery()
-            app._poll_power_status(now=now)
-            app._pump_lvgl_backend(now)
-            app._feed_watchdog_if_due(now)
-            app._update_screen_power(now)
-            time.sleep(0.05)
-
-    def _exercise_sleep_wake(app: YoyoPodApp) -> tuple[bool, str]:
-        """Force one sleep/wake cycle against the current app."""
-        timeout_seconds = max(1.0, float(app._screen_timeout_seconds or 0.0))
-        app._last_user_activity_at = time.monotonic() - timeout_seconds - 1.0
-        _pump_app(app, 0.35)
-        if app.context is None or app.context.screen_awake:
-            return False, "screen did not enter sleep during soak"
-
-        app.event_bus.publish(UserActivityEvent(action_name="lvgl_soak"))
-        _pump_app(app, 0.35)
-        if app.context is None or not app.context.screen_awake:
-            return False, "screen did not wake after simulated activity"
-
-        return True, "sleep/wake ok"
-
-    def run_lvgl_soak(
-        *,
-        config_dir: str = "config",
-        simulate: bool = False,
-        cycles: int = 2,
-        hold_seconds: float = 0.2,
-        exercise_sleep: bool = True,
-    ) -> tuple[bool, str]:
-        """Run a deterministic screen-transition soak and return success/details."""
-        app = YoyoPodApp(config_dir=config_dir, simulate=simulate)
-        if not app.setup():
-            return False, "app setup failed"
-
-        try:
-            if app.display is None or app.screen_manager is None:
-                return False, "display or screen manager not initialized"
-
-            if app.display.backend_kind != "lvgl":
-                return False, f"backend is {app.display.backend_kind}, expected lvgl"
-
-            screens = [
-                "hub",
-                "listen",
-                "playlists",
-                "now_playing",
-                "call",
-                "talk_contact",
-                "call_history",
-                "contacts",
-                "voice_note",
-                "ask",
-                "power",
-            ]
-
-            transitions = 0
-            for _cycle in range(max(1, cycles)):
-                for screen_name in screens:
-                    if screen_name not in app.screen_manager.screens:
-                        continue
-                    app.screen_manager.replace_screen(screen_name)
-                    _pump_app(app, hold_seconds)
-                    transitions += 1
-
-            sleep_details = "sleep/wake skipped"
-            if exercise_sleep:
-                sleep_ok, sleep_details = _exercise_sleep_wake(app)
-                if not sleep_ok:
-                    return False, sleep_details
-
-            return True, f"backend=lvgl, transitions={transitions}, {sleep_details}"
-        finally:
-            app.stop()
-
-    ok, details = run_lvgl_soak(
-        config_dir=config_dir,
-        simulate=simulate,
-        cycles=cycles,
-        hold_seconds=hold_seconds,
-        exercise_sleep=not skip_sleep,
-    )
-    if ok:
-        logger.info(f"LVGL soak passed: {details}")
-    else:
-        logger.error(f"LVGL soak failed: {details}")
+    try:
+        report = run_navigation_idle_soak(
+            config_dir=config_dir,
+            simulate=simulate,
+            cycles=cycles,
+            hold_seconds=hold_seconds,
+            idle_seconds=idle_seconds,
+            skip_sleep=skip_sleep,
+            with_music=with_music,
+            provision_test_music=provision_test_music,
+            test_music_dir=test_music_dir,
+        )
+    except NavigationSoakError as exc:
+        logger.error(f"LVGL soak failed: {exc}")
         raise typer.Exit(code=1)
+    logger.info(f"LVGL soak passed: {report.summary()}")
 
 
 @lvgl_app.command()

--- a/src/yoyopod/cli/pi/navigation.py
+++ b/src/yoyopod/cli/pi/navigation.py
@@ -1,0 +1,643 @@
+"""Target-hardware navigation and idle soak helpers."""
+
+from __future__ import annotations
+
+import os
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Iterator
+
+from loguru import logger
+
+from yoyopod.audio.test_music import (
+    DEFAULT_TEST_MUSIC_TARGET_DIR,
+    provision_test_music_library,
+)
+from yoyopod.events import UserActivityEvent
+from yoyopod.ui.input import InputAction, InteractionProfile
+
+if TYPE_CHECKING:
+    from yoyopod.app import YoyoPodApp
+
+
+class NavigationSoakFailure(RuntimeError):
+    """Raised when the navigation soak cannot complete its expected path."""
+
+
+@dataclass(slots=True)
+class NavigationSoakStats:
+    """Accumulate compact soak diagnostics for the final summary."""
+
+    actions: int = 0
+    visited_screens: set[str] = field(default_factory=set)
+    explicit_idle_seconds: float = 0.0
+    max_runtime_iteration_ms: float = 0.0
+    max_runtime_loop_gap_ms: float = 0.0
+    max_voip_schedule_delay_ms: float = 0.0
+    heaviest_blocking_span_name: str | None = None
+    heaviest_blocking_span_ms: float = 0.0
+    last_track_name: str | None = None
+    playback_verified: bool = False
+    sleep_wake_status: str = "skipped"
+
+    def observe_snapshot(self, snapshot: dict[str, float | int | None]) -> None:
+        """Record high-level loop timing from one runtime snapshot."""
+
+        runtime_iteration = snapshot.get("runtime_iteration_seconds")
+        if runtime_iteration is not None:
+            self.max_runtime_iteration_ms = max(
+                self.max_runtime_iteration_ms,
+                float(runtime_iteration) * 1000.0,
+            )
+
+        loop_gap = snapshot.get("runtime_loop_gap_seconds")
+        if loop_gap is not None:
+            self.max_runtime_loop_gap_ms = max(
+                self.max_runtime_loop_gap_ms,
+                float(loop_gap) * 1000.0,
+            )
+
+        voip_schedule_delay = snapshot.get("voip_schedule_delay_seconds")
+        if voip_schedule_delay is not None:
+            self.max_voip_schedule_delay_ms = max(
+                self.max_voip_schedule_delay_ms,
+                float(voip_schedule_delay) * 1000.0,
+            )
+
+        blocking_name = snapshot.get("runtime_blocking_span_name")
+        blocking_seconds = snapshot.get("runtime_blocking_span_seconds")
+        if blocking_name and blocking_seconds is not None:
+            blocking_ms = float(blocking_seconds) * 1000.0
+            if blocking_ms >= self.heaviest_blocking_span_ms:
+                self.heaviest_blocking_span_ms = blocking_ms
+                self.heaviest_blocking_span_name = str(blocking_name)
+
+
+@contextmanager
+def _temporary_env_var(name: str, value: str | None) -> Iterator[None]:
+    """Temporarily override one environment variable."""
+
+    previous = os.environ.get(name)
+    if value is None:
+        yield
+        return
+
+    os.environ[name] = value
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = previous
+
+
+class _RuntimePump:
+    """Drive the app loop without entering the long-running production loop."""
+
+    def __init__(self, app: "YoyoPodApp", stats: NavigationSoakStats) -> None:
+        self._app = app
+        self._stats = stats
+        self._last_screen_update = time.time()
+        self._screen_update_interval = 1.0
+
+    def run_for(self, duration_seconds: float) -> None:
+        """Pump the app for the requested duration."""
+
+        deadline = time.monotonic() + max(0.0, duration_seconds)
+        while time.monotonic() < deadline:
+            time.sleep(min(0.05, max(0.01, self._app._voip_iterate_interval_seconds)))
+            monotonic_now = time.monotonic()
+            current_time = time.time()
+            iteration_started_at = time.monotonic()
+            self._last_screen_update = self._app.runtime_loop.run_iteration(
+                monotonic_now=monotonic_now,
+                current_time=current_time,
+                last_screen_update=self._last_screen_update,
+                screen_update_interval=self._screen_update_interval,
+            )
+            iteration_duration_ms = (time.monotonic() - iteration_started_at) * 1000.0
+            self._stats.max_runtime_iteration_ms = max(
+                self._stats.max_runtime_iteration_ms,
+                iteration_duration_ms,
+            )
+
+            current_screen = self._app.screen_manager.get_current_screen()
+            if current_screen is not None and current_screen.route_name is not None:
+                self._stats.visited_screens.add(current_screen.route_name)
+
+            snapshot = self._app.runtime_loop.timing_snapshot(now=monotonic_now)
+            self._stats.observe_snapshot(snapshot)
+
+            if self._app._shutdown_completed:
+                raise NavigationSoakFailure(
+                    "app completed shutdown unexpectedly during navigation soak"
+                )
+
+
+class NavigationSoakRunner:
+    """Exercise the target one-button UI with repeatable action-driven flows."""
+
+    _PLAYBACK_TIMEOUT_SECONDS = 8.0
+
+    def __init__(
+        self,
+        *,
+        config_dir: str,
+        cycles: int,
+        hold_seconds: float,
+        idle_seconds: float,
+        tail_idle_seconds: float,
+        with_playback: bool,
+        provision_test_music: bool,
+        test_music_dir: str,
+        skip_sleep: bool,
+    ) -> None:
+        self.config_dir = config_dir
+        self.cycles = max(1, cycles)
+        self.hold_seconds = max(0.05, hold_seconds)
+        self.idle_seconds = max(0.0, idle_seconds)
+        self.tail_idle_seconds = max(0.0, tail_idle_seconds)
+        self.with_playback = with_playback
+        self.provision_test_music = provision_test_music
+        self.test_music_dir = test_music_dir
+        self.skip_sleep = skip_sleep
+
+        self.stats = NavigationSoakStats()
+        self._app: YoyoPodApp | None = None
+        self._pump: _RuntimePump | None = None
+
+    def run(self) -> tuple[bool, str]:
+        """Run the full soak and return success plus one-line details."""
+
+        from yoyopod.app import YoyoPodApp
+
+        music_dir_override = None
+        if self.with_playback and self.provision_test_music:
+            library = provision_test_music_library(Path(self.test_music_dir))
+            music_dir_override = str(library.target_dir)
+            logger.info(
+                "Navigation soak provisioned validation music at {}",
+                music_dir_override,
+            )
+
+        with _temporary_env_var("YOYOPOD_MUSIC_DIR", music_dir_override):
+            app = YoyoPodApp(config_dir=self.config_dir, simulate=False)
+            self._app = app
+            if not app.setup():
+                try:
+                    app.stop()
+                except Exception:
+                    logger.exception("Navigation soak cleanup failed after unsuccessful app setup")
+                return False, "app setup failed"
+
+            try:
+                if app.display is None or app.screen_manager is None or app.input_manager is None:
+                    return False, "display, screen manager, or input manager not initialized"
+                if app.display.backend_kind != "lvgl":
+                    return False, f"backend is {app.display.backend_kind}, expected lvgl"
+                if app.input_manager.interaction_profile != InteractionProfile.ONE_BUTTON:
+                    profile_name = app.input_manager.interaction_profile.value
+                    return False, f"profile is {profile_name}, expected one_button"
+
+                app.recovery_service.start_watchdog(now=time.monotonic())
+                self._pump = _RuntimePump(app, self.stats)
+                self._pump.run_for(self.hold_seconds)
+
+                self._require_screen("hub")
+                for cycle_number in range(1, self.cycles + 1):
+                    logger.info(
+                        "Navigation soak cycle {}/{}",
+                        cycle_number,
+                        self.cycles,
+                    )
+                    self._exercise_cycle()
+
+                self._idle_phase("hub_tail_idle", self.tail_idle_seconds)
+                self._exercise_sleep_wake()
+            except NavigationSoakFailure as exc:
+                return False, str(exc)
+            finally:
+                app.stop()
+
+        return True, self._summary_details()
+
+    @property
+    def app(self) -> "YoyoPodApp":
+        """Return the active app or raise when the runner is uninitialized."""
+
+        if self._app is None:
+            raise NavigationSoakFailure("navigation soak app is not initialized")
+        return self._app
+
+    @property
+    def pump(self) -> _RuntimePump:
+        """Return the runtime pump or raise when the runner is uninitialized."""
+
+        if self._pump is None:
+            raise NavigationSoakFailure("navigation soak runtime pump is not initialized")
+        return self._pump
+
+    def _summary_details(self) -> str:
+        """Return a compact summary string for CLI output."""
+
+        blocking_span = "none"
+        if self.stats.heaviest_blocking_span_name is not None:
+            blocking_span = (
+                f"{self.stats.heaviest_blocking_span_name}:"
+                f"{self.stats.heaviest_blocking_span_ms:.1f}ms"
+            )
+
+        screen_list = ",".join(sorted(self.stats.visited_screens)) or "none"
+        playback_state = "verified" if self.stats.playback_verified else "not_requested"
+        if self.with_playback and not self.stats.playback_verified:
+            playback_state = "requested_not_verified"
+
+        track_name = self.stats.last_track_name or "none"
+        return (
+            f"profile=one_button, cycles={self.cycles}, actions={self.stats.actions}, "
+            f"screens={screen_list}, explicit_idle_s={self.stats.explicit_idle_seconds:.1f}, "
+            f"playback={playback_state}, last_track={track_name}, "
+            f"max_iteration_ms={self.stats.max_runtime_iteration_ms:.1f}, "
+            f"max_loop_gap_ms={self.stats.max_runtime_loop_gap_ms:.1f}, "
+            f"max_voip_delay_ms={self.stats.max_voip_schedule_delay_ms:.1f}, "
+            f"heaviest_span={blocking_span}, sleep_wake={self.stats.sleep_wake_status}"
+        )
+
+    def _current_screen_name(self) -> str:
+        """Return the active route name."""
+
+        current_screen = self.app.screen_manager.get_current_screen()
+        route_name = None if current_screen is None else current_screen.route_name
+        return route_name or "unknown"
+
+    def _require_screen(self, expected_screen: str) -> None:
+        """Assert the active route name matches the expected screen."""
+
+        actual_screen = self._current_screen_name()
+        if actual_screen != expected_screen:
+            raise NavigationSoakFailure(f"expected screen {expected_screen}, got {actual_screen}")
+
+    def _simulate_action(
+        self,
+        action: InputAction,
+        *,
+        expected_screen: str | None = None,
+        label: str,
+        settle_seconds: float | None = None,
+    ) -> None:
+        """Send one semantic action through the real input dispatcher."""
+
+        logger.info(
+            "Navigation soak action: {} on {}",
+            label,
+            self._current_screen_name(),
+        )
+        self.app.input_manager.simulate_action(action)
+        self.stats.actions += 1
+        self.pump.run_for(self.hold_seconds if settle_seconds is None else settle_seconds)
+
+        if expected_screen is not None:
+            actual_screen = self._current_screen_name()
+            if actual_screen != expected_screen:
+                raise NavigationSoakFailure(
+                    f"{label} expected {expected_screen}, got {actual_screen}"
+                )
+
+    def _idle_phase(self, label: str, duration_seconds: float) -> None:
+        """Leave the app idle for one explicit dwell period."""
+
+        if duration_seconds <= 0:
+            return
+
+        logger.info(
+            "Navigation soak idle: {} for {:.1f}s on {}",
+            label,
+            duration_seconds,
+            self._current_screen_name(),
+        )
+        self.stats.explicit_idle_seconds += duration_seconds
+        self.pump.run_for(duration_seconds)
+
+    def _advance_until(
+        self,
+        *,
+        expected_screen: str,
+        target_value: str,
+        current_value: Callable[[], str],
+        label: str,
+        max_steps: int,
+    ) -> None:
+        """Advance through one carousel or list until the requested item is selected."""
+
+        for _ in range(max_steps):
+            if current_value() == target_value:
+                return
+            self._simulate_action(
+                InputAction.ADVANCE,
+                expected_screen=expected_screen,
+                label=label,
+            )
+
+        raise NavigationSoakFailure(f"could not reach {target_value} on {expected_screen}")
+
+    def _hub_mode(self) -> str:
+        """Return the selected hub card mode."""
+
+        self._require_screen("hub")
+        hub_screen = self.app.screen_manager.get_current_screen()
+        cards = [] if hub_screen is None else hub_screen._cards()
+        if not cards:
+            raise NavigationSoakFailure("hub has no cards to navigate")
+        return cards[hub_screen.selected_index % len(cards)].mode
+
+    def _listen_item_key(self) -> str:
+        """Return the selected Listen landing item key."""
+
+        self._require_screen("listen")
+        listen_screen = self.app.screen_manager.get_current_screen()
+        items = [] if listen_screen is None else getattr(listen_screen, "items", [])
+        if not items:
+            raise NavigationSoakFailure("listen screen has no items to navigate")
+        return items[listen_screen.selected_index % len(items)].key
+
+    def _move_hub_to(self, mode: str) -> None:
+        """Advance the hub carousel until one mode is selected."""
+
+        self._advance_until(
+            expected_screen="hub",
+            target_value=mode,
+            current_value=self._hub_mode,
+            label=f"hub advance to {mode}",
+            max_steps=8,
+        )
+
+    def _move_listen_to(self, key: str) -> None:
+        """Advance the Listen landing screen until one item is selected."""
+
+        self._advance_until(
+            expected_screen="listen",
+            target_value=key,
+            current_value=self._listen_item_key,
+            label=f"listen advance to {key}",
+            max_steps=8,
+        )
+
+    def _current_track_name(self) -> str | None:
+        """Return the current track name when playback is active."""
+
+        music_backend = self.app.music_backend
+        if music_backend is None or not music_backend.is_connected:
+            return None
+        current_track = music_backend.get_current_track()
+        if current_track is None:
+            return None
+        return current_track.name
+
+    def _wait_for_playback_started(self, context_label: str) -> None:
+        """Wait until playback produces one current track snapshot."""
+
+        if not self.with_playback:
+            return
+
+        deadline = time.monotonic() + self._PLAYBACK_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            current_track_name = self._current_track_name()
+            if current_track_name is not None:
+                self.stats.playback_verified = True
+                self.stats.last_track_name = current_track_name
+                return
+            self.pump.run_for(0.2)
+
+        raise NavigationSoakFailure(
+            f"{context_label} did not produce a playable track within "
+            f"{self._PLAYBACK_TIMEOUT_SECONDS:.1f}s"
+        )
+
+    def _wait_for_track_change(
+        self,
+        *,
+        previous_track_name: str | None,
+        context_label: str,
+    ) -> None:
+        """Wait until the current track changes after a skip action."""
+
+        deadline = time.monotonic() + self._PLAYBACK_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            current_track_name = self._current_track_name()
+            if current_track_name is not None and current_track_name != previous_track_name:
+                self.stats.last_track_name = current_track_name
+                self.stats.playback_verified = True
+                return
+            self.pump.run_for(0.2)
+
+        raise NavigationSoakFailure(
+            f"{context_label} did not change the current track within "
+            f"{self._PLAYBACK_TIMEOUT_SECONDS:.1f}s"
+        )
+
+    def _exercise_now_playing(self, *, phase_label: str, back_target: str) -> None:
+        """Exercise idle, play/pause, and next-track on Now Playing."""
+
+        self._require_screen("now_playing")
+        self._wait_for_playback_started(phase_label)
+        self._idle_phase(f"{phase_label}_idle", self.idle_seconds)
+
+        self._simulate_action(
+            InputAction.PLAY_PAUSE,
+            expected_screen="now_playing",
+            label=f"{phase_label} pause",
+        )
+        self.pump.run_for(self.hold_seconds)
+        self._simulate_action(
+            InputAction.PLAY_PAUSE,
+            expected_screen="now_playing",
+            label=f"{phase_label} resume",
+        )
+
+        previous_track_name = self._current_track_name()
+        self._simulate_action(
+            InputAction.NEXT_TRACK,
+            expected_screen="now_playing",
+            label=f"{phase_label} next track",
+        )
+        self._wait_for_track_change(
+            previous_track_name=previous_track_name,
+            context_label=phase_label,
+        )
+        self._idle_phase(f"{phase_label}_post_next_idle", self.idle_seconds)
+        self._simulate_action(
+            InputAction.BACK,
+            expected_screen=back_target,
+            label=f"{phase_label} back",
+        )
+
+    def _exercise_listen_branch(self) -> None:
+        """Exercise Listen, playlists, recent, and playback-related navigation."""
+
+        self._move_hub_to("listen")
+        self._simulate_action(
+            InputAction.SELECT,
+            expected_screen="listen",
+            label="open Listen",
+        )
+        self._idle_phase("listen_landing", self.idle_seconds)
+
+        self._move_listen_to("playlists")
+        self._simulate_action(
+            InputAction.SELECT,
+            expected_screen="playlists",
+            label="open Playlists",
+        )
+        self._idle_phase("playlists_idle", self.idle_seconds)
+
+        if self.with_playback:
+            playlist_screen = self.app.screen_manager.get_current_screen()
+            playlists = [] if playlist_screen is None else getattr(playlist_screen, "playlists", [])
+            if not playlists:
+                raise NavigationSoakFailure(
+                    "playlists screen is empty; disable playback or provision test music"
+                )
+            self._simulate_action(
+                InputAction.SELECT,
+                expected_screen="now_playing",
+                label="load validation playlist",
+            )
+            self._exercise_now_playing(
+                phase_label="playlist_playback",
+                back_target="playlists",
+            )
+
+        self._simulate_action(
+            InputAction.BACK,
+            expected_screen="listen",
+            label="back to Listen from Playlists",
+        )
+
+        self._move_listen_to("recent")
+        self._simulate_action(
+            InputAction.SELECT,
+            expected_screen="recent_tracks",
+            label="open Recent",
+        )
+        self._idle_phase("recent_tracks_idle", self.idle_seconds)
+        self._simulate_action(
+            InputAction.BACK,
+            expected_screen="listen",
+            label="back to Listen from Recent",
+        )
+
+        if self.with_playback:
+            self._move_listen_to("shuffle")
+            self._simulate_action(
+                InputAction.SELECT,
+                expected_screen="now_playing",
+                label="shuffle local music",
+            )
+            self._exercise_now_playing(
+                phase_label="shuffle_playback",
+                back_target="listen",
+            )
+
+        self._simulate_action(
+            InputAction.BACK,
+            expected_screen="hub",
+            label="back to Hub from Listen",
+        )
+
+    def _exercise_simple_hub_branch(
+        self,
+        *,
+        mode: str,
+        target_screen: str,
+        idle_label: str,
+    ) -> None:
+        """Open one hub card, idle briefly, and return."""
+
+        self._move_hub_to(mode)
+        self._simulate_action(
+            InputAction.SELECT,
+            expected_screen=target_screen,
+            label=f"open {mode}",
+        )
+        self._idle_phase(idle_label, self.idle_seconds)
+        self._simulate_action(
+            InputAction.BACK,
+            expected_screen="hub",
+            label=f"back from {target_screen}",
+        )
+
+    def _exercise_cycle(self) -> None:
+        """Run one full navigation cycle."""
+
+        self._exercise_listen_branch()
+        self._exercise_simple_hub_branch(
+            mode="talk",
+            target_screen="call",
+            idle_label="talk_idle",
+        )
+        self._exercise_simple_hub_branch(
+            mode="ask",
+            target_screen="ask",
+            idle_label="ask_idle",
+        )
+        self._exercise_simple_hub_branch(
+            mode="setup",
+            target_screen="power",
+            idle_label="power_idle",
+        )
+        self._move_hub_to("listen")
+
+    def _exercise_sleep_wake(self) -> None:
+        """Force one sleep/wake cycle when screen timeout is enabled."""
+
+        if self.skip_sleep:
+            self.stats.sleep_wake_status = "skipped"
+            return
+
+        timeout_seconds = float(self.app._screen_timeout_seconds or 0.0)
+        if timeout_seconds <= 0.0:
+            self.stats.sleep_wake_status = "timeout_disabled"
+            return
+
+        self.app._last_user_activity_at = time.monotonic() - timeout_seconds - 1.0
+        self.pump.run_for(max(0.35, self.hold_seconds))
+        if self.app.context is None or self.app.context.screen_awake:
+            raise NavigationSoakFailure("screen did not enter sleep during navigation soak")
+
+        self.app.event_bus.publish(UserActivityEvent(action_name="navigation_soak"))
+        self.pump.run_for(max(0.35, self.hold_seconds))
+        if self.app.context is None or not self.app.context.screen_awake:
+            raise NavigationSoakFailure("screen did not wake after simulated navigation activity")
+
+        self.stats.sleep_wake_status = "ok"
+
+
+def run_navigation_soak(
+    *,
+    config_dir: str = "config",
+    cycles: int = 2,
+    hold_seconds: float = 0.35,
+    idle_seconds: float = 3.0,
+    tail_idle_seconds: float = 10.0,
+    with_playback: bool = True,
+    provision_test_music: bool = True,
+    test_music_dir: str = DEFAULT_TEST_MUSIC_TARGET_DIR,
+    skip_sleep: bool = False,
+) -> tuple[bool, str]:
+    """Run the target-hardware navigation and idle stability soak."""
+
+    runner = NavigationSoakRunner(
+        config_dir=config_dir,
+        cycles=cycles,
+        hold_seconds=hold_seconds,
+        idle_seconds=idle_seconds,
+        tail_idle_seconds=tail_idle_seconds,
+        with_playback=with_playback,
+        provision_test_music=provision_test_music,
+        test_music_dir=test_music_dir,
+        skip_sleep=skip_sleep,
+    )
+    return runner.run()

--- a/src/yoyopod/cli/pi/smoke.py
+++ b/src/yoyopod/cli/pi/smoke.py
@@ -454,74 +454,35 @@ def _voip_check(config_dir: Path, registration_timeout: float) -> CheckResult:
         manager.stop()
 
 
-def _lvgl_soak_check(config_dir: Path) -> CheckResult:
-    """Run a small LVGL transition and sleep/wake soak on the active app path."""
-    import time as _time
-
-    from yoyopod.app import YoyoPodApp
-    from yoyopod.events import UserActivityEvent
-
-    def _pump_app(app: YoyoPodApp, duration_seconds: float) -> None:
-        deadline = _time.monotonic() + max(0.0, duration_seconds)
-        while _time.monotonic() < deadline:
-            app._process_pending_main_thread_actions()
-            now = _time.monotonic()
-            app._attempt_manager_recovery()
-            app._poll_power_status(now=now)
-            app._pump_lvgl_backend(now)
-            app._feed_watchdog_if_due(now)
-            app._update_screen_power(now)
-            _time.sleep(0.05)
-
-    def _exercise_sleep_wake(app: YoyoPodApp) -> tuple[bool, str]:
-        timeout_seconds = max(1.0, float(app._screen_timeout_seconds or 0.0))
-        app._last_user_activity_at = _time.monotonic() - timeout_seconds - 1.0
-        _pump_app(app, 0.35)
-        if app.context is None or app.context.screen_awake:
-            return False, "screen did not enter sleep during soak"
-        app.event_bus.publish(UserActivityEvent(action_name="lvgl_soak"))
-        _pump_app(app, 0.35)
-        if app.context is None or not app.context.screen_awake:
-            return False, "screen did not wake after simulated activity"
-        return True, "sleep/wake ok"
-
-    app = YoyoPodApp(config_dir=str(config_dir), simulate=False)
-    if not app.setup():
-        return CheckResult(name="lvgl_soak", status="fail", details="app setup failed")
+def _lvgl_soak_check(
+    config_dir: Path,
+    *,
+    with_music: bool = False,
+    provision_test_music: bool = True,
+    test_music_dir: str = DEFAULT_TEST_MUSIC_TARGET_DIR,
+) -> CheckResult:
+    """Run the target navigation and idle soak on the active LVGL app path."""
+    from yoyopod.cli.pi.stability import NavigationSoakError, run_navigation_idle_soak
 
     try:
-        if app.display is None or app.screen_manager is None:
-            return CheckResult(name="lvgl_soak", status="fail", details="display or screen manager not initialized")
-
-        if app.display.backend_kind != "lvgl":
-            return CheckResult(name="lvgl_soak", status="fail", details=f"backend is {app.display.backend_kind}, expected lvgl")
-
-        screens = [
-            "hub", "listen", "playlists", "now_playing",
-            "call", "talk_contact", "call_history", "contacts",
-            "voice_note", "ask", "power",
-        ]
-
-        transitions = 0
-        for _cycle in range(1):
-            for screen_name in screens:
-                if screen_name not in app.screen_manager.screens:
-                    continue
-                app.screen_manager.replace_screen(screen_name)
-                _pump_app(app, 0.15)
-                transitions += 1
-
-        sleep_ok, sleep_details = _exercise_sleep_wake(app)
-        if not sleep_ok:
-            return CheckResult(name="lvgl_soak", status="fail", details=sleep_details)
-
-        return CheckResult(
-            name="lvgl_soak",
-            status="pass",
-            details=f"backend=lvgl, transitions={transitions}, {sleep_details}",
+        report = run_navigation_idle_soak(
+            config_dir=str(config_dir),
+            simulate=False,
+            cycles=1,
+            hold_seconds=0.15,
+            idle_seconds=0.5,
+            with_music=with_music,
+            provision_test_music=provision_test_music,
+            test_music_dir=test_music_dir,
         )
-    finally:
-        app.stop()
+    except NavigationSoakError as exc:
+        return CheckResult(name="lvgl_soak", status="fail", details=str(exc))
+
+    return CheckResult(
+        name="lvgl_soak",
+        status="pass",
+        details=report.summary(),
+    )
 
 
 def _print_summary(results: list[CheckResult]) -> None:
@@ -606,7 +567,14 @@ def smoke(
             results.append(_voip_check(config_path, voip_timeout))
 
         if with_lvgl_soak:
-            results.append(_lvgl_soak_check(config_path))
+            results.append(
+                _lvgl_soak_check(
+                    config_path,
+                    with_music=with_music,
+                    provision_test_music=provision_test_music,
+                    test_music_dir=test_music_dir,
+                )
+            )
     finally:
         if display is not None:
             try:

--- a/src/yoyopod/cli/pi/stability.py
+++ b/src/yoyopod/cli/pi/stability.py
@@ -1,0 +1,468 @@
+"""Target-side navigation and idle stability soak helpers."""
+
+from __future__ import annotations
+
+import os
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+from loguru import logger
+
+from yoyopod.app import YoyoPodApp
+from yoyopod.audio.test_music import (
+    DEFAULT_TEST_MUSIC_TARGET_DIR,
+    ProvisionedTestMusicLibrary,
+    provision_test_music_library,
+)
+from yoyopod.events import UserActivityEvent
+from yoyopod.ui.input import InputAction
+
+
+class NavigationSoakError(RuntimeError):
+    """Raised when the target navigation soak cannot complete successfully."""
+
+
+@dataclass(frozen=True, slots=True)
+class NavigationSoakStep:
+    """One deterministic transition or simulated click in the soak plan."""
+
+    kind: str
+    description: str
+    target: str | None = None
+    action: InputAction | None = None
+    wait_for_route: str | None = None
+    expect_track_loaded: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class NavigationSoakReport:
+    """Compact result summary for one navigation and idle stability pass."""
+
+    cycles: int
+    actions: int
+    transitions: int
+    final_route: str
+    sleep_details: str
+    music_enabled: bool
+    music_state: str
+    track_name: str | None
+    music_dir: Path | None
+
+    def summary(self) -> str:
+        """Return a stable human-readable summary string."""
+
+        details = [
+            "backend=lvgl",
+            f"cycles={self.cycles}",
+            f"actions={self.actions}",
+            f"transitions={self.transitions}",
+            f"final_screen={self.final_route}",
+            self.sleep_details,
+        ]
+        if self.music_enabled:
+            details.append(f"music_state={self.music_state}")
+            if self.track_name:
+                details.append(f"track={self.track_name}")
+            if self.music_dir is not None:
+                details.append(f"music_dir={self.music_dir}")
+        return ", ".join(details)
+
+
+def build_navigation_soak_plan(*, with_music: bool) -> tuple[NavigationSoakStep, ...]:
+    """Build the deterministic screen-and-click soak plan for the target app."""
+
+    steps: list[NavigationSoakStep] = [
+        NavigationSoakStep("replace", "Reset to the root hub", target="hub"),
+        NavigationSoakStep(
+            "action",
+            "Open Listen from the hub",
+            action=InputAction.SELECT,
+            wait_for_route="listen",
+        ),
+        NavigationSoakStep(
+            "action",
+            "Open Playlists from Listen",
+            action=InputAction.SELECT,
+            wait_for_route="playlists",
+        ),
+    ]
+
+    if with_music:
+        steps.extend(
+            [
+                NavigationSoakStep(
+                    "action",
+                    "Load the first playlist into Now Playing",
+                    action=InputAction.SELECT,
+                    wait_for_route="now_playing",
+                    expect_track_loaded=True,
+                ),
+                NavigationSoakStep(
+                    "action",
+                    "Pause playback from Now Playing",
+                    action=InputAction.PLAY_PAUSE,
+                ),
+                NavigationSoakStep(
+                    "action",
+                    "Resume playback from Now Playing",
+                    action=InputAction.PLAY_PAUSE,
+                ),
+                NavigationSoakStep(
+                    "action",
+                    "Skip to the next track",
+                    action=InputAction.NEXT_TRACK,
+                    expect_track_loaded=True,
+                ),
+                NavigationSoakStep(
+                    "action",
+                    "Return to Playlists",
+                    action=InputAction.BACK,
+                    wait_for_route="playlists",
+                ),
+            ]
+        )
+
+    steps.extend(
+        [
+            NavigationSoakStep(
+                "action",
+                "Return to Listen",
+                action=InputAction.BACK,
+                wait_for_route="listen",
+            ),
+            NavigationSoakStep(
+                "action",
+                "Move to the Recent row",
+                action=InputAction.ADVANCE,
+            ),
+            NavigationSoakStep(
+                "action",
+                "Open Recent tracks",
+                action=InputAction.SELECT,
+                wait_for_route="recent_tracks",
+            ),
+            NavigationSoakStep(
+                "action",
+                "Return to Listen from Recent",
+                action=InputAction.BACK,
+                wait_for_route="listen",
+            ),
+            NavigationSoakStep(
+                "action",
+                "Return to the hub",
+                action=InputAction.BACK,
+                wait_for_route="hub",
+            ),
+            NavigationSoakStep(
+                "action",
+                "Advance to Talk",
+                action=InputAction.ADVANCE,
+            ),
+            NavigationSoakStep(
+                "action",
+                "Open Talk",
+                action=InputAction.SELECT,
+                wait_for_route="call",
+            ),
+            NavigationSoakStep(
+                "action",
+                "Return to the hub from Talk",
+                action=InputAction.BACK,
+                wait_for_route="hub",
+            ),
+            NavigationSoakStep(
+                "action",
+                "Advance to Ask",
+                action=InputAction.ADVANCE,
+            ),
+            NavigationSoakStep(
+                "action",
+                "Open Ask",
+                action=InputAction.SELECT,
+                wait_for_route="ask",
+            ),
+            NavigationSoakStep(
+                "action",
+                "Return to the hub from Ask",
+                action=InputAction.BACK,
+                wait_for_route="hub",
+            ),
+            NavigationSoakStep(
+                "action",
+                "Advance to Setup",
+                action=InputAction.ADVANCE,
+            ),
+            NavigationSoakStep(
+                "action",
+                "Open Setup",
+                action=InputAction.SELECT,
+                wait_for_route="power",
+            ),
+            NavigationSoakStep(
+                "action",
+                "Return to the hub from Setup",
+                action=InputAction.BACK,
+                wait_for_route="hub",
+            ),
+        ]
+    )
+    return tuple(steps)
+
+
+@contextmanager
+def _temporary_env(updates: dict[str, str]) -> Iterator[None]:
+    """Apply environment overrides for the lifetime of one soak run."""
+
+    original_values = {name: os.environ.get(name) for name in updates}
+    try:
+        os.environ.update(updates)
+        yield
+    finally:
+        for name, previous in original_values.items():
+            if previous is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = previous
+
+
+def _pump_app(app: YoyoPodApp, duration_seconds: float) -> None:
+    """Pump the coordinator-thread services without entering the full app loop."""
+
+    deadline = time.monotonic() + max(0.0, duration_seconds)
+    while time.monotonic() < deadline:
+        app._process_pending_main_thread_actions()
+        now = time.monotonic()
+        app._attempt_manager_recovery()
+        app._poll_power_status(now=now)
+        app._pump_lvgl_backend(now)
+        app._feed_watchdog_if_due(now)
+        app._update_screen_power(now)
+        time.sleep(0.05)
+
+
+def _current_route(app: YoyoPodApp) -> str:
+    """Return the current route name or a stable placeholder."""
+
+    if app.screen_manager is None or app.screen_manager.current_screen is None:
+        return "none"
+    route_name = app.screen_manager.current_screen.route_name
+    if route_name:
+        return route_name
+    return app.screen_manager.current_screen.name
+
+
+def _dispatch_action(app: YoyoPodApp, action: InputAction) -> None:
+    """Drive one semantic action through the same screen handler path as live input."""
+
+    if app.screen_manager is None or app.screen_manager.current_screen is None:
+        raise NavigationSoakError("screen manager is not initialized")
+
+    if app.input_manager is not None:
+        app.input_manager.simulate_action(action)
+        return
+
+    previous_screen = app.screen_manager.current_screen
+    previous_screen.handle_action(action)
+    navigation_request = previous_screen.consume_navigation_request()
+    if navigation_request is not None:
+        app.screen_manager.apply_navigation_request(
+            navigation_request,
+            source_screen=previous_screen,
+        )
+    if app.screen_manager.current_screen is previous_screen:
+        app.screen_manager.refresh_current_screen()
+
+
+def _wait_for_route(
+    app: YoyoPodApp,
+    route_name: str,
+    *,
+    timeout_seconds: float,
+) -> None:
+    """Pump the app until the requested route becomes active."""
+
+    deadline = time.monotonic() + max(0.1, timeout_seconds)
+    while time.monotonic() < deadline:
+        if _current_route(app) == route_name:
+            return
+        _pump_app(app, 0.05)
+    raise NavigationSoakError(
+        f"navigation soak expected route '{route_name}', got '{_current_route(app)}'"
+    )
+
+
+def _wait_for_track(
+    app: YoyoPodApp,
+    *,
+    timeout_seconds: float,
+    expected_library: ProvisionedTestMusicLibrary | None,
+) -> str:
+    """Wait for one playback track to appear after playlist navigation."""
+
+    if app.music_backend is None:
+        raise NavigationSoakError("music backend is unavailable for playback soak")
+
+    expected_uris = (
+        {str(path) for path in expected_library.track_paths}
+        if expected_library is not None
+        else None
+    )
+    deadline = time.monotonic() + max(0.1, timeout_seconds)
+    while time.monotonic() < deadline:
+        current_track = app.music_backend.get_current_track()
+        if current_track is not None:
+            if expected_uris is None or current_track.uri in expected_uris:
+                return current_track.name
+        _pump_app(app, 0.05)
+
+    current_track = app.music_backend.get_current_track() if app.music_backend is not None else None
+    current_uri = current_track.uri if current_track is not None else "none"
+    raise NavigationSoakError(
+        "navigation soak did not load a validation track; " f"current_track={current_uri}"
+    )
+
+
+def _exercise_sleep_wake(app: YoyoPodApp) -> str:
+    """Force one idle sleep/wake cycle against the current app instance."""
+
+    timeout_seconds = max(1.0, float(app._screen_timeout_seconds or 0.0))
+    app._last_user_activity_at = time.monotonic() - timeout_seconds - 1.0
+    _pump_app(app, 0.35)
+    if app.context is None or app.context.screen_awake:
+        raise NavigationSoakError("screen did not enter sleep during soak")
+
+    app.event_bus.publish(UserActivityEvent(action_name="navigation_soak"))
+    _pump_app(app, 0.35)
+    if app.context is None or not app.context.screen_awake:
+        raise NavigationSoakError("screen did not wake after simulated activity")
+
+    return "sleep/wake ok"
+
+
+def _prepare_validation_music_dir(
+    *,
+    with_music: bool,
+    provision_test_music: bool,
+    test_music_dir: str,
+) -> tuple[Path | None, ProvisionedTestMusicLibrary | None]:
+    """Resolve and optionally provision the dedicated music directory for the soak."""
+
+    if not with_music:
+        return None, None
+
+    resolved_dir = Path(test_music_dir or DEFAULT_TEST_MUSIC_TARGET_DIR).expanduser().resolve()
+    if provision_test_music:
+        library = provision_test_music_library(resolved_dir)
+        return library.target_dir, library
+
+    return resolved_dir, None
+
+
+def run_navigation_idle_soak(
+    *,
+    config_dir: str = "config",
+    simulate: bool = False,
+    cycles: int = 2,
+    hold_seconds: float = 0.2,
+    idle_seconds: float = 1.0,
+    skip_sleep: bool = False,
+    with_music: bool = False,
+    provision_test_music: bool = True,
+    test_music_dir: str = DEFAULT_TEST_MUSIC_TARGET_DIR,
+) -> NavigationSoakReport:
+    """Run the deterministic target-side navigation and idle stability soak."""
+
+    music_dir, expected_library = _prepare_validation_music_dir(
+        with_music=with_music,
+        provision_test_music=provision_test_music,
+        test_music_dir=test_music_dir,
+    )
+    env_updates = {}
+    if music_dir is not None:
+        env_updates["YOYOPOD_MUSIC_DIR"] = str(music_dir)
+
+    with _temporary_env(env_updates):
+        app = YoyoPodApp(config_dir=config_dir, simulate=simulate)
+        if not app.setup():
+            raise NavigationSoakError("app setup failed")
+
+        try:
+            if app.display is None or app.screen_manager is None:
+                raise NavigationSoakError("display or screen manager not initialized")
+            if app.display.backend_kind != "lvgl":
+                raise NavigationSoakError(f"backend is {app.display.backend_kind}, expected lvgl")
+            if with_music and (app.local_music_service is None or app.music_backend is None):
+                raise NavigationSoakError("music services are unavailable for playback soak")
+
+            actions = 0
+            transitions = 0
+            plan = build_navigation_soak_plan(with_music=with_music)
+            wait_timeout_seconds = max(1.0, hold_seconds + 0.8)
+            for cycle_index in range(max(1, cycles)):
+                logger.info(
+                    "Running target navigation soak cycle {}/{} (with_music={})",
+                    cycle_index + 1,
+                    max(1, cycles),
+                    with_music,
+                )
+                for step in plan:
+                    previous_route = _current_route(app)
+                    logger.debug("Navigation soak step: {}", step.description)
+                    if step.kind == "replace":
+                        assert step.target is not None
+                        app.screen_manager.replace_screen(step.target)
+                    elif step.kind == "action":
+                        assert step.action is not None
+                        _dispatch_action(app, step.action)
+                        actions += 1
+                    else:
+                        raise NavigationSoakError(f"unsupported soak step kind: {step.kind}")
+
+                    if step.wait_for_route is not None:
+                        _wait_for_route(
+                            app,
+                            step.wait_for_route,
+                            timeout_seconds=wait_timeout_seconds,
+                        )
+                    _pump_app(app, hold_seconds)
+
+                    if step.expect_track_loaded:
+                        _wait_for_track(
+                            app,
+                            timeout_seconds=wait_timeout_seconds,
+                            expected_library=expected_library,
+                        )
+
+                    if _current_route(app) != previous_route:
+                        transitions += 1
+
+                if idle_seconds > 0:
+                    logger.debug("Navigation soak idling for {:.2f}s", idle_seconds)
+                    _pump_app(app, idle_seconds)
+
+            sleep_details = "sleep/wake skipped"
+            if not skip_sleep:
+                sleep_details = _exercise_sleep_wake(app)
+
+            current_track = app.music_backend.get_current_track() if app.music_backend else None
+            music_state = (
+                app.music_backend.get_playback_state()
+                if with_music and app.music_backend is not None
+                else "disabled"
+            )
+            return NavigationSoakReport(
+                cycles=max(1, cycles),
+                actions=actions,
+                transitions=transitions,
+                final_route=_current_route(app),
+                sleep_details=sleep_details,
+                music_enabled=with_music,
+                music_state=music_state,
+                track_name=current_track.name if current_track is not None else None,
+                music_dir=music_dir,
+            )
+        finally:
+            app.stop()

--- a/src/yoyopod/cli/pi/validate.py
+++ b/src/yoyopod/cli/pi/validate.py
@@ -10,8 +10,10 @@ from typing import Annotated
 
 import typer
 
+from yoyopod.audio.test_music import DEFAULT_TEST_MUSIC_TARGET_DIR
 from yoyopod.cli.common import REPO_ROOT, configure_logging, resolve_config_dir
 from yoyopod.cli.pi.lvgl import soak as run_lvgl_soak
+from yoyopod.cli.pi.navigation import run_navigation_soak
 from yoyopod.cli.pi.smoke import (
     CheckResult,
     _display_check,
@@ -27,7 +29,10 @@ from yoyopod.cli.remote.config import PiDeployConfig, load_pi_deploy_config
 
 validate_app = typer.Typer(
     name="validate",
-    help="Focused target-side validation suite for deploy, smoke, music, voip, and stability checks.",
+    help=(
+        "Focused target-side validation suite for deploy, smoke, music, voip, "
+        "and navigation stability checks."
+    ),
     no_args_is_help=True,
 )
 
@@ -333,17 +338,125 @@ def stability(
         float,
         typer.Option("--hold-seconds", help="How long to keep each screen active during the soak."),
     ] = 0.2,
+    idle_seconds: Annotated[
+        float,
+        typer.Option("--idle-seconds", help="How long to idle after each full navigation cycle."),
+    ] = 1.0,
+    with_music: Annotated[
+        bool,
+        typer.Option(
+            "--with-music",
+            help="Also exercise playlist loading and now-playing actions during the soak.",
+        ),
+    ] = False,
+    provision_test_music: Annotated[
+        bool,
+        typer.Option(
+            "--provision-test-music/--no-provision-test-music",
+            help="Seed deterministic validation music before playback soak steps.",
+        ),
+    ] = True,
+    test_music_dir: Annotated[
+        str,
+        typer.Option(
+            "--test-music-dir",
+            help="Dedicated target directory for validation-only test music assets.",
+        ),
+    ] = DEFAULT_TEST_MUSIC_TARGET_DIR,
     skip_sleep: Annotated[
         bool, typer.Option("--skip-sleep", help="Skip the sleep and wake exercise.")
     ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
 ) -> None:
-    """Run a repeated LVGL screen-transition stability pass on the target checkout."""
+    """Run a repeated navigation and idle stability pass on the target checkout."""
     run_lvgl_soak(
         config_dir=config_dir,
         simulate=False,
         cycles=cycles,
         hold_seconds=hold_seconds,
+        idle_seconds=idle_seconds,
+        with_music=with_music,
+        provision_test_music=provision_test_music,
+        test_music_dir=test_music_dir,
         skip_sleep=skip_sleep,
         verbose=verbose,
     )
+
+
+@validate_app.command()
+def navigation(
+    config_dir: Annotated[
+        str, typer.Option("--config-dir", help="Configuration directory to use.")
+    ] = "config",
+    cycles: Annotated[
+        int, typer.Option("--cycles", help="How many full navigation cycles to run.")
+    ] = 2,
+    hold_seconds: Annotated[
+        float,
+        typer.Option(
+            "--hold-seconds",
+            help="How long to pump after each simulated click or route change.",
+        ),
+    ] = 0.35,
+    idle_seconds: Annotated[
+        float,
+        typer.Option(
+            "--idle-seconds",
+            help="How long to leave each exercised screen idle before the next action.",
+        ),
+    ] = 3.0,
+    tail_idle_seconds: Annotated[
+        float,
+        typer.Option(
+            "--tail-idle-seconds",
+            help="Final idle dwell on the hub after all navigation cycles complete.",
+        ),
+    ] = 10.0,
+    with_playback: Annotated[
+        bool,
+        typer.Option(
+            "--with-playback/--no-with-playback",
+            help="Drive playlist and shuffle playback paths during the soak.",
+        ),
+    ] = True,
+    provision_test_music: Annotated[
+        bool,
+        typer.Option(
+            "--provision-test-music/--no-provision-test-music",
+            help="Seed deterministic validation music before playback-driven navigation.",
+        ),
+    ] = True,
+    test_music_dir: Annotated[
+        str,
+        typer.Option(
+            "--test-music-dir",
+            help="Dedicated target directory for validation-only test music assets.",
+        ),
+    ] = DEFAULT_TEST_MUSIC_TARGET_DIR,
+    skip_sleep: Annotated[
+        bool, typer.Option("--skip-sleep", help="Skip the final sleep/wake exercise.")
+    ] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
+) -> None:
+    """Run the one-button target navigation and idle stability soak on LVGL hardware."""
+    from loguru import logger
+
+    configure_logging(verbose)
+
+    ok, details = run_navigation_soak(
+        config_dir=config_dir,
+        cycles=cycles,
+        hold_seconds=hold_seconds,
+        idle_seconds=idle_seconds,
+        tail_idle_seconds=tail_idle_seconds,
+        with_playback=with_playback,
+        provision_test_music=provision_test_music,
+        test_music_dir=test_music_dir,
+        skip_sleep=skip_sleep,
+    )
+    if ok:
+        logger.info("Navigation soak passed: {}", details)
+        return
+
+    logger.error("Navigation soak failed: {}", details)
+    raise typer.Exit(code=1)

--- a/src/yoyopod/cli/remote/__init__.py
+++ b/src/yoyopod/cli/remote/__init__.py
@@ -8,16 +8,16 @@ from yoyopod.cli.remote.infra import config, power, service
 from yoyopod.cli.remote.lvgl import lvgl_soak
 from yoyopod.cli.remote.ops import (
     logs,
-    preflight,
-    provision_test_music,
+    remote_preflight,
+    remote_provision_test_music,
+    remote_smoke,
+    remote_validate,
     restart,
     rsync,
     rtc,
     screenshot,
-    smoke,
     status,
     sync,
-    validate,
     whisplay,
 )
 from yoyopod.cli.remote.setup import setup, verify_setup
@@ -30,15 +30,52 @@ remote_app = typer.Typer(
 
 remote_app.command()(status)
 remote_app.command()(sync)
-remote_app.command()(validate)
-remote_app.command()(smoke)
-remote_app.command(name="provision-test-music")(provision_test_music)
-remote_app.command()(preflight)
+remote_app.command(name="validate")(remote_validate)
+remote_app.command(name="smoke")(remote_smoke)
+remote_app.command(name="provision-test-music")(remote_provision_test_music)
+remote_app.command(name="preflight")(remote_preflight)
 remote_app.command()(restart)
 remote_app.command()(logs)
 remote_app.command()(screenshot)
 remote_app.command()(rsync)
 remote_app.command(name="lvgl-soak")(lvgl_soak)
+
+
+@remote_app.command(name="navigation-soak")
+def navigation_soak_command(
+    host: str = "",
+    user: str = "",
+    project_dir: str = "",
+    branch: str = "",
+    cycles: int = 2,
+    hold_seconds: float = 0.35,
+    idle_seconds: float = 3.0,
+    tail_idle_seconds: float = 10.0,
+    with_playback: bool = True,
+    provision_test_music: bool = True,
+    test_music_dir: str = "",
+    skip_sleep: bool = False,
+    verbose: bool = False,
+) -> None:
+    from yoyopod.cli.remote.navigation import navigation_soak
+
+    return navigation_soak(
+        host=host,
+        user=user,
+        project_dir=project_dir,
+        branch=branch,
+        cycles=cycles,
+        hold_seconds=hold_seconds,
+        idle_seconds=idle_seconds,
+        tail_idle_seconds=tail_idle_seconds,
+        with_playback=with_playback,
+        provision_test_music=provision_test_music,
+        test_music_dir=test_music_dir,
+        skip_sleep=skip_sleep,
+        verbose=verbose,
+    )
+
+
 remote_app.command()(power)
 remote_app.command()(whisplay)
 remote_app.command()(rtc)

--- a/src/yoyopod/cli/remote/lvgl.py
+++ b/src/yoyopod/cli/remote/lvgl.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import shlex
 from typing import Annotated
 
 import typer
 
+from yoyopod.audio.test_music import DEFAULT_TEST_MUSIC_TARGET_DIR
 from yoyopod.cli.remote.ops import (
     _resolve_remote_config,
     run_remote,
@@ -21,6 +23,10 @@ def build_lvgl_soak_command(
     *,
     cycles: int = 2,
     hold_seconds: float = 0.2,
+    idle_seconds: float = 1.0,
+    with_music: bool = False,
+    provision_test_music: bool = True,
+    test_music_dir: str = DEFAULT_TEST_MUSIC_TARGET_DIR,
     skip_sleep: bool = False,
     verbose: bool = False,
 ) -> str:
@@ -32,6 +38,14 @@ def build_lvgl_soak_command(
         parts.extend(["--cycles", str(cycles)])
     if hold_seconds != 0.2:
         parts.extend(["--hold-seconds", str(hold_seconds)])
+    if idle_seconds != 1.0:
+        parts.extend(["--idle-seconds", str(idle_seconds)])
+    if with_music:
+        parts.append("--with-music")
+        if not provision_test_music:
+            parts.append("--no-provision-test-music")
+        elif test_music_dir != DEFAULT_TEST_MUSIC_TARGET_DIR:
+            parts.extend(["--test-music-dir", shlex.quote(test_music_dir)])
     if skip_sleep:
         parts.append("--skip-sleep")
     return " ".join(parts)
@@ -61,6 +75,31 @@ def lvgl_soak(
     hold_seconds: Annotated[
         float, typer.Option("--hold-seconds", help="How long to keep each screen active.")
     ] = 0.2,
+    idle_seconds: Annotated[
+        float,
+        typer.Option("--idle-seconds", help="How long to idle after each full navigation cycle."),
+    ] = 1.0,
+    with_music: Annotated[
+        bool,
+        typer.Option(
+            "--with-music",
+            help="Exercise playlist loading and now-playing actions during the soak.",
+        ),
+    ] = False,
+    provision_test_music: Annotated[
+        bool,
+        typer.Option(
+            "--provision-test-music/--no-provision-test-music",
+            help="Seed deterministic validation music before playback soak steps.",
+        ),
+    ] = True,
+    test_music_dir: Annotated[
+        str,
+        typer.Option(
+            "--test-music-dir",
+            help="Dedicated target directory for validation-only test music assets.",
+        ),
+    ] = DEFAULT_TEST_MUSIC_TARGET_DIR,
     skip_sleep: Annotated[
         bool, typer.Option("--skip-sleep", help="Skip the sleep/wake exercise.")
     ] = False,
@@ -76,6 +115,10 @@ def lvgl_soak(
         build_lvgl_soak_command(
             cycles=cycles,
             hold_seconds=hold_seconds,
+            idle_seconds=idle_seconds,
+            with_music=with_music,
+            provision_test_music=provision_test_music,
+            test_music_dir=test_music_dir,
             skip_sleep=skip_sleep,
             verbose=verbose,
         ),

--- a/src/yoyopod/cli/remote/navigation.py
+++ b/src/yoyopod/cli/remote/navigation.py
@@ -1,0 +1,142 @@
+"""src/yoyopod/cli/remote/navigation.py — navigation soak over SSH."""
+
+from __future__ import annotations
+
+import shlex
+from typing import Annotated
+
+import typer
+
+from yoyopod.audio.test_music import DEFAULT_TEST_MUSIC_TARGET_DIR
+from yoyopod.cli.remote.config import load_pi_deploy_config
+from yoyopod.cli.remote.ops import (
+    _resolve_remote_config,
+    run_remote,
+    validate_config,
+)
+
+
+def build_navigation_soak_command(
+    *,
+    cycles: int = 2,
+    hold_seconds: float = 0.35,
+    idle_seconds: float = 3.0,
+    tail_idle_seconds: float = 10.0,
+    with_playback: bool = True,
+    provision_test_music: bool = True,
+    test_music_target_dir: str | None = None,
+    skip_sleep: bool = False,
+    verbose: bool = False,
+) -> str:
+    """Create the remote target navigation-soak command."""
+
+    parts = ["uv run yoyoctl pi validate navigation"]
+    if verbose:
+        parts.append("--verbose")
+    if cycles != 2:
+        parts.extend(["--cycles", str(cycles)])
+    if hold_seconds != 0.35:
+        parts.extend(["--hold-seconds", str(hold_seconds)])
+    if idle_seconds != 3.0:
+        parts.extend(["--idle-seconds", str(idle_seconds)])
+    if tail_idle_seconds != 10.0:
+        parts.extend(["--tail-idle-seconds", str(tail_idle_seconds)])
+    if not with_playback:
+        parts.append("--no-with-playback")
+    if not provision_test_music:
+        parts.append("--no-provision-test-music")
+    if test_music_target_dir and test_music_target_dir != DEFAULT_TEST_MUSIC_TARGET_DIR:
+        parts.extend(["--test-music-dir", shlex.quote(test_music_target_dir)])
+    if skip_sleep:
+        parts.append("--skip-sleep")
+    return " ".join(parts)
+
+
+def navigation_soak(
+    host: Annotated[
+        str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
+    ] = "",
+    user: Annotated[
+        str, typer.Option("--user", help="SSH user for the Raspberry Pi (optional).")
+    ] = "",
+    project_dir: Annotated[
+        str, typer.Option("--project-dir", help="Project directory on the Raspberry Pi.")
+    ] = "",
+    branch: Annotated[
+        str, typer.Option("--branch", help="Git branch to sync on the Raspberry Pi.")
+    ] = "",
+    cycles: Annotated[
+        int, typer.Option("--cycles", help="How many full navigation cycles to run.")
+    ] = 2,
+    hold_seconds: Annotated[
+        float,
+        typer.Option(
+            "--hold-seconds",
+            help="How long to pump after each simulated click or route change.",
+        ),
+    ] = 0.35,
+    idle_seconds: Annotated[
+        float,
+        typer.Option(
+            "--idle-seconds",
+            help="How long to leave each exercised screen idle before the next action.",
+        ),
+    ] = 3.0,
+    tail_idle_seconds: Annotated[
+        float,
+        typer.Option(
+            "--tail-idle-seconds",
+            help="Final idle dwell on the hub after all navigation cycles complete.",
+        ),
+    ] = 10.0,
+    with_playback: Annotated[
+        bool,
+        typer.Option(
+            "--with-playback/--no-with-playback",
+            help="Drive playlist and shuffle playback paths during the soak.",
+        ),
+    ] = True,
+    provision_test_music: Annotated[
+        bool,
+        typer.Option(
+            "--provision-test-music/--no-provision-test-music",
+            help="Seed deterministic validation music before playback-driven navigation.",
+        ),
+    ] = True,
+    test_music_dir: Annotated[
+        str,
+        typer.Option(
+            "--test-music-dir",
+            help="Dedicated target directory for validation-only test music assets.",
+        ),
+    ] = "",
+    skip_sleep: Annotated[
+        bool, typer.Option("--skip-sleep", help="Skip the final sleep/wake exercise.")
+    ] = False,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", help="Enable verbose soak logging.")
+    ] = False,
+) -> None:
+    """Run the target navigation and idle soak helper remotely."""
+
+    config = _resolve_remote_config(host, user, project_dir, branch)
+    validate_config(config)
+    deploy_config = load_pi_deploy_config()
+    resolved_test_music_dir = test_music_dir or deploy_config.test_music_target_dir
+    rc = run_remote(
+        config,
+        build_navigation_soak_command(
+            cycles=cycles,
+            hold_seconds=hold_seconds,
+            idle_seconds=idle_seconds,
+            tail_idle_seconds=tail_idle_seconds,
+            with_playback=with_playback,
+            provision_test_music=provision_test_music,
+            test_music_target_dir=resolved_test_music_dir,
+            skip_sleep=skip_sleep,
+            verbose=verbose,
+        ),
+        tty=True,
+    )
+    if rc != 0:
+        raise typer.Exit(code=rc)

--- a/src/yoyopod/cli/remote/ops.py
+++ b/src/yoyopod/cli/remote/ops.py
@@ -675,6 +675,7 @@ def build_smoke_command(
     with_rtc: bool = False,
     with_music: bool = False,
     with_voip: bool = False,
+    with_navigation_soak: bool = False,
     with_lvgl_soak: bool = False,
     provision_test_music: bool = True,
     test_music_target_dir: str | None = None,
@@ -710,8 +711,24 @@ def build_smoke_command(
             voip_command += f" --timeout {voip_timeout}"
         commands.append(voip_command)
 
+    if with_navigation_soak:
+        navigation_command = "uv run yoyoctl pi validate navigation"
+        if verbose:
+            navigation_command += " --verbose"
+        if not provision_test_music:
+            navigation_command += " --no-provision-test-music"
+        elif test_music_target_dir:
+            navigation_command += f" --test-music-dir {shlex.quote(test_music_target_dir)}"
+        commands.append(navigation_command)
+
     if with_lvgl_soak:
         stability_command = "uv run yoyoctl pi validate stability"
+        if with_music:
+            stability_command += " --with-music"
+            if not provision_test_music:
+                stability_command += " --no-provision-test-music"
+            elif test_music_target_dir:
+                stability_command += f" --test-music-dir {shlex.quote(test_music_target_dir)}"
         if verbose:
             stability_command += " --verbose"
         commands.append(stability_command)
@@ -829,7 +846,7 @@ def sync(
         raise typer.Exit(code=rc)
 
 
-def validate(
+def remote_validate(
     host: Annotated[
         str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
     ] = "",
@@ -885,10 +902,18 @@ def validate(
     with_voip: Annotated[
         bool, typer.Option("--with-voip", help="Include SIP registration checks.")
     ] = False,
+    with_navigation_soak: Annotated[
+        bool,
+        typer.Option(
+            "--with-navigation-soak",
+            help="Include the target navigation and idle stability soak.",
+        ),
+    ] = False,
     with_lvgl_soak: Annotated[
         bool,
         typer.Option(
-            "--with-lvgl-soak", help="Include a short LVGL transition and sleep/wake soak."
+            "--with-lvgl-soak",
+            help="Include the legacy LVGL transition and sleep/wake soak.",
         ),
     ] = False,
     verbose: Annotated[
@@ -933,8 +958,11 @@ def validate(
             with_rtc=with_rtc,
             with_music=with_music,
             provision_test_music=provision_test_music,
-            test_music_target_dir=resolved_test_music_dir if with_music else None,
+            test_music_target_dir=(
+                resolved_test_music_dir if (with_music or with_navigation_soak) else None
+            ),
             with_voip=with_voip,
+            with_navigation_soak=with_navigation_soak,
             with_lvgl_soak=with_lvgl_soak,
             verbose=verbose,
             music_timeout=music_timeout,
@@ -956,7 +984,7 @@ def validate(
         raise typer.Exit(code=inspect_exit_code)
 
 
-def smoke(
+def remote_smoke(
     host: Annotated[
         str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
     ] = "",
@@ -995,10 +1023,18 @@ def smoke(
     with_voip: Annotated[
         bool, typer.Option("--with-voip", help="Include SIP registration checks.")
     ] = False,
+    with_navigation_soak: Annotated[
+        bool,
+        typer.Option(
+            "--with-navigation-soak",
+            help="Include the target navigation and idle stability soak.",
+        ),
+    ] = False,
     with_lvgl_soak: Annotated[
         bool,
         typer.Option(
-            "--with-lvgl-soak", help="Include a short LVGL transition and sleep/wake soak."
+            "--with-lvgl-soak",
+            help="Include the legacy LVGL transition and sleep/wake soak.",
         ),
     ] = False,
     verbose: Annotated[
@@ -1023,8 +1059,11 @@ def smoke(
             with_rtc=with_rtc,
             with_music=with_music,
             provision_test_music=provision_test_music,
-            test_music_target_dir=resolved_test_music_dir if with_music else None,
+            test_music_target_dir=(
+                resolved_test_music_dir if (with_music or with_navigation_soak) else None
+            ),
             with_voip=with_voip,
+            with_navigation_soak=with_navigation_soak,
             with_lvgl_soak=with_lvgl_soak,
             verbose=verbose,
             music_timeout=music_timeout,
@@ -1035,7 +1074,7 @@ def smoke(
         raise typer.Exit(code=rc)
 
 
-def provision_test_music(
+def remote_provision_test_music(
     host: Annotated[
         str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
     ] = "",
@@ -1076,7 +1115,7 @@ def provision_test_music(
         raise typer.Exit(code=rc)
 
 
-def preflight(
+def remote_preflight(
     host: Annotated[
         str, typer.Option("--host", help="SSH host or alias for the Raspberry Pi.")
     ] = "",
@@ -1138,10 +1177,18 @@ def preflight(
             "--with-voip", help="Include SIP registration checks in the remote smoke pass."
         ),
     ] = False,
+    with_navigation_soak: Annotated[
+        bool,
+        typer.Option(
+            "--with-navigation-soak",
+            help="Include the target navigation and idle stability soak.",
+        ),
+    ] = False,
     with_lvgl_soak: Annotated[
         bool,
         typer.Option(
-            "--with-lvgl-soak", help="Include the LVGL soak helper in the remote smoke pass."
+            "--with-lvgl-soak",
+            help="Include the legacy LVGL transition and sleep/wake soak in the remote smoke pass.",
         ),
     ] = False,
     verbose: Annotated[
@@ -1181,8 +1228,11 @@ def preflight(
             with_rtc=with_rtc,
             with_music=with_music,
             provision_test_music=provision_test_music,
-            test_music_target_dir=resolved_test_music_dir if with_music else None,
+            test_music_target_dir=(
+                resolved_test_music_dir if (with_music or with_navigation_soak) else None
+            ),
             with_voip=with_voip,
+            with_navigation_soak=with_navigation_soak,
             with_lvgl_soak=with_lvgl_soak,
             verbose=verbose,
             music_timeout=music_timeout,
@@ -1549,6 +1599,7 @@ def build_parser(deploy_config: PiDeployConfig) -> argparse.ArgumentParser:
         default=deploy_config.test_music_target_dir,
     )
     validate_parser.add_argument("--with-voip", action="store_true")
+    validate_parser.add_argument("--with-navigation-soak", action="store_true")
     validate_parser.add_argument("--with-lvgl-soak", action="store_true")
     validate_parser.add_argument("--verbose", action="store_true")
     validate_parser.add_argument("--music-timeout", type=int, default=5)
@@ -1586,6 +1637,7 @@ def build_parser(deploy_config: PiDeployConfig) -> argparse.ArgumentParser:
         default=deploy_config.test_music_target_dir,
     )
     smoke_parser.add_argument("--with-voip", action="store_true")
+    smoke_parser.add_argument("--with-navigation-soak", action="store_true")
     smoke_parser.add_argument("--with-lvgl-soak", action="store_true")
     smoke_parser.add_argument("--verbose", action="store_true")
     smoke_parser.add_argument("--music-timeout", type=int, default=5)
@@ -1618,8 +1670,32 @@ def build_parser(deploy_config: PiDeployConfig) -> argparse.ArgumentParser:
     )
     lvgl_soak_parser.add_argument("--cycles", type=int, default=2)
     lvgl_soak_parser.add_argument("--hold-seconds", type=float, default=0.2)
+    lvgl_soak_parser.add_argument("--idle-seconds", type=float, default=1.0)
+    lvgl_soak_parser.add_argument("--with-music", action="store_true")
+    lvgl_soak_parser.add_argument("--no-provision-test-music", action="store_true")
+    lvgl_soak_parser.add_argument(
+        "--test-music-dir",
+        default=deploy_config.test_music_target_dir,
+    )
     lvgl_soak_parser.add_argument("--skip-sleep", action="store_true")
     lvgl_soak_parser.add_argument("--verbose", action="store_true")
+
+    navigation_soak_parser = subparsers.add_parser(
+        "navigation-soak",
+        help="Run the target navigation and idle stability soak remotely",
+    )
+    navigation_soak_parser.add_argument("--cycles", type=int, default=2)
+    navigation_soak_parser.add_argument("--hold-seconds", type=float, default=0.35)
+    navigation_soak_parser.add_argument("--idle-seconds", type=float, default=3.0)
+    navigation_soak_parser.add_argument("--tail-idle-seconds", type=float, default=10.0)
+    navigation_soak_parser.add_argument("--no-with-playback", action="store_true")
+    navigation_soak_parser.add_argument("--no-provision-test-music", action="store_true")
+    navigation_soak_parser.add_argument(
+        "--test-music-dir",
+        default=deploy_config.test_music_target_dir,
+    )
+    navigation_soak_parser.add_argument("--skip-sleep", action="store_true")
+    navigation_soak_parser.add_argument("--verbose", action="store_true")
 
     rtc_parser = subparsers.add_parser(
         "rtc",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,7 @@ def test_pi_music_provision_test_library_help():
 def test_remote_help():
     result = runner.invoke(app, ["remote", "--help"])
     assert result.exit_code == 0
+    assert "navigation-soak" in _plain(result.output)
 
 
 def test_build_help():
@@ -128,6 +129,9 @@ def test_pi_lvgl_soak_help():
     assert "--cycles" in _plain(result.output)
     assert "--simulate" in _plain(result.output)
     assert "--hold-seconds" in _plain(result.output)
+    assert "--idle-seconds" in _plain(result.output)
+    assert "--with-music" in _plain(result.output)
+    assert "--test-music-dir" in _plain(result.output)
 
 
 def test_pi_lvgl_probe_help():
@@ -168,6 +172,7 @@ def test_pi_validate_help():
     assert "smoke" in output
     assert "music" in output
     assert "voip" in output
+    assert "navigation" in output
     assert "stability" in output
 
 
@@ -203,6 +208,25 @@ def test_pi_validate_stability_help():
     output = _plain(result.output)
     assert "--cycles" in output
     assert "--hold-seconds" in output
+    assert "--idle-seconds" in output
+    assert "--with-music" in output
+    assert "--test-music-dir" in output
+
+
+def test_pi_validate_navigation_help():
+    result = runner.invoke(
+        app,
+        ["pi", "validate", "navigation", "--help"],
+        terminal_width=200,
+    )
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "--cycles" in output
+    assert "--idle-seconds" in output
+    assert "--tail-idle-seconds" in output
+    assert "--with-playback" in output
+    assert "--provision-test-mu" in output
+    assert "--test-music-dir" in output
 
 
 def test_pi_tune_help():
@@ -234,19 +258,23 @@ def test_remote_sync_help():
 
 
 def test_remote_validate_help():
-    result = runner.invoke(app, ["remote", "validate", "--help"])
+    result = runner.invoke(app, ["remote", "validate", "--help"], terminal_width=200)
     assert result.exit_code == 0
-    assert "--branch" in _plain(result.output)
-    assert "--sha" in _plain(result.output)
-    assert "--with-music" in _plain(result.output)
-    assert "--test-music-dir" in _plain(result.output)
-    assert "--lines" in _plain(result.output)
+    output = _plain(result.output)
+    assert "--branch" in output
+    assert "--sha" in output
+    assert "--with-music" in output
+    assert "--with-navigation-s" in output
+    assert "--test-music-dir" in output
+    assert "--lines" in output
 
 
 def test_remote_smoke_help():
-    result = runner.invoke(app, ["remote", "smoke", "--help"])
+    result = runner.invoke(app, ["remote", "smoke", "--help"], terminal_width=200)
     assert result.exit_code == 0
-    assert "--test-music-dir" in _plain(result.output)
+    output = _plain(result.output)
+    assert "--test-music-dir" in output
+    assert "--with-navigation-s" in output
 
 
 def test_remote_provision_test_music_help():
@@ -256,13 +284,33 @@ def test_remote_provision_test_music_help():
 
 
 def test_remote_preflight_help():
-    result = runner.invoke(app, ["remote", "preflight", "--help"])
+    result = runner.invoke(app, ["remote", "preflight", "--help"], terminal_width=200)
     assert result.exit_code == 0
+    assert "--with-navigation-s" in _plain(result.output)
 
 
 def test_remote_lvgl_soak_help():
     result = runner.invoke(app, ["remote", "lvgl-soak", "--help"])
     assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "--cycles" in output
+    assert "--hold-seconds" in output
+    assert "--idle-seconds" in output
+    assert "--with-music" in output
+    assert "--test-music-dir" in output
+    assert "--skip-sleep" in output
+
+
+def test_remote_navigation_soak_help():
+    result = runner.invoke(app, ["remote", "navigation-soak", "--help"], terminal_width=200)
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "--cycles" in output
+    assert "--idle-seconds" in output
+    assert "--tail-idle-seconds" in output
+    assert "--with-playback" in output
+    assert "--provision-test-mu" in output
+    assert "--test-music-dir" in output
 
 
 def test_remote_power_help():

--- a/tests/test_navigation_soak.py
+++ b/tests/test_navigation_soak.py
@@ -1,0 +1,57 @@
+"""Tests for the target navigation and stability soak helpers."""
+
+from pathlib import Path
+
+from yoyopod.cli.pi.stability import NavigationSoakReport, build_navigation_soak_plan
+from yoyopod.ui.input import InputAction
+
+
+def test_build_navigation_soak_plan_without_music_skips_playback_steps() -> None:
+    """The base soak should cover navigation without forcing playback actions."""
+
+    plan = build_navigation_soak_plan(with_music=False)
+
+    assert plan[0].kind == "replace"
+    assert plan[0].target == "hub"
+    assert all(step.wait_for_route != "now_playing" for step in plan)
+    assert all(step.action != InputAction.PLAY_PAUSE for step in plan if step.action is not None)
+    assert all(step.action != InputAction.NEXT_TRACK for step in plan if step.action is not None)
+    assert plan[-1].wait_for_route == "hub"
+
+
+def test_build_navigation_soak_plan_with_music_adds_now_playing_actions() -> None:
+    """Playback-enabled soak should include playlist loading and transport actions."""
+
+    plan = build_navigation_soak_plan(with_music=True)
+    wait_routes = [step.wait_for_route for step in plan]
+    actions = [step.action for step in plan if step.action is not None]
+
+    assert "now_playing" in wait_routes
+    assert InputAction.PLAY_PAUSE in actions
+    assert InputAction.NEXT_TRACK in actions
+    assert any(step.expect_track_loaded for step in plan)
+
+
+def test_navigation_soak_report_summary_includes_music_details() -> None:
+    """The final summary should expose the key playback and route details."""
+
+    report = NavigationSoakReport(
+        cycles=2,
+        actions=14,
+        transitions=9,
+        final_route="hub",
+        sleep_details="sleep/wake ok",
+        music_enabled=True,
+        music_state="playing",
+        track_name="Alpha Beacon",
+        music_dir=Path("/tmp/yoyopod-music"),
+    )
+
+    summary = report.summary()
+
+    assert "cycles=2" in summary
+    assert "actions=14" in summary
+    assert "final_screen=hub" in summary
+    assert "music_state=playing" in summary
+    assert "track=Alpha Beacon" in summary
+    assert "music_dir=/tmp/yoyopod-music" in summary

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -41,6 +41,7 @@ from yoyopod.cli.remote.infra import (
     build_service_command,
 )
 from yoyopod.cli.remote.lvgl import build_lvgl_soak_command
+from yoyopod.cli.remote.navigation import build_navigation_soak_command
 from yoyopod.cli.remote.setup import build_setup_command, build_verify_setup_command
 from argparse import Namespace
 from pathlib import Path
@@ -357,6 +358,7 @@ def test_build_smoke_command_adds_optional_checks() -> None:
         with_music=True,
         test_music_target_dir=DEPLOY_CONFIG.test_music_target_dir,
         with_voip=True,
+        with_navigation_soak=True,
         with_lvgl_soak=True,
         verbose=True,
         music_timeout=10,
@@ -369,6 +371,7 @@ def test_build_smoke_command_adds_optional_checks() -> None:
     assert "uv run yoyoctl pi validate music" in command
     assert shlex.quote(DEPLOY_CONFIG.test_music_target_dir) in command
     assert "uv run yoyoctl pi validate voip" in command
+    assert "uv run yoyoctl pi validate navigation" in command
     assert "uv run yoyoctl pi validate stability" in command
     assert "--verbose" in command
     assert "--timeout 10" in command
@@ -578,6 +581,9 @@ def test_build_lvgl_soak_command_supports_cycles_and_sleep_toggle() -> None:
         verbose=True,
         cycles=3,
         hold_seconds=0.35,
+        idle_seconds=5.0,
+        with_music=True,
+        test_music_dir="/tmp/yoyopod-lvgl",
         skip_sleep=True,
     )
 
@@ -585,6 +591,36 @@ def test_build_lvgl_soak_command_supports_cycles_and_sleep_toggle() -> None:
     assert "--verbose" in command
     assert "--cycles 3" in command
     assert "--hold-seconds 0.35" in command
+    assert "--idle-seconds 5.0" in command
+    assert "--with-music" in command
+    assert "--test-music-dir /tmp/yoyopod-lvgl" in command
+    assert "--skip-sleep" in command
+
+
+def test_build_navigation_soak_command_supports_playback_and_idle_flags() -> None:
+    """Navigation soak helper should forward the target-side soak options."""
+
+    command = build_navigation_soak_command(
+        verbose=True,
+        cycles=3,
+        hold_seconds=0.4,
+        idle_seconds=6.0,
+        tail_idle_seconds=20.0,
+        with_playback=False,
+        provision_test_music=False,
+        test_music_target_dir="/tmp/yoyopod-nav",
+        skip_sleep=True,
+    )
+
+    assert command.startswith("uv run yoyoctl pi validate navigation")
+    assert "--verbose" in command
+    assert "--cycles 3" in command
+    assert "--hold-seconds 0.4" in command
+    assert "--idle-seconds 6.0" in command
+    assert "--tail-idle-seconds 20.0" in command
+    assert "--no-with-playback" in command
+    assert "--no-provision-test-music" in command
+    assert "--test-music-dir /tmp/yoyopod-nav" in command
     assert "--skip-sleep" in command
 
 
@@ -638,6 +674,27 @@ def test_build_parser_describes_current_screenshot_signal_contract() -> None:
 
     assert "SIGUSR1" in readback_action.help
     assert "SIGUSR2" in readback_action.help
+
+
+def test_build_parser_includes_navigation_soak_surface() -> None:
+    """Legacy argparse parity should include the navigation soak command and flags."""
+
+    parser = build_parser(DEPLOY_CONFIG)
+    command_action = next(
+        action for action in parser._actions if getattr(action, "dest", "") == "command"
+    )
+
+    validate_parser = command_action.choices["validate"]
+    smoke_parser = command_action.choices["smoke"]
+    navigation_parser = command_action.choices["navigation-soak"]
+
+    assert any("--with-navigation-soak" in action.option_strings for action in validate_parser._actions)
+    assert any("--with-navigation-soak" in action.option_strings for action in smoke_parser._actions)
+    assert any("--tail-idle-seconds" in action.option_strings for action in navigation_parser._actions)
+    assert any(
+        "--no-provision-test-music" in action.option_strings
+        for action in navigation_parser._actions
+    )
 
 
 def test_run_screenshot_uses_sigusr1_for_readback(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add a dedicated target navigation and idle soak flow plus remote wrapper command
- thread navigation soak into Pi remote validate, smoke, and preflight workflows with configurable test music provisioning
- document the new target-side validation path and extend CLI coverage tests

## Testing
- uv run python scripts/quality.py gate
- uv run pytest -q

Fixes #132