### PR TITLE
[codex] Own contributor setup and target prerequisites explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,20 @@ Supported display/input modes:
 
 ## Quick Start
 
+Local-only contributor path:
+
 ```bash
 uv run yoyoctl setup host
 uv run yoyoctl setup verify-host
 python yoyopod.py --simulate
 uv run python scripts/quality.py ci
-yoyoctl pi validate smoke
-yoyoctl pi validate navigation --with-playback
+```
+
+If you plan to validate on a Raspberry Pi or use GitHub CLI helpers, verify those host prerequisites explicitly before you need them:
+
+```bash
+uv run yoyoctl setup verify-host --with-remote-tools
+uv run yoyoctl setup verify-host --with-github
 ```
 
 For the full setup, validation, and Pi workflow, start with:

--- a/docs/CONTRIBUTOR_WORKFLOW.md
+++ b/docs/CONTRIBUTOR_WORKFLOW.md
@@ -31,6 +31,15 @@ This is the baseline executable setup contract.
 
 It is not the same thing as complete setup ownership. Feature-specific assets and unusual hardware edges can still need extra follow-through.
 
+Before you start a workflow that depends on more than local simulation and CI-safe checks, verify the extra host prerequisites explicitly:
+
+```bash
+uv run yoyoctl setup verify-host --with-remote-tools
+uv run yoyoctl setup verify-host --with-github
+```
+
+Use `--with-remote-tools --with-github` together when you plan to both validate on a Raspberry Pi over SSH and use GitHub CLI helpers for branch or PR work.
+
 ## Fast local loop
 
 Simulation run:
@@ -42,6 +51,8 @@ python yoyopod.py --simulate
 Core validation loop:
 
 ```bash
+uv run python scripts/quality.py gate
+uv run pytest -q
 uv run python scripts/quality.py ci
 ```
 
@@ -51,7 +62,8 @@ Full quality debt audit:
 uv run python scripts/quality.py audit
 ```
 
-Use `gate` for the tracked workflow surface that CI enforces now.
+CI currently runs `uv run python scripts/quality.py gate` plus `uv run pytest -q`.
+Use `uv run python scripts/quality.py ci` as the local wrapper when you want both in one command.
 Use `audit` when you want to see the broader repo debt without pretending it is all gated yet.
 
 ## Choose the right doc path for the work
@@ -84,16 +96,16 @@ Read:
 Baseline commands:
 
 ```bash
-uv run yoyoctl setup pi
-uv run yoyoctl setup verify-pi
-yoyoctl pi validate deploy
-yoyoctl pi validate smoke
-uv run yoyoctl remote setup
-uv run yoyoctl remote verify-setup
+uv run yoyoctl setup verify-host --with-remote-tools
+yoyoctl remote config edit
+uv run yoyoctl remote setup --with-pisugar
+uv run yoyoctl remote verify-setup --with-pisugar
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip
 ```
 
-These are the canonical baseline commands.
-They do not yet fully solve non-apt assets, every board/modem bringup edge, or deep native-health validation.
+These are the canonical contributor-path commands.
+Add `--with-voice` and/or `--with-network` when the target needs the TTS or modem paths.
+For direct on-Pi validation commands such as `yoyoctl pi validate smoke`, use [`RPI_SMOKE_VALIDATION.md`](RPI_SMOKE_VALIDATION.md).
 
 ### Docs and contributor guidance work
 
@@ -113,16 +125,19 @@ When updating docs:
 
 ## Before opening a PR
 
-At minimum, run:
+At minimum, run the same validation commands CI enforces today:
 
 ```bash
-uv run python scripts/quality.py ci
+uv run python scripts/quality.py gate
+uv run pytest -q
 ```
+
+`uv run python scripts/quality.py ci` is the local convenience wrapper for those same two steps.
 
 Then add any focused commands relevant to your area, for example:
 
 ```bash
-python -m compileall yoyopod tests demos scripts
+python -m compileall src/yoyopod tests demos scripts
 uv run pytest -q tests/test_app_orchestration.py
 uv run pytest -q tests/test_setup_cli.py tests/test_pi_remote.py tests/test_cli.py
 ```

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -29,6 +29,21 @@ uv run yoyoctl setup verify-host
 These commands define the baseline executable setup contract. They do not yet
 cover non-apt assets like Vosk models or every board/modem-specific setup edge.
 
+If you plan to use the remote Pi workflow from your dev machine, verify the
+extra host tools explicitly:
+
+```bash
+uv run yoyoctl setup verify-host --with-remote-tools
+```
+
+If you plan to use GitHub CLI helpers for branch or PR work, verify that too:
+
+```bash
+uv run yoyoctl setup verify-host --with-github
+```
+
+Combine both flags when you need both surfaces.
+
 ## System Dependencies
 
 The current repo-owned setup contract lives in [`SETUP_CONTRACT.md`](SETUP_CONTRACT.md).
@@ -55,14 +70,14 @@ Feature-gated extras are documented there too, including:
 Example:
 
 ```bash
