### PR TITLE
[codex] Remove blocking runtime work from interactive paths

### DIFF
--- a/src/yoyopod/app.py
+++ b/src/yoyopod/app.py
@@ -192,7 +192,9 @@ class YoyoPodApp:
         self._screen_awake = True
         self._watchdog_active = False
         self._watchdog_feed_suppressed = False
+        self._watchdog_feed_in_flight = False
         self._next_watchdog_feed_at = 0.0
+        self._power_refresh_in_flight = False
         self._stopped = False
         self._lvgl_backend: Optional[LvglDisplayBackend] = None
         self._lvgl_input_bridge: Optional[LvglInputBridge] = None
@@ -317,14 +319,19 @@ class YoyoPodApp:
         else:
             logger.warning("    Failed to set startup music volume to {}%", volume)
 
-    def get_output_volume(self) -> int | None:
+    def get_output_volume(self, *, refresh_system: bool = True) -> int | None:
         """Return the current shared output volume."""
         if self.output_volume is not None:
-            volume = self.output_volume.get_volume()
+            volume = (
+                self.output_volume.get_volume()
+                if refresh_system
+                else self.output_volume.peek_cached_volume()
+            )
             if self.context is not None and volume is not None:
                 self.context.playback.volume = volume
                 self.context.voice.output_volume = volume
-            return volume
+            if volume is not None:
+                return volume
         if self.context is not None:
             return self.context.playback.volume
         return None
@@ -761,7 +768,7 @@ class YoyoPodApp:
         """Clean up and stop the application."""
         self.shutdown_service.stop(disable_watchdog=disable_watchdog)
 
-    def get_status(self) -> Dict[str, Any]:
+    def get_status(self, *, refresh_output_volume: bool = False) -> Dict[str, Any]:
         """Return the current application status."""
         monotonic_now = time.monotonic()
         pending_shutdown_in_seconds = None
@@ -787,7 +794,7 @@ class YoyoPodApp:
             "auto_resume": self.auto_resume_after_call,
             "voip_available": self.voip_manager is not None and self.voip_manager.running,
             "music_available": self.music_backend is not None and self.music_backend.is_connected,
-            "volume": self.get_output_volume(),
+            "volume": self.get_output_volume(refresh_system=refresh_output_volume),
             "power_available": power_snapshot.available if power_snapshot is not None else False,
             "current_screen": getattr(current_screen, "route_name", None),
             "screen_stack_depth": (
@@ -885,6 +892,7 @@ class YoyoPodApp:
                 else False
             ),
             "watchdog_active": self._watchdog_active,
+            "watchdog_feed_in_flight": self._watchdog_feed_in_flight,
             "watchdog_feed_suppressed": self._watchdog_feed_suppressed,
             "watchdog_timeout_seconds": (
                 self.power_manager.config.watchdog_timeout_seconds
@@ -896,11 +904,20 @@ class YoyoPodApp:
                 if self.power_manager is not None
                 else None
             ),
