### PR TITLE
perf: surface slow interactive runtime paths

### DIFF
--- a/src/yoyopod/runtime/loop.py
+++ b/src/yoyopod/runtime/loop.py
@@ -63,6 +63,9 @@ def _queue_depth(queue_obj: object) -> int | None:
 class RuntimeLoopService:
     """Own the coordinator loop cadence and queued main-thread work."""
 
+    _SLOW_MAIN_THREAD_DRAIN_WARNING_SECONDS = 0.1
+    _SLOW_LVGL_PUMP_WARNING_SECONDS = 0.25
+    _SLOW_VOIP_ITERATE_WARNING_SECONDS = 0.25
     _VOIP_TIMING_SUMMARY_INTERVAL_SECONDS = 10.0
     _MIN_RUNTIME_LOOP_GAP_WARNING_SECONDS = 0.2
     _MIN_RUNTIME_BLOCKING_SPAN_WARNING_SECONDS = 0.2
@@ -151,6 +154,7 @@ class RuntimeLoopService:
 
     def process_pending_main_thread_actions(self, limit: Optional[int] = None) -> int:
         """Drain queued typed events scheduled by worker threads."""
+        started_at = time.monotonic()
         processed = 0
         while not self.app._pending_main_thread_callbacks.empty():
             callback = self.app._pending_main_thread_callbacks.get()
@@ -163,7 +167,14 @@ class RuntimeLoopService:
                 return processed
 
         remaining_limit = None if limit is None else max(0, limit - processed)
-        return processed + self.app.event_bus.drain(remaining_limit)
+        processed += self.app.event_bus.drain(remaining_limit)
+        self._warn_if_slow(
+            "main-thread drain",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_MAIN_THREAD_DRAIN_WARNING_SECONDS,
+            detail=f"callbacks={processed}",
+        )
+        return processed
 
     def queue_main_thread_callback(self, callback: Callable[[], None]) -> None:
         """Schedule a callback to run on the coordinator thread."""
@@ -180,6 +191,7 @@ class RuntimeLoopService:
         if self.app._lvgl_backend is None or not self.app._lvgl_backend.initialized:
             return
 
+        started_at = time.monotonic()
         monotonic_now = time.monotonic() if now is None else now
         if self.app._last_lvgl_pump_at <= 0.0:
             delta_ms = 0
@@ -190,6 +202,12 @@ class RuntimeLoopService:
         if self.app._lvgl_input_bridge is not None:
             self.app._lvgl_input_bridge.process_pending()
         self.app._lvgl_backend.pump(delta_ms)
+        self._warn_if_slow(
+            "lvgl pump",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_LVGL_PUMP_WARNING_SECONDS,
+            detail=f"delta_ms={delta_ms}",
+        )
 
     def iterate_voip_backend_if_due(self, now: float | None = None) -> None:
         """Advance the Liblinphone core on the coordinator thread at its configured cadence."""
@@ -258,6 +276,15 @@ class RuntimeLoopService:
                 self._current_screen_name(),
                 self._runtime_state_name(),
             )
