### PR TITLE
[codex] Cut over power onto the canonical config and package topology

### DIFF
--- a/config/boards/radxa-cubie-a7z/device/hardware.yaml
+++ b/config/boards/radxa-cubie-a7z/device/hardware.yaml
@@ -1,8 +1,5 @@
 # Radxa Cubie A7Z board overrides.
 
-power:
-  watchdog_i2c_bus: 7
-
 display:
   pimoroni_gpio:
     spi_bus: 1

--- a/config/boards/radxa-cubie-a7z/power/backend.yaml
+++ b/config/boards/radxa-cubie-a7z/power/backend.yaml
@@ -1,0 +1,4 @@
+# Radxa Cubie A7Z power-domain overrides.
+
+power:
+  watchdog_i2c_bus: 7

--- a/config/boards/rpi-zero-2w/device/hardware.yaml
+++ b/config/boards/rpi-zero-2w/device/hardware.yaml
@@ -1,4 +1,0 @@
-# Raspberry Pi Zero 2W board overrides.
-
-power:
-  watchdog_i2c_bus: 1

--- a/config/boards/rpi-zero-2w/power/backend.yaml
+++ b/config/boards/rpi-zero-2w/power/backend.yaml
@@ -1,0 +1,4 @@
+# Raspberry Pi Zero 2W power-domain overrides.
+
+power:
+  watchdog_i2c_bus: 1

--- a/config/device/hardware.yaml
+++ b/config/device/hardware.yaml
@@ -6,29 +6,6 @@ input:
   whisplay_double_tap_ms: 300
   whisplay_long_hold_ms: 800
 
-power:
-  enabled: true
-  backend: "pisugar"
-  transport: "auto"
-  socket_path: "/tmp/pisugar-server.sock"
-  tcp_host: "127.0.0.1"
-  tcp_port: 8423
-  timeout_seconds: 2.0
-  poll_interval_seconds: 30.0
-  low_battery_warning_percent: 20.0
-  low_battery_warning_cooldown_seconds: 300.0
-  auto_shutdown_enabled: true
-  critical_shutdown_percent: 10.0
-  shutdown_delay_seconds: 15.0
-  shutdown_command: "sudo -n shutdown -h now"
-  shutdown_state_file: "data/last_shutdown_state.json"
-  watchdog_enabled: false
-  watchdog_timeout_seconds: 60
-  watchdog_feed_interval_seconds: 15.0
-  watchdog_i2c_bus: 1
-  watchdog_i2c_address: 0x57
-  watchdog_command_timeout_seconds: 5.0
-
 display:
   hardware: "auto"
   whisplay_renderer: "lvgl"

--- a/config/power/backend.yaml
+++ b/config/power/backend.yaml
@@ -1,0 +1,24 @@
+# Power-domain backend, watchdog, and shutdown policy.
+
+power:
+  enabled: true
+  backend: "pisugar"
+  transport: "auto"
+  socket_path: "/tmp/pisugar-server.sock"
+  tcp_host: "127.0.0.1"
+  tcp_port: 8423
+  timeout_seconds: 2.0
+  poll_interval_seconds: 30.0
+  low_battery_warning_percent: 20.0
+  low_battery_warning_cooldown_seconds: 300.0
+  auto_shutdown_enabled: true
+  critical_shutdown_percent: 10.0
+  shutdown_delay_seconds: 15.0
+  shutdown_command: "sudo -n shutdown -h now"
+  shutdown_state_file: "data/last_shutdown_state.json"
+  watchdog_enabled: false
+  watchdog_timeout_seconds: 60
+  watchdog_feed_interval_seconds: 15.0
+  watchdog_i2c_bus: 1
+  watchdog_i2c_address: 0x57
+  watchdog_command_timeout_seconds: 5.0

--- a/docs/CANONICAL_STRUCTURE.md
+++ b/docs/CANONICAL_STRUCTURE.md
@@ -23,7 +23,9 @@ Tracked authored config lives under `config/` and is split by ownership:
 - `config/audio/music.yaml`
   - local music policy, startup volume, and media runtime paths
 - `config/device/hardware.yaml`
-  - shared hardware truth: `input`, `display`, `power`, `communication_audio`, `media_audio`, `voice_audio`
+  - shared hardware truth: `input`, `display`, `communication_audio`, `media_audio`, `voice_audio`
+- `config/power/backend.yaml`
+  - PiSugar backend transport, watchdog, polling, and shutdown policy
 - `config/network/cellular.yaml`
   - cellular modem policy and transport settings
 - `config/voice/assistant.yaml`
@@ -74,9 +76,11 @@ Examples:
 
 - `config/boards/rpi-zero-2w/audio/music.yaml`
 - `config/boards/rpi-zero-2w/device/hardware.yaml`
+- `config/boards/rpi-zero-2w/power/backend.yaml`
 - `config/boards/rpi-zero-2w/network/cellular.yaml`
 - `config/boards/radxa-cubie-a7z/audio/music.yaml`
 - `config/boards/radxa-cubie-a7z/device/hardware.yaml`
+- `config/boards/radxa-cubie-a7z/power/backend.yaml`
 
 Future domains should follow the same pattern instead of inventing one-off
 overlay shapes.
@@ -107,6 +111,9 @@ Current exemplar package homes:
 - `src/yoyopod/audio/`
   - local music/media behavior, history, output-volume coordination, and mpv backend wiring
   - `__init__.py` is the app-facing seam
+- `src/yoyopod/power/`
+  - PiSugar backend, watchdog, safety policy, typed events, and power-runtime supervision
+  - `__init__.py` is the app-facing seam
 - `src/yoyopod/voice/`
   - local voice behavior, models, and backends
   - device inventory/helpers live outside this package
@@ -117,6 +124,7 @@ The app layer should import from domain seams such as:
 
 - `yoyopod.network`
 - `yoyopod.audio`
+- `yoyopod.power`
 - `yoyopod.communication`
 - `yoyopod.people`
 
@@ -169,6 +177,19 @@ The media/audio migration follows the same cutover shape:
 - `src/yoyopod/audio/` as the domain-owned package home
 - app/runtime composition depending on the `yoyopod.audio` seam via
   `MusicConfig.from_config_manager()` instead of hand-mapping media fields
+
+## Power Migration Pattern
+
+The power migration follows the same cutover shape:
+
+- power backend and shutdown policy under `config/power/backend.yaml`
+- `ConfigManager.get_power_settings()` as the typed runtime seam
+- `src/yoyopod/power/` as the domain-owned package home
+- app/runtime composition depending on `PowerManager.from_config_manager()`
+  instead of reading power state from app-shell config
+- power polling and PiSugar watchdog cadence owned by the power domain via
+  `src/yoyopod/power/runtime.py`, while app/runtime composition still owns
+  scheduling and shutdown orchestration
 
 ## Template For Future Migrations
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -86,6 +86,7 @@ Tracked config files live under `config/`:
 - `config/app/core.yaml`
 - `config/audio/music.yaml`
 - `config/device/hardware.yaml`
+- `config/power/backend.yaml`
 - `config/network/cellular.yaml`
 - `config/voice/assistant.yaml`
 - `config/communication/calling.yaml`
@@ -102,7 +103,9 @@ Key settings:
 - `config/audio/music.yaml`
   - `audio.music_dir`, `audio.recent_tracks_file`, `audio.mpv_*`, `audio.default_volume`
 - `config/device/hardware.yaml`
-  - `input.*`, `display.*`, `power.*`, `communication_audio.*`, `media_audio.*`, `voice_audio.*`
+  - `input.*`, `display.*`, `communication_audio.*`, `media_audio.*`, `voice_audio.*`
+- `config/power/backend.yaml`
+  - `power.*` PiSugar backend transport, watchdog, polling, warning, and shutdown policy
 - `config/network/cellular.yaml`
   - `network.*` cellular modem enablement, ports, APN, GPS, and PPP timeout
 - `config/voice/assistant.yaml`

--- a/docs/POWER_MODULE.md
+++ b/docs/POWER_MODULE.md
@@ -29,6 +29,7 @@ Main files:
 - `src/yoyopod/power/backend.py`
 - `src/yoyopod/power/manager.py`
 - `src/yoyopod/power/policies.py`
+- `src/yoyopod/power/runtime.py`
 - `src/yoyopod/power/watchdog.py`
 - `src/yoyopod/power/events.py`
 - `src/yoyopod/coordinators/power.py`
@@ -39,7 +40,8 @@ Runtime flow:
 
 ```text
 YoyoPodApp
-  -> PowerManager
+  -> PowerRuntimeService
+     -> PowerManager
      -> PiSugarBackend
         -> Unix socket or TCP PiSugar server transport
      -> PiSugarWatchdog
@@ -51,7 +53,9 @@ YoyoPodApp
      -> current screen refresh
 ```
 
-The app polls PiSugar on the coordinator thread, publishes typed power events, updates shared runtime state, and then applies safety or UI behavior from those events.
+The app schedules PiSugar polling and watchdog work through `PowerRuntimeService`,
+publishes typed power events, updates shared runtime state, and then applies safety
+or UI behavior from those events.
 
 ## Backends And Transports
 
@@ -112,7 +116,7 @@ Important nested fields:
 
 ## Configuration
 
-Power configuration lives in `config/device/hardware.yaml` under `power:`.
+Power configuration lives in `config/power/backend.yaml` under `power:`.
 
 Current keys:
 - `enabled`
@@ -223,10 +227,10 @@ yoyoctl remote rtc status --host rpi-zero
 
 ## Watchdog Support
 
-The watchdog implementation is intentionally app-centric.
+The watchdog implementation is intentionally power-domain-owned but app-scheduled.
 
 Current model:
-- the app loop enables the PiSugar software watchdog
+- the app loop enables the PiSugar software watchdog through `PowerRuntimeService`
 - the app feeds it at a configured interval while healthy
 - ordinary app shutdown disables the watchdog
 - battery-driven emergency shutdown suppresses feeding without disabling it

--- a/docs/RUNTIME_EVENT_FLOW.md
+++ b/docs/RUNTIME_EVENT_FLOW.md
@@ -60,7 +60,7 @@ This is where the app decides which backend signals become typed runtime events.
 Owns:
 - loop cadence
 - draining queued callbacks and typed events
-- calling recovery, power, shutdown, LVGL, and periodic screen refresh work in a stable order
+- calling recovery, power-runtime, shutdown, LVGL, and periodic screen refresh work in a stable order
 
 This service is the bridge between queued background work and deterministic main-thread handling.
 
@@ -119,9 +119,14 @@ It reacts to `ScreenChangedEvent`, `UserActivityEvent`, and low-battery events, 
 
 Owns:
 - backend recovery attempts
-- periodic power polling
-- watchdog feeding
 - publishing recovery completion events
+
+### `PowerRuntimeService`
+
+Owns:
+- periodic power polling
+- watchdog start/feed/disable cadence
+- queueing PiSugar I/O off the coordinator thread when needed
 
 ### `NetworkManager`
 
@@ -205,7 +210,7 @@ Ownership: playback truth comes from the music backend; playback interpretation 
 
 ### Power snapshot flow
 
-1. `RecoverySupervisor.poll_power_status()` fetches a snapshot from `PowerManager`.
+1. `PowerRuntimeService.poll_status()` fetches a snapshot from `PowerManager`.
 2. It calls `PowerCoordinator.publish_snapshot()` and, on availability transitions, `publish_availability_change()`.
 3. `PowerCoordinator.handle_snapshot_updated()`:
    - stores the snapshot in `CoordinatorRuntime`

--- a/docs/SETUP_CONTRACT.md
+++ b/docs/SETUP_CONTRACT.md
@@ -158,6 +158,7 @@ Tracked config lives in:
 - `config/app/core.yaml`
 - `config/audio/music.yaml`
 - `config/device/hardware.yaml`
+- `config/power/backend.yaml`
 - `config/network/cellular.yaml`
 - `config/voice/assistant.yaml`
 - `config/communication/calling.yaml`

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -42,14 +42,15 @@ This is the startup sequence that exists on `main` today.
    - The installed `yoyopod` console script in `pyproject.toml` also targets `yoyopod.main:main`.
 2. `main()` configures process-level runtime plumbing before app setup starts.
    - `load_composed_app_settings()` reads `config/app/core.yaml` and `config/device/hardware.yaml` early enough to resolve logging settings.
-   - `ConfigManager` later composes domain-owned layers such as `config/audio/music.yaml`, `config/network/cellular.yaml`, `config/voice/assistant.yaml`, and the communication files into the full runtime model.
+   - `ConfigManager` later composes domain-owned layers such as `config/audio/music.yaml`, `config/power/backend.yaml`, `config/network/cellular.yaml`, `config/voice/assistant.yaml`, and the communication files into the full runtime model.
    - `configure_logger()` builds the shared `loguru` runtime config and enables console plus file logging.
    - `write_pid_file()` writes the current PID.
    - `log_startup()` emits the startup marker consumed by Pi deploy and remote-validation workflows.
    - `--simulate` is parsed before the app is constructed.
 3. `main()` constructs `YoyoPodApp(config_dir="config", simulate=simulate)`.
    - The constructor does not start hardware or backend processes yet.
-   - It allocates the typed `EventBus`, runtime services (`RuntimeBootService`, `RuntimeLoopService`, `RecoverySupervisor`, `ScreenPowerService`, `ShutdownLifecycleService`), and the long-lived placeholder fields for managers, screens, and shared context.
+   - It allocates the typed `EventBus`, runtime services (`RuntimeBootService`, `RuntimeLoopService`, `RecoverySupervisor`, `PowerRuntimeService`, `ScreenPowerService`, `ShutdownLifecycleService`), and the long-lived placeholder fields for managers, screens, and shared context.
+   - `RecoverySupervisor` now keeps VoIP/music recovery while `yoyopod.power.runtime.PowerRuntimeService` owns PiSugar polling and watchdog cadence.
    - It also registers app-level event subscriptions on the `EventBus` so later boot stages can publish typed events back onto the coordinator thread.
 4. `main()` calls `app.setup()`, which delegates to `RuntimeBootService.setup()`.
 5. `RuntimeBootService.setup()` currently executes boot in this order:
@@ -116,6 +117,7 @@ yoyopod.py / yoyopod.main
      -> RuntimeBootService
      -> RuntimeLoopService
      -> RecoverySupervisor
+     -> PowerRuntimeService
      -> ScreenPowerService
       -> ShutdownLifecycleService
       -> EventBus
@@ -166,9 +168,10 @@ yoyopod.py / yoyopod.main
 - `src/yoyopod/runtime_state.py`: focused runtime state objects owned by `AppContext`
 - `src/yoyopod/runtime/boot.py`: boot-time composition and manager wiring
 - `src/yoyopod/runtime/loop.py`: coordinator-loop scheduling and queued main-thread work
-- `src/yoyopod/runtime/recovery.py`: backend recovery, power polling, and watchdog supervision
+- `src/yoyopod/runtime/recovery.py`: backend recovery supervision
 - `src/yoyopod/runtime/screen_power.py`: screen wake/sleep policy and power overlays
 - `src/yoyopod/runtime/shutdown.py`: shutdown countdowns, hooks, and lifecycle cleanup
+- `src/yoyopod/power/runtime.py`: power polling and watchdog cadence
 
 ### Coordinators
 

--- a/scripts/quality.py
+++ b/scripts/quality.py
@@ -85,21 +85,55 @@ def _python_module_command(module: str, *args: str) -> tuple[str, ...]:
     return (sys.executable, "-m", module, *args)
 
 
+def _expand_python_paths(paths: tuple[str, ...]) -> tuple[str, ...]:
+    """Expand tracked directory targets into stable Python file lists."""
+
+    expanded_paths: list[str] = []
+    for raw_path in paths:
+        candidate = REPO_ROOT / raw_path
+        if candidate.is_dir():
+            expanded_paths.extend(
+                str(path.relative_to(REPO_ROOT))
+                for path in sorted(candidate.rglob("*.py"))
+                if "__pycache__" not in path.parts
+            )
+            continue
+        expanded_paths.append(raw_path)
+    return tuple(expanded_paths)
+
+
+def _build_black_steps(label: str, paths: tuple[str, ...]) -> tuple[QualityStep, ...]:
+    """Run Black one tracked file at a time to keep gate progress bounded."""
+
+    expanded_paths = _expand_python_paths(paths)
+    return tuple(
+        QualityStep(
+            label=label,
+            command=_python_module_command("black", "--check", path),
+        )
+        for path in expanded_paths
+    )
+
+
 def build_gate_steps(config: QualityConfig) -> tuple[QualityStep, ...]:
     """Build the staged, CI-gated workflow checks."""
 
     return (
-        QualityStep(
-            label="black --check (workflow surface)",
-            command=_python_module_command("black", "--check", *config.gate_format_paths),
-        ),
+        *_build_black_steps("black --check (workflow surface)", config.gate_format_paths),
         QualityStep(
             label="ruff check (workflow surface)",
-            command=_python_module_command("ruff", "check", *config.gate_lint_paths),
+            command=_python_module_command(
+                "ruff",
+                "check",
+                *_expand_python_paths(config.gate_lint_paths),
+            ),
         ),
         QualityStep(
             label="mypy (workflow surface)",
-            command=_python_module_command("mypy", *config.gate_type_paths),
+            command=_python_module_command(
+                "mypy",
+                *_expand_python_paths(config.gate_type_paths),
+            ),
         ),
     )
 

