### PR TITLE
[codex] Optimize Whisplay/PIL render hot paths for target-device responsiveness

### DIFF
--- a/src/yoyopod/ui/display/adapters/whisplay.py
+++ b/src/yoyopod/ui/display/adapters/whisplay.py
@@ -18,6 +18,7 @@ Date: 2025-11-30
 
 from importlib import import_module
 from pathlib import Path
+import time
 from types import ModuleType
 from typing import Optional, Tuple
 
@@ -28,6 +29,7 @@ from yoyopod.ui.display.adapters.whisplay_paths import ensure_whisplay_driver_on
 from yoyopod.ui.display.hal import DisplayHAL
 
 DRIVER_PATH = ensure_whisplay_driver_on_path()
+DEFAULT_FONT_PATH = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
 
 
 def _normalize_gpiochip_path(candidate: object) -> object:
@@ -148,6 +150,9 @@ class WhisplayDisplayAdapter(DisplayHAL):
     HEIGHT = 280
     ORIENTATION = "portrait"
     STATUS_BAR_HEIGHT = 25  # Slightly taller for portrait mode
+    _SLOW_FULL_FRAME_UPDATE_THRESHOLD_SECONDS = 0.03
+    _SLOW_REGION_FLUSH_THRESHOLD_SECONDS = 0.008
+    _PARTIAL_FLUSH_TIMING_LOG_INTERVAL = 60
 
     def __init__(
         self,
@@ -169,6 +174,21 @@ class WhisplayDisplayAdapter(DisplayHAL):
         self.lvgl_buffer_lines = max(1, int(lvgl_buffer_lines))
         self.ui_backend = None
         self._force_shadow_buffer_sync = False
+        self._font_cache: dict[tuple[str, int], object] = {}
+        self._timing_metrics: dict[str, float | int] = {
+            "full_frame_updates": 0,
+            "last_full_frame_convert_ms": 0.0,
+            "last_full_frame_device_ms": 0.0,
+            "last_full_frame_total_ms": 0.0,
+            "max_full_frame_total_ms": 0.0,
+            "partial_flushes": 0,
+            "partial_flush_shadow_syncs": 0,
+            "last_partial_flush_device_ms": 0.0,
+            "last_partial_flush_shadow_ms": 0.0,
+            "last_partial_flush_total_ms": 0.0,
+            "max_partial_flush_total_ms": 0.0,
+            "partial_flush_total_ms": 0.0,
+        }
 
         # Create PIL drawing buffer
         self._create_buffer()
@@ -228,6 +248,151 @@ class WhisplayDisplayAdapter(DisplayHAL):
         self.buffer = Image.new("RGB", (self.WIDTH, self.HEIGHT), self.COLOR_BLACK)
         self.draw = ImageDraw.Draw(self.buffer)
 
+    def _load_font(
+        self,
+        font_size: int,
+        font_path: Optional[Path] = None,
+    ) -> object:
+        """Load and cache the requested font once per path/size pair."""
+
+        resolved_path: Path | None = None
+        if font_path is not None and font_path.exists():
+            resolved_path = font_path
+        elif DEFAULT_FONT_PATH.exists():
+            resolved_path = DEFAULT_FONT_PATH
+
+        cache_key = (
+            str(resolved_path.resolve()) if resolved_path is not None else "__pil_default__",
+            font_size,
+        )
+        cached_font = self._font_cache.get(cache_key)
+        if cached_font is not None:
+            return cached_font
+
+        try:
+            if resolved_path is not None:
+                font = ImageFont.truetype(str(resolved_path), font_size)
+            else:
+                font = ImageFont.load_default()
+        except Exception as e:
+            logger.warning("Failed to load font {} at {} px: {}", resolved_path, font_size, e)
+            cache_key = ("__pil_default__", font_size)
+            cached_font = self._font_cache.get(cache_key)
+            if cached_font is not None:
+                return cached_font
+            font = ImageFont.load_default()
+
+        self._font_cache[cache_key] = font
+        return font
+
+    @staticmethod
+    def _rgb565_to_image(width: int, height: int, pixel_data: bytes) -> Image.Image:
+        """Decode big-endian RGB565 bytes into a PIL image."""
+
+        swapped = bytearray(len(pixel_data))
+        swapped[0::2] = pixel_data[1::2]
+        swapped[1::2] = pixel_data[0::2]
+        return Image.frombytes("RGB", (width, height), bytes(swapped), "raw", "BGR;16")
+
+    def _record_partial_flush_timing(
+        self,
+        *,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        device_seconds: float,
+        shadow_seconds: float,
+        total_seconds: float,
+        shadow_synced: bool,
+    ) -> None:
+        """Record lightweight timing visibility for LVGL partial flushes."""
+
+        metrics = self._timing_metrics
+        metrics["partial_flushes"] = int(metrics["partial_flushes"]) + 1
+        if shadow_synced:
+            metrics["partial_flush_shadow_syncs"] = int(metrics["partial_flush_shadow_syncs"]) + 1
+        metrics["last_partial_flush_device_ms"] = device_seconds * 1000.0
+        metrics["last_partial_flush_shadow_ms"] = shadow_seconds * 1000.0
+        metrics["last_partial_flush_total_ms"] = total_seconds * 1000.0
+        metrics["partial_flush_total_ms"] = float(metrics["partial_flush_total_ms"]) + (
+            total_seconds * 1000.0
+        )
+        metrics["max_partial_flush_total_ms"] = max(
+            float(metrics["max_partial_flush_total_ms"]),
+            total_seconds * 1000.0,
+        )
+
+        if total_seconds >= self._SLOW_REGION_FLUSH_THRESHOLD_SECONDS:
+            logger.warning(
+                "Slow Whisplay RGB565 flush: area={}x{} at {},{} total_ms={:.1f} device_ms={:.1f} shadow_ms={:.1f} shadow_sync={}",
+                width,
+                height,
+                x,
+                y,
+                total_seconds * 1000.0,
+                device_seconds * 1000.0,
+                shadow_seconds * 1000.0,
+                shadow_synced,
+            )
+            return
+
+        flush_count = int(metrics["partial_flushes"])
+        if flush_count % self._PARTIAL_FLUSH_TIMING_LOG_INTERVAL == 0:
+            average_ms = float(metrics["partial_flush_total_ms"]) / max(1, flush_count)
+            logger.debug(
+                "Whisplay RGB565 flush timing: flushes={} avg_ms={:.1f} max_ms={:.1f} shadow_syncs={}",
+                flush_count,
+                average_ms,
+                float(metrics["max_partial_flush_total_ms"]),
+                int(metrics["partial_flush_shadow_syncs"]),
+            )
+
+    def _record_full_frame_timing(
+        self,
+        *,
+        convert_seconds: float,
+        device_seconds: float,
+        total_seconds: float,
+    ) -> None:
+        """Record timing visibility for the PIL full-frame update path."""
+
+        metrics = self._timing_metrics
+        metrics["full_frame_updates"] = int(metrics["full_frame_updates"]) + 1
+        metrics["last_full_frame_convert_ms"] = convert_seconds * 1000.0
+        metrics["last_full_frame_device_ms"] = device_seconds * 1000.0
+        metrics["last_full_frame_total_ms"] = total_seconds * 1000.0
+        metrics["max_full_frame_total_ms"] = max(
+            float(metrics["max_full_frame_total_ms"]),
+            total_seconds * 1000.0,
+        )
+
+        if total_seconds >= self._SLOW_FULL_FRAME_UPDATE_THRESHOLD_SECONDS:
+            logger.warning(
+                "Slow Whisplay full-frame update: convert_ms={:.1f} device_ms={:.1f} total_ms={:.1f}",
+                convert_seconds * 1000.0,
+                device_seconds * 1000.0,
+                total_seconds * 1000.0,
+            )
+            return
+
+        logger.debug(
+            "Whisplay full-frame update timing: convert_ms={:.1f} device_ms={:.1f} total_ms={:.1f}",
+            convert_seconds * 1000.0,
+            device_seconds * 1000.0,
+            total_seconds * 1000.0,
+        )
+
+    def timing_snapshot(self) -> dict[str, float | int]:
+        """Return the most recent Whisplay render/update timing metrics."""
+
+        metrics = dict(self._timing_metrics)
+        flush_count = int(metrics["partial_flushes"])
+        metrics["avg_partial_flush_ms"] = (
+            float(metrics["partial_flush_total_ms"]) / max(1, flush_count) if flush_count else 0.0
+        )
+        return metrics
+
     def _convert_to_rgb565(self) -> bytes:
         """
         Convert PIL RGB888 buffer to RGB565 byte array for Whisplay display.
@@ -241,21 +406,25 @@ class WhisplayDisplayAdapter(DisplayHAL):
         Returns:
             Byte array in RGB565 format (big-endian)
         """
-        pixel_data = []
+        if self.buffer is None:
+            return b""
 
-        for y in range(self.HEIGHT):
-            for x in range(self.WIDTH):
-                # Get RGB888 pixel from PIL buffer
-                r, g, b = self.buffer.getpixel((x, y))
+        rgb_bytes = self.buffer.tobytes()
+        pixel_count = self.WIDTH * self.HEIGHT
+        pixel_data = bytearray(pixel_count * 2)
 
-                # Convert to RGB565
-                # R: 8 bits -> 5 bits (keep upper 5 bits)
-                # G: 8 bits -> 6 bits (keep upper 6 bits)
-                # B: 8 bits -> 5 bits (keep upper 5 bits)
-                rgb565 = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3)
+        src_index = 0
+        dst_index = 0
+        for _ in range(pixel_count):
+            red = rgb_bytes[src_index]
+            green = rgb_bytes[src_index + 1]
+            blue = rgb_bytes[src_index + 2]
+            src_index += 3
 