-uv run yoyoctl setup pi
-uv run yoyoctl setup verify-pi
+uv run yoyoctl setup pi --with-pisugar
+uv run yoyoctl setup verify-pi --with-pisugar
 ```
 
 Treat those commands as the baseline package/build verifier, not proof that all
 feature assets and hardware-specific setup are complete.
 
-For PiSugar-based hardware, make sure `pisugar-server` is installed and running too.
+Add `--with-voice` and/or `--with-network` when the target uses the TTS or modem paths. For PiSugar-based hardware, `--with-pisugar` is what makes `pisugar-server` part of the verified contract.
 
 ## Configuration
 
@@ -123,13 +138,18 @@ python demos/demo_runtime_state.py --simulate
 Local validation:
 
 ```bash
+uv run python scripts/quality.py gate
+uv run pytest -q
 uv run python scripts/quality.py ci
 ```
+
+CI currently runs `uv run python scripts/quality.py gate` plus `uv run pytest -q`.
+Use `uv run python scripts/quality.py ci` as the local wrapper when you want both in one command.
 
 Optional extra syntax/import smoke for broad tree changes:
 
 ```bash
-python -m compileall yoyopod tests demos scripts
+python -m compileall src/yoyopod tests demos scripts
 ```
 
 Full quality audit of the current repo debt:
@@ -157,9 +177,11 @@ yoyoctl pi validate stability
 Preferred remote helper:
 
 ```bash
+uv run yoyoctl setup verify-host --with-remote-tools
+yoyoctl remote config edit
+uv run yoyoctl remote setup --with-pisugar
+uv run yoyoctl remote verify-setup --with-pisugar
 yoyoctl remote config show
-uv run yoyoctl remote setup
-uv run yoyoctl remote verify-setup
 yoyoctl remote status
 git branch --show-current
 git rev-parse HEAD
@@ -173,6 +195,7 @@ yoyoctl remote logs --lines 200
 
 That remote flow mirrors the same baseline contract. You still need feature-specific
 follow-through for assets like Vosk models and for unusual board/modem bringup.
+Add `--with-voice` and/or `--with-network` to the setup commands when the target depends on those paths.
 
 The detailed deploy and validation flows live in:
 

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -29,6 +29,18 @@ Do not normalize ad hoc per-branch checkout directories on the board.
 
 Make sure your dev machine can SSH into the Raspberry Pi with an alias or reachable host name.
 
+Before the first `yoyoctl remote validate`, verify the host prerequisites that the remote workflow depends on:
+
+```bash
+uv run yoyoctl setup verify-host --with-remote-tools
+```
+
+If you also use GitHub CLI helpers for branch or PR work, verify that separately:
+
+```bash
+uv run yoyoctl setup verify-host --with-github
+```
+
 The repo-tracked deploy contract lives in `deploy/pi-deploy.yaml`.
 
 - keep `host` and `user` blank there
@@ -39,6 +51,15 @@ The repo-tracked deploy contract lives in `deploy/pi-deploy.yaml`.
 ```bash
 yoyoctl remote config edit
 ```
+
+Bootstrap and verify the target with flags that match the hardware and feature paths you actually expect:
+
+```bash
+uv run yoyoctl remote setup --with-pisugar
+uv run yoyoctl remote verify-setup --with-pisugar
+```
+
+Add `--with-voice` and/or `--with-network` when the target needs the TTS or modem paths. `--with-pisugar` is the normal Whisplay and PiSugar path because it pulls in the `pisugar-server` package and service check.
 
 Examples:
 

--- a/docs/SETUP_CONTRACT.md
+++ b/docs/SETUP_CONTRACT.md
@@ -74,6 +74,16 @@ Optional but useful for repo operations:
 
 - `gh`
 
+Workflow-specific host verification:
+
+```bash
+uv run yoyoctl setup verify-host --with-remote-tools
+uv run yoyoctl setup verify-host --with-github
+uv run yoyoctl setup verify-host --with-remote-tools --with-github
+```
+
+Use the baseline command for local-only work. Add `--with-remote-tools` before using `yoyoctl remote`, `--with-github` before relying on `gh`, and combine them when you need both.
+
 ### 2. Target Raspberry Pi runtime
 
 Current core system packages and services expected by the active stack:
@@ -110,6 +120,15 @@ uv run yoyoctl setup verify-pi
 
 This verifies presence and basic build state. It does not perform deeper
 artifact health checks for every native/runtime dependency.
+
+Use flags that match the actual target you are bringing up:
+
+```bash
+uv run yoyoctl setup pi --with-pisugar
+uv run yoyoctl setup verify-pi --with-pisugar
+```
+
+Add `--with-voice` and/or `--with-network` when the target depends on the TTS or modem paths. `--with-pisugar` is the normal Whisplay/PiSugar hardware path because it adds the `pisugar-server` package and service check.
 
 ### 3. Feature-gated or hardware-specific extras
 
@@ -161,7 +180,7 @@ The tracked deploy contract must stay generic:
 uv run yoyoctl setup host
 uv run yoyoctl setup verify-host
 python yoyopod.py --simulate
-uv run pytest -q
+uv run python scripts/quality.py ci
 ```
 
 This is the minimum executable contract for contributors. Feature assets and
@@ -170,8 +189,8 @@ hardware-specific extras still need follow-through when the feature requires the
 ### Target Pi bringup baseline
 
 ```bash
-uv run yoyoctl setup pi
-uv run yoyoctl setup verify-pi
+uv run yoyoctl setup pi --with-pisugar
+uv run yoyoctl setup verify-pi --with-pisugar
 yoyoctl pi validate deploy
 yoyoctl pi validate smoke
 yoyoctl pi validate smoke --with-power --with-rtc
@@ -179,22 +198,24 @@ uv run python yoyopod.py
 ```
 
 This does not yet provision non-apt assets such as Vosk models or encode every
-board/modem-specific permission step.
+board/modem-specific permission step. Add `--with-voice` and/or `--with-network`
+when the target needs those feature paths.
 
 ### Remote Pi workflow baseline
 
 ```bash
-yoyoctl remote config show
-uv run yoyoctl remote setup
-uv run yoyoctl remote verify-setup
+uv run yoyoctl setup verify-host --with-remote-tools
+yoyoctl remote config edit
+uv run yoyoctl remote setup --with-pisugar
+uv run yoyoctl remote verify-setup --with-pisugar
 yoyoctl remote status
-yoyoctl remote sync --branch main
-yoyoctl remote smoke --with-music --with-voip
-yoyoctl remote service status
+yoyoctl remote validate --branch <branch> --sha <commit> --with-music --with-voip
 ```
 
 These remote helpers mirror the same baseline contract. They still rely on
-feature-specific follow-up for assets and unusual hardware bringup.
+feature-specific follow-up for assets and unusual hardware bringup. Add
+`--with-voice` and/or `--with-network` to the setup commands when the target
+needs those feature paths.
 
 ## Verification before blaming product code
 
@@ -204,8 +225,11 @@ Checklist:
 
 - local bootstrap completes with `uv run yoyoctl setup host`
 - local verification passes with `uv run yoyoctl setup verify-host`
+- remote Pi workflows use `uv run yoyoctl setup verify-host --with-remote-tools`
+- GitHub CLI workflows use `uv run yoyoctl setup verify-host --with-github`
 - tracked config files are present under `config/`
 - required system packages are verified with `uv run yoyoctl setup verify-pi`
+- target feature extras are verified with the matching `--with-pisugar`, `--with-voice`, and `--with-network` flags
 - native shims have been built when the feature requires them
 - `yoyoctl pi validate smoke` passes for the requested hardware path
 - remote config values come from `deploy/pi-deploy.yaml` plus local overrides, not tribal knowledge


### PR DESCRIPTION
## Summary
- make the README quick start local-only and call out the extra host checks for remote Pi and GitHub CLI workflows
- update the contributor, development, setup-contract, and Pi workflow docs to document `--with-remote-tools`, `--with-github`, and target setup flags like `--with-pisugar` explicitly
- align contributor validation guidance with the current repo commands, including the CI-enforced `gate` plus `pytest -q` flow and the existing `ci` wrapper

## Why
- contributor setup still relied on hidden knowledge for remote Pi validation, GitHub CLI usage, and target-specific package/service expectations
- the onboarding docs also mixed local quick-start guidance with target-only validation commands

Closes #136.

## Validation
- `uv sync --extra dev`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`