+            "power_refresh_in_flight": self._power_refresh_in_flight,
             "responsiveness_watchdog_enabled": bool(
-                getattr(getattr(self.app_settings, "diagnostics", None), "responsiveness_watchdog_enabled", False)
+                getattr(
+                    getattr(self.app_settings, "diagnostics", None),
+                    "responsiveness_watchdog_enabled",
+                    False,
+                )
             ),
             "responsiveness_capture_dir": (
-                getattr(getattr(self.app_settings, "diagnostics", None), "responsiveness_capture_dir", None)
+                getattr(
+                    getattr(self.app_settings, "diagnostics", None),
+                    "responsiveness_capture_dir",
+                    None,
+                )
             ),
             "responsiveness_last_capture_age_seconds": (
                 max(0.0, monotonic_now - self._last_responsiveness_capture_at)

--- a/src/yoyopod/audio/volume.py
+++ b/src/yoyopod/audio/volume.py
@@ -35,6 +35,10 @@ class OutputVolumeController:
         """Attach or replace the active music backend."""
         self.music_backend = music_backend
 
+    def peek_cached_volume(self) -> int | None:
+        """Return the last known shared volume without touching ALSA or mpv."""
+        return self._last_requested_volume
+
     def get_volume(self) -> int | None:
         """Return the best current app-facing output volume."""
         system_volume = self.get_system_volume()

--- a/src/yoyopod/main.py
+++ b/src/yoyopod/main.py
@@ -486,7 +486,7 @@ def main() -> int:
         app_log.info("  - Full UI navigation")
         app_log.info("")
         app_log.info("Current Configuration:")
-        status = app.get_status()
+        status = app.get_status(refresh_output_volume=True)
         app_log.info(f"  Auto-resume: {status['auto_resume']}")
         app_log.info(f"  VoIP available: {status['voip_available']}")
         app_log.info(f"  Music available: {status['music_available']}")

--- a/src/yoyopod/runtime/loop.py
+++ b/src/yoyopod/runtime/loop.py
@@ -63,6 +63,9 @@ def _queue_depth(queue_obj: object) -> int | None:
 class RuntimeLoopService:
     """Own the coordinator loop cadence and queued main-thread work."""
 
+    _SLOW_MAIN_THREAD_DRAIN_WARNING_SECONDS = 0.1
+    _SLOW_LVGL_PUMP_WARNING_SECONDS = 0.25
+    _SLOW_VOIP_ITERATE_WARNING_SECONDS = 0.25
     _VOIP_TIMING_SUMMARY_INTERVAL_SECONDS = 10.0
     _MIN_RUNTIME_LOOP_GAP_WARNING_SECONDS = 0.2
     _MIN_RUNTIME_BLOCKING_SPAN_WARNING_SECONDS = 0.2
@@ -151,6 +154,7 @@ class RuntimeLoopService:
 
     def process_pending_main_thread_actions(self, limit: Optional[int] = None) -> int:
         """Drain queued typed events scheduled by worker threads."""
+        started_at = time.monotonic()
         processed = 0
         while not self.app._pending_main_thread_callbacks.empty():
             callback = self.app._pending_main_thread_callbacks.get()
@@ -163,7 +167,14 @@ class RuntimeLoopService:
                 return processed
 
         remaining_limit = None if limit is None else max(0, limit - processed)
-        return processed + self.app.event_bus.drain(remaining_limit)
+        processed += self.app.event_bus.drain(remaining_limit)
+        self._warn_if_slow(
+            "main-thread drain",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_MAIN_THREAD_DRAIN_WARNING_SECONDS,
+            detail=f"callbacks={processed}",
+        )
+        return processed
 
     def queue_main_thread_callback(self, callback: Callable[[], None]) -> None:
         """Schedule a callback to run on the coordinator thread."""
@@ -180,6 +191,7 @@ class RuntimeLoopService:
         if self.app._lvgl_backend is None or not self.app._lvgl_backend.initialized:
             return
 
+        started_at = time.monotonic()
         monotonic_now = time.monotonic() if now is None else now
         if self.app._last_lvgl_pump_at <= 0.0:
             delta_ms = 0
@@ -190,6 +202,12 @@ class RuntimeLoopService:
         if self.app._lvgl_input_bridge is not None:
             self.app._lvgl_input_bridge.process_pending()
         self.app._lvgl_backend.pump(delta_ms)
+        self._warn_if_slow(
+            "lvgl pump",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_LVGL_PUMP_WARNING_SECONDS,
+            detail=f"delta_ms={delta_ms}",
+        )
 
     def iterate_voip_backend_if_due(self, now: float | None = None) -> None:
         """Advance the Liblinphone core on the coordinator thread at its configured cadence."""
@@ -258,6 +276,15 @@ class RuntimeLoopService:
                 self._current_screen_name(),
                 self._runtime_state_name(),
             )
