### PR TITLE
[codex] Reduce unnecessary local-music library scans and playlist I/O

### DIFF
--- a/src/yoyopod/audio/local_service.py
+++ b/src/yoyopod/audio/local_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import random
 from collections import deque
 from dataclasses import dataclass
@@ -14,7 +15,7 @@ from yoyopod.audio.history import RecentTrackEntry, RecentTrackHistoryStore
 from yoyopod.audio.music.backend import MusicBackend
 from yoyopod.audio.music.models import Playlist, Track
 
-AUDIO_EXTENSIONS = ("*.mp3", "*.flac", "*.ogg", "*.wav", "*.m4a", "*.opus")
+AUDIO_EXTENSIONS = (".mp3", ".flac", ".ogg", ".wav", ".m4a", ".opus")
 LEGACY_PLAYLIST_SCHEMES = ("m3u:",)
 LEGACY_TRACK_SCHEMES = ("local:", "file:")
 LEGACY_LIBRARY_ROOTS = ("file:", "local:directory")
@@ -79,11 +80,7 @@ class LocalMusicService:
         if self.music_dir.is_dir():
             playlists: list[Playlist] = []
             for p in sorted(self.music_dir.glob("**/*.m3u")):
-                try:
-                    lines = p.read_text(encoding="utf-8", errors="replace").splitlines()
-                    track_count = sum(1 for ln in lines if ln.strip() and not ln.startswith("#"))
-                except OSError:
-                    track_count = 0
+                track_count = self._count_playlist_tracks(p) if fetch_track_counts else 0
                 playlists.append(Playlist(uri=str(p), name=p.stem, track_count=track_count))
             return playlists
 
@@ -173,15 +170,22 @@ class LocalMusicService:
     def _collect_local_track_uris(self) -> list[str]:
         """Scan the music directory for audio files."""
         tracks: list[str] = []
-        seen: set[str] = set()
 
         if self.music_dir.is_dir():
+            tracks_by_extension: dict[str, list[str]] = {ext: [] for ext in AUDIO_EXTENSIONS}
+
+            # Keep the previous extension bucket ordering without paying for one
+            # recursive filesystem glob per extension.
+            for root, dirnames, filenames in os.walk(self.music_dir):
+                dirnames.sort()
+                for filename in sorted(filenames):
+                    ext = Path(filename).suffix.lower()
+                    if ext not in tracks_by_extension:
+                        continue
+                    tracks_by_extension[ext].append(str(Path(root) / filename))
+
             for ext in AUDIO_EXTENSIONS:
-                for p in self.music_dir.glob(f"**/{ext}"):
-                    s = str(p)
-                    if s not in seen:
-                        seen.add(s)
-                        tracks.append(s)
+                tracks.extend(tracks_by_extension[ext])
             if tracks:
                 return tracks
 
@@ -221,3 +225,11 @@ class LocalMusicService:
                 return tracks
 
         return tracks
+
+    def _count_playlist_tracks(self, path: Path) -> int:
+        """Return the number of playable entries declared in one M3U file."""
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            return 0
+        return sum(1 for line in lines if line.strip() and not line.startswith("#"))

--- a/tests/test_local_music_service.py
+++ b/tests/test_local_music_service.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+import yoyopod.audio.local_service as local_service_module
 from yoyopod.audio import LocalMusicService, MockMusicBackend, RecentTrackHistoryStore, Track
 from yoyopod.coordinators.playback import PlaybackCoordinator
 
@@ -29,7 +32,9 @@ class StubScreenCoordinator:
         self.now_playing_refreshes += 1
 
 
-def test_local_music_service_scans_playlists_and_loads_local_only(tmp_path: Path) -> None:
+def test_local_music_service_scans_playlists_with_track_counts_and_loads_local_only(
+    tmp_path: Path,
+) -> None:
     music_dir = tmp_path / "Music"
     music_dir.mkdir()
     playlist_path = music_dir / "local-mix.m3u"
@@ -39,13 +44,35 @@ def test_local_music_service_scans_playlists_and_loads_local_only(tmp_path: Path
     backend.start()
     service = LocalMusicService(backend, music_dir=music_dir)
 
-    playlists = service.list_playlists()
+    playlists = service.list_playlists(fetch_track_counts=True)
 
     assert [playlist.name for playlist in playlists] == ["local-mix"]
     assert playlists[0].track_count == 2
     assert service.load_playlist(str(playlist_path)) is True
     assert backend.commands[-1] == f"load_playlist:{playlist_path}"
     assert service.load_playlist(str(tmp_path / "outside.m3u")) is False
+
+
+def test_local_music_service_skips_playlist_track_counts_when_not_requested(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    music_dir = tmp_path / "Music"
+    music_dir.mkdir()
+    playlist_path = music_dir / "local-mix.m3u"
+    playlist_path.write_text("#EXTM3U\ntrack-a.mp3\ntrack-b.mp3\n", encoding="utf-8")
+
+    service = LocalMusicService(None, music_dir=music_dir)
+
+    def _fail_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        raise AssertionError(f"unexpected playlist file read for {self}")
+
+    monkeypatch.setattr(Path, "read_text", _fail_read_text)
+
+    playlists = service.list_playlists(fetch_track_counts=False)
+
+    assert [playlist.name for playlist in playlists] == ["local-mix"]
+    assert playlists[0].track_count == 0
 
 
 def test_recent_track_history_store_deduplicates_and_persists(tmp_path: Path) -> None:
@@ -77,6 +104,40 @@ def test_local_music_service_shuffle_collects_local_tracks_and_starts_playback(t
 
     assert service.shuffle_all() is True
     assert backend.commands[-1] == "load_tracks:2"
+
+
+def test_local_music_service_collects_tracks_with_single_library_walk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    music_dir = tmp_path / "Music"
+    albums_dir = music_dir / "Albums"
+    singles_dir = music_dir / "Singles"
+    albums_dir.mkdir(parents=True)
+    singles_dir.mkdir()
+    (albums_dir / "bravo.flac").write_bytes(b"b")
+    (singles_dir / "alpha.mp3").write_bytes(b"a")
+    (singles_dir / "ignore.txt").write_text("skip", encoding="utf-8")
+    (music_dir / "charlie.opus").write_bytes(b"c")
+
+    service = LocalMusicService(None, music_dir=music_dir)
+    walk_calls: list[Path] = []
+    original_walk = local_service_module.os.walk
+
+    def _counting_walk(root: Path, *args: object, **kwargs: object):
+        walk_calls.append(root)
+        yield from original_walk(root, *args, **kwargs)
+
+    monkeypatch.setattr(local_service_module.os, "walk", _counting_walk)
+
+    track_uris = service._collect_local_track_uris()
+
+    assert walk_calls == [music_dir]
+    assert track_uris == [
+        str(singles_dir / "alpha.mp3"),
+        str(albums_dir / "bravo.flac"),
+        str(music_dir / "charlie.opus"),
+    ]
 
 
 def test_playback_coordinator_records_recent_local_tracks(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- avoid reading each playlist file when `fetch_track_counts=False`
- replace repeated extension-specific recursive globs with one ordered library walk
- add focused tests covering the cheaper playlist and library scan paths

## Validation
- `uv run pytest -q tests/test_local_music_service.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`
- initial sandboxed full-suite run hit AF_UNIX bind restrictions in `tests/test_mpv_ipc.py`; reran unsandboxed and the full suite passed (`546 passed`)

## Notes
- keeps the local-library ordering stable by preserving extension-bucket output order while reducing filesystem walks
- the unrelated dirty fixture file `data/test_messages/messages.json` was left untouched and is not part of this branch