### PR TITLE
[codex] Finish app/runtime shell and residue cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # YoyoPod - Agent Instructions
 
-**Last Updated:** 2026-04-09
+**Last Updated:** 2026-04-16
 **Target Hardware:** Raspberry Pi Zero 2W
-**Project:** iPod-inspired VoIP and mpv-based local music player with a small-screen, button-driven UI
+**Project:** iPod-inspired communication, local music, modem, and voice device with a small-screen button UI
 
 ---
 
@@ -60,9 +60,9 @@ When asked to deploy, sync, restart, check status, view logs, or take a screensh
   - split `MusicFSM` and `CallFSM`
   - coordinator modules under `src/yoyopod/coordinators/`
   - derived runtime state in `CoordinatorRuntime`
-  - declarative screen routing
-  - typed config models with YAML plus env overlay
-  - dedicated `src/yoyopod/voip/` package
+  - focused runtime services under `src/yoyopod/runtime/`
+  - typed config models with canonical domain-owned YAML layers plus env overlay
+  - `src/yoyopod/communication/`, `src/yoyopod/people/`, `src/yoyopod/network/`, and `src/yoyopod/voice/` packages
 - PiSugar-backed power management is now implemented:
   - telemetry polling
   - low-battery warning and graceful shutdown
@@ -72,7 +72,7 @@ When asked to deploy, sync, restart, check status, view logs, or take a screensh
 - Production Raspberry Pi deployment now has a committed systemd unit template under `deploy/systemd/`.
 - Whisplay now runs on the LVGL rendering path in production under `src/yoyopod/ui/lvgl_binding/`.
 - Production local music now runs through the app-managed mpv backend under `src/yoyopod/audio/music/`.
-- Production VoIP now runs through Liblinphone under `src/yoyopod/voip/liblinphone_binding/` and `src/yoyopod/voip/backend.py`.
+- Production communication now runs through Liblinphone under `src/yoyopod/communication/integrations/liblinphone_binding/` and `src/yoyopod/communication/calling/backend.py`.
 - CI validates the staged quality gate plus Python test suite; the local mirror is `uv run python scripts/quality.py ci`.
 - Raspberry Pi validation has a defined path through the `yoyoctl pi validate` suite and `yoyoctl remote`.
 
@@ -99,12 +99,15 @@ When in doubt, trust these files first:
 - `src/yoyopod/events.py`
 - `src/yoyopod/coordinators/runtime.py`
 - `src/yoyopod/audio/`
-- `src/yoyopod/voip/`
+- `src/yoyopod/communication/`
+- `src/yoyopod/people/`
+- `src/yoyopod/network/`
 - `src/yoyopod/power/`
 - `src/yoyopod/ui/display/`
 - `src/yoyopod/ui/lvgl_binding/`
 - `src/yoyopod/ui/input/`
 - `src/yoyopod/ui/screens/`
+- `src/yoyopod/voice/`
 - `README.md`
 - `docs/SYSTEM_ARCHITECTURE.md`
 - `docs/POWER_MODULE.md`
@@ -120,12 +123,14 @@ Current production topology:
 ```text
 yoyopod.py / yoyopod.main
   -> YoyoPodApp
+     -> RuntimeBootService / RuntimeLoopService / RecoverySupervisor
+     -> ScreenPowerService / ShutdownLifecycleService
      -> EventBus
      -> MusicFSM
      -> CallFSM
      -> CallInterruptionPolicy
      -> CoordinatorRuntime
-     -> CallCoordinator / PlaybackCoordinator / ScreenCoordinator
+     -> CallCoordinator / PlaybackCoordinator / PowerCoordinator / ScreenCoordinator
      -> Display facade
         -> display factory
         -> Pimoroni | Whisplay | Simulation adapters
@@ -140,9 +145,12 @@ yoyopod.py / yoyopod.main
         -> MpvIpcClient
      -> VoIPManager
         -> LiblinphoneBackend
+     -> PeopleDirectory
      -> PowerManager
         -> PiSugarBackend
         -> PiSugarWatchdog
+     -> NetworkManager
+     -> VoiceRuntimeCoordinator
 ```
 
 Key design points:
@@ -173,7 +181,7 @@ Key design points:
 - `src/yoyopod/coordinators/screen.py` - screen refresh and call-screen updates
 - `src/yoyopod/coordinators/runtime.py` - derived `AppRuntimeState` and shared runtime references
 
-### Audio And VoIP
+### Audio And Communication
 
 - `src/yoyopod/audio/local_service.py` - filesystem-backed playlists, shuffle source collection, and recent-track integration
 - `src/yoyopod/audio/music/backend.py` - `MusicBackend`, `MpvBackend`, and `MockMusicBackend`
@@ -181,12 +189,18 @@ Key design points:
 - `src/yoyopod/audio/music/ipc.py` - low-level mpv JSON IPC client
 - `src/yoyopod/audio/music/models.py` - `Track`, `Playlist`, and `MusicConfig`
 - `src/yoyopod/audio/volume.py` - shared output-volume coordination across ALSA and mpv
-- `src/yoyopod/voip/manager.py` - app-facing VoIP facade
-- `src/yoyopod/voip/backend.py` - `VoIPBackend`, `LiblinphoneBackend`, `MockVoIPBackend`
-- `src/yoyopod/voip/models.py` - SIP config plus typed call/message backend events
-- `src/yoyopod/voip/liblinphone_binding/` - native Liblinphone shim and CPython cffi binding
-- `src/yoyopod/voip/messages.py` - persistent voice-note/message metadata store
-- `src/yoyopod/voip/history.py` - persistent recent/missed-call store for the Talk flow
+- `src/yoyopod/communication/calling/manager.py` - app-facing VoIP facade
+- `src/yoyopod/communication/calling/backend.py` - `VoIPBackend`, `LiblinphoneBackend`, and `MockVoIPBackend`
+- `src/yoyopod/communication/models.py` - shared communication-facing typed models and re-exports
+- `src/yoyopod/communication/calling/history.py` - persistent recent/missed-call store for the Talk flow
+- `src/yoyopod/communication/messaging/` - voice-note/message metadata store
+- `src/yoyopod/communication/integrations/liblinphone_binding/` - native Liblinphone shim and CPython cffi binding
+- `src/yoyopod/people/directory.py` - mutable contacts and people lookup
+
+### Network And Voice
+
+- `src/yoyopod/network/` - modem, PPP, GPS, and transport code
+- `src/yoyopod/voice/` - local capture, STT, TTS, and command matching
 
 ### Power
 
@@ -224,10 +238,17 @@ Key design points:
 
 ### Configuration
 
-- `config/voip_config.yaml`
-- `config/liblinphone_factory.conf`
-- `config/contacts.yaml`
-- `config/yoyopod_config.yaml`
+- `config/app/core.yaml`
+- `config/audio/music.yaml`
+- `config/device/hardware.yaml`
+- `config/network/cellular.yaml`
+- `config/voice/assistant.yaml`
+- `config/communication/calling.yaml`
+- `config/communication/messaging.yaml`
+- `config/communication/calling.secrets.example.yaml`
+- `config/communication/integrations/liblinphone_factory.conf`
+- `config/people/directory.yaml`
+- `config/people/contacts.seed.yaml`
 - `src/yoyopod/config/models.py` - typed config models
 - `src/yoyopod/config/manager.py` - current config facade used by the app
 
@@ -340,9 +361,9 @@ ssh rpi-zero "killall -9 python"
 
 If SIP behavior looks wrong, inspect the Liblinphone shim and backend boundary:
 
-- `src/yoyopod/voip/liblinphone_binding/native/liblinphone_shim.c`
-- `src/yoyopod/voip/liblinphone_binding/binding.py`
-- `src/yoyopod/voip/backend.py`
+- `src/yoyopod/communication/integrations/liblinphone_binding/native/liblinphone_shim.c`
+- `src/yoyopod/communication/integrations/liblinphone_binding/binding.py`
+- `src/yoyopod/communication/calling/backend.py`
 
 ---
 
@@ -369,10 +390,10 @@ CI-safe tests are in `tests/`. Hardware diagnostics were intentionally moved out
 
 These old names are no longer correct:
 
