### PR TITLE
[codex] Cut over media/audio onto the canonical config and package topology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ deploy/pi-deploy.local.yaml
 .cache/
 data/*.json
 data/communication/
+data/media/
 data/people/
 
 # OS files

--- a/config/audio/music.yaml
+++ b/config/audio/music.yaml
@@ -2,9 +2,9 @@
 
 audio:
   music_dir: "/home/tifo/Music"
+  recent_tracks_file: "data/media/recent_tracks.json"
   mpv_socket: "/tmp/yoyopod-mpv.sock"
   mpv_binary: "mpv"
-  alsa_device: "default"
   auto_resume_after_call: true
   fade_out_duration_ms: 0
   fade_in_duration_ms: 0

--- a/config/device/hardware.yaml
+++ b/config/device/hardware.yaml
@@ -47,6 +47,9 @@ communication_audio:
   media_device_id: "ALSA: wm8960-soundcard"
   ring_output_device: ""
 
+media_audio:
+  alsa_device: "default"
+
 voice_audio:
   speaker_device_id: "ALSA: wm8960-soundcard"
   capture_device_id: "ALSA: wm8960-soundcard"

--- a/docs/AUDIO_STACK.md
+++ b/docs/AUDIO_STACK.md
@@ -41,21 +41,26 @@ So music and VoIP use different software stacks, but they converge on the same R
 
 `YoyoPodApp` owns the audio stack startup in production.
 
-- `audio.music_dir` selects the local music root.
-- `audio.mpv_socket` selects the mpv IPC socket.
-- `audio.mpv_binary` selects the binary to spawn.
-- `audio.alsa_device` selects the mpv ALSA target.
-- `audio.default_volume` is applied at startup through the shared output-volume controller.
+- `config/audio/music.yaml` owns `audio.music_dir`, `audio.recent_tracks_file`, `audio.mpv_socket`, `audio.mpv_binary`, and `audio.default_volume`.
+- `config/device/hardware.yaml` owns `media_audio.alsa_device`.
+- `ConfigManager.get_media_settings()` composes those layers into `MediaConfig.music` and `MediaConfig.audio`.
+- `MusicConfig.from_config_manager()` is the app-facing seam that turns the composed media config into mpv runtime settings.
+- startup output volume is applied through the shared output-volume controller.
 
 Current production config shape:
 
 ```yaml
 audio:
   music_dir: /home/tifo/Music
+  recent_tracks_file: data/media/recent_tracks.json
   mpv_socket: /tmp/yoyopod-mpv.sock
   mpv_binary: mpv
-  alsa_device: default
   default_volume: 100
+```
+
+```yaml
+media_audio:
+  alsa_device: default
 ```
 
 ## Music Domain Models
@@ -197,7 +202,7 @@ Liblinphone uses the communication audio selectors from
 
 So:
 
-- music path: `mpv -> alsa/default -> wm8960`
+- music path: `mpv -> media_audio.alsa_device -> wm8960`
 - VoIP path: `Liblinphone -> ALSA: wm8960-soundcard`
 
 They are separate software paths that meet at the same codec/hardware.

--- a/docs/CANONICAL_STRUCTURE.md
+++ b/docs/CANONICAL_STRUCTURE.md
@@ -21,9 +21,9 @@ Tracked authored config lives under `config/` and is split by ownership:
 - `config/app/core.yaml`
   - app shell concerns: `app`, `ui`, `logging`, `diagnostics`
 - `config/audio/music.yaml`
-  - local music policy and mpv settings
+  - local music policy, startup volume, and media runtime paths
 - `config/device/hardware.yaml`
-  - shared hardware truth: `input`, `display`, `power`, `communication_audio`, `voice_audio`
+  - shared hardware truth: `input`, `display`, `power`, `communication_audio`, `media_audio`, `voice_audio`
 - `config/network/cellular.yaml`
   - cellular modem policy and transport settings
 - `config/voice/assistant.yaml`
@@ -46,6 +46,7 @@ Untracked local secrets live in:
 Mutable runtime user data lives outside tracked config:
 
 - `data/communication/`
+- `data/media/`
 - `data/people/`
 
 ### Composition Rule
@@ -55,7 +56,7 @@ ad hoc.
 
 - `ConfigManager` composes the canonical files
 - `YoyoPodRuntimeConfig` is the single typed runtime model
-- `load_composed_app_settings()` is the app-shell loader for `app` + `audio` + `device`
+- `load_composed_app_settings()` is the app-shell loader for `app` + `device`
 
 ### Secret Boundary Rule
 
@@ -103,6 +104,9 @@ Current exemplar package homes:
 - `src/yoyopod/people/`
   - mutable contacts/address-book concerns
   - `__init__.py` is the app-facing seam
+- `src/yoyopod/audio/`
+  - local music/media behavior, history, output-volume coordination, and mpv backend wiring
+  - `__init__.py` is the app-facing seam
 - `src/yoyopod/voice/`
   - local voice behavior, models, and backends
   - device inventory/helpers live outside this package
@@ -112,6 +116,7 @@ Current exemplar package homes:
 The app layer should import from domain seams such as:
 
 - `yoyopod.network`
+- `yoyopod.audio`
 - `yoyopod.communication`
 - `yoyopod.people`
 
@@ -151,6 +156,19 @@ The network migration follows the same cutover shape:
 - `src/yoyopod/network/` as the domain-owned package home
 - app/runtime composition depending on `NetworkManager.from_config_manager()`
   instead of reading network state from app-shell config
+
+## Media Migration Pattern
+
+The media/audio migration follows the same cutover shape:
+
+- media policy under `config/audio/music.yaml`
+- device-owned playback routing under `config/device/hardware.yaml` as `media_audio.*`
+- mutable recent-track history under `data/media/`
+- `ConfigManager.get_media_settings()` as the typed runtime seam for `music` policy
+  plus device-owned `audio` routing
+- `src/yoyopod/audio/` as the domain-owned package home
+- app/runtime composition depending on the `yoyopod.audio` seam via
+  `MusicConfig.from_config_manager()` instead of hand-mapping media fields
 
 ## Template For Future Migrations
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -100,9 +100,9 @@ Key settings:
 - `config/app/core.yaml`
   - `app.*`, `ui.*`, `logging.*`, `diagnostics.*`
 - `config/audio/music.yaml`
-  - `audio.music_dir`, `audio.mpv_*`, `audio.alsa_device`, `audio.default_volume`
+  - `audio.music_dir`, `audio.recent_tracks_file`, `audio.mpv_*`, `audio.default_volume`
 - `config/device/hardware.yaml`
-  - `input.*`, `display.*`, `power.*`, `communication_audio.*`, `voice_audio.*`
+  - `input.*`, `display.*`, `power.*`, `communication_audio.*`, `media_audio.*`, `voice_audio.*`
 - `config/network/cellular.yaml`
   - `network.*` cellular modem enablement, ports, APN, GPS, and PPP timeout
 - `config/voice/assistant.yaml`
@@ -116,7 +116,8 @@ Key settings:
 
 Local SIP credentials belong in `config/communication/calling.secrets.yaml` or
 env vars. Mutable contacts live in `data/people/contacts.yaml`, optionally
-bootstrapped from `config/people/contacts.seed.yaml`.
+bootstrapped from `config/people/contacts.seed.yaml`. Mutable media history
+lives in `data/media/recent_tracks.json`.
 
 ## Running
 

--- a/docs/GLOBAL_AUDIO_DEVICE_FACADE_CONTRACT.md
+++ b/docs/GLOBAL_AUDIO_DEVICE_FACADE_CONTRACT.md
@@ -7,7 +7,7 @@
 
 YoyoPod currently reaches ALSA and device selection through multiple partially overlapping paths:
 
-- music playback uses `audio.alsa_device` plus `OutputVolumeController`
+- music playback uses `media_audio.alsa_device` plus `OutputVolumeController`
 - Liblinphone receives its own playback, ringer, capture, and media device IDs
 - `LiblinphoneBackend` also applies capture-side `amixer` commands directly
 - voice-command capture resolves `arecord` devices independently

--- a/docs/MPV_DEPENDENCIES.md
+++ b/docs/MPV_DEPENDENCIES.md
@@ -53,16 +53,24 @@ YoyoPod adds on top of that:
 ```yaml
 audio:
   music_dir: /home/tifo/Music
+  recent_tracks_file: data/media/recent_tracks.json
   mpv_socket: /tmp/yoyopod-mpv.sock
   mpv_binary: mpv
-  alsa_device: default
   default_volume: 100
+```
+
+## Example `config/device/hardware.yaml`
+
+```yaml
+media_audio:
+  alsa_device: default
 ```
 
 Notes:
 
 - `hw:1` is the Whisplay HAT audio device in the current Raspberry Pi setup.
 - `audio.music_dir` is the source of truth for local library scanning.
+- `media_audio.alsa_device` is the source of truth for the mpv ALSA route.
 - `.m3u` playlists can live anywhere under that music directory.
 - mpv is spawned and supervised by the app; there is no separate music daemon to manage.
 

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -41,8 +41,8 @@ This is the startup sequence that exists on `main` today.
    - `yoyopod.py` is only a thin launcher.
    - The installed `yoyopod` console script in `pyproject.toml` also targets `yoyopod.main:main`.
 2. `main()` configures process-level runtime plumbing before app setup starts.
-   - `load_composed_app_settings()` reads `config/app/core.yaml`, `config/audio/music.yaml`, and `config/device/hardware.yaml` early enough to resolve logging settings.
-   - `ConfigManager` later composes domain-owned layers such as `config/network/cellular.yaml`, `config/voice/assistant.yaml`, and the communication files into the full runtime model.
+   - `load_composed_app_settings()` reads `config/app/core.yaml` and `config/device/hardware.yaml` early enough to resolve logging settings.
+   - `ConfigManager` later composes domain-owned layers such as `config/audio/music.yaml`, `config/network/cellular.yaml`, `config/voice/assistant.yaml`, and the communication files into the full runtime model.
    - `configure_logger()` builds the shared `loguru` runtime config and enables console plus file logging.
    - `write_pid_file()` writes the current PID.
    - `log_startup()` emits the startup marker consumed by Pi deploy and remote-validation workflows.

--- a/rules/project.md
+++ b/rules/project.md
@@ -49,8 +49,8 @@ artifact deeply, or cover every board/modem-specific edge.
 
 Tracked authored config lives under `config/`:
 - `app/core.yaml` -- app shell, UI, logging, diagnostics
-- `audio/music.yaml` -- local music and mpv settings
-- `device/hardware.yaml` -- shared hardware truth for display, input, power, communication audio, and voice audio
+- `audio/music.yaml` -- local music policy, startup volume, and media runtime paths
+- `device/hardware.yaml` -- shared hardware truth for display, input, power, communication audio, media audio, and voice audio
 - `network/cellular.yaml` -- cellular modem policy and transport settings
 - `voice/assistant.yaml` -- local voice policy and assistant defaults
 - `communication/calling.yaml` -- non-secret SIP identity and calling policy
@@ -60,8 +60,9 @@ Tracked authored config lives under `config/`:
 - `people/directory.yaml` -- mutable people-data paths only
 - `people/contacts.seed.yaml` -- tracked bootstrap seed for the mutable address book
 
-Runtime user data lives under `data/communication/` and `data/people/`. Local SIP
-secrets belong in `config/communication/calling.secrets.yaml` or env vars.
+Runtime user data lives under `data/communication/`, `data/media/`, and
+`data/people/`. Local SIP secrets belong in
+`config/communication/calling.secrets.yaml` or env vars.
 
 ## Current Gaps
 

--- a/src/yoyopod/app.py
+++ b/src/yoyopod/app.py
@@ -14,9 +14,13 @@ from typing import Any, Callable, Dict, Optional
 from loguru import logger
 
 from yoyopod.app_context import AppContext
-from yoyopod.audio import LocalMusicService, OutputVolumeController, RecentTrackHistoryStore
-from yoyopod.audio.music import MpvBackend
-from yoyopod.config import ConfigManager, YoyoPodConfig
+from yoyopod.audio import (
+    LocalMusicService,
+    MpvBackend,
+    OutputVolumeController,
+    RecentTrackHistoryStore,
+)
+from yoyopod.config import ConfigManager, MediaConfig, YoyoPodConfig
 from yoyopod.coordinators import (
     AppRuntimeState,
     CallCoordinator,
@@ -116,6 +120,7 @@ class YoyoPodApp:
         self.context: Optional[AppContext] = None
         self.config_manager: Optional[ConfigManager] = None
         self.app_settings: Optional[YoyoPodConfig] = None
+        self.media_settings: Optional[MediaConfig] = None
         self.screen_manager: Optional[ScreenManager] = None
         self.input_manager: Optional[InputManager] = None
         self.people_directory: Optional[PeopleDirectory] = None
@@ -291,8 +296,8 @@ class YoyoPodApp:
 
     def _resolve_default_music_volume(self) -> int:
         """Return the configured startup volume for the music backend."""
-        audio_cfg = self.app_settings.audio if self.app_settings else None
-        raw_volume = audio_cfg.default_volume if audio_cfg else 100
+        media_cfg = self.media_settings
+        raw_volume = media_cfg.music.default_volume if media_cfg else 100
         return max(0, min(100, int(raw_volume)))
 
     def _apply_default_music_volume(self) -> None:

--- a/src/yoyopod/audio/__init__.py
+++ b/src/yoyopod/audio/__init__.py
@@ -1,8 +1,4 @@
-"""
-Audio management for YoyoPod.
-
-Provides audio playback, volume control, and device management.
-"""
+"""App-facing seam for the media/audio domain."""
 
 from yoyopod.audio.history import RecentTrackEntry, RecentTrackHistoryStore
 from yoyopod.audio.local_service import LocalLibraryItem, LocalMusicService

--- a/src/yoyopod/audio/music/models.py
+++ b/src/yoyopod/audio/music/models.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from yoyopod.config import ConfigManager, MediaConfig as RuntimeMediaConfig
 
 
 def _normalized_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
@@ -206,3 +209,32 @@ class MusicConfig:
     def __post_init__(self) -> None:
         if not self.mpv_socket:
             self.mpv_socket = _default_mpv_socket()
+
+    @classmethod
+    def from_media_settings(cls, settings: "RuntimeMediaConfig | None") -> MusicConfig:
+        """Translate composed media settings into the backend-facing mpv config."""
+
+        music_settings = settings.music if settings is not None else None
+        audio_settings = settings.audio if settings is not None else None
+        return cls(
+            music_dir=(
+                Path(music_settings.music_dir)
+                if music_settings is not None
+                else Path("/home/pi/Music")
+            ),
+            mpv_socket=(
+                music_settings.mpv_socket
+                if music_settings and music_settings.mpv_socket
+                else ""
+            ),
+            mpv_binary=music_settings.mpv_binary if music_settings is not None else "mpv",
+            alsa_device=audio_settings.alsa_device if audio_settings is not None else "default",
+        )
+
+    @classmethod
+    def from_config_manager(cls, config_manager: "ConfigManager | None") -> MusicConfig:
+        """Build the backend-facing mpv config from the typed media runtime seam."""
+
+        if config_manager is None:
+            return cls()
+        return cls.from_media_settings(config_manager.get_media_settings())

--- a/src/yoyopod/cli/pi/smoke.py
+++ b/src/yoyopod/cli/pi/smoke.py
@@ -6,12 +6,16 @@ import platform
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any, Optional
+from typing import TYPE_CHECKING, Annotated, Any, Optional
 
 import typer
 
 from yoyopod.audio.test_music import DEFAULT_TEST_MUSIC_TARGET_DIR
 from yoyopod.cli.common import configure_logging, resolve_config_dir
+
+if TYPE_CHECKING:
+    from yoyopod.audio.test_music import ProvisionedTestMusicLibrary
+    from yoyopod.config import MediaConfig
 
 smoke_app = typer.Typer(
     name="smoke",
@@ -40,12 +44,18 @@ def _load_app_config(config_dir: Path) -> dict[str, Any]:
         path.exists()
         for path in (
             config_dir / "app" / "core.yaml",
-            config_dir / "audio" / "music.yaml",
             config_dir / "device" / "hardware.yaml",
         )
     ):
         logger.warning("Composed app config not found under {}", config_dir)
     return config_to_dict(load_composed_app_settings(config_dir))
+
+
+def _load_media_config(config_dir: Path) -> MediaConfig:
+    """Load the typed composed media config if present."""
+    from yoyopod.config import ConfigManager
+
+    return ConfigManager(config_dir=str(config_dir)).get_media_settings()
 
 
 def _environment_check() -> CheckResult:
@@ -250,11 +260,11 @@ def _rtc_check(config_dir: Path) -> CheckResult:
 
 
 def _prepare_music_validation_library(
-    app_config: dict[str, Any],
+    media_settings: MediaConfig,
     *,
     provision_test_music: bool,
     test_music_dir: str,
-):
+) -> ProvisionedTestMusicLibrary | None:
     """Provision the deterministic validation music library and point smoke at it."""
     from yoyopod.audio.test_music import provision_test_music_library
 
@@ -262,31 +272,20 @@ def _prepare_music_validation_library(
         return None
 
     library = provision_test_music_library(Path(test_music_dir))
-    audio_config = app_config.get("audio")
-    if not isinstance(audio_config, dict):
-        audio_config = {}
-        app_config["audio"] = audio_config
-    audio_config["music_dir"] = str(library.target_dir)
+    media_settings.music.music_dir = str(library.target_dir)
     return library
 
 
 def _music_check(
-    app_config: dict[str, Any],
+    media_settings: MediaConfig,
     timeout_seconds: int,
     *,
-    expected_library=None,
+    expected_library: ProvisionedTestMusicLibrary | None = None,
 ) -> CheckResult:
     """Validate music-backend startup and basic state queries."""
-    from yoyopod.audio.local_service import LocalMusicService
-    from yoyopod.audio.music import MpvBackend, MusicConfig
+    from yoyopod.audio import LocalMusicService, MpvBackend, MusicConfig
 
-    audio_config = app_config.get("audio", {})
-    config = MusicConfig(
-        music_dir=Path(str(audio_config.get("music_dir", "/home/pi/Music"))),
-        mpv_socket=str(audio_config.get("mpv_socket", "")),
-        mpv_binary=str(audio_config.get("mpv_binary", "mpv")),
-        alsa_device=str(audio_config.get("alsa_device", "default")),
-    )
+    config = MusicConfig.from_media_settings(media_settings)
     backend = MpvBackend(config)
     try:
         started_at = time.monotonic()
@@ -540,10 +539,11 @@ def smoke(
     logger.info(f"Using config directory: {config_path}")
 
     app_config = _load_app_config(config_path)
+    media_config = _load_media_config(config_path)
     expected_music_library = None
     if with_music:
         expected_music_library = _prepare_music_validation_library(
-            app_config,
+            media_config,
             provision_test_music=provision_test_music,
             test_music_dir=test_music_dir,
         )
@@ -566,7 +566,7 @@ def smoke(
         if with_music:
             results.append(
                 _music_check(
-                    app_config,
+                    media_config,
                     music_timeout,
                     expected_library=expected_music_library,
                 )

--- a/src/yoyopod/cli/pi/validate.py
+++ b/src/yoyopod/cli/pi/validate.py
@@ -20,6 +20,7 @@ from yoyopod.cli.pi.smoke import (
     _environment_check,
     _input_check,
     _load_app_config,
+    _load_media_config,
     _music_check,
     _power_check,
     _rtc_check,
@@ -299,8 +300,8 @@ def music(
 
     logger.info("Running target music validation")
 
-    app_config = _load_app_config(config_path)
-    results = [_music_check(app_config, timeout)]
+    media_config = _load_media_config(config_path)
+    results = [_music_check(media_config, timeout)]
 
     _print_summary("music", results)
     if any(result.status == "fail" for result in results):

--- a/src/yoyopod/config/__init__.py
+++ b/src/yoyopod/config/__init__.py
@@ -4,6 +4,7 @@ from yoyopod.config.manager import ConfigManager, load_composed_app_settings
 from yoyopod.config.models import (
     AppPowerConfig,
     CommunicationConfig,
+    MediaConfig,
     NetworkConfig,
     PeopleDirectoryConfig,
     VoiceConfig,
@@ -16,6 +17,7 @@ from yoyopod.config.models import (
 __all__ = [
     "ConfigManager",
     "CommunicationConfig",
+    "MediaConfig",
     "NetworkConfig",
     "AppPowerConfig",
     "PeopleDirectoryConfig",

--- a/src/yoyopod/config/manager.py
+++ b/src/yoyopod/config/manager.py
@@ -10,6 +10,7 @@ from loguru import logger
 from yoyopod.config.layers import resolve_config_board, resolve_config_layers
 from yoyopod.config.models import (
     CommunicationConfig,
+    MediaConfig,
     NetworkConfig,
     PeopleDirectoryConfig,
     VoiceConfig,
@@ -57,13 +58,12 @@ def load_composed_app_settings(
     *,
     config_board: str | None = None,
 ) -> YoyoPodConfig:
-    """Load the typed app settings from the canonical app/audio/device topology."""
+    """Load the typed app settings from the canonical app/device topology."""
 
     base_dir = Path(config_dir)
     active_board = resolve_config_board(explicit_board=config_board)
     payload = _merge_layer_groups(
         resolve_config_layers(base_dir, active_board, APP_CORE_CONFIG),
-        resolve_config_layers(base_dir, active_board, AUDIO_MUSIC_CONFIG),
         resolve_config_layers(base_dir, active_board, DEVICE_HARDWARE_CONFIG),
     )
     return build_config_model(YoyoPodConfig, payload)
@@ -85,7 +85,7 @@ class ConfigManager:
             self.config_board,
             APP_CORE_CONFIG,
         )
-        self.audio_music_layers = resolve_config_layers(
+        self.media_music_layers = resolve_config_layers(
             self.config_dir,
             self.config_board,
             AUDIO_MUSIC_CONFIG,
@@ -124,6 +124,7 @@ class ConfigManager:
 
         self.app_config_file = self.app_core_layers[-1]
         self.device_hardware_file = self.device_hardware_layers[-1]
+        self.media_music_file = self.media_music_layers[-1]
         self.network_cellular_file = self.network_cellular_layers[-1]
         self.voice_assistant_file = self.voice_assistant_layers[-1]
         self.communication_calling_file = self.communication_calling_layers[-1]
@@ -131,6 +132,7 @@ class ConfigManager:
         self.people_directory_file = self.people_directory_layers[-1]
 
         self.app_settings = YoyoPodConfig()
+        self.media_settings = MediaConfig()
         self.network_settings = NetworkConfig()
         self.voice_settings = VoiceConfig()
         self.communication_settings = CommunicationConfig()
@@ -138,12 +140,14 @@ class ConfigManager:
         self.runtime_settings = YoyoPodRuntimeConfig()
 
         self.app_config: dict[str, Any] = config_to_dict(self.app_settings)
+        self.media_config: dict[str, Any] = config_to_dict(self.media_settings)
         self.network_config: dict[str, Any] = config_to_dict(self.network_settings)
         self.voice_config: dict[str, Any] = config_to_dict(self.voice_settings)
         self.communication_config: dict[str, Any] = config_to_dict(self.communication_settings)
         self.runtime_config: dict[str, Any] = config_to_dict(self.runtime_settings)
 
         self.app_config_loaded = False
+        self.media_config_loaded = False
         self.network_config_loaded = False
         self.voice_config_loaded = False
         self.communication_config_loaded = False
@@ -157,6 +161,7 @@ class ConfigManager:
         )
 
         self.load_app_config()
+        self.load_media_config()
         self.load_network_config()
         self.load_voice_config()
         self.load_communication_config()
@@ -168,6 +173,7 @@ class ConfigManager:
 
         self.runtime_settings = YoyoPodRuntimeConfig(
             app=self.app_settings,
+            media=self.media_settings,
             network=self.network_settings,
             voice=self.voice_settings,
             communication=self.communication_settings,
@@ -240,13 +246,11 @@ class ConfigManager:
 
         self.app_config_loaded = _config_loaded(
             self.app_core_layers,
-            self.audio_music_layers,
             self.device_hardware_layers,
         )
         try:
             payload = _merge_layer_groups(
                 self.app_core_layers,
-                self.audio_music_layers,
                 self.device_hardware_layers,
             )
             self.app_settings = build_config_model(YoyoPodConfig, payload)
@@ -260,7 +264,6 @@ class ConfigManager:
                         str(path)
                         for group in (
                             self.app_core_layers,
-                            self.audio_music_layers,
                             self.device_hardware_layers,
                         )
                         for path in group
@@ -270,7 +273,6 @@ class ConfigManager:
             else:
                 logger.warning("No authored app config found; using typed defaults")
 
-            logger.debug("Music directory: {}", self.app_settings.audio.music_dir)
             logger.debug("Display hardware: {}", self.app_settings.display.hardware)
             return self.app_config_loaded
         except Exception:
@@ -278,6 +280,49 @@ class ConfigManager:
             self.app_settings = YoyoPodConfig()
             self.app_config = config_to_dict(self.app_settings)
             self.app_config_loaded = False
+            self._refresh_runtime_settings()
+            return False
+
+    def load_media_config(self) -> bool:
+        """Load the typed media config from audio-owned and device-owned layers."""
+
+        self.media_config_loaded = _config_loaded(
+            self.media_music_layers,
+            self.device_hardware_layers,
+        )
+        try:
+            music_payload = load_yaml_layers(self.media_music_layers)
+            device_payload = load_yaml_layers(self.device_hardware_layers)
+            media_policy = music_payload.get("music", music_payload.get("audio", music_payload))
+            if not isinstance(media_policy, dict):
+                media_policy = {}
+
+            media_audio = device_payload.get("media_audio", {})
+            if not isinstance(media_audio, dict):
+                media_audio = {}
+
+            payload = {
+                "music": media_policy,
+                "audio": media_audio,
+            }
+
+            self.media_settings = build_config_model(MediaConfig, payload)
+            self.media_config = config_to_dict(self.media_settings)
+            self._refresh_runtime_settings()
+
+            if self.media_config_loaded:
+                logger.info("Media configuration loaded successfully")
+            else:
+                logger.warning("No authored media config found; using typed defaults")
+
+            logger.debug("Music directory: {}", self.media_settings.music.music_dir)
+            logger.debug("Media ALSA device: {}", self.media_settings.audio.alsa_device)
+            return self.media_config_loaded
+        except Exception:
+            logger.exception("Error loading media config")
+            self.media_settings = MediaConfig()
+            self.media_config = config_to_dict(self.media_settings)
+            self.media_config_loaded = False
             self._refresh_runtime_settings()
             return False
 
@@ -444,6 +489,11 @@ class ConfigManager:
 
         return self.voice_settings
 
+    def get_media_settings(self) -> MediaConfig:
+        """Return the composed typed media settings."""
+
+        return self.media_settings
+
     def get_network_settings(self) -> NetworkConfig:
         """Return the composed typed network settings."""
 
@@ -468,6 +518,11 @@ class ConfigManager:
         """Return the plain-dict form of the composed app settings."""
 
         return dict(self.app_config)
+
+    def get_media_config_dict(self) -> dict[str, Any]:
+        """Return the plain-dict form of the composed media settings."""
+
+        return dict(self.media_config)
 
     def get_runtime_config_dict(self) -> dict[str, Any]:
         """Return the plain-dict form of the composed runtime settings."""
@@ -601,7 +656,16 @@ class ConfigManager:
         return self.communication_settings.audio.mic_gain
 
     def get_default_output_volume(self) -> int:
-        return self.app_settings.audio.default_volume
+        return self.media_settings.music.default_volume
+
+    def get_media_alsa_device(self) -> str:
+        return self.media_settings.audio.alsa_device
+
+    def get_speaker_test_path(self) -> str:
+        return self.media_settings.music.speaker_test_path
+
+    def get_recent_tracks_file(self) -> str:
+        return self.media_settings.music.recent_tracks_file
 
     def get_ring_output_device(self) -> str:
         ring_output = self.communication_settings.audio.ring_output_device
@@ -624,6 +688,7 @@ class ConfigManager:
 
         logger.info("Reloading configuration...")
         self.load_app_config()
+        self.load_media_config()
         self.load_network_config()
         self.load_voice_config()
         self.load_communication_config()

--- a/src/yoyopod/config/models.py
+++ b/src/yoyopod/config/models.py
@@ -142,13 +142,12 @@ class AppMetadataConfig:
 
 
 @dataclass(slots=True)
-class AppAudioConfig:
-    """Audio and local music-backend settings."""
+class MediaMusicConfig:
+    """Local music playback policy and runtime paths."""
 
     music_dir: str = config_value(default="/home/pi/Music", env="YOYOPOD_MUSIC_DIR")
     mpv_socket: str = config_value(default="", env="YOYOPOD_MPV_SOCKET")
     mpv_binary: str = config_value(default="mpv", env="YOYOPOD_MPV_BINARY")
-    alsa_device: str = config_value(default="default", env="YOYOPOD_ALSA_DEVICE")
     auto_resume_after_call: bool = config_value(
         default=True,
         env="YOYOPOD_AUTO_RESUME_AFTER_CALL",
@@ -157,6 +156,25 @@ class AppAudioConfig:
     fade_in_duration_ms: int = config_value(default=0, env="YOYOPOD_FADE_IN_DURATION_MS")
     default_volume: int = config_value(default=100, env="YOYOPOD_DEFAULT_VOLUME")
     speaker_test_path: str = config_value(default="speaker-test", env="YOYOPOD_SPEAKER_TEST_PATH")
+    recent_tracks_file: str = config_value(
+        default="data/media/recent_tracks.json",
+        env="YOYOPOD_RECENT_TRACKS_FILE",
+    )
+
+
+@dataclass(slots=True)
+class MediaAudioConfig:
+    """Device-owned playback routing for the local media domain."""
+
+    alsa_device: str = config_value(default="default", env="YOYOPOD_ALSA_DEVICE")
+
+
+@dataclass(slots=True)
+class MediaConfig:
+    """Composed media/audio config built from music policy and device-owned routing."""
+
+    music: MediaMusicConfig = config_value(default_factory=MediaMusicConfig)
+    audio: MediaAudioConfig = config_value(default_factory=MediaAudioConfig)
 
 
 @dataclass(slots=True)
@@ -412,10 +430,9 @@ class AppDiagnosticsConfig:
 
 @dataclass(slots=True)
 class YoyoPodConfig:
-    """Composed application-shell config built from the canonical app/audio/device files."""
+    """Composed application-shell config built from the canonical app/device files."""
 
     app: AppMetadataConfig = config_value(default_factory=AppMetadataConfig)
-    audio: AppAudioConfig = config_value(default_factory=AppAudioConfig)
     ui: AppUiConfig = config_value(default_factory=AppUiConfig)
     input: AppInputConfig = config_value(default_factory=AppInputConfig)
     power: AppPowerConfig = config_value(default_factory=AppPowerConfig)
@@ -583,6 +600,7 @@ class YoyoPodRuntimeConfig:
     """One typed runtime model composed from the canonical authored config topology."""
 
     app: YoyoPodConfig = config_value(default_factory=YoyoPodConfig)
+    media: MediaConfig = config_value(default_factory=MediaConfig)
     network: NetworkConfig = config_value(default_factory=NetworkConfig)
     voice: VoiceConfig = config_value(default_factory=VoiceConfig)
     communication: CommunicationConfig = config_value(default_factory=CommunicationConfig)

--- a/src/yoyopod/coordinators/call.py
+++ b/src/yoyopod/coordinators/call.py
@@ -108,11 +108,13 @@ class CallCoordinator:
 
         try:
             ring_output_device = None
+            speaker_test_path = "speaker-test"
             if self.runtime.config_manager:
                 ring_output_device = self.runtime.config_manager.get_ring_output_device()
+                speaker_test_path = self.runtime.config_manager.get_speaker_test_path()
 
             command = [
-                self.runtime.config.get("audio", {}).get("speaker_test_path", "speaker-test"),
+                speaker_test_path,
                 "-t",
                 "sine",
                 "-f",

--- a/src/yoyopod/runtime/boot.py
+++ b/src/yoyopod/runtime/boot.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import time
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
 
 from yoyopod.app_context import AppContext
-from yoyopod.audio import LocalMusicService, OutputVolumeController, RecentTrackHistoryStore
-from yoyopod.audio.music import MpvBackend, MusicConfig
+from yoyopod.audio import (
+    LocalMusicService,
+    MpvBackend,
+    MusicConfig,
+    OutputVolumeController,
+    RecentTrackHistoryStore,
+)
 from yoyopod.config import ConfigManager
 from yoyopod.coordinators import (
     AppRuntimeState,
@@ -107,6 +111,7 @@ class RuntimeBootService:
         try:
             self.app.config_manager = ConfigManager(config_dir=self.app.config_dir)
             self.app.app_settings = self.app.config_manager.get_app_settings()
+            self.app.media_settings = self.app.config_manager.get_media_settings()
             self.app.config = self.app.config_manager.get_app_config_dict()
             self.app.people_directory = PeopleDirectory.from_config_manager(self.app.config_manager)
             self.app.call_history_store = CallHistoryStore(
@@ -115,7 +120,9 @@ class RuntimeBootService:
                 )
             )
             self.app.recent_track_store = RecentTrackHistoryStore(
-                self.app.config_manager.config_dir / "recent_tracks.json"
+                self.app.config_manager.resolve_runtime_path(
+                    self.app.config_manager.get_recent_tracks_file()
+                )
             )
             self.app.audio_device_catalog = AudioDeviceCatalog()
             self.app.audio_device_catalog.refresh_async()
@@ -128,7 +135,10 @@ class RuntimeBootService:
             else:
                 logger.info("Using default application configuration")
 
-            self.app.auto_resume_after_call = self.app.app_settings.audio.auto_resume_after_call
+            if self.app.media_settings is not None:
+                self.app.auto_resume_after_call = (
+                    self.app.media_settings.music.auto_resume_after_call
+                )
             self.app._screen_timeout_seconds = (
                 self.app.screen_power_service.resolve_screen_timeout_seconds()
             )
@@ -322,13 +332,7 @@ class RuntimeBootService:
                 )
 
             logger.info("  - MpvBackend")
-            audio_cfg = self.app.app_settings.audio if self.app.app_settings else None
-            music_config = MusicConfig(
-                music_dir=Path(audio_cfg.music_dir) if audio_cfg else Path("/home/pi/Music"),
-                mpv_socket=audio_cfg.mpv_socket if audio_cfg and audio_cfg.mpv_socket else "",
-                mpv_binary=audio_cfg.mpv_binary if audio_cfg else "mpv",
-                alsa_device=audio_cfg.alsa_device if audio_cfg else "default",
-            )
+            music_config = MusicConfig.from_config_manager(config_manager)
             self.app.music_backend = MpvBackend(music_config)
             self.app.local_music_service = LocalMusicService(
                 self.app.music_backend,

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -527,7 +527,7 @@ def test_apply_default_music_volume_updates_backend_and_context() -> None:
     """Startup should push the configured music volume into mpv and app context."""
     app = YoyoPodApp(simulate=True)
     app.context = AppContext()
-    app.app_settings = SimpleNamespace(audio=SimpleNamespace(default_volume=100))
+    app.media_settings = SimpleNamespace(music=SimpleNamespace(default_volume=100))
     app.music_backend = MockMusicBackend()
     app.music_backend.start()
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -127,11 +127,13 @@ def test_board_config_overlays_base_config(tmp_path, monkeypatch) -> None:
     config_manager = ConfigManager(config_dir=str(tmp_path))
 
     assert config_manager.config_board == "radxa-cubie-a7z"
-    assert config_manager.app_config_file == tmp_path / "boards" / "radxa-cubie-a7z" / "app" / "core.yaml"
-    assert config_manager.audio_music_layers[-1] == board_audio_file
+    assert config_manager.app_config_file == (
+        tmp_path / "boards" / "radxa-cubie-a7z" / "app" / "core.yaml"
+    )
+    assert config_manager.media_music_layers[-1] == board_audio_file
     assert config_manager.app_settings.ui.theme == "retro"
-    assert config_manager.app_settings.audio.music_dir == "/home/radxa/Music"
-    assert config_manager.app_settings.audio.default_volume == 72
+    assert config_manager.get_media_settings().music.music_dir == "/home/radxa/Music"
+    assert config_manager.get_default_output_volume() == 72
     assert config_manager.app_settings.power.watchdog_i2c_bus == 7
 
 
@@ -171,10 +173,10 @@ def test_missing_board_overlay_falls_back_to_base_config(tmp_path, monkeypatch) 
     config_manager = ConfigManager(config_dir=str(tmp_path))
 
     assert config_manager.app_config_file == tmp_path / "app" / "core.yaml"
-    assert config_manager.audio_music_layers[0] == base_file
-    assert config_manager.audio_music_layers[-1] == base_file
+    assert config_manager.media_music_layers[0] == base_file
+    assert config_manager.media_music_layers[-1] == base_file
     assert config_manager.device_hardware_layers[0] == base_device_file
     assert config_manager.device_hardware_layers[-1] == base_device_file
     assert config_manager.app_settings.ui.theme == "dark"
-    assert config_manager.app_settings.audio.music_dir == "/srv/base-music"
+    assert config_manager.get_media_settings().music.music_dir == "/srv/base-music"
     assert config_manager.app_settings.power.watchdog_i2c_bus == 1

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -7,7 +7,13 @@ from pathlib import Path
 
 import yaml
 
-from yoyopod.config import ConfigManager, VoiceConfig, YoyoPodConfig, load_config_model_from_yaml
+from yoyopod.config import (
+    ConfigManager,
+    MediaConfig,
+    VoiceConfig,
+    YoyoPodConfig,
+    load_config_model_from_yaml,
+)
 
 
 def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> None:
@@ -26,13 +32,6 @@ def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> Non
     settings = load_config_model_from_yaml(YoyoPodConfig, config_file)
 
     assert not config_file.exists()
-    assert settings.audio.music_dir == "/home/pi/Music"
-    assert settings.audio.mpv_socket == ""
-    assert settings.audio.mpv_binary == "mpv"
-    assert settings.audio.alsa_device == "default"
-    assert settings.audio.default_volume == 100
-    assert settings.audio.auto_resume_after_call is True
-    assert settings.audio.speaker_test_path == "speaker-test"
     assert settings.input.ptt_navigation is True
     assert settings.input.whisplay_double_tap_ms == 300
     assert settings.input.whisplay_long_hold_ms == 800
@@ -72,6 +71,31 @@ def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> Non
     assert settings.diagnostics.responsiveness_capture_cooldown_seconds == 30.0
     assert settings.diagnostics.responsiveness_recent_input_window_seconds == 3.0
     assert settings.diagnostics.responsiveness_capture_dir == "logs/responsiveness"
+
+
+def test_media_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> None:
+    """Missing media config should still resolve to typed defaults."""
+
+    monkeypatch.delenv("YOYOPOD_MUSIC_DIR", raising=False)
+    monkeypatch.delenv("YOYOPOD_MPV_SOCKET", raising=False)
+    monkeypatch.delenv("YOYOPOD_MPV_BINARY", raising=False)
+    monkeypatch.delenv("YOYOPOD_ALSA_DEVICE", raising=False)
+    monkeypatch.delenv("YOYOPOD_AUTO_RESUME_AFTER_CALL", raising=False)
+    monkeypatch.delenv("YOYOPOD_DEFAULT_VOLUME", raising=False)
+    monkeypatch.delenv("YOYOPOD_RECENT_TRACKS_FILE", raising=False)
+
+    config_file = tmp_path / "audio" / "music.yaml"
+    settings = load_config_model_from_yaml(MediaConfig, config_file)
+
+    assert not config_file.exists()
+    assert settings.music.music_dir == "/home/pi/Music"
+    assert settings.music.mpv_socket == ""
+    assert settings.music.mpv_binary == "mpv"
+    assert settings.audio.alsa_device == "default"
+    assert settings.music.default_volume == 100
+    assert settings.music.auto_resume_after_call is True
+    assert settings.music.speaker_test_path == "speaker-test"
+    assert settings.music.recent_tracks_file == "data/media/recent_tracks.json"
 
 
 def test_voice_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> None:
@@ -124,6 +148,9 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
                 "display": {
                     "hardware": "pimoroni",
                 },
+                "media_audio": {
+                    "alsa_device": "hw:Loopback,0",
+                },
             },
             sort_keys=False,
         ),
@@ -146,7 +173,6 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     )
 
     monkeypatch.setenv("YOYOPOD_MPV_SOCKET", "/tmp/test-mpv.sock")
-    monkeypatch.setenv("YOYOPOD_ALSA_DEVICE", "hw:Loopback,0")
     monkeypatch.setenv("YOYOPOD_AUTO_RESUME_AFTER_CALL", "false")
     monkeypatch.setenv("YOYOPOD_WHISPLAY_DOUBLE_TAP_MS", "260")
     monkeypatch.setenv("YOYOPOD_WHISPLAY_LONG_HOLD_MS", "900")
@@ -176,16 +202,20 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
 
     config_manager = ConfigManager(config_dir=str(tmp_path))
     settings = config_manager.get_app_settings()
+    media_settings = config_manager.get_media_settings()
     voice_settings = config_manager.get_voice_settings()
     config_dict = config_manager.get_app_config_dict()
+    media_dict = config_manager.get_media_config_dict()
+    runtime_dict = config_manager.get_runtime_config_dict()
 
     assert config_manager.app_config_loaded is True
-    assert settings.audio.music_dir == "/srv/music"
-    assert settings.audio.mpv_socket == "/tmp/test-mpv.sock"
-    assert settings.audio.mpv_binary == "/usr/local/bin/mpv"
-    assert settings.audio.alsa_device == "hw:Loopback,0"
-    assert settings.audio.auto_resume_after_call is False
-    assert not hasattr(settings.audio, "listen_sources")
+    assert config_manager.media_config_loaded is True
+    assert not hasattr(settings, "audio")
+    assert media_settings.music.music_dir == "/srv/music"
+    assert media_settings.music.mpv_socket == "/tmp/test-mpv.sock"
+    assert media_settings.music.mpv_binary == "/usr/local/bin/mpv"
+    assert media_settings.audio.alsa_device == "hw:Loopback,0"
+    assert media_settings.music.auto_resume_after_call is False
     assert settings.input.whisplay_double_tap_ms == 260
     assert settings.input.whisplay_long_hold_ms == 900
     assert settings.power.transport == "tcp"
@@ -212,12 +242,15 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     assert settings.diagnostics.responsiveness_watchdog_enabled is True
     assert settings.diagnostics.responsiveness_stall_threshold_seconds == 8.0
     assert settings.diagnostics.responsiveness_capture_dir == "/tmp/yoyopod-watchdog"
-    assert config_dict["audio"]["music_dir"] == "/srv/music"
-    assert config_dict["audio"]["mpv_socket"] == "/tmp/test-mpv.sock"
-    assert "listen_sources" not in config_dict["audio"]
+    assert "audio" not in config_dict
     assert config_dict["display"]["hardware"] == "whisplay"
     assert config_dict["display"]["whisplay_renderer"] == "lvgl"
     assert config_dict["display"]["lvgl_buffer_lines"] == 24
+    assert media_dict["music"]["music_dir"] == "/srv/music"
+    assert media_dict["music"]["mpv_socket"] == "/tmp/test-mpv.sock"
+    assert media_dict["audio"]["alsa_device"] == "hw:Loopback,0"
+    assert runtime_dict["media"]["music"]["music_dir"] == "/srv/music"
+    assert runtime_dict["media"]["audio"]["alsa_device"] == "hw:Loopback,0"
     assert "network" not in config_dict
     assert "voice" not in config_dict
     assert config_dict["logging"]["file"] == "/var/log/yoyopod.log"

--- a/tests/test_config_topology.py
+++ b/tests/test_config_topology.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import yaml
 
 from yoyopod.config import ConfigManager
+from yoyopod.audio import MusicConfig
 from yoyopod.network import NetworkManager
 from yoyopod.people import PeopleDirectory
 
@@ -111,6 +112,45 @@ def test_voice_config_composes_domain_policy_with_device_owned_selectors(tmp_pat
     assert manager.get_voice_settings().assistant.tts_backend == "dummy-tts"
     assert manager.get_voice_settings().audio.speaker_device_id == "plughw:CARD=SE,DEV=0"
     assert manager.get_voice_settings().audio.capture_device_id == "plughw:CARD=SE,DEV=1"
+
+
+def test_media_config_composes_domain_policy_with_device_owned_routing(tmp_path: Path) -> None:
+    """Media should read policy from audio config and routing from device config."""
+
+    config_dir = tmp_path / "config"
+    _write_yaml(
+        config_dir,
+        "audio/music.yaml",
+        {
+            "audio": {
+                "music_dir": "/srv/music",
+                "default_volume": 72,
+                "recent_tracks_file": "data/media/recent_tracks.json",
+            }
+        },
+    )
+    _write_yaml(
+        config_dir,
+        "device/hardware.yaml",
+        {
+            "media_audio": {
+                "alsa_device": "hw:Loopback,0",
+            }
+        },
+    )
+
+    manager = ConfigManager(config_dir=str(config_dir))
+
+    assert manager.media_config_loaded is True
+    assert not hasattr(manager.get_app_settings(), "audio")
+    assert manager.get_media_settings().music.music_dir == "/srv/music"
+    assert manager.get_media_settings().audio.alsa_device == "hw:Loopback,0"
+    assert manager.get_default_output_volume() == 72
+    assert MusicConfig.from_config_manager(manager).alsa_device == "hw:Loopback,0"
+    assert (
+        manager.resolve_runtime_path(manager.get_recent_tracks_file())
+        == tmp_path / "data" / "media" / "recent_tracks.json"
+    )
 
 
 def test_network_config_composes_domain_owned_cellular_settings(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- split media/audio runtime config away from the app-shell config by composing a typed `MediaConfig` from domain-owned music policy plus device-owned playback routing
- route the touched app/runtime/CLI media consumers through canonical accessors such as `ConfigManager.get_media_settings()` and `MusicConfig.from_config_manager()` instead of `app_settings.audio`
- move recent-track history under `data/media/` and update the related docs/tests/rules to match the canonical media/audio package and config topology

## What Changed
- `load_composed_app_settings()` now stays on the app/device shell surface, while `ConfigManager` separately composes media settings and exposes `get_media_settings()` / `get_media_config_dict()`
- added `MediaMusicConfig`, `MediaAudioConfig`, and `MediaConfig`, then wired the composed media seam into `YoyoPodRuntimeConfig`
- updated runtime boot, startup music volume, ring playback, and Pi smoke/validate helpers to consume the canonical media seam
- documented the media ownership split in the canonical-structure, audio-stack, development, mpv, and system-architecture docs, and added media-topology coverage in tests

## Validation
- `uv run pytest -q tests/test_config_models.py tests/test_config_manager.py tests/test_config_topology.py tests/test_app_orchestration.py tests/test_runtime_voice.py tests/test_local_music_service.py tests/test_music_models.py tests/test_screen_routing.py tests/test_main.py` (`130 passed`)
- `uv run python scripts/quality.py gate`
- `uv run pytest -q` (`534 passed in 13.14s`)

## Notes
- `config/audio/music.yaml` now owns media policy and runtime paths, while shared playback routing lives in `config/device/hardware.yaml` under `media_audio.*`
- refs #152