--- a/src/yoyopod/app.py
+++ b/src/yoyopod/app.py
@@ -49,6 +49,7 @@ from yoyopod.power import (
     GracefulShutdownRequested,
     LowBatteryWarningRaised,
     PowerManager,
+    PowerRuntimeService,
 )
 from yoyopod.runtime import (
     PendingShutdown,
@@ -223,6 +224,7 @@ class YoyoPodApp:
         # Runtime services
         self.screen_power_service = ScreenPowerService(self)
         self.recovery_service = RecoverySupervisor(self)
+        self.power_runtime = PowerRuntimeService(self)
         self.shutdown_service = ShutdownLifecycleService(self)
         self.runtime_loop = RuntimeLoopService(self)
         self.boot_service = RuntimeBootService(self)
@@ -697,7 +699,7 @@ class YoyoPodApp:
         self.recovery_service.attempt_manager_recovery(now)
 
     def _poll_power_status(self, now: float | None = None, force: bool = False) -> None:
-        self.recovery_service.poll_power_status(now, force)
+        self.power_runtime.poll_status(now=now, force=force)
 
     def _set_power_alert(
         self,
@@ -727,16 +729,16 @@ class YoyoPodApp:
         self.shutdown_service.execute_pending_shutdown()
 
     def _start_watchdog(self, now: float | None = None) -> None:
-        self.recovery_service.start_watchdog(now)
+        self.power_runtime.start_watchdog(now=now)
 
     def _feed_watchdog_if_due(self, now: float) -> None:
-        self.recovery_service.feed_watchdog_if_due(now)
+        self.power_runtime.feed_watchdog_if_due(now)
 
     def _disable_watchdog(self) -> None:
-        self.recovery_service.disable_watchdog()
+        self.power_runtime.disable_watchdog()
 
     def _suppress_watchdog_feeding(self, reason: str) -> None:
-        self.recovery_service.suppress_watchdog_feeding(reason)
+        self.power_runtime.suppress_watchdog_feeding(reason)
 
     def _attempt_voip_recovery(self, recovery_now: float) -> None:
         self.recovery_service.attempt_voip_recovery(recovery_now)

--- a/src/yoyopod/cli/pi/navigation.py
+++ b/src/yoyopod/cli/pi/navigation.py
@@ -202,7 +202,7 @@ class NavigationSoakRunner:
                     profile_name = app.input_manager.interaction_profile.value
                     return False, f"profile is {profile_name}, expected one_button"
 
-                app.recovery_service.start_watchdog(now=time.monotonic())
+                app.power_runtime.start_watchdog(now=time.monotonic())
                 self._pump = _RuntimePump(app, self.stats)
                 self._pump.run_for(self.hold_seconds)
 

--- a/src/yoyopod/cli/pi/power.py
+++ b/src/yoyopod/cli/pi/power.py
@@ -30,7 +30,7 @@ def battery(
     config_manager = ConfigManager(config_dir=str(config_path))
     manager = PowerManager.from_config_manager(config_manager)
     if not manager.config.enabled:
-        logger.error("power backend disabled in config/app/core.yaml")
+        logger.error("power backend disabled in config/power/backend.yaml")
         raise typer.Exit(code=1)
 
     snapshot = manager.refresh()
@@ -91,7 +91,7 @@ def _build_power_manager(config_dir: str) -> object:
     config_manager = ConfigManager(config_dir=str(config_path))
     manager = PowerManager.from_config_manager(config_manager)
     if not manager.config.enabled:
-        logger.error("power backend disabled in config/app/core.yaml")
+        logger.error("power backend disabled in config/power/backend.yaml")
         raise typer.Exit(code=1)
     return manager
 

--- a/src/yoyopod/cli/pi/smoke.py
+++ b/src/yoyopod/cli/pi/smoke.py
@@ -202,7 +202,7 @@ def _power_check(config_dir: Path) -> CheckResult:
         return CheckResult(
             name="power",
             status="warn",
-            details="power backend disabled in config/app/core.yaml",
+            details="power backend disabled in config/power/backend.yaml",
         )
 
     snapshot = manager.refresh()
@@ -233,7 +233,7 @@ def _rtc_check(config_dir: Path) -> CheckResult:
         return CheckResult(
             name="rtc",
             status="warn",
-            details="power backend disabled in config/app/core.yaml",
+            details="power backend disabled in config/power/backend.yaml",
         )
 
     snapshot = manager.refresh()

--- a/src/yoyopod/config/__init__.py
+++ b/src/yoyopod/config/__init__.py
@@ -2,11 +2,11 @@
 
 from yoyopod.config.manager import ConfigManager, load_composed_app_settings
 from yoyopod.config.models import (
-    AppPowerConfig,
     CommunicationConfig,
     MediaConfig,
     NetworkConfig,
     PeopleDirectoryConfig,
+    PowerConfig,
     VoiceConfig,
     YoyoPodConfig,
     YoyoPodRuntimeConfig,
@@ -19,8 +19,8 @@ __all__ = [
     "CommunicationConfig",
     "MediaConfig",
     "NetworkConfig",
-    "AppPowerConfig",
     "PeopleDirectoryConfig",
+    "PowerConfig",
     "VoiceConfig",
     "YoyoPodConfig",
     "YoyoPodRuntimeConfig",

--- a/src/yoyopod/config/manager.py
+++ b/src/yoyopod/config/manager.py
@@ -13,6 +13,7 @@ from yoyopod.config.models import (
     MediaConfig,
     NetworkConfig,
     PeopleDirectoryConfig,
+    PowerConfig,
     VoiceConfig,
     YoyoPodConfig,
     YoyoPodRuntimeConfig,
@@ -29,6 +30,7 @@ from yoyopod.config.storage import (
 APP_CORE_CONFIG = Path("app/core.yaml")
 AUDIO_MUSIC_CONFIG = Path("audio/music.yaml")
 DEVICE_HARDWARE_CONFIG = Path("device/hardware.yaml")
+POWER_BACKEND_CONFIG = Path("power/backend.yaml")
 NETWORK_CELLULAR_CONFIG = Path("network/cellular.yaml")
 VOICE_ASSISTANT_CONFIG = Path("voice/assistant.yaml")
 COMMUNICATION_CALLING_CONFIG = Path("communication/calling.yaml")
@@ -95,6 +97,11 @@ class ConfigManager:
             self.config_board,
             DEVICE_HARDWARE_CONFIG,
         )
+        self.power_backend_layers = resolve_config_layers(
+            self.config_dir,
+            self.config_board,
+            POWER_BACKEND_CONFIG,
+        )
         self.network_cellular_layers = resolve_config_layers(
             self.config_dir,
             self.config_board,
@@ -125,6 +132,7 @@ class ConfigManager:
         self.app_config_file = self.app_core_layers[-1]
         self.device_hardware_file = self.device_hardware_layers[-1]
         self.media_music_file = self.media_music_layers[-1]
+        self.power_backend_file = self.power_backend_layers[-1]
         self.network_cellular_file = self.network_cellular_layers[-1]
         self.voice_assistant_file = self.voice_assistant_layers[-1]
         self.communication_calling_file = self.communication_calling_layers[-1]
@@ -133,6 +141,7 @@ class ConfigManager:
 
         self.app_settings = YoyoPodConfig()
         self.media_settings = MediaConfig()
+        self.power_settings = PowerConfig()
         self.network_settings = NetworkConfig()
         self.voice_settings = VoiceConfig()
         self.communication_settings = CommunicationConfig()
@@ -141,6 +150,7 @@ class ConfigManager:
 
         self.app_config: dict[str, Any] = config_to_dict(self.app_settings)
         self.media_config: dict[str, Any] = config_to_dict(self.media_settings)
+        self.power_config: dict[str, Any] = config_to_dict(self.power_settings)
         self.network_config: dict[str, Any] = config_to_dict(self.network_settings)
         self.voice_config: dict[str, Any] = config_to_dict(self.voice_settings)
         self.communication_config: dict[str, Any] = config_to_dict(self.communication_settings)
@@ -148,6 +158,7 @@ class ConfigManager:
 
         self.app_config_loaded = False
         self.media_config_loaded = False
+        self.power_config_loaded = False
         self.network_config_loaded = False
         self.voice_config_loaded = False
         self.communication_config_loaded = False
@@ -162,6 +173,7 @@ class ConfigManager:
 
         self.load_app_config()
         self.load_media_config()
+        self.load_power_config()
         self.load_network_config()
         self.load_voice_config()
         self.load_communication_config()
@@ -174,6 +186,7 @@ class ConfigManager:
         self.runtime_settings = YoyoPodRuntimeConfig(
             app=self.app_settings,
             media=self.media_settings,
+            power=self.power_settings,
             network=self.network_settings,
             voice=self.voice_settings,
             communication=self.communication_settings,
@@ -323,6 +336,30 @@ class ConfigManager:
             self.media_settings = MediaConfig()
             self.media_config = config_to_dict(self.media_settings)
             self.media_config_loaded = False
+            self._refresh_runtime_settings()
+            return False
+
+    def load_power_config(self) -> bool:
+        """Load the typed power config from domain-owned backend layers."""
+
+        self.power_config_loaded = _config_loaded(self.power_backend_layers)
+        try:
+            payload = load_yaml_layers(self.power_backend_layers)
+            self.power_settings = build_config_model(PowerConfig, payload.get("power", payload))
+            self.power_config = config_to_dict(self.power_settings)
+            self._refresh_runtime_settings()
+
+            if self.power_config_loaded:
+                logger.info("Power configuration loaded successfully")
+            else:
+                logger.warning("No authored power config found; using typed defaults")
+
+            return self.power_config_loaded
+        except Exception:
+            logger.exception("Error loading power config")
+            self.power_settings = PowerConfig()
+            self.power_config = config_to_dict(self.power_settings)
+            self.power_config_loaded = False
             self._refresh_runtime_settings()
             return False
 
@@ -494,6 +531,11 @@ class ConfigManager:
 
         return self.media_settings
 
+    def get_power_settings(self) -> PowerConfig:
+        """Return the composed typed power settings."""
+
+        return self.power_settings
+
     def get_network_settings(self) -> NetworkConfig:
         """Return the composed typed network settings."""
 
@@ -523,6 +565,11 @@ class ConfigManager:
         """Return the plain-dict form of the composed media settings."""
 
         return dict(self.media_config)
+
+    def get_power_config_dict(self) -> dict[str, Any]:
+        """Return the plain-dict form of the composed power settings."""
+
+        return dict(self.power_config)
 
     def get_runtime_config_dict(self) -> dict[str, Any]:
         """Return the plain-dict form of the composed runtime settings."""

--- a/src/yoyopod/config/models.py
+++ b/src/yoyopod/config/models.py
@@ -239,8 +239,8 @@ class VoiceAudioConfig:
 
 
 @dataclass(slots=True)
-class AppPowerConfig:
-    """Power-management backend settings."""
+class PowerConfig:
+    """Power-domain backend, watchdog, and shutdown settings."""
 
     enabled: bool = config_value(default=True, env="YOYOPOD_POWER_ENABLED")
     backend: str = config_value(default="pisugar", env="YOYOPOD_POWER_BACKEND")
@@ -435,7 +435,6 @@ class YoyoPodConfig:
     app: AppMetadataConfig = config_value(default_factory=AppMetadataConfig)
     ui: AppUiConfig = config_value(default_factory=AppUiConfig)
     input: AppInputConfig = config_value(default_factory=AppInputConfig)
-    power: AppPowerConfig = config_value(default_factory=AppPowerConfig)
     display: AppDisplayConfig = config_value(default_factory=AppDisplayConfig)
     logging: AppLoggingConfig = config_value(default_factory=AppLoggingConfig)
     diagnostics: AppDiagnosticsConfig = config_value(default_factory=AppDiagnosticsConfig)
@@ -601,6 +600,7 @@ class YoyoPodRuntimeConfig:
 
     app: YoyoPodConfig = config_value(default_factory=YoyoPodConfig)
     media: MediaConfig = config_value(default_factory=MediaConfig)
+    power: PowerConfig = config_value(default_factory=PowerConfig)
     network: NetworkConfig = config_value(default_factory=NetworkConfig)
     voice: VoiceConfig = config_value(default_factory=VoiceConfig)
     communication: CommunicationConfig = config_value(default_factory=CommunicationConfig)

--- a/src/yoyopod/main.py
+++ b/src/yoyopod/main.py
@@ -467,6 +467,7 @@ def main() -> int:
             app_log.error("  - config/app/core.yaml exists")
             app_log.error("  - config/audio/music.yaml exists")
             app_log.error("  - config/device/hardware.yaml exists")
+            app_log.error("  - config/power/backend.yaml exists")
             app_log.error("  - config/network/cellular.yaml exists")
             app_log.error("  - config/voice/assistant.yaml exists")
             app_log.error("  - config/communication/calling.yaml exists")

--- a/src/yoyopod/power/__init__.py
+++ b/src/yoyopod/power/__init__.py
@@ -1,5 +1,6 @@
 """Power management foundation for YoyoPod."""
 
+from yoyopod.config.models import PowerConfig
 from yoyopod.power.backend import (
     PiSugarAutoTransport,
     PiSugarBackend,
@@ -19,13 +20,13 @@ from yoyopod.power.events import (
 from yoyopod.power.manager import PowerManager
 from yoyopod.power.models import (
     BatteryState,
-    PowerConfig,
     PowerDeviceInfo,
     PowerSnapshot,
     RTCState,
     ShutdownState,
 )
 from yoyopod.power.policies import PowerSafetyPolicy
+from yoyopod.power.runtime import PowerRuntimeService
 from yoyopod.power.watchdog import PiSugarWatchdog, WatchdogCommandError
 
 __all__ = [
@@ -37,6 +38,7 @@ __all__ = [
     "PiSugarAutoTransport",
     "build_pisugar_transport",
     "PowerManager",
+    "PowerRuntimeService",
     "PiSugarWatchdog",
     "WatchdogCommandError",
     "PowerConfig",
@@ -52,4 +54,3 @@ __all__ = [
     "GracefulShutdownCancelled",
     "PowerSafetyPolicy",
 ]
-

--- a/src/yoyopod/power/backend.py
+++ b/src/yoyopod/power/backend.py
@@ -9,9 +9,9 @@ from typing import Callable, Protocol
 
 from loguru import logger
 
+from yoyopod.config.models import PowerConfig
 from yoyopod.power.models import (
     BatteryState,
-    PowerConfig,
     PowerDeviceInfo,
     PowerSnapshot,
     RTCState,
@@ -306,4 +306,3 @@ def _extract_response_value(command: str, response: str) -> str:
     if not value:
         raise PowerTransportError(f"Malformed response for {command!r}: {response!r}")
     return value
-

--- a/src/yoyopod/power/manager.py
+++ b/src/yoyopod/power/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 import shlex
 import subprocess
 from datetime import datetime
@@ -9,8 +10,9 @@ from typing import TYPE_CHECKING, Callable
 
 from loguru import logger
 
+from yoyopod.config.models import PowerConfig
 from yoyopod.power.backend import PiSugarBackend, PowerBackend
-from yoyopod.power.models import PowerConfig, PowerSnapshot, RTCState
+from yoyopod.power.models import PowerSnapshot, RTCState
 from yoyopod.power.watchdog import PiSugarWatchdog, WatchdogCommandError
 
 if TYPE_CHECKING:
@@ -46,9 +48,9 @@ class PowerManager:
 
     @classmethod
     def from_config_manager(cls, config_manager: "ConfigManager") -> "PowerManager":
-        """Build a power manager from the typed app configuration."""
+        """Build a power manager from the typed power-domain configuration."""
 
-        return cls(PowerConfig.from_config_manager(config_manager))
+        return cls(replace(config_manager.get_power_settings()))
 
     def probe(self) -> bool:
         """Return True when the configured backend is reachable."""
@@ -179,4 +181,3 @@ class PowerManager:
         """Execute the real shutdown command via subprocess."""
         completed = subprocess.run(command, check=False)
         return completed.returncode
-

--- a/src/yoyopod/power/models.py
+++ b/src/yoyopod/power/models.py
@@ -4,66 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from yoyopod.config import ConfigManager
-
-
-@dataclass(slots=True)
-class PowerConfig:
-    """Runtime power-backend configuration."""
-
-    enabled: bool = True
-    backend: str = "pisugar"
-    transport: str = "auto"
-    socket_path: str = "/tmp/pisugar-server.sock"
-    tcp_host: str = "127.0.0.1"
-    tcp_port: int = 8423
-    timeout_seconds: float = 2.0
-    poll_interval_seconds: float = 30.0
-    low_battery_warning_percent: float = 20.0
-    low_battery_warning_cooldown_seconds: float = 300.0
-    auto_shutdown_enabled: bool = True
-    critical_shutdown_percent: float = 10.0
-    shutdown_delay_seconds: float = 15.0
-    shutdown_command: str = "sudo -n shutdown -h now"
-    shutdown_state_file: str = "data/last_shutdown_state.json"
-    watchdog_enabled: bool = False
-    watchdog_timeout_seconds: int = 60
-    watchdog_feed_interval_seconds: float = 15.0
-    watchdog_i2c_bus: int = 1
-    watchdog_i2c_address: int = 0x57
-    watchdog_command_timeout_seconds: float = 5.0
-
-    @staticmethod
-    def from_config_manager(config_manager: "ConfigManager") -> "PowerConfig":
-        """Create a power config from the current application settings."""
-
-        settings = config_manager.get_app_settings().power
-        return PowerConfig(
-            enabled=settings.enabled,
-            backend=settings.backend,
-            transport=settings.transport,
-            socket_path=settings.socket_path,
-            tcp_host=settings.tcp_host,
-            tcp_port=settings.tcp_port,
-            timeout_seconds=settings.timeout_seconds,
-            poll_interval_seconds=settings.poll_interval_seconds,
-            low_battery_warning_percent=settings.low_battery_warning_percent,
-            low_battery_warning_cooldown_seconds=settings.low_battery_warning_cooldown_seconds,
-            auto_shutdown_enabled=settings.auto_shutdown_enabled,
-            critical_shutdown_percent=settings.critical_shutdown_percent,
-            shutdown_delay_seconds=settings.shutdown_delay_seconds,
-            shutdown_command=settings.shutdown_command,
-            shutdown_state_file=settings.shutdown_state_file,
-            watchdog_enabled=settings.watchdog_enabled,
-            watchdog_timeout_seconds=settings.watchdog_timeout_seconds,
-            watchdog_feed_interval_seconds=settings.watchdog_feed_interval_seconds,
-            watchdog_i2c_bus=settings.watchdog_i2c_bus,
-            watchdog_i2c_address=settings.watchdog_i2c_address,
-            watchdog_command_timeout_seconds=settings.watchdog_command_timeout_seconds,
-        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/yoyopod/power/policies.py
+++ b/src/yoyopod/power/policies.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from yoyopod.config.models import PowerConfig
 from yoyopod.power.events import (
     GracefulShutdownCancelled,
     GracefulShutdownRequested,
     LowBatteryWarningRaised,
 )
-from yoyopod.power.models import PowerConfig, PowerSnapshot
+from yoyopod.power.models import PowerSnapshot
 
 
 @dataclass(slots=True)

--- a/src/yoyopod/power/runtime.py
+++ b/src/yoyopod/power/runtime.py
@@ -1,0 +1,220 @@
+"""Power-domain runtime service for PiSugar polling and watchdog cadence."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from yoyopod.app import YoyoPodApp
+    from yoyopod.power.models import PowerSnapshot
+
+
+class PowerRuntimeService:
+    """Own power refresh and watchdog work that should stay out of generic recovery."""
+
+    _SLOW_POWER_REFRESH_WARNING_SECONDS = 0.25
+    _SLOW_WATCHDOG_FEED_WARNING_SECONDS = 0.25
+
+    def __init__(self, app: "YoyoPodApp") -> None:
+        self.app = app
+        self._power_io_lock = threading.Lock()
+
+    def poll_status(self, now: float | None = None, force: bool = False) -> None:
+        """Refresh PiSugar power telemetry without stalling the coordinator loop."""
+        if self.app.power_manager is None:
+            return
+
+        poll_now = time.monotonic() if now is None else now
+        if not force and poll_now < self.app._next_power_poll_at:
+            return
+
+        interval = max(1.0, self.app.power_manager.config.poll_interval_seconds)
+        self.app._next_power_poll_at = poll_now + interval
+
+        if force:
+            snapshot = self._refresh_snapshot()
+            self._complete_refresh(snapshot=snapshot)
+            return
+
+        if self.app._power_refresh_in_flight:
+            return
+
+        self.app._power_refresh_in_flight = True
+        worker = threading.Thread(
+            target=self.run_power_refresh_attempt,
+            daemon=True,
+            name="power-refresh",
+        )
+        worker.start()
+
+    def run_power_refresh_attempt(self) -> None:
+        """Collect one PiSugar snapshot off the coordinator thread."""
+
+        snapshot = self._refresh_snapshot()
+        self.app._queue_main_thread_callback(
+            lambda snapshot=snapshot: self._complete_refresh(snapshot=snapshot)
+        )
+
+    def _refresh_snapshot(self) -> "PowerSnapshot":
+        """Collect one PiSugar snapshot under the shared power-I/O lock."""
+
+        assert self.app.power_manager is not None
+        started_at = time.monotonic()
+        with self._power_io_lock:
+            snapshot = self.app.power_manager.refresh()
+        duration_seconds = max(0.0, time.monotonic() - started_at)
+        if duration_seconds >= self._SLOW_POWER_REFRESH_WARNING_SECONDS:
+            logger.warning(
+                "Power refresh worker slow: duration_ms={:.1f}",
+                duration_seconds * 1000.0,
+            )
+        return snapshot
+
+    def _complete_refresh(self, *, snapshot: "PowerSnapshot") -> None:
+        """Publish one completed power refresh back onto the coordinator thread."""
+
+        self.app._power_refresh_in_flight = False
+        self.app.boot_service.ensure_coordinators()
+        assert self.app.power_coordinator is not None
+        self.app.power_coordinator.publish_snapshot(snapshot)
+
+        if self.app._power_available is None or self.app._power_available != snapshot.available:
+            reason = snapshot.error or ("ready" if snapshot.available else "unavailable")
+            self.app._power_available = snapshot.available
+            self.app.power_coordinator.publish_availability_change(snapshot.available, reason)
+
+    def start_watchdog(self, now: float | None = None) -> None:
+        """Enable the PiSugar software watchdog once the app loop is ready."""
+        if self.app.simulate or self.app.power_manager is None:
+            return
+
+        if not self.app.power_manager.config.watchdog_enabled or self.app._watchdog_active:
+            return
+
+        feed_interval = max(
+            1.0,
+            float(self.app.power_manager.config.watchdog_feed_interval_seconds),
+        )
+        timeout_seconds = max(1, int(self.app.power_manager.config.watchdog_timeout_seconds))
+        if feed_interval >= timeout_seconds:
+            logger.warning(
+                "Power watchdog feed interval ({}) should be less than timeout ({})",
+                feed_interval,
+                timeout_seconds,
+            )
+
+        with self._power_io_lock:
+            enabled = self.app.power_manager.enable_watchdog()
+        if not enabled:
+            logger.warning("Power watchdog could not be enabled")
+            return
+
+        watchdog_now = time.monotonic() if now is None else now
+        self.app._watchdog_active = True
+        self.app._watchdog_feed_in_flight = False
+        self.app._watchdog_feed_suppressed = False
+        self.app._next_watchdog_feed_at = watchdog_now + feed_interval
+        logger.info(
+            "Power watchdog enabled (timeout={}s, feed={}s)",
+            timeout_seconds,
+            feed_interval,
+        )
+
+    def feed_watchdog_if_due(self, now: float) -> None:
+        """Feed the PiSugar software watchdog without blocking the coordinator loop."""
+        if not self.app._watchdog_active or self.app._watchdog_feed_suppressed:
+            return
+
+        if self.app.power_manager is None or now < self.app._next_watchdog_feed_at:
+            return
+
+        if self.app._watchdog_feed_in_flight:
+            return
+
+        self.app._watchdog_feed_in_flight = True
+        worker = threading.Thread(
+            target=self.run_watchdog_feed_attempt,
+            daemon=True,
+            name="power-watchdog-feed",
+        )
+        worker.start()
+
+    def run_watchdog_feed_attempt(self) -> None:
+        """Feed the watchdog off the coordinator thread and report the outcome."""
+
+        power_manager = self.app.power_manager
+        feed_interval = 1.0
+        success = False
+        if power_manager is not None:
+            feed_interval = max(
+                1.0,
+                float(power_manager.config.watchdog_feed_interval_seconds),
+            )
+            started_at = time.monotonic()
+            with self._power_io_lock:
+                success = power_manager.feed_watchdog()
+            duration_seconds = max(0.0, time.monotonic() - started_at)
+            if duration_seconds >= self._SLOW_WATCHDOG_FEED_WARNING_SECONDS:
+                logger.warning(
+                    "Watchdog feed worker slow: duration_ms={:.1f}",
+                    duration_seconds * 1000.0,
+                )
+
+        completed_at = time.monotonic()
+        self.app._queue_main_thread_callback(
+            lambda success=success, completed_at=completed_at, feed_interval=feed_interval: self._complete_watchdog_feed(
+                success=success,
+                completed_at=completed_at,
+                feed_interval=feed_interval,
+            )
+        )
+
+    def _complete_watchdog_feed(
+        self,
+        *,
+        success: bool,
+        completed_at: float,
+        feed_interval: float,
+    ) -> None:
+        """Update watchdog cadence after one off-thread feed attempt completes."""
+
+        self.app._watchdog_feed_in_flight = False
+        if not self.app._watchdog_active:
+            return
+
+        if success:
+            self.app._next_watchdog_feed_at = completed_at + feed_interval
+            return
+
+        self.app._next_watchdog_feed_at = completed_at + min(feed_interval, 5.0)
+
+    def disable_watchdog(self) -> None:
+        """Disable the PiSugar watchdog during intentional app shutdowns."""
+        if not self.app._watchdog_active:
+            return
+
+        disabled = False
+        if self.app.power_manager is not None:
+            with self._power_io_lock:
+                disabled = self.app.power_manager.disable_watchdog()
+        if disabled:
+            logger.info("Power watchdog disabled for intentional stop")
+        else:
+            logger.warning("Failed to disable power watchdog cleanly")
+
+        self.app._watchdog_active = False
+        self.app._watchdog_feed_in_flight = False
+        self.app._watchdog_feed_suppressed = False
+        self.app._next_watchdog_feed_at = 0.0
+
+    def suppress_watchdog_feeding(self, reason: str) -> None:
+        """Stop feeding the watchdog without disabling it."""
+        if not self.app._watchdog_active or self.app._watchdog_feed_suppressed:
+            return
+
+        self.app._watchdog_feed_suppressed = True
+        logger.info(f"Power watchdog feeding suppressed: {reason}")

--- a/src/yoyopod/power/watchdog.py
+++ b/src/yoyopod/power/watchdog.py
@@ -6,7 +6,7 @@ import subprocess
 from math import ceil
 from typing import Callable, Protocol
 
-from yoyopod.power.models import PowerConfig
+from yoyopod.config.models import PowerConfig
 
 
 class WatchdogRunnerResult(Protocol):

--- a/src/yoyopod/runtime/boot.py
+++ b/src/yoyopod/runtime/boot.py
@@ -96,7 +96,7 @@ class RuntimeBootService:
             self.setup_voip_callbacks()
             self.setup_music_callbacks()
             self.app.shutdown_service.register_power_shutdown_hooks()
-            self.app.recovery_service.poll_power_status(force=True, now=time.monotonic())
+            self.app.power_runtime.poll_status(force=True, now=time.monotonic())
 
             logger.info("YoyoPod setup complete")
             return True

--- a/src/yoyopod/runtime/loop.py
+++ b/src/yoyopod/runtime/loop.py
@@ -313,7 +313,7 @@ class RuntimeLoopService:
             )
             self._measure_blocking_span(
                 "power_poll",
-                lambda: self.app.recovery_service.poll_power_status(now=monotonic_now),
+                lambda: self.app.power_runtime.poll_status(now=monotonic_now),
             )
             self._measure_blocking_span(
                 "lvgl_pump",
@@ -321,7 +321,7 @@ class RuntimeLoopService:
             )
             self._measure_blocking_span(
                 "watchdog_feed",
-                lambda: self.app.recovery_service.feed_watchdog_if_due(monotonic_now),
+                lambda: self.app.power_runtime.feed_watchdog_if_due(monotonic_now),
             )
             self._measure_blocking_span(
                 "pending_shutdown",
@@ -449,7 +449,7 @@ class RuntimeLoopService:
         try:
             last_screen_update = time.time()
             screen_update_interval = 1.0
-            self.app.recovery_service.start_watchdog(now=time.monotonic())
+            self.app.power_runtime.start_watchdog(now=time.monotonic())
 
             if self.app.simulate:
                 logger.info("")

--- a/src/yoyopod/runtime/recovery.py
+++ b/src/yoyopod/runtime/recovery.py
@@ -1,4 +1,4 @@
-"""Recovery, watchdog, and manager-health supervision helpers."""
+"""Recovery and manager-health supervision helpers."""
 
 from __future__ import annotations
 
@@ -12,19 +12,14 @@ from yoyopod.events import RecoveryAttemptCompletedEvent
 
 if TYPE_CHECKING:
     from yoyopod.app import YoyoPodApp
-    from yoyopod.power import PowerSnapshot
     from yoyopod.runtime.models import RecoveryState
 
 
 class RecoverySupervisor:
-    """Supervise recoverable backends and the PiSugar watchdog."""
-
-    _SLOW_POWER_REFRESH_WARNING_SECONDS = 0.25
-    _SLOW_WATCHDOG_FEED_WARNING_SECONDS = 0.25
+    """Supervise recoverable VoIP/music backends."""
 
     def __init__(self, app: "YoyoPodApp") -> None:
         self.app = app
-        self._power_io_lock = threading.Lock()
 
     def handle_recovery_attempt_completed_event(
         self,
@@ -62,202 +57,6 @@ class RecoverySupervisor:
         recovery_now = time.monotonic() if now is None else now
         self.attempt_voip_recovery(recovery_now)
         self.attempt_music_recovery(recovery_now)
-
-    def poll_power_status(self, now: float | None = None, force: bool = False) -> None:
-        """Refresh PiSugar power telemetry without stalling the coordinator loop."""
-        if self.app.power_manager is None:
-            return
-
-        poll_now = time.monotonic() if now is None else now
-        if not force and poll_now < self.app._next_power_poll_at:
-            return
-
-        interval = max(1.0, self.app.power_manager.config.poll_interval_seconds)
-        self.app._next_power_poll_at = poll_now + interval
-
-        if force:
-            snapshot = self._refresh_power_snapshot()
-            self._complete_power_refresh(snapshot=snapshot)
-            return
-
-        if self.app._power_refresh_in_flight:
-            return
-
-        self.app._power_refresh_in_flight = True
-        worker = threading.Thread(
-            target=self.run_power_refresh_attempt,
-            daemon=True,
-            name="power-refresh",
-        )
-        worker.start()
-
-    def run_power_refresh_attempt(self) -> None:
-        """Collect one PiSugar snapshot off the coordinator thread."""
-
-        snapshot = self._refresh_power_snapshot()
-        self.app._queue_main_thread_callback(
-            lambda snapshot=snapshot: self._complete_power_refresh(snapshot=snapshot)
-        )
-
-    def _refresh_power_snapshot(self) -> "PowerSnapshot":
-        """Collect one PiSugar snapshot under the shared power-I/O lock."""
-
-        assert self.app.power_manager is not None
-        started_at = time.monotonic()
-        with self._power_io_lock:
-            snapshot = self.app.power_manager.refresh()
-        duration_seconds = max(0.0, time.monotonic() - started_at)
-        if duration_seconds >= self._SLOW_POWER_REFRESH_WARNING_SECONDS:
-            logger.warning(
-                "Power refresh worker slow: duration_ms={:.1f}",
-                duration_seconds * 1000.0,
-            )
-        return snapshot
-
-    def _complete_power_refresh(self, *, snapshot: "PowerSnapshot") -> None:
-        """Publish one completed power refresh back onto the coordinator thread."""
-
-        self.app._power_refresh_in_flight = False
-        self.app.boot_service.ensure_coordinators()
-        assert self.app.power_coordinator is not None
-        self.app.power_coordinator.publish_snapshot(snapshot)
-
-        if self.app._power_available is None or self.app._power_available != snapshot.available:
-            reason = snapshot.error or ("ready" if snapshot.available else "unavailable")
-            self.app._power_available = snapshot.available
-            self.app.power_coordinator.publish_availability_change(snapshot.available, reason)
-
-    def start_watchdog(self, now: float | None = None) -> None:
-        """Enable the PiSugar software watchdog once the app loop is ready."""
-        if self.app.simulate or self.app.power_manager is None:
-            return
-
-        if not self.app.power_manager.config.watchdog_enabled or self.app._watchdog_active:
-            return
-
-        feed_interval = max(
-            1.0,
-            float(self.app.power_manager.config.watchdog_feed_interval_seconds),
-        )
-        timeout_seconds = max(1, int(self.app.power_manager.config.watchdog_timeout_seconds))
-        if feed_interval >= timeout_seconds:
-            logger.warning(
-                "Power watchdog feed interval ({}) should be less than timeout ({})",
-                feed_interval,
-                timeout_seconds,
-            )
-
-        with self._power_io_lock:
-            enabled = self.app.power_manager.enable_watchdog()
-        if not enabled:
-            logger.warning("Power watchdog could not be enabled")
-            return
-
-        watchdog_now = time.monotonic() if now is None else now
-        self.app._watchdog_active = True
-        self.app._watchdog_feed_in_flight = False
-        self.app._watchdog_feed_suppressed = False
-        self.app._next_watchdog_feed_at = watchdog_now + feed_interval
-        logger.info(
-            "Power watchdog enabled (timeout={}s, feed={}s)",
-            timeout_seconds,
-            feed_interval,
-        )
-
-    def feed_watchdog_if_due(self, now: float) -> None:
-        """Feed the PiSugar software watchdog without blocking the coordinator loop."""
-        if not self.app._watchdog_active or self.app._watchdog_feed_suppressed:
-            return
-
-        if self.app.power_manager is None or now < self.app._next_watchdog_feed_at:
-            return
-
-        if self.app._watchdog_feed_in_flight:
-            return
-
-        self.app._watchdog_feed_in_flight = True
-        worker = threading.Thread(
-            target=self.run_watchdog_feed_attempt,
-            daemon=True,
-            name="power-watchdog-feed",
-        )
-        worker.start()
-
-    def run_watchdog_feed_attempt(self) -> None:
-        """Feed the watchdog off the coordinator thread and report the outcome."""
-
-        power_manager = self.app.power_manager
-        feed_interval = 1.0
-        success = False
-        if power_manager is not None:
-            feed_interval = max(
-                1.0,
-                float(power_manager.config.watchdog_feed_interval_seconds),
-            )
-            started_at = time.monotonic()
-            with self._power_io_lock:
-                success = power_manager.feed_watchdog()
-            duration_seconds = max(0.0, time.monotonic() - started_at)
-            if duration_seconds >= self._SLOW_WATCHDOG_FEED_WARNING_SECONDS:
-                logger.warning(
-                    "Watchdog feed worker slow: duration_ms={:.1f}",
-                    duration_seconds * 1000.0,
-                )
-
-        completed_at = time.monotonic()
-        self.app._queue_main_thread_callback(
-            lambda success=success, completed_at=completed_at, feed_interval=feed_interval: self._complete_watchdog_feed(
-                success=success,
-                completed_at=completed_at,
-                feed_interval=feed_interval,
-            )
-        )
-
-    def _complete_watchdog_feed(
-        self,
-        *,
-        success: bool,
-        completed_at: float,
-        feed_interval: float,
-    ) -> None:
-        """Update watchdog cadence after one off-thread feed attempt completes."""
-
-        self.app._watchdog_feed_in_flight = False
-        if not self.app._watchdog_active:
-            return
-
-        if success:
-            self.app._next_watchdog_feed_at = completed_at + feed_interval
-            return
-
-        self.app._next_watchdog_feed_at = completed_at + min(feed_interval, 5.0)
-
-    def disable_watchdog(self) -> None:
-        """Disable the PiSugar watchdog during intentional app shutdowns."""
-        if not self.app._watchdog_active:
-            return
-
-        disabled = False
-        if self.app.power_manager is not None:
-            with self._power_io_lock:
-                disabled = self.app.power_manager.disable_watchdog()
-        if disabled:
-            logger.info("Power watchdog disabled for intentional stop")
-        else:
-            logger.warning("Failed to disable power watchdog cleanly")
-
-        self.app._watchdog_active = False
-        self.app._watchdog_feed_in_flight = False
-        self.app._watchdog_feed_suppressed = False
-        self.app._next_watchdog_feed_at = 0.0
-
-    def suppress_watchdog_feeding(self, reason: str) -> None:
-        """Stop feeding the watchdog without disabling it."""
-        if not self.app._watchdog_active or self.app._watchdog_feed_suppressed:
-            return
-
-        self.app._watchdog_feed_suppressed = True
-        logger.info(f"Power watchdog feeding suppressed: {reason}")
 
     def attempt_voip_recovery(self, recovery_now: float) -> None:
         """Restart the VoIP backend when it is not running."""

--- a/src/yoyopod/runtime/shutdown.py
+++ b/src/yoyopod/runtime/shutdown.py
@@ -146,7 +146,7 @@ class ShutdownLifecycleService:
         if self.app._shutdown_completed:
             return
 
-        self.app.recovery_service.suppress_watchdog_feeding("pending system poweroff")
+        self.app.power_runtime.suppress_watchdog_feeding("pending system poweroff")
         self.app.screen_power_service.render_power_overlay(
             "Powering Off",
             "Saving state...",
@@ -174,7 +174,7 @@ class ShutdownLifecycleService:
         self.app._stopping = True
 
         if disable_watchdog:
-            self.app.recovery_service.disable_watchdog()
+            self.app.power_runtime.disable_watchdog()
 
         self.app.boot_service.ensure_coordinators()
         assert self.app.call_coordinator is not None

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -842,6 +842,17 @@ def test_recovery_service_schedules_music_reconnect_off_main_thread() -> None:
     assert app._voip_recovery.next_attempt_at == 1.0
 
 
+def test_recovery_service_no_longer_owns_power_runtime_helpers() -> None:
+    """Power polling/watchdog ownership should stay on the dedicated power runtime service."""
+
+    app = YoyoPodApp(simulate=True)
+
+    assert hasattr(app, "power_runtime")
+    assert not hasattr(app.recovery_service, "poll_power_status")
+    assert not hasattr(app.recovery_service, "start_watchdog")
+    assert not hasattr(app.recovery_service, "feed_watchdog_if_due")
+
+
 def test_music_recovery_backoff_doubles_after_success() -> None:
     """Background music recovery results should update backoff on success and failure."""
     app = YoyoPodApp(simulate=True)
@@ -1585,13 +1596,13 @@ def test_runtime_loop_logs_named_blocking_spans(
         lambda self: 0.01,
     )
     monkeypatch.setattr(RuntimeLoopService, "_VOIP_TIMING_SUMMARY_INTERVAL_SECONDS", 0.0)
-    original_poll_power_status = app.recovery_service.poll_power_status
+    original_poll_power_status = app.power_runtime.poll_status
 
     def slow_poll_power_status(*, now: float | None = None, force: bool = False) -> None:
         time.sleep(0.02)
         original_poll_power_status(now=now, force=force)
 
-    app.recovery_service.poll_power_status = slow_poll_power_status
+    app.power_runtime.poll_status = slow_poll_power_status
     try:
         app.runtime_loop.run_iteration(
             monotonic_now=1.0,

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -86,7 +86,7 @@ def test_board_config_overlays_base_config(tmp_path, monkeypatch) -> None:
     )
     _write_yaml(
         tmp_path,
-        "device/hardware.yaml",
+        "power/backend.yaml",
         {
             "power": {
                 "watchdog_i2c_bus": 1,
@@ -114,7 +114,7 @@ def test_board_config_overlays_base_config(tmp_path, monkeypatch) -> None:
     )
     _write_yaml(
         tmp_path,
-        "boards/radxa-cubie-a7z/device/hardware.yaml",
+        "boards/radxa-cubie-a7z/power/backend.yaml",
         {
             "power": {
                 "watchdog_i2c_bus": 7,
@@ -134,7 +134,10 @@ def test_board_config_overlays_base_config(tmp_path, monkeypatch) -> None:
     assert config_manager.app_settings.ui.theme == "retro"
     assert config_manager.get_media_settings().music.music_dir == "/home/radxa/Music"
     assert config_manager.get_default_output_volume() == 72
-    assert config_manager.app_settings.power.watchdog_i2c_bus == 7
+    assert config_manager.power_backend_layers[-1] == (
+        tmp_path / "boards" / "radxa-cubie-a7z" / "power" / "backend.yaml"
+    )
+    assert config_manager.get_power_settings().watchdog_i2c_bus == 7
 
 
 def test_missing_board_overlay_falls_back_to_base_config(tmp_path, monkeypatch) -> None:
@@ -158,9 +161,9 @@ def test_missing_board_overlay_falls_back_to_base_config(tmp_path, monkeypatch) 
             }
         },
     )
-    base_device_file = _write_yaml(
+    base_power_file = _write_yaml(
         tmp_path,
-        "device/hardware.yaml",
+        "power/backend.yaml",
         {
             "power": {
                 "watchdog_i2c_bus": 1,
@@ -175,8 +178,8 @@ def test_missing_board_overlay_falls_back_to_base_config(tmp_path, monkeypatch) 
     assert config_manager.app_config_file == tmp_path / "app" / "core.yaml"
     assert config_manager.media_music_layers[0] == base_file
     assert config_manager.media_music_layers[-1] == base_file
-    assert config_manager.device_hardware_layers[0] == base_device_file
-    assert config_manager.device_hardware_layers[-1] == base_device_file
+    assert config_manager.power_backend_layers[0] == base_power_file
+    assert config_manager.power_backend_layers[-1] == base_power_file
     assert config_manager.app_settings.ui.theme == "dark"
     assert config_manager.get_media_settings().music.music_dir == "/srv/base-music"
-    assert config_manager.app_settings.power.watchdog_i2c_bus == 1
+    assert config_manager.get_power_settings().watchdog_i2c_bus == 1

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -10,14 +10,15 @@ import yaml
 from yoyopod.config import (
     ConfigManager,
     MediaConfig,
+    PowerConfig,
     VoiceConfig,
     YoyoPodConfig,
     load_config_model_from_yaml,
 )
 
 
-def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> None:
-    """Missing authored config should resolve to typed defaults in memory."""
+def test_app_shell_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> None:
+    """Missing app-shell config should resolve to typed defaults in memory."""
 
     monkeypatch.delenv("YOYOPOD_MUSIC_DIR", raising=False)
     monkeypatch.delenv("YOYOPOD_MPV_SOCKET", raising=False)
@@ -35,23 +36,7 @@ def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> Non
     assert settings.input.ptt_navigation is True
     assert settings.input.whisplay_double_tap_ms == 300
     assert settings.input.whisplay_long_hold_ms == 800
-    assert settings.power.enabled is True
-    assert settings.power.backend == "pisugar"
-    assert settings.power.transport == "auto"
-    assert settings.power.socket_path == "/tmp/pisugar-server.sock"
-    assert settings.power.tcp_port == 8423
-    assert settings.power.low_battery_warning_percent == 20.0
-    assert settings.power.low_battery_warning_cooldown_seconds == 300.0
-    assert settings.power.auto_shutdown_enabled is True
-    assert settings.power.critical_shutdown_percent == 10.0
-    assert settings.power.shutdown_delay_seconds == 15.0
-    assert settings.power.shutdown_command == "sudo -n shutdown -h now"
-    assert settings.power.shutdown_state_file == "data/last_shutdown_state.json"
-    assert settings.power.watchdog_enabled is False
-    assert settings.power.watchdog_timeout_seconds == 60
-    assert settings.power.watchdog_feed_interval_seconds == 15.0
-    assert settings.power.watchdog_i2c_bus == 1
-    assert settings.power.watchdog_i2c_address == 0x57
+    assert not hasattr(settings, "power")
     assert settings.display.hardware == "auto"
     assert settings.display.whisplay_renderer == "lvgl"
     assert settings.display.lvgl_buffer_lines == 40
@@ -71,6 +56,41 @@ def test_app_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> Non
     assert settings.diagnostics.responsiveness_capture_cooldown_seconds == 30.0
     assert settings.diagnostics.responsiveness_recent_input_window_seconds == 3.0
     assert settings.diagnostics.responsiveness_capture_dir == "logs/responsiveness"
+
+
+def test_power_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> None:
+    """Missing power config should still resolve to typed PiSugar defaults."""
+
+    monkeypatch.delenv("YOYOPOD_POWER_ENABLED", raising=False)
+    monkeypatch.delenv("YOYOPOD_POWER_TRANSPORT", raising=False)
+    monkeypatch.delenv("YOYOPOD_PISUGAR_PORT", raising=False)
+    monkeypatch.delenv("YOYOPOD_LOW_BATTERY_WARNING_PERCENT", raising=False)
+    monkeypatch.delenv("YOYOPOD_CRITICAL_BATTERY_SHUTDOWN_PERCENT", raising=False)
+    monkeypatch.delenv("YOYOPOD_POWER_SHUTDOWN_COMMAND", raising=False)
+    monkeypatch.delenv("YOYOPOD_POWER_WATCHDOG_ENABLED", raising=False)
+    monkeypatch.delenv("YOYOPOD_POWER_WATCHDOG_I2C_ADDRESS", raising=False)
+
+    config_file = tmp_path / "power" / "backend.yaml"
+    settings = load_config_model_from_yaml(PowerConfig, config_file)
+
+    assert not config_file.exists()
+    assert settings.enabled is True
+    assert settings.backend == "pisugar"
+    assert settings.transport == "auto"
+    assert settings.socket_path == "/tmp/pisugar-server.sock"
+    assert settings.tcp_port == 8423
+    assert settings.low_battery_warning_percent == 20.0
+    assert settings.low_battery_warning_cooldown_seconds == 300.0
+    assert settings.auto_shutdown_enabled is True
+    assert settings.critical_shutdown_percent == 10.0
+    assert settings.shutdown_delay_seconds == 15.0
+    assert settings.shutdown_command == "sudo -n shutdown -h now"
+    assert settings.shutdown_state_file == "data/last_shutdown_state.json"
+    assert settings.watchdog_enabled is False
+    assert settings.watchdog_timeout_seconds == 60
+    assert settings.watchdog_feed_interval_seconds == 15.0
+    assert settings.watchdog_i2c_bus == 1
+    assert settings.watchdog_i2c_address == 0x57
 
 
 def test_media_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> None:
@@ -171,6 +191,19 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
         ),
         encoding="utf-8",
     )
+    power_file = tmp_path / "power" / "backend.yaml"
+    power_file.parent.mkdir(parents=True, exist_ok=True)
+    power_file.write_text(
+        yaml.safe_dump(
+            {
+                "power": {
+                    "enabled": True,
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
 
     monkeypatch.setenv("YOYOPOD_MPV_SOCKET", "/tmp/test-mpv.sock")
     monkeypatch.setenv("YOYOPOD_AUTO_RESUME_AFTER_CALL", "false")
@@ -203,14 +236,18 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     config_manager = ConfigManager(config_dir=str(tmp_path))
     settings = config_manager.get_app_settings()
     media_settings = config_manager.get_media_settings()
+    power_settings = config_manager.get_power_settings()
     voice_settings = config_manager.get_voice_settings()
     config_dict = config_manager.get_app_config_dict()
     media_dict = config_manager.get_media_config_dict()
+    power_dict = config_manager.get_power_config_dict()
     runtime_dict = config_manager.get_runtime_config_dict()
 
     assert config_manager.app_config_loaded is True
     assert config_manager.media_config_loaded is True
+    assert config_manager.power_config_loaded is True
     assert not hasattr(settings, "audio")
+    assert not hasattr(settings, "power")
     assert media_settings.music.music_dir == "/srv/music"
     assert media_settings.music.mpv_socket == "/tmp/test-mpv.sock"
     assert media_settings.music.mpv_binary == "/usr/local/bin/mpv"
@@ -218,16 +255,16 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     assert media_settings.music.auto_resume_after_call is False
     assert settings.input.whisplay_double_tap_ms == 260
     assert settings.input.whisplay_long_hold_ms == 900
-    assert settings.power.transport == "tcp"
-    assert settings.power.tcp_port == 9001
-    assert settings.power.low_battery_warning_percent == 17.5
-    assert settings.power.critical_shutdown_percent == 8.5
-    assert settings.power.shutdown_delay_seconds == 22.0
-    assert settings.power.shutdown_command == "sudo -n poweroff"
-    assert settings.power.watchdog_enabled is True
-    assert settings.power.watchdog_timeout_seconds == 90
-    assert settings.power.watchdog_feed_interval_seconds == 30.0
-    assert settings.power.watchdog_i2c_address == 0x58
+    assert power_settings.transport == "tcp"
+    assert power_settings.tcp_port == 9001
+    assert power_settings.low_battery_warning_percent == 17.5
+    assert power_settings.critical_shutdown_percent == 8.5
+    assert power_settings.shutdown_delay_seconds == 22.0
+    assert power_settings.shutdown_command == "sudo -n poweroff"
+    assert power_settings.watchdog_enabled is True
+    assert power_settings.watchdog_timeout_seconds == 90
+    assert power_settings.watchdog_feed_interval_seconds == 30.0
+    assert power_settings.watchdog_i2c_address == 0x58
     assert settings.display.hardware == "whisplay"
     assert settings.display.whisplay_renderer == "lvgl"
     assert settings.display.lvgl_buffer_lines == 24
@@ -243,14 +280,18 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     assert settings.diagnostics.responsiveness_stall_threshold_seconds == 8.0
     assert settings.diagnostics.responsiveness_capture_dir == "/tmp/yoyopod-watchdog"
     assert "audio" not in config_dict
+    assert "power" not in config_dict
     assert config_dict["display"]["hardware"] == "whisplay"
     assert config_dict["display"]["whisplay_renderer"] == "lvgl"
     assert config_dict["display"]["lvgl_buffer_lines"] == 24
     assert media_dict["music"]["music_dir"] == "/srv/music"
     assert media_dict["music"]["mpv_socket"] == "/tmp/test-mpv.sock"
     assert media_dict["audio"]["alsa_device"] == "hw:Loopback,0"
+    assert power_dict["transport"] == "tcp"
+    assert power_dict["watchdog_i2c_address"] == 0x58
     assert runtime_dict["media"]["music"]["music_dir"] == "/srv/music"
     assert runtime_dict["media"]["audio"]["alsa_device"] == "hw:Loopback,0"
+    assert runtime_dict["power"]["transport"] == "tcp"
     assert "network" not in config_dict
     assert "voice" not in config_dict
     assert config_dict["logging"]["file"] == "/var/log/yoyopod.log"

--- a/tests/test_config_topology.py
+++ b/tests/test_config_topology.py
@@ -1,4 +1,4 @@
-"""Focused tests for canonical config topology and people-data ownership."""
+"""Focused tests for canonical config topology, power ownership, and people data."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ from yoyopod.config import ConfigManager
 from yoyopod.audio import MusicConfig
 from yoyopod.network import NetworkManager
 from yoyopod.people import PeopleDirectory
+from yoyopod.power import PowerManager
 
 
 def _write_yaml(base_dir: Path, relative_path: str, payload: dict) -> Path:
@@ -151,6 +152,35 @@ def test_media_config_composes_domain_policy_with_device_owned_routing(tmp_path:
         manager.resolve_runtime_path(manager.get_recent_tracks_file())
         == tmp_path / "data" / "media" / "recent_tracks.json"
     )
+
+
+def test_power_config_loads_from_canonical_domain_backend_file(tmp_path: Path) -> None:
+    """Power should load from its domain-owned backend file instead of app-shell config."""
+
+    config_dir = tmp_path / "config"
+    _write_yaml(
+        config_dir,
+        "power/backend.yaml",
+        {
+            "power": {
+                "transport": "tcp",
+                "tcp_host": "192.168.178.10",
+                "tcp_port": 9002,
+                "watchdog_enabled": True,
+                "watchdog_i2c_bus": 7,
+            }
+        },
+    )
+
+    manager = ConfigManager(config_dir=str(config_dir))
+    power_manager = PowerManager.from_config_manager(manager)
+
+    assert manager.power_config_loaded is True
+    assert not hasattr(manager.get_app_settings(), "power")
+    assert manager.get_power_settings().transport == "tcp"
+    assert manager.get_runtime_settings().power.tcp_port == 9002
+    assert power_manager.config.tcp_host == "192.168.178.10"
+    assert power_manager.config.watchdog_i2c_bus == 7
 
 
 def test_network_config_composes_domain_owned_cellular_settings(tmp_path: Path) -> None:

--- a/tests/test_config_voice_device_persistence.py
+++ b/tests/test_config_voice_device_persistence.py
@@ -41,9 +41,9 @@ def test_voice_device_persistence_does_not_flatten_env_overrides(
 
     cfg_dir = tmp_path / "config"
     cfg_dir.mkdir(parents=True, exist_ok=True)
-    config_file = cfg_dir / "device" / "hardware.yaml"
-    config_file.parent.mkdir(parents=True, exist_ok=True)
-    config_file.write_text(
+    power_file = cfg_dir / "power" / "backend.yaml"
+    power_file.parent.mkdir(parents=True, exist_ok=True)
+    power_file.write_text(
         yaml.safe_dump(
             {
                 "power": {
@@ -60,8 +60,13 @@ def test_voice_device_persistence_does_not_flatten_env_overrides(
 
     assert manager.set_voice_speaker_device_id("plughw:CARD=SE,DEV=0") is True
 
-    persisted = yaml.safe_load(config_file.read_text(encoding="utf-8"))
-    assert persisted["power"]["watchdog_i2c_bus"] == 7
+    assert yaml.safe_load(power_file.read_text(encoding="utf-8")) == {
+        "power": {
+            "watchdog_i2c_bus": 7,
+        }
+    }
+    voice_file = cfg_dir / "device" / "hardware.yaml"
+    persisted = yaml.safe_load(voice_file.read_text(encoding="utf-8"))
     assert persisted["voice_audio"]["speaker_device_id"] == "plughw:CARD=SE,DEV=0"
     assert "audio" not in persisted
 
@@ -74,7 +79,7 @@ def test_voice_device_persistence_only_updates_active_overlay(
 
     cfg_dir = tmp_path / "config"
     cfg_dir.mkdir(parents=True, exist_ok=True)
-    base_file = cfg_dir / "device" / "hardware.yaml"
+    base_file = cfg_dir / "power" / "backend.yaml"
     base_file.parent.mkdir(parents=True, exist_ok=True)
     base_file.write_text(
         yaml.safe_dump(

--- a/tests/test_power_backend.py
+++ b/tests/test_power_backend.py
@@ -6,8 +6,8 @@ from datetime import datetime, timezone
 
 import pytest
 
+from yoyopod.power import PowerConfig
 from yoyopod.power.backend import PiSugarBackend, PowerTransportError
-from yoyopod.power.models import PowerConfig
 
 
 class FakeTransport:
@@ -156,4 +156,3 @@ def test_pisugar_backend_issues_documented_rtc_control_commands() -> None:
         "rtc_alarm_set 2026-04-06T07:30:00+00:00 31",
         "rtc_alarm_disable",
     ]
-

--- a/tests/test_power_manager.py
+++ b/tests/test_power_manager.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+
 from yoyopod.config import ConfigManager
-from yoyopod.power.manager import PowerManager
-from yoyopod.power.models import BatteryState, PowerConfig, PowerSnapshot, RTCState
+from yoyopod.power import BatteryState, PowerConfig, PowerManager, PowerSnapshot, RTCState
 
 
 class FakeBackend:
@@ -99,12 +99,12 @@ def test_power_manager_returns_unavailable_snapshot_when_backend_refresh_fails()
 
 
 def test_power_manager_reads_power_config_from_config_manager(tmp_path) -> None:
-    """Typed application settings should feed the power manager configuration."""
+    """Typed power-domain settings should feed the power manager configuration."""
 
     config_dir = tmp_path
-    hardware_file = config_dir / "device" / "hardware.yaml"
-    hardware_file.parent.mkdir(parents=True, exist_ok=True)
-    hardware_file.write_text(
+    power_file = config_dir / "power" / "backend.yaml"
+    power_file.parent.mkdir(parents=True, exist_ok=True)
+    power_file.write_text(
         """
 power:
   enabled: true

--- a/tests/test_power_watchdog.py
+++ b/tests/test_power_watchdog.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from yoyopod.power.models import PowerConfig
+from yoyopod.power import PowerConfig
 from yoyopod.power.watchdog import PiSugarWatchdog, WatchdogCommandError
 
 

--- a/tests/test_quality_script.py
+++ b/tests/test_quality_script.py
@@ -27,3 +27,16 @@ def test_parser_accepts_ci_command() -> None:
     args = parser.parse_args(["ci"])
 
     assert args.command == "ci"
+
+
+def test_gate_steps_expand_directory_targets_into_python_files() -> None:
+    config = QUALITY["load_quality_config"]()
+
+    gate_steps = QUALITY["build_gate_steps"](config)
+    black_steps = [step for step in gate_steps if step.label == "black --check (workflow surface)"]
+    black_targets = [Path(step.command[-1]) for step in black_steps]
+
+    assert black_targets
+    assert Path("src/yoyopod/cli/remote") not in black_targets
+    assert Path("src/yoyopod/cli/remote/navigation.py") in black_targets
+    assert all(target.suffix == ".py" for target in black_targets)


### PR DESCRIPTION
## Summary
- move power authored settings into the canonical `config/power/backend.yaml` topology, including board overlays under `config/boards/<board>/power/backend.yaml`
- move typed power ownership onto `yoyopod.config` and `yoyopod.power`, with `ConfigManager.get_power_settings()` feeding `PowerManager.from_config_manager()`
- make `PowerRuntimeService` own PiSugar polling and watchdog cadence while `RecoverySupervisor` stays focused on VoIP/music recovery
- update docs and tests so the power cutover follows the reusable migration pattern established by #148 / #149

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_app_orchestration.py tests/test_config_manager.py tests/test_config_models.py tests/test_config_topology.py tests/test_power_manager.py`
- `PYTHONUNBUFFERED=1 UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/quality.py gate`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
  - the in-sandbox run failed only on `tests/test_mpv_ipc.py` because `socket.AF_UNIX` bind returned `PermissionError`; reran the full suite outside the sandbox and got `538 passed, 1 warning`

## Notes
- this lane targets reviewable `self_checked` publication, not merge authority
- Closes #154