-- `src/yoyopod/connectivity/` -> use `src/yoyopod/voip/`
-- `src/yoyopod/connectivity/voip_manager.py` -> use `src/yoyopod/voip/manager.py`
-- `src/yoyopod/connectivity/voip_backend.py` -> use `src/yoyopod/voip/backend.py`
-- `src/yoyopod/connectivity/voip_types.py` -> use `src/yoyopod/voip/models.py`
+- `src/yoyopod/connectivity/` -> use `src/yoyopod/communication/`
+- `src/yoyopod/connectivity/voip_manager.py` -> use `src/yoyopod/communication/calling/manager.py`
+- `src/yoyopod/connectivity/voip_backend.py` -> use `src/yoyopod/communication/calling/backend.py`
+- `src/yoyopod/connectivity/voip_types.py` -> use `src/yoyopod/communication/models.py`
 - `state_machine.py` -> removed; use `src/yoyopod/fsm.py` and `src/yoyopod/coordinators/runtime.py`
 - `demo_yoyopod_phase1.py` -> removed
 - `tests/test_phase1_state_machine.py` -> replaced by `tests/test_fsm_runtime.py`

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -234,7 +234,7 @@ Useful remote log commands:
 ```bash
 yoyoctl remote logs --lines 200
 yoyoctl remote logs --errors
-yoyoctl remote logs --filter voip
+yoyoctl remote logs --filter comm
 yoyoctl remote logs --follow --filter ERROR
 ```
 
@@ -273,17 +273,22 @@ src/yoyopod/
   config/
     manager.py
     models.py
-  voip/
-    backend.py
-    history.py
-    manager.py
+  communication/
+    calling/
+    integrations/
+    messaging/
+  people/
+    directory.py
     models.py
+  network/
+  power/
   ui/
     display/
     input/
     lvgl_binding/
     screens/
     web_server.py
+  voice/
 scripts/
   quality.py
 sitecustomize.py

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -214,7 +214,7 @@ This waits for the startup marker and matching PID before returning success.
 ```bash
 yoyoctl remote logs --lines 200
 yoyoctl remote logs --errors
-yoyoctl remote logs --filter voip
+yoyoctl remote logs --filter comm
 yoyoctl remote logs --filter coord
 yoyoctl remote logs --follow --filter ERROR
 ```
@@ -225,7 +225,7 @@ This tails the file sinks declared in `deploy/pi-deploy.yaml`, which is the stab
 - `<project-dir>/logs/yoyopod_errors.log`
 - `/tmp/yoyopod.pid`
 
-For keep-alive freeze triage, watch the `voip` and `coord` lines together:
+For keep-alive freeze triage, watch the `comm` and `coord` lines together:
 
 - `VoIP timing window`: rolling summary of keep-alive schedule delay, iterate duration, and the worst loop gap in that window
 - `VoIP iterate timing drift`: one-off warning when a keep-alive step ran late or took unusually long

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -55,7 +55,7 @@ This is the startup sequence that exists on `main` today.
 5. `RuntimeBootService.setup()` currently executes boot in this order:
    1. `load_configuration()`
       - builds `ConfigManager`
-      - loads typed app settings and the compatibility config dict
+      - loads the typed app, media, network, voice, communication, and people settings
       - opens persistent stores for call history and recent tracks
       - starts the async voice-device catalog refresh
       - resolves screen timeout, brightness, and auto-resume settings

--- a/rules/architecture.md
+++ b/rules/architecture.md
@@ -17,8 +17,8 @@ yoyopod.py / src/yoyopod/main.py  (entry points)
     |- MpvBackend (audio/music/backend.py)
     |  |- MpvProcess (audio/music/process.py)
     |  `- MpvIpcClient (audio/music/ipc.py) -- mpv JSON IPC
-    |- VoIPManager (voip/manager.py)
-    |  `- LiblinphoneBackend (voip/backend.py)
+    |- VoIPManager (communication/calling/manager.py)
+    |  `- LiblinphoneBackend (communication/calling/backend.py)
     |- Display HAL (ui/display/) -- factory pattern, 3 adapters
     |- Input HAL (ui/input/) -- semantic actions, 3 adapters
     `- ScreenManager (ui/screens/manager.py) -- stack-based navigation