-                # Split into 2 bytes (big-endian)
-                pixel_data.extend([(rgb565 >> 8) & 0xFF, rgb565 & 0xFF])
+            rgb565 = ((red & 0xF8) << 8) | ((green & 0xFC) << 3) | (blue >> 3)
+            pixel_data[dst_index] = (rgb565 >> 8) & 0xFF
+            pixel_data[dst_index + 1] = rgb565 & 0xFF
+            dst_index += 2
 
         return bytes(pixel_data)
 
@@ -272,16 +441,7 @@ class WhisplayDisplayAdapter(DisplayHAL):
         if self.buffer is None:
             return
 
-        region = Image.new("RGB", (width, height))
-        pixels: list[tuple[int, int, int]] = []
-        for index in range(0, len(pixel_data), 2):
-            rgb565 = (pixel_data[index] << 8) | pixel_data[index + 1]
-            red = ((rgb565 >> 11) & 0x1F) * 255 // 31
-            green = ((rgb565 >> 5) & 0x3F) * 255 // 63
-            blue = (rgb565 & 0x1F) * 255 // 31
-            pixels.append((red, green, blue))
-
-        region.putdata(pixels)
+        region = self._rgb565_to_image(width, height, pixel_data)
         self.buffer.paste(region, (x, y))
 
     def draw_rgb565_region(
@@ -294,13 +454,30 @@ class WhisplayDisplayAdapter(DisplayHAL):
     ) -> None:
         """Write an RGB565 region to hardware and optionally the PIL shadow buffer."""
 