+        self._warn_if_slow(
+            "voip iterate",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_VOIP_ITERATE_WARNING_SECONDS,
+            detail=(
+                f"screen={self._current_screen_name()} "
+                f"state={self._runtime_state_name()}"
+            ),
+        )
 
     def run_iteration(
         self,
@@ -687,3 +714,24 @@ class RuntimeLoopService:
             return str(self.app.coordinator_runtime.get_state_name())
 
         return str(getattr(self.app._ui_state, "value", self.app._ui_state))
+
+    def _warn_if_slow(
+        self,
+        phase: str,
+        *,
+        started_at: float,
+        threshold_seconds: float,
+        detail: str = "",
+    ) -> None:
+        """Emit a targeted warning when one coordinator-loop phase runs unusually long."""
+
+        elapsed_seconds = time.monotonic() - started_at
+        if elapsed_seconds < threshold_seconds:
+            return
+
+        logger.warning(
+            "Slow runtime phase: {} took {:.1f} ms ({})",
+            phase,
+            elapsed_seconds * 1000.0,
+            detail or "no extra detail",
+        )

--- a/src/yoyopod/ui/screens/manager.py
+++ b/src/yoyopod/ui/screens/manager.py
@@ -4,6 +4,7 @@ Screen management and navigation for YoyoPod.
 Handles screen transitions, route resolution, and the navigation stack.
 """
 
+import time
 from typing import Callable, Optional, Dict, TYPE_CHECKING
 from loguru import logger
 
@@ -30,6 +31,10 @@ class ScreenManager:
     Maintains a stack of screens for back navigation and
     handles screen lifecycle (enter/exit).
     """
+
+    _SLOW_NAVIGATION_WARNING_SECONDS = 0.2
+    _SLOW_INPUT_ACTION_WARNING_SECONDS = 0.2
+    _SLOW_RENDER_WARNING_SECONDS = 0.2
 
     def __init__(
         self,
@@ -77,6 +82,7 @@ class ScreenManager:
         Args:
             screen_name: Name of the registered screen to display
         """
+        started_at = time.monotonic()
         if screen_name not in self.screens:
             logger.error(f"Screen not found: {screen_name}")
             return
@@ -95,6 +101,12 @@ class ScreenManager:
         self._notify_screen_changed()
 
         logger.info(f"Pushed screen: {screen_name} (stack depth: {len(self.screen_stack)})")
+        self._warn_if_slow(
+            "push_screen",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_NAVIGATION_WARNING_SECONDS,
+            detail=f"target={screen_name} stack_depth={len(self.screen_stack)}",
+        )
 
     def pop_screen(self) -> bool:
         """
@@ -103,6 +115,7 @@ class ScreenManager:
         Returns:
             True if successful, False if stack is empty
         """
+        started_at = time.monotonic()
         if not self.screen_stack:
             logger.warning("Cannot pop: screen stack is empty")
             return False
@@ -120,6 +133,12 @@ class ScreenManager:
         self._notify_screen_changed()
 
         logger.info(f"Popped screen (stack depth: {len(self.screen_stack)})")
+        self._warn_if_slow(
+            "pop_screen",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_NAVIGATION_WARNING_SECONDS,
+            detail=f"target={self.current_screen.route_name if self.current_screen else 'none'} stack_depth={len(self.screen_stack)}",
+        )
         return True
 
     def replace_screen(self, screen_name: str) -> None:
@@ -129,6 +148,7 @@ class ScreenManager:
         Args:
             screen_name: Name of the registered screen to display
         """
+        started_at = time.monotonic()
         if screen_name not in self.screens:
             logger.error(f"Screen not found: {screen_name}")
             return
@@ -146,6 +166,12 @@ class ScreenManager:
         self._notify_screen_changed()
 
         logger.info(f"Replaced screen with: {screen_name}")
+        self._warn_if_slow(
+            "replace_screen",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_NAVIGATION_WARNING_SECONDS,
+            detail=f"target={screen_name}",
+        )
 
     def clear_stack(self) -> None:
         """Clear the screen stack."""
@@ -159,7 +185,14 @@ class ScreenManager:
     def refresh_current_screen(self) -> None:
         """Re-render the current screen."""
         if self.current_screen:
+            started_at = time.monotonic()
             self.current_screen.render()
+            self._warn_if_slow(
+                "refresh_current_screen",
+                started_at=started_at,
+                threshold_seconds=self._SLOW_RENDER_WARNING_SECONDS,
+                detail=f"screen={self.current_screen.route_name or self.current_screen.name}",
+            )
 
     def _notify_screen_changed(self) -> None:
         """Notify listeners when the active screen changes."""
@@ -218,6 +251,7 @@ class ScreenManager:
 
         # Helper function to dispatch an action and then refresh or route
         def dispatch_action(action: "InputAction", data=None) -> None:
+            started_at = time.monotonic()
             previous_screen = self.current_screen
             if previous_screen is None:
                 return
@@ -228,6 +262,15 @@ class ScreenManager:
                 self.apply_navigation_request(navigation_request, source_screen=previous_screen)
             if self.current_screen is previous_screen:
                 self.refresh_current_screen()
+            self._warn_if_slow(
+                "screen action",
+                started_at=started_at,
+                threshold_seconds=self._SLOW_INPUT_ACTION_WARNING_SECONDS,
+                detail=(
+                    f"action={action.value} "
+                    f"screen={previous_screen.route_name or previous_screen.name}"
+                ),
+            )
 
         def wrap_with_refresh(action: "InputAction"):
             """Wrap action handler to automatically refresh display after execution."""
@@ -300,3 +343,24 @@ class ScreenManager:
     def _disconnect_buttons(self) -> None:
         """Legacy method - redirects to _disconnect_inputs()."""
         self._disconnect_inputs()
+
+    def _warn_if_slow(
+        self,
+        operation: str,
+        *,
+        started_at: float,
+        threshold_seconds: float,
+        detail: str = "",
+    ) -> None:
+        """Emit a targeted warning when one navigation/UI step blocks unusually long."""
+
+        elapsed_seconds = time.monotonic() - started_at
+        if elapsed_seconds < threshold_seconds:
+            return
+
+        logger.warning(
+            "Slow screen manager operation: {} took {:.1f} ms ({})",
+            operation,
+            elapsed_seconds * 1000.0,
+            detail or "no extra detail",
+        )


### PR DESCRIPTION
## Summary
- warn when main-thread drains, LVGL pumps, and VoIP iterate work block longer than expected
- warn when screen navigation, screen actions, and screen refreshes block interactive paths
- keep the change focused on surfacing hot-path stalls for issue #133

## Testing
- uv run pytest -q tests/test_screen_routing.py tests/test_main.py
- uv run --extra dev python scripts/quality.py gate
- uv run --extra dev pytest -q

Closes #133