@@ -71,7 +71,7 @@ yoyopod.py / src/yoyopod/main.py  (entry points)
 
 ### Subsystem managers and backends
 
-- `audio/`, `voip/`, `power/`, `network/`, and `voice/` own subsystem behavior and backend integration.
+- `audio/`, `communication/`, `people/`, `power/`, `network/`, and `voice/` own subsystem behavior and backend integration.
 - Manager layers provide the app-facing facade.
 - Backend-specific details stay behind the subsystem boundary whenever possible.
 

--- a/src/yoyopod/app.py
+++ b/src/yoyopod/app.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import threading
 import time
 from queue import SimpleQueue
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Optional
 
 from loguru import logger
 
@@ -165,9 +165,6 @@ class YoyoPodApp:
         self.auto_resume_after_call = True
         self._voip_registered = False
         self._ui_state = AppRuntimeState.IDLE
-
-        # Configuration
-        self.config: Dict[str, Any] = {}
 
         # Extracted coordinators
         self.coordinator_runtime: Optional[CoordinatorRuntime] = None

--- a/src/yoyopod/coordinators/call.py
+++ b/src/yoyopod/coordinators/call.py
@@ -313,8 +313,7 @@ class CallCoordinator:
             if self.runtime.config_manager.get_sip_username().strip():
                 return True
 
-        config_file = self.runtime.config.get("voip", {}).get("config_file")
-        return bool(config_file)
+        return False
 
     def _ensure_outgoing_call_session(self) -> None:
         """Capture callee metadata for an outgoing call once it starts."""

--- a/src/yoyopod/coordinators/runtime.py
+++ b/src/yoyopod/coordinators/runtime.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
@@ -90,7 +90,6 @@ class CoordinatorRuntime:
     incoming_call_screen: IncomingCallScreen | None
     outgoing_call_screen: OutgoingCallScreen | None
     in_call_screen: InCallScreen | None
-    config: dict[str, Any]
     config_manager: ConfigManager | None
     music_backend: MusicBackend | None = None
     context: AppContext | None = None

--- a/src/yoyopod/runtime/boot.py
+++ b/src/yoyopod/runtime/boot.py
@@ -112,7 +112,6 @@ class RuntimeBootService:
             self.app.config_manager = ConfigManager(config_dir=self.app.config_dir)
             self.app.app_settings = self.app.config_manager.get_app_settings()
             self.app.media_settings = self.app.config_manager.get_media_settings()