+        started_at = time.monotonic()
+        device_started_at = started_at
         if not self.simulate and self.device:
             self.device.draw_image(x, y, width, height, pixel_data)
+        device_seconds = max(0.0, time.monotonic() - device_started_at)
 
         # Keep the PIL buffer in sync only when it is the active renderer or simulation target.
         # Doing this for every LVGL partial flush on hardware is too expensive on the Pi.
-        if self.shadow_buffer_sync_enabled:
+        shadow_started_at = time.monotonic()
+        shadow_synced = self.shadow_buffer_sync_enabled
+        if shadow_synced:
             self._paste_rgb565_region(x, y, width, height, pixel_data)
+        shadow_seconds = max(0.0, time.monotonic() - shadow_started_at) if shadow_synced else 0.0
+        total_seconds = max(0.0, time.monotonic() - started_at)
+        self._record_partial_flush_timing(
+            x=x,
+            y=y,
+            width=width,
+            height=height,
+            device_seconds=device_seconds,
+            shadow_seconds=shadow_seconds,
+            total_seconds=total_seconds,
+            shadow_synced=shadow_synced,
+        )
 
     def clear(self, color: Optional[Tuple[int, int, int]] = None) -> None:
         """Clear the display with specified color."""
@@ -323,21 +500,7 @@ class WhisplayDisplayAdapter(DisplayHAL):
         if color is None:
             color = self.COLOR_WHITE
 