+        self._warn_if_slow(
+            "voip iterate",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_VOIP_ITERATE_WARNING_SECONDS,
+            detail=(
+                f"screen={self._current_screen_name()} "
+                f"state={self._runtime_state_name()}"
+            ),
+        )
 
     def run_iteration(
         self,
@@ -687,3 +714,24 @@ class RuntimeLoopService:
             return str(self.app.coordinator_runtime.get_state_name())
 
         return str(getattr(self.app._ui_state, "value", self.app._ui_state))
+
+    def _warn_if_slow(
+        self,
+        phase: str,
+        *,
+        started_at: float,
+        threshold_seconds: float,
+        detail: str = "",
+    ) -> None:
+        """Emit a targeted warning when one coordinator-loop phase runs unusually long."""
+
+        elapsed_seconds = time.monotonic() - started_at
+        if elapsed_seconds < threshold_seconds:
+            return
+
+        logger.warning(
+            "Slow runtime phase: {} took {:.1f} ms ({})",
+            phase,
+            elapsed_seconds * 1000.0,
+            detail or "no extra detail",
+        )

--- a/src/yoyopod/runtime/recovery.py
+++ b/src/yoyopod/runtime/recovery.py
@@ -12,14 +12,19 @@ from yoyopod.events import RecoveryAttemptCompletedEvent
 
 if TYPE_CHECKING:
     from yoyopod.app import YoyoPodApp
+    from yoyopod.power import PowerSnapshot
     from yoyopod.runtime.models import RecoveryState
 
 
 class RecoverySupervisor:
     """Supervise recoverable backends and the PiSugar watchdog."""
 
+    _SLOW_POWER_REFRESH_WARNING_SECONDS = 0.25
+    _SLOW_WATCHDOG_FEED_WARNING_SECONDS = 0.25
+
     def __init__(self, app: "YoyoPodApp") -> None:
         self.app = app
+        self._power_io_lock = threading.Lock()
 
     def handle_recovery_attempt_completed_event(
         self,
@@ -59,7 +64,7 @@ class RecoverySupervisor:
         self.attempt_music_recovery(recovery_now)
 
     def poll_power_status(self, now: float | None = None, force: bool = False) -> None:
-        """Refresh PiSugar power telemetry on the coordinator thread."""
+        """Refresh PiSugar power telemetry without stalling the coordinator loop."""
         if self.app.power_manager is None:
             return
 
@@ -67,18 +72,60 @@ class RecoverySupervisor:
         if not force and poll_now < self.app._next_power_poll_at:
             return
 
+        interval = max(1.0, self.app.power_manager.config.poll_interval_seconds)
+        self.app._next_power_poll_at = poll_now + interval
+
+        if force:
+            snapshot = self._refresh_power_snapshot()
+            self._complete_power_refresh(snapshot=snapshot)
+            return
+
+        if self.app._power_refresh_in_flight:
+            return
+
+        self.app._power_refresh_in_flight = True
+        worker = threading.Thread(
+            target=self.run_power_refresh_attempt,
+            daemon=True,
+            name="power-refresh",
+        )
+        worker.start()
+
+    def run_power_refresh_attempt(self) -> None:
+        """Collect one PiSugar snapshot off the coordinator thread."""
+
+        snapshot = self._refresh_power_snapshot()
+        self.app._queue_main_thread_callback(
+            lambda snapshot=snapshot: self._complete_power_refresh(snapshot=snapshot)
+        )
+
+    def _refresh_power_snapshot(self) -> "PowerSnapshot":
+        """Collect one PiSugar snapshot under the shared power-I/O lock."""
+
+        assert self.app.power_manager is not None
+        started_at = time.monotonic()
+        with self._power_io_lock:
+            snapshot = self.app.power_manager.refresh()
+        duration_seconds = max(0.0, time.monotonic() - started_at)
+        if duration_seconds >= self._SLOW_POWER_REFRESH_WARNING_SECONDS:
+            logger.warning(
+                "Power refresh worker slow: duration_ms={:.1f}",
+                duration_seconds * 1000.0,
+            )
+        return snapshot
+
+    def _complete_power_refresh(self, *, snapshot: "PowerSnapshot") -> None:
+        """Publish one completed power refresh back onto the coordinator thread."""
+
+        self.app._power_refresh_in_flight = False
         self.app.boot_service.ensure_coordinators()
         assert self.app.power_coordinator is not None
-        snapshot = self.app.power_manager.refresh()
         self.app.power_coordinator.publish_snapshot(snapshot)
 
         if self.app._power_available is None or self.app._power_available != snapshot.available:
             reason = snapshot.error or ("ready" if snapshot.available else "unavailable")
             self.app._power_available = snapshot.available
             self.app.power_coordinator.publish_availability_change(snapshot.available, reason)
-
-        interval = max(1.0, self.app.power_manager.config.poll_interval_seconds)
-        self.app._next_power_poll_at = poll_now + interval
 
     def start_watchdog(self, now: float | None = None) -> None:
         """Enable the PiSugar software watchdog once the app loop is ready."""
@@ -100,12 +147,15 @@ class RecoverySupervisor:
                 timeout_seconds,
             )
 
-        if not self.app.power_manager.enable_watchdog():
+        with self._power_io_lock:
+            enabled = self.app.power_manager.enable_watchdog()
+        if not enabled:
             logger.warning("Power watchdog could not be enabled")
             return
 
         watchdog_now = time.monotonic() if now is None else now
         self.app._watchdog_active = True
+        self.app._watchdog_feed_in_flight = False
         self.app._watchdog_feed_suppressed = False
         self.app._next_watchdog_feed_at = watchdog_now + feed_interval
         logger.info(
@@ -115,34 +165,89 @@ class RecoverySupervisor:
         )
 
     def feed_watchdog_if_due(self, now: float) -> None:
-        """Feed the PiSugar software watchdog on the coordinator thread."""
+        """Feed the PiSugar software watchdog without blocking the coordinator loop."""
         if not self.app._watchdog_active or self.app._watchdog_feed_suppressed:
             return
 
         if self.app.power_manager is None or now < self.app._next_watchdog_feed_at:
             return
 
-        feed_interval = max(
-            1.0,
-            float(self.app.power_manager.config.watchdog_feed_interval_seconds),
-        )
-        if self.app.power_manager.feed_watchdog():
-            self.app._next_watchdog_feed_at = now + feed_interval
+        if self.app._watchdog_feed_in_flight:
             return
 
-        self.app._next_watchdog_feed_at = now + min(feed_interval, 5.0)
+        self.app._watchdog_feed_in_flight = True
+        worker = threading.Thread(
+            target=self.run_watchdog_feed_attempt,
+            daemon=True,
+            name="power-watchdog-feed",
+        )
+        worker.start()
+
+    def run_watchdog_feed_attempt(self) -> None:
+        """Feed the watchdog off the coordinator thread and report the outcome."""
+
+        power_manager = self.app.power_manager
+        feed_interval = 1.0
+        success = False
+        if power_manager is not None:
+            feed_interval = max(
+                1.0,
+                float(power_manager.config.watchdog_feed_interval_seconds),
+            )
+            started_at = time.monotonic()
+            with self._power_io_lock:
+                success = power_manager.feed_watchdog()
+            duration_seconds = max(0.0, time.monotonic() - started_at)
+            if duration_seconds >= self._SLOW_WATCHDOG_FEED_WARNING_SECONDS:
+                logger.warning(
+                    "Watchdog feed worker slow: duration_ms={:.1f}",
+                    duration_seconds * 1000.0,
+                )
+
+        completed_at = time.monotonic()
+        self.app._queue_main_thread_callback(
+            lambda success=success, completed_at=completed_at, feed_interval=feed_interval: self._complete_watchdog_feed(
+                success=success,
+                completed_at=completed_at,
+                feed_interval=feed_interval,
+            )
+        )
+
+    def _complete_watchdog_feed(
+        self,
+        *,
+        success: bool,
+        completed_at: float,
+        feed_interval: float,
+    ) -> None:
+        """Update watchdog cadence after one off-thread feed attempt completes."""
+
+        self.app._watchdog_feed_in_flight = False
+        if not self.app._watchdog_active:
+            return
+
+        if success:
+            self.app._next_watchdog_feed_at = completed_at + feed_interval
+            return
+
+        self.app._next_watchdog_feed_at = completed_at + min(feed_interval, 5.0)
 
     def disable_watchdog(self) -> None:
         """Disable the PiSugar watchdog during intentional app shutdowns."""
         if not self.app._watchdog_active:
             return
 
-        if self.app.power_manager is not None and self.app.power_manager.disable_watchdog():
+        disabled = False
+        if self.app.power_manager is not None:
+            with self._power_io_lock:
+                disabled = self.app.power_manager.disable_watchdog()
+        if disabled:
             logger.info("Power watchdog disabled for intentional stop")
         else:
             logger.warning("Failed to disable power watchdog cleanly")
 
         self.app._watchdog_active = False
+        self.app._watchdog_feed_in_flight = False
         self.app._watchdog_feed_suppressed = False
         self.app._next_watchdog_feed_at = 0.0
 

--- a/src/yoyopod/ui/screens/manager.py
+++ b/src/yoyopod/ui/screens/manager.py
@@ -4,6 +4,7 @@ Screen management and navigation for YoyoPod.
 Handles screen transitions, route resolution, and the navigation stack.
 """
 
+import time
 from typing import Callable, Optional, Dict, TYPE_CHECKING
 from loguru import logger
 
@@ -30,6 +31,10 @@ class ScreenManager:
     Maintains a stack of screens for back navigation and
     handles screen lifecycle (enter/exit).
     """
+
+    _SLOW_NAVIGATION_WARNING_SECONDS = 0.2
+    _SLOW_INPUT_ACTION_WARNING_SECONDS = 0.2
+    _SLOW_RENDER_WARNING_SECONDS = 0.2
 
     def __init__(
         self,
@@ -77,6 +82,7 @@ class ScreenManager:
         Args:
             screen_name: Name of the registered screen to display
         """
+        started_at = time.monotonic()
         if screen_name not in self.screens:
             logger.error(f"Screen not found: {screen_name}")
             return
@@ -95,6 +101,12 @@ class ScreenManager:
         self._notify_screen_changed()
 
         logger.info(f"Pushed screen: {screen_name} (stack depth: {len(self.screen_stack)})")
+        self._warn_if_slow(
+            "push_screen",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_NAVIGATION_WARNING_SECONDS,
+            detail=f"target={screen_name} stack_depth={len(self.screen_stack)}",
+        )
 
     def pop_screen(self) -> bool:
         """
@@ -103,6 +115,7 @@ class ScreenManager:
         Returns:
             True if successful, False if stack is empty
         """
+        started_at = time.monotonic()
         if not self.screen_stack:
             logger.warning("Cannot pop: screen stack is empty")
             return False
@@ -120,6 +133,12 @@ class ScreenManager:
         self._notify_screen_changed()
 
         logger.info(f"Popped screen (stack depth: {len(self.screen_stack)})")
+        self._warn_if_slow(
+            "pop_screen",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_NAVIGATION_WARNING_SECONDS,
+            detail=f"target={self.current_screen.route_name if self.current_screen else 'none'} stack_depth={len(self.screen_stack)}",
+        )
         return True
 
     def replace_screen(self, screen_name: str) -> None:
@@ -129,6 +148,7 @@ class ScreenManager:
         Args:
             screen_name: Name of the registered screen to display
         """
+        started_at = time.monotonic()
         if screen_name not in self.screens:
             logger.error(f"Screen not found: {screen_name}")
             return
@@ -146,6 +166,12 @@ class ScreenManager:
         self._notify_screen_changed()
 
         logger.info(f"Replaced screen with: {screen_name}")
+        self._warn_if_slow(
+            "replace_screen",
+            started_at=started_at,
+            threshold_seconds=self._SLOW_NAVIGATION_WARNING_SECONDS,
+            detail=f"target={screen_name}",
+        )
 
     def clear_stack(self) -> None:
         """Clear the screen stack."""
@@ -159,7 +185,14 @@ class ScreenManager:
     def refresh_current_screen(self) -> None:
         """Re-render the current screen."""
         if self.current_screen:
+            started_at = time.monotonic()
             self.current_screen.render()
+            self._warn_if_slow(
+                "refresh_current_screen",
+                started_at=started_at,
+                threshold_seconds=self._SLOW_RENDER_WARNING_SECONDS,
+                detail=f"screen={self.current_screen.route_name or self.current_screen.name}",
+            )
 
     def _notify_screen_changed(self) -> None:
         """Notify listeners when the active screen changes."""
@@ -218,6 +251,7 @@ class ScreenManager:
 
         # Helper function to dispatch an action and then refresh or route
         def dispatch_action(action: "InputAction", data=None) -> None:
+            started_at = time.monotonic()
             previous_screen = self.current_screen
             if previous_screen is None:
                 return
@@ -228,6 +262,15 @@ class ScreenManager:
                 self.apply_navigation_request(navigation_request, source_screen=previous_screen)
             if self.current_screen is previous_screen:
                 self.refresh_current_screen()
+            self._warn_if_slow(
+                "screen action",
+                started_at=started_at,
+                threshold_seconds=self._SLOW_INPUT_ACTION_WARNING_SECONDS,
+                detail=(
+                    f"action={action.value} "
+                    f"screen={previous_screen.route_name or previous_screen.name}"
+                ),
+            )
 
         def wrap_with_refresh(action: "InputAction"):
             """Wrap action handler to automatically refresh display after execution."""
@@ -300,3 +343,24 @@ class ScreenManager:
     def _disconnect_buttons(self) -> None:
         """Legacy method - redirects to _disconnect_inputs()."""
         self._disconnect_inputs()
+
+    def _warn_if_slow(
+        self,
+        operation: str,
+        *,
+        started_at: float,
+        threshold_seconds: float,
+        detail: str = "",
+    ) -> None:
+        """Emit a targeted warning when one navigation/UI step blocks unusually long."""
+
+        elapsed_seconds = time.monotonic() - started_at
+        if elapsed_seconds < threshold_seconds:
+            return
+
+        logger.warning(
+            "Slow screen manager operation: {} took {:.1f} ms ({})",
+            operation,
+            elapsed_seconds * 1000.0,
+            detail or "no extra detail",
+        )

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -318,6 +318,17 @@ def _publish_from_worker(app: YoyoPodApp, event: object) -> None:
     worker.join()
 
 
+def _wait_for(predicate, *, timeout_seconds: float = 1.0) -> None:
+    """Wait for one async test predicate to become true."""
+
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("Timed out waiting for async condition")
+
+
 def _navigate_from_worker(screen_manager: FakeScreenManager, screen_name: str) -> None:
     worker = threading.Thread(target=lambda: screen_manager.push_screen(screen_name))
     worker.start()
@@ -950,6 +961,8 @@ def test_power_poll_honors_interval_and_tracks_unavailable_backend() -> None:
     app._poll_power_status(now=0.0, force=True)
     app._poll_power_status(now=10.0)
     app._poll_power_status(now=30.0)
+    _wait_for(lambda: not app._pending_main_thread_callbacks.empty())
+    app._process_pending_main_thread_actions()
 
     assert app.power_manager.refresh_calls == 2
     assert app.context.battery_percent == 61
@@ -957,6 +970,42 @@ def test_power_poll_honors_interval_and_tracks_unavailable_backend() -> None:
     assert app.context.power_error == "I2C not connected"
     assert app.coordinator_runtime.power_available is False
     assert app.menu_screen.render_calls == 2
+
+
+def test_periodic_power_poll_runs_off_the_coordinator_thread() -> None:
+    """Loop-driven power refresh should return immediately and publish results later."""
+
+    refresh_started = threading.Event()
+    refresh_release = threading.Event()
+
+    class BlockingPowerManager(FakePowerManager):
+        def refresh(self) -> PowerSnapshot:
+            refresh_started.set()
+            refresh_release.wait(timeout=1.0)
+            return super().refresh()
+
+    app, _, _ = _build_app(playback_state="stopped")
+    app.power_manager = BlockingPowerManager(
+        [_power_snapshot(available=True, battery_percent=48.0, charging=False, power_plugged=False)]
+    )
+
+    started_at = time.monotonic()
+    app._poll_power_status(now=0.0)
+    elapsed_seconds = time.monotonic() - started_at
+
+    assert elapsed_seconds < 0.1
+    assert refresh_started.wait(timeout=1.0) is True
+    assert app.get_status()["power_refresh_in_flight"] is True
+    assert app.menu_screen.render_calls == 0
+
+    refresh_release.set()
+    _wait_for(lambda: not app._pending_main_thread_callbacks.empty())
+    app._process_pending_main_thread_actions()
+
+    assert app.power_manager.refresh_calls == 1
+    assert app.context.battery_percent == 48
+    assert app.menu_screen.render_calls == 1
+    assert app.get_status()["power_refresh_in_flight"] is False
 
 
 def test_screen_timeout_turns_backlight_off_after_inactivity() -> None:
@@ -1054,6 +1103,26 @@ def test_status_exposes_input_and_responsiveness_markers() -> None:
     assert status["responsiveness_last_capture_reason"] == "coordinator_stall_after_input"
     assert status["responsiveness_last_capture_scope"] == "input_to_runtime_handoff"
     assert status["responsiveness_last_capture_artifacts"] == {"snapshot": "/tmp/test.json"}
+
+
+def test_status_uses_cached_output_volume_without_touching_system_mixer() -> None:
+    """Runtime status snapshots should not block on live ALSA reads."""
+
+    app, _, _ = _build_app(playback_state="stopped")
+    app.context.set_volume(61)
+
+    class FakeOutputVolume:
+        def peek_cached_volume(self) -> int:
+            return 61
+
+        def get_volume(self) -> int:
+            raise AssertionError("status should not call get_volume()")
+
+    app.output_volume = FakeOutputVolume()
+
+    status = app.get_status()
+
+    assert status["volume"] == 61
 
 
 def test_raw_user_activity_wakes_screen_without_rerendering_current_pil_screen() -> None:
@@ -1313,10 +1382,54 @@ def test_watchdog_starts_and_feeds_from_app_loop() -> None:
     app._start_watchdog(now=0.0)
     app._feed_watchdog_if_due(9.0)
     app._feed_watchdog_if_due(10.0)
+    _wait_for(lambda: power_manager.feed_watchdog_calls == 1)
+    _wait_for(lambda: not app._pending_main_thread_callbacks.empty())
+    app._process_pending_main_thread_actions()
 
     assert power_manager.enable_watchdog_calls == 1
     assert power_manager.feed_watchdog_calls == 1
     assert app.get_status()["watchdog_active"] is True
+    assert app.get_status()["watchdog_feed_in_flight"] is False
+
+
+def test_watchdog_feed_runs_off_the_coordinator_thread() -> None:
+    """Periodic watchdog feeds should not block the interactive runtime loop."""
+
+    feed_started = threading.Event()
+    feed_release = threading.Event()
+
+    class BlockingWatchdogPowerManager(FakePowerManager):
+        def feed_watchdog(self) -> bool:
+            self.feed_watchdog_calls += 1
+            feed_started.set()
+            feed_release.wait(timeout=1.0)
+            return True
+
+    power_manager = BlockingWatchdogPowerManager(
+        [_power_snapshot(available=True, battery_percent=60.0)],
+        watchdog_enabled=True,
+        watchdog_timeout_seconds=60,
+        watchdog_feed_interval_seconds=10.0,
+    )
+    app, _, _ = _build_app_with_power(power_manager)
+    app.simulate = False
+
+    app._start_watchdog(now=0.0)
+    started_at = time.monotonic()
+    app._feed_watchdog_if_due(10.0)
+    elapsed_seconds = time.monotonic() - started_at
+
+    assert elapsed_seconds < 0.1
+    assert feed_started.wait(timeout=1.0) is True
+    assert app.get_status()["watchdog_feed_in_flight"] is True
+
+    feed_release.set()
+    _wait_for(lambda: not app._pending_main_thread_callbacks.empty())
+    app._process_pending_main_thread_actions()
+
+    assert power_manager.feed_watchdog_calls == 1
+    assert app.get_status()["watchdog_active"] is True
+    assert app.get_status()["watchdog_feed_in_flight"] is False
 
 
 def test_intentional_stop_disables_watchdog() -> None:


### PR DESCRIPTION
## Summary
- move loop-driven PiSugar snapshot refresh off the coordinator thread and publish the result back onto the main loop
- move periodic watchdog feeding off the coordinator thread while keeping watchdog state visible in runtime status
- make runtime status snapshots use cached output volume by default so the Setup screen stops triggering live `amixer` reads on every render

## Why
The interactive runtime still had blocking power and mixer work on hot paths:
- `poll_power_status()` performed synchronous PiSugar refresh work on the coordinator loop
- periodic watchdog feeds executed blocking I2C subprocesses on the coordinator loop
- `get_status()` could trigger live ALSA reads during Setup screen renders

Those paths could stall UI updates and other live runtime work on target hardware.

## Impact
- periodic power telemetry and watchdog maintenance no longer block the hot loop
- power and watchdog ownership remain explicit, with in-flight state surfaced through runtime status
- startup logging can still request a live volume snapshot when needed, but runtime screens stay on cached state

## Validation
- `uv run pytest -q tests/test_app_orchestration.py tests/test_output_volume.py`
- `uv run python scripts/quality.py gate`
- `uv run python -m black --check src/yoyopod/app.py src/yoyopod/audio/volume.py src/yoyopod/runtime/recovery.py src/yoyopod/main.py tests/test_app_orchestration.py`
- `uv run python -m ruff check src/yoyopod/app.py src/yoyopod/audio/volume.py src/yoyopod/runtime/recovery.py src/yoyopod/main.py tests/test_app_orchestration.py`
- `uv run pytest -q`

Closes #133