-            self.app.config = self.app.config_manager.get_app_config_dict()
             self.app.people_directory = PeopleDirectory.from_config_manager(self.app.config_manager)
             self.app.call_history_store = CallHistoryStore(
                 self.app.config_manager.resolve_runtime_path(
@@ -246,7 +245,7 @@ class RuntimeBootService:
             logger.info("  - InputManager")
             self.app.input_manager = get_input_manager(
                 display_adapter=display.get_adapter(),
-                config=self.app.config,
+                input_settings=self.app.app_settings.input,
                 simulate=self.app.simulate,
             )
             if self.app.input_manager:
@@ -802,7 +801,6 @@ class RuntimeBootService:
             incoming_call_screen=self.app.incoming_call_screen,
             outgoing_call_screen=self.app.outgoing_call_screen,
             in_call_screen=self.app.in_call_screen,
-            config=self.app.config,
             config_manager=self.app.config_manager,
             context=self.app.context,
             ui_state=self.app._ui_state,

--- a/src/yoyopod/ui/input/factory.py
+++ b/src/yoyopod/ui/input/factory.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional
 
 from loguru import logger
 
+from yoyopod.config.models import AppInputConfig
 from yoyopod.ui.input.hal import InputAction, InteractionProfile
 from yoyopod.ui.input.manager import InputManager
 
@@ -42,6 +43,8 @@ def _get_simulated_hardware(display_adapter: object) -> str | None:
 def get_input_manager(
     display_adapter: object,
     config: Optional[Dict[str, Any]] = None,
+    *,
+    input_settings: AppInputConfig | None = None,
     simulate: bool = False,
 ) -> Optional[InputManager]:
     """
@@ -52,7 +55,8 @@ def get_input_manager(
 
     Args:
         display_adapter: Display adapter instance (to determine hardware type)
-        config: Configuration dict with input settings (optional)
+        config: Legacy configuration dict with input settings (optional)
+        input_settings: Typed input settings from the canonical app config
         simulate: Run in simulation mode (no hardware)
 
     Returns:
@@ -60,6 +64,8 @@ def get_input_manager(
     """
     config = config or {}
     input_config = config.get("input", {})
+    if not isinstance(input_config, dict):
+        input_config = {}
 
     manager = InputManager(interaction_profile=InteractionProfile.STANDARD)
     adapter_name = display_adapter.__class__.__name__
@@ -72,7 +78,11 @@ def get_input_manager(
     if display_type == "pimoroni":
         logger.info("  Detected Pimoroni Display HAT Mini")
         display_device = getattr(display_adapter, "device", None)
-        gpio_input_config = input_config.get("pimoroni_gpio", {})
+        gpio_input_config = (
+            input_settings.pimoroni_gpio
+            if input_settings is not None
+            else input_config.get("pimoroni_gpio", {})
+        )
 
         # Try Pi-native displayhatmini button reading first
         _has_displayhatmini = False
@@ -108,16 +118,32 @@ def get_input_manager(
     elif display_type == "whisplay":
         logger.info("  Detected Whisplay HAT")
         whisplay_device = getattr(display_adapter, "device", None)
-        enable_navigation = input_config.get("ptt_navigation", True)
+        enable_navigation = (
+            input_settings.ptt_navigation
+            if input_settings is not None
+            else input_config.get("ptt_navigation", True)
+        )
         if enable_navigation:
             manager.set_interaction_profile(InteractionProfile.ONE_BUTTON)
         else:
             logger.warning(
                 "  -> Whisplay raw PTT mode is experimental; keeping standard interaction profile",
             )
-        debounce_time = float(input_config.get("whisplay_debounce_ms", 50)) / 1000.0
-        double_click_time = float(input_config.get("whisplay_double_tap_ms", 300)) / 1000.0
-        long_press_time = float(input_config.get("whisplay_long_hold_ms", 800)) / 1000.0
+        debounce_time = float(
+            input_settings.whisplay_debounce_ms
+            if input_settings is not None
+            else input_config.get("whisplay_debounce_ms", 50)
+        ) / 1000.0
+        double_click_time = float(
+            input_settings.whisplay_double_tap_ms
+            if input_settings is not None
+            else input_config.get("whisplay_double_tap_ms", 300)
+        ) / 1000.0
+        long_press_time = float(
+            input_settings.whisplay_long_hold_ms
+            if input_settings is not None
+            else input_config.get("whisplay_long_hold_ms", 800)
+        ) / 1000.0
         adapter_simulate = bool(simulate or display_type == "simulation" or whisplay_device is None)
 
         if whisplay_device or adapter_simulate:

--- a/tests/test_call_coordinator.py
+++ b/tests/test_call_coordinator.py
@@ -1,0 +1,77 @@
+"""Focused tests for the call coordinator's config-driven status behavior."""
+
+from __future__ import annotations
+
+from yoyopod.app_context import AppContext
+from yoyopod.communication import RegistrationState
+from yoyopod.coordinators.call import CallCoordinator
+from yoyopod.coordinators.runtime import CoordinatorRuntime
+from yoyopod.fsm import CallFSM, CallInterruptionPolicy, MusicFSM
+
+
+class _ScreenCoordinatorStub:
+    """Small screen-coordinator double for call-coordinator tests."""
+
+    def __init__(self) -> None:
+        self.refresh_calls = 0
+
+    def refresh_call_screen_if_visible(self) -> None:
+        self.refresh_calls += 1
+
+
+class _ConfigManagerStub:
+    """Small config-manager double exposing only the SIP accessors under test."""
+
+    def __init__(self, *, sip_identity: str = "", sip_username: str = "") -> None:
+        self._sip_identity = sip_identity
+        self._sip_username = sip_username
+
+    def get_sip_identity(self) -> str:
+        return self._sip_identity
+
+    def get_sip_username(self) -> str:
+        return self._sip_username
+
+
+def _build_runtime(*, config_manager: _ConfigManagerStub, context: AppContext) -> CoordinatorRuntime:
+    """Create the minimal coordinator runtime required by CallCoordinator."""
+
+    return CoordinatorRuntime(
+        music_fsm=MusicFSM(),
+        call_fsm=CallFSM(),
+        call_interruption_policy=CallInterruptionPolicy(),
+        screen_manager=None,
+        music_backend=None,
+        power_manager=None,
+        now_playing_screen=None,
+        call_screen=None,
+        power_screen=None,
+        incoming_call_screen=None,
+        outgoing_call_screen=None,
+        in_call_screen=None,
+        config_manager=config_manager,
+        context=context,
+    )
+
+
+def test_registration_change_uses_config_manager_for_voip_configured_status() -> None:
+    """VoIP status should come from the canonical config manager, not legacy app config dicts."""
+
+    context = AppContext()
+    runtime = _build_runtime(
+        config_manager=_ConfigManagerStub(sip_username="kid@example.com"),
+        context=context,
+    )
+    screen_coordinator = _ScreenCoordinatorStub()
+    coordinator = CallCoordinator(
+        runtime=runtime,
+        screen_coordinator=screen_coordinator,
+        auto_resume_after_call=True,
+    )
+
+    coordinator.handle_registration_change(RegistrationState.OK)
+
+    assert context.voip.configured is True
+    assert context.voip.ready is True
+    assert runtime.voip_ready is True
+    assert screen_coordinator.refresh_calls == 1

--- a/tests/test_fsm_runtime.py
+++ b/tests/test_fsm_runtime.py
@@ -25,7 +25,6 @@ def _build_runtime() -> CoordinatorRuntime:
         incoming_call_screen=None,
         outgoing_call_screen=None,
         in_call_screen=None,
-        config={},
         config_manager=None,
     )
 

--- a/tests/test_input_factory.py
+++ b/tests/test_input_factory.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import sys
+import types
+
+from yoyopod.config.models import AppInputConfig
 from yoyopod.ui.input.hal import InputAction
 from yoyopod.ui.input import InteractionProfile, get_input_manager
 from yoyopod.ui.input.adapters.ptt_button import PTTInputAdapter
@@ -27,14 +31,12 @@ def test_whisplay_factory_applies_one_button_profile_and_custom_timings() -> Non
     """Whisplay factory wiring should pass typed timing settings into the adapter."""
     manager = get_input_manager(
         WhisplayDisplayAdapter(),
-        config={
-            "input": {
-                "ptt_navigation": True,
-                "whisplay_debounce_ms": 80,
-                "whisplay_double_tap_ms": 240,
-                "whisplay_long_hold_ms": 950,
-            }
-        },
+        input_settings=AppInputConfig(
+            ptt_navigation=True,
+            whisplay_debounce_ms=80,
+            whisplay_double_tap_ms=240,
+            whisplay_long_hold_ms=950,
+        ),
         simulate=True,
     )
 
@@ -79,9 +81,9 @@ def test_simulation_factory_uses_whisplay_profile_and_browser_buttons(monkeypatc
 
     server = FakeServer()
 
-    import yoyopod.ui.web_server as web_server
-
-    monkeypatch.setattr(web_server, "get_server", lambda *args, **kwargs: server)
+    fake_web_server = types.ModuleType("yoyopod.ui.web_server")
+    fake_web_server.get_server = lambda *args, **kwargs: server
+    monkeypatch.setitem(sys.modules, "yoyopod.ui.web_server", fake_web_server)
 
     manager = get_input_manager(
         SimulationDisplayAdapter(),


### PR DESCRIPTION
## Summary
- finish the remaining app/runtime shell cleanup by routing boot/runtime wiring through the canonical config manager and current package paths
- tighten the input factory so it understands typed display identities, preserves the standard simulation controls, and covers Whisplay profile behavior with focused tests
- clean the related docs and agent guidance so the canonical package/runtime topology matches the repo as it exists now

## Validation
- `uv run pytest -q tests/test_input_factory.py tests/test_call_coordinator.py tests/test_fsm_runtime.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`

## Notes
- I intentionally did **not** stage the unrelated dirty file `data/test_messages/messages.json`.