-        try:
-            if font_path and font_path.exists():
-                font = ImageFont.truetype(str(font_path), font_size)
-            else:
-                # Try to use default system font
-                try:
-                    font = ImageFont.truetype(
-                        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", font_size
-                    )
-                except Exception:
-                    font = ImageFont.load_default()
-        except Exception as e:
-            logger.warning(f"Failed to load font: {e}, using default")
-            font = ImageFont.load_default()
-
+        font = self._load_font(font_size, font_path)
         self.draw.text((x, y), text, fill=color, font=font)
 
     def rectangle(
@@ -506,12 +669,20 @@ class WhisplayDisplayAdapter(DisplayHAL):
 
         if not self.simulate and self.device:
             try:
-                # Convert PIL buffer to RGB565 byte array
+                started_at = time.monotonic()
+                convert_started_at = started_at
                 pixel_data = self._convert_to_rgb565()
+                convert_seconds = max(0.0, time.monotonic() - convert_started_at)
 
-                # Send to Whisplay display
+                device_started_at = time.monotonic()
                 self.device.draw_image(0, 0, self.WIDTH, self.HEIGHT, pixel_data)
-                logger.debug("Whisplay display updated")
+                device_seconds = max(0.0, time.monotonic() - device_started_at)
+                total_seconds = max(0.0, time.monotonic() - started_at)
+                self._record_full_frame_timing(
+                    convert_seconds=convert_seconds,
+                    device_seconds=device_seconds,
+                    total_seconds=total_seconds,
+                )
             except Exception as e:
                 logger.error(f"Failed to update Whisplay display: {e}")
         else:
@@ -586,19 +757,7 @@ class WhisplayDisplayAdapter(DisplayHAL):
                 logger.error("LVGL snapshot returned no data")
                 return False
 
-            # Convert RGB565_SWAPPED to RGB888 PIL Image
-            from PIL import Image as PilImage
-
-            img = PilImage.new("RGB", (self.WIDTH, self.HEIGHT))
-            pixels: list[tuple[int, int, int]] = []
-            for index in range(0, len(pixel_data), 2):
-                rgb565 = (pixel_data[index] << 8) | pixel_data[index + 1]
-                red = ((rgb565 >> 11) & 0x1F) * 255 // 31
-                green = ((rgb565 >> 5) & 0x3F) * 255 // 63
-                blue = (rgb565 & 0x1F) * 255 // 31
-                pixels.append((red, green, blue))
-
-            img.putdata(pixels)
+            img = self._rgb565_to_image(self.WIDTH, self.HEIGHT, pixel_data)
             img.save(path, "PNG")
             logger.info("LVGL readback screenshot saved to {}", path)
             return True
@@ -645,10 +804,7 @@ class WhisplayDisplayAdapter(DisplayHAL):
 
     def get_text_size(self, text: str, font_size: int = 16) -> Tuple[int, int]:
         """Calculate rendered text dimensions."""
-        try:
-            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", font_size)
-        except Exception:
-            font = ImageFont.load_default()
+        font = self._load_font(font_size)
 
         bbox = self.draw.textbbox((0, 0), text, font=font)
         return (bbox[2] - bbox[0], bbox[3] - bbox[1])

--- a/src/yoyopod/ui/screens/theme.py
+++ b/src/yoyopod/ui/screens/theme.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from PIL import Image
-
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.theme_assets import ICON_ASSET_DIR, PHOSPHOR_ICON_FILES, load_icon_asset
+from yoyopod.ui.screens.theme_assets import (
+    ICON_ASSET_DIR,
+    PHOSPHOR_ICON_FILES,
+    load_icon_variant,
+)
 from yoyopod.ui.screens.theme_text import mix, text_fit, wrap_text
 from yoyopod.ui.screens.theme_tokens import (
     ASK,
@@ -64,6 +66,21 @@ from yoyopod.ui.screens.theme_tokens import (
 
 if TYPE_CHECKING:
     from yoyopod.app_context import AppContext
+
+
+__all__ = [
+    "ASK",
+    "BACKGROUND",
+    "FOOTER_BAR",
+    "ICON_ASSET_DIR",
+    "INK",
+    "LISTEN",
+    "MUTED",
+    "NEUTRAL",
+    "SETUP",
+    "TALK",
+    "WARNING",
+]
 
 
 def _get_draw(display: Display):
@@ -911,16 +928,14 @@ def _paste_phosphor_icon(
     if buffer is None:
         return False
 
-    source = load_icon_asset(filename)
-    if source is None:
+    rendered = load_icon_variant(filename, size, color)
+    if rendered is None:
         return False
 
-    rendered = source.resize((size, size), Image.Resampling.LANCZOS)
-    alpha = rendered.getchannel("A")
-    tinted = Image.new("RGBA", rendered.size, color + (0,))
-    tinted.putalpha(alpha)
-    buffer.paste(tinted, (x, y), tinted)
+    buffer.paste(rendered, (x, y), rendered)
     return True
+
+
 def _draw_listen_icon(display: Display, draw, x: int, y: int, size: int, color: Color) -> None:
     stroke = max(2, size // 14)
     pad = max(4, size // 6)

--- a/src/yoyopod/ui/screens/theme_assets.py
+++ b/src/yoyopod/ui/screens/theme_assets.py
@@ -17,6 +17,7 @@ PHOSPHOR_ICON_FILES = {
     "power": "gear-six.png",
 }
 ICON_CACHE: dict[str, Image.Image] = {}
+ICON_VARIANT_CACHE: dict[tuple[str, int, tuple[int, int, int]], Image.Image] = {}
 
 
 def load_icon_asset(filename: str) -> Image.Image | None:
@@ -34,3 +35,27 @@ def load_icon_asset(filename: str) -> Image.Image | None:
         rgba_icon = icon.convert("RGBA")
     ICON_CACHE[filename] = rgba_icon
     return rgba_icon
+
+
+def load_icon_variant(
+    filename: str,
+    size: int,
+    color: tuple[int, int, int],
+) -> Image.Image | None:
+    """Load, resize, tint, and cache a reusable icon variant."""
+
+    cache_key = (filename, size, color)
+    cached = ICON_VARIANT_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    source = load_icon_asset(filename)
+    if source is None:
+        return None
+
+    rendered = source.resize((size, size), Image.Resampling.LANCZOS)
+    alpha = rendered.getchannel("A")
+    tinted = Image.new("RGBA", rendered.size, color + (0,))
+    tinted.putalpha(alpha)
+    ICON_VARIANT_CACHE[cache_key] = tinted
+    return tinted

--- a/tests/test_theme_icons.py
+++ b/tests/test_theme_icons.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from PIL import Image, ImageChops
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.theme import BACKGROUND, FOOTER_BAR, ICON_ASSET_DIR, draw_icon, render_footer
+from yoyopod.ui.screens.theme import FOOTER_BAR, ICON_ASSET_DIR, draw_icon, render_footer
+from yoyopod.ui.screens.theme_assets import ICON_VARIANT_CACHE, load_icon_variant
 
 
 def test_hub_icon_assets_exist_and_are_56px() -> None:
@@ -58,3 +59,19 @@ def test_render_footer_reserves_a_clean_bottom_strip() -> None:
         assert ImageChops.difference(footer_strip, footer_bar_strip).getbbox() is not None
     finally:
         display.cleanup()
+
+
+def test_icon_variants_are_cached_by_filename_size_and_color() -> None:
+    """Repeated icon draws should reuse the same resized+tinted asset variant."""
+
+    ICON_VARIANT_CACHE.clear()
+
+    first = load_icon_variant("hub-listen.png", 24, (255, 255, 255))
+    second = load_icon_variant("hub-listen.png", 24, (255, 255, 255))
+    third = load_icon_variant("hub-listen.png", 24, (0, 255, 0))
+
+    assert first is not None
+    assert first is second
+    assert third is not None
+    assert third is not first
+    assert len(ICON_VARIANT_CACHE) == 2

--- a/tests/test_whisplay_adapter.py
+++ b/tests/test_whisplay_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
 
 from yoyopod.ui.display.adapters.whisplay import (
     WhisplayDisplayAdapter,
@@ -253,3 +253,81 @@ def test_simulated_whisplay_adapter_does_not_own_browser_preview() -> None:
     adapter.update()
 
     assert not hasattr(adapter, "web_server")
+
+
+def test_whisplay_font_cache_reuses_loaded_fonts(monkeypatch) -> None:
+    """Repeated text draws should not reload the same font on every call."""
+
+    adapter = WhisplayDisplayAdapter(simulate=True, renderer="pil")
+    adapter._font_cache.clear()
+
+    original_truetype = ImageFont.truetype
+    load_calls: list[tuple[str, int]] = []
+
+    def counting_truetype(path: str, size: int, *args, **kwargs):
+        load_calls.append((path, size))
+        return original_truetype(path, size, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "yoyopod.ui.display.adapters.whisplay.ImageFont.truetype", counting_truetype
+    )
+
+    adapter.text("Hello", 4, 4, font_size=16)
+    adapter.text("Again", 4, 24, font_size=16)
+    adapter.get_text_size("Measured", 16)
+
+    assert len(load_calls) == 1
+
+
+def test_rgb565_conversion_matches_expected_byte_order() -> None:
+    """The optimized conversion should preserve the adapter's big-endian RGB565 contract."""
+
+    adapter = WhisplayDisplayAdapter(simulate=True, renderer="pil")
+    adapter.WIDTH = 2
+    adapter.HEIGHT = 1
+    adapter.buffer = Image.new("RGB", (2, 1))
+    adapter.draw = ImageDraw.Draw(adapter.buffer)
+    adapter.buffer.putdata([(255, 0, 0), (0, 255, 0)])
+
+    assert adapter._convert_to_rgb565() == bytes.fromhex("f80007e0")
+
+
+def test_paste_rgb565_region_decodes_into_shadow_buffer() -> None:
+    """Shadow-buffer region pastes should decode RGB565 bytes back into RGB pixels."""
+
+    adapter = WhisplayDisplayAdapter(simulate=True, renderer="pil")
+    adapter.WIDTH = 2
+    adapter.HEIGHT = 1
+    adapter.buffer = Image.new("RGB", (2, 1))
+    adapter.draw = ImageDraw.Draw(adapter.buffer)
+
+    adapter._paste_rgb565_region(0, 0, 2, 1, bytes.fromhex("f80007e0"))
+
+    assert adapter.buffer.getpixel((0, 0)) == (255, 0, 0)
+    assert adapter.buffer.getpixel((1, 0)) == (0, 255, 0)
+
+
+def test_timing_snapshot_tracks_full_frame_and_partial_flushes() -> None:
+    """The adapter should expose recent timing metrics for both update paths."""
+
+    adapter = WhisplayDisplayAdapter(simulate=True, renderer="pil")
+    adapter.WIDTH = 2
+    adapter.HEIGHT = 1
+    adapter.buffer = Image.new("RGB", (2, 1))
+    adapter.draw = ImageDraw.Draw(adapter.buffer)
+    adapter.buffer.putdata([(255, 0, 0), (0, 255, 0)])
+
+    adapter.simulate = False
+    adapter.device = FakeDevice()
+    adapter.update()
+
+    adapter.simulate = True
+    adapter.draw_rgb565_region(0, 0, 2, 1, bytes.fromhex("f80007e0"))
+
+    snapshot = adapter.timing_snapshot()
+
+    assert snapshot["full_frame_updates"] == 1
+    assert snapshot["partial_flushes"] == 1
+    assert snapshot["last_full_frame_total_ms"] >= 0.0
+    assert snapshot["last_partial_flush_total_ms"] >= 0.0
+    assert snapshot["avg_partial_flush_ms"] >= 0.0


### PR DESCRIPTION
## Summary
- cache Whisplay font objects so repeated `text()` and `get_text_size()` calls stop reloading the same font file
- replace the Whisplay full-frame RGB565 `getpixel()` loop with a sequential byte conversion path, and decode RGB565 shadow/readback regions through Pillow's raw image path
- cache tinted Phosphor icon variants so repeated theme icon draws reuse the same resize+tint result
- add lightweight timing visibility for both full-frame PIL updates and partial RGB565 flushes via logs plus `WhisplayDisplayAdapter.timing_snapshot()`

## Evidence
Local microbench on this branch after the change:
- `_convert_to_rgb565()`: `88.268 ms -> 30.297 ms` average over 10 runs
- repeated `adapter.text(..., font_size=16)`: `0.893 ms -> 0.597 ms` average over 200 runs
- repeated `draw_icon("listen", 24px, white)`: `0.188 ms -> 0.063 ms` average over 200 runs

## Testing
- `uv run pytest -q tests/test_whisplay_adapter.py`
- `uv run pytest -q tests/test_theme_icons.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q` (`544 passed`)

## Notes
- simulation/debug behavior stays intact: simulated LVGL still mirrors into the PIL shadow buffer, while hardware LVGL continues to skip per-flush shadow sync except when screenshots explicitly force it
- this PR stays in the Whisplay/PIL hot path only; it does not change broader UI structure or LVGL scene ownership

Closes #159