### PR TITLE
[codex] Make missing dev dependencies fail gracefully during bootstrap and test collection

### DIFF
--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -28,6 +28,8 @@ uv run yoyoctl setup verify-host
 
 These commands define the baseline executable setup contract. They do not yet
 cover non-apt assets like Vosk models or every board/modem-specific setup edge.
+If `yoyoctl` reports that the contributor CLI dependencies are missing, run
+`uv sync --extra dev` and retry.
 
 If you plan to use the remote Pi workflow from your dev machine, verify the
 extra host tools explicitly:

--- a/docs/SETUP_CONTRACT.md
+++ b/docs/SETUP_CONTRACT.md
@@ -58,6 +58,8 @@ uv run yoyoctl setup host
 
 This is the executable baseline, not full setup ownership. It does not provision
 non-apt assets like Vosk models or cover every board-specific edge.
+If `yoyoctl` is invoked before the contributor CLI stack is present, it should
+now exit with a short bootstrap hint instead of crashing during import.
 
 Current repo-owned validation baseline:
 

--- a/src/yoyopod/cli/__init__.py
+++ b/src/yoyopod/cli/__init__.py
@@ -2,48 +2,86 @@
 
 from __future__ import annotations
 
+import importlib
 import os
+import sys
+from functools import lru_cache
+from typing import Any
 
 os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
 
-try:
-    import typer
-except ImportError:
-    import sys
-
-    print(
-        "yoyoctl requires dev dependencies. Install with:\n" "  uv sync --extra dev",
-        file=sys.stderr,
-    )
-    raise SystemExit(1)
-
-app = typer.Typer(
-    name="yoyoctl",
-    help="YoyoPod development and hardware CLI.",
-    no_args_is_help=True,
+_MISSING_CLI_DEPENDENCY_MESSAGE = (
+    "yoyoctl requires the contributor CLI dependencies. Bootstrap the repo with:\n"
+    "  uv sync --extra dev"
 )
 
-# -- pi group (on-device commands) -----------------------------------------
-from yoyopod.cli.pi import pi_app  # noqa: E402
 
-app.add_typer(pi_app)
+class MissingCliDependencyError(ImportError):
+    """Raised when the optional CLI dependency stack is unavailable."""
 
-# -- remote group (SSH wrapper commands) ------------------------------------
-from yoyopod.cli.remote import remote_app  # noqa: E402
 
-app.add_typer(remote_app)
+class _LazyCliApp:
+    """Resolve the Typer application only when the CLI is actually used."""
 
-# -- build group (native extension builds) ----------------------------------
-from yoyopod.cli.build import build_app  # noqa: E402
+    def _resolve(self) -> Any:
+        return build_app()
 
-app.add_typer(build_app)
+    def __call__(self, *args: object, **kwargs: object) -> Any:
+        return self._resolve()(*args, **kwargs)
 
-# -- setup group (repo-owned bootstrap/verify commands) ---------------------
-from yoyopod.cli.setup import setup_app  # noqa: E402
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._resolve(), name)
 
-app.add_typer(setup_app)
+
+def _load_typer() -> Any:
+    """Import Typer lazily so plain module import does not abort test collection."""
+
+    try:
+        import typer
+    except ImportError as exc:  # pragma: no cover - exercised via import monkeypatching
+        raise MissingCliDependencyError(_MISSING_CLI_DEPENDENCY_MESSAGE) from exc
+    return typer
+
+
+@lru_cache(maxsize=1)
+def build_app() -> Any:
+    """Build the root Typer app on demand."""
+
+    typer = _load_typer()
+    root_app = typer.Typer(
+        name="yoyoctl",
+        help="YoyoPod development and hardware CLI.",
+        no_args_is_help=True,
+    )
+
+    from yoyopod.cli.build import build_app as build_group
+    from yoyopod.cli.pi import pi_app
+    from yoyopod.cli.remote import remote_app
+    from yoyopod.cli.setup import setup_app
+
+    root_app.add_typer(pi_app)
+    root_app.add_typer(remote_app)
+    root_app.add_typer(build_group)
+    root_app.add_typer(setup_app)
+    return root_app
+
+
+app = _LazyCliApp()
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve CLI subpackages lazily for dotted imports and monkeypatch paths."""
+
+    if name in {"build", "pi", "remote", "setup"}:
+        return importlib.import_module(f"yoyopod.cli.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def run() -> None:
     """Entry point for the yoyoctl console script."""
-    app()
+
+    try:
+        app()
+    except MissingCliDependencyError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,10 @@
 
 import re
 
+import pytest
+
+pytest.importorskip("typer")
+
 from typer.testing import CliRunner
 
 from yoyopod.cli import app

--- a/tests/test_cli_bootstrap.py
+++ b/tests/test_cli_bootstrap.py
@@ -1,0 +1,60 @@
+"""Regression tests for graceful CLI bootstrap failures."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+
+
+def _import_cli_without_typer(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Import `yoyopod.cli` while forcing `typer` imports to fail."""
+
+    original_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals_dict: dict[str, object] | None = None,
+        locals_dict: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "typer" or name.startswith("typer."):
+            raise ModuleNotFoundError("No module named 'typer'")
+        return original_import(name, globals_dict, locals_dict, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "typer", raising=False)
+    monkeypatch.delitem(sys.modules, "typer.testing", raising=False)
+    monkeypatch.delitem(sys.modules, "yoyopod.cli", raising=False)
+    return importlib.import_module("yoyopod.cli")
+
+
+def test_importing_cli_without_typer_does_not_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Plain module import should stay lazy when the optional CLI stack is missing."""
+
+    module = _import_cli_without_typer(monkeypatch)
+
+    assert module.__name__ == "yoyopod.cli"
+    assert module.app is not None
+
+
+def test_running_cli_without_typer_prints_bootstrap_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The failure should happen at invocation time with a short bootstrap message."""
+
+    module = _import_cli_without_typer(monkeypatch)
+
+    with pytest.raises(module.MissingCliDependencyError):
+        module.build_app()
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.run()
+
+    assert exc_info.value.code == 1
+    assert "uv sync --extra dev" in capsys.readouterr().err

--- a/tests/test_pi_remote.py
+++ b/tests/test_pi_remote.py
@@ -5,6 +5,8 @@ import shlex
 import pytest
 import yaml
 
+pytest.importorskip("typer")
+
 from yoyopod.cli.remote.ops import (
     DEPLOY_CONFIG_PATH,
     PiDeployConfig,

--- a/tests/test_setup_cli.py
+++ b/tests/test_setup_cli.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
+pytest.importorskip("typer")
+
 import yoyopod.cli.setup as setup_cli_module
 from yoyopod.cli.setup import (
     SetupCheck,

--- a/tests/test_whisplay_tune.py
+++ b/tests/test_whisplay_tune.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
+
+pytest.importorskip("typer")
+
 from yoyopod.cli.pi.tune import apply_timing_overrides, summarize_timings
 
 


### PR DESCRIPTION
## Summary
- make `yoyopod.cli` lazy-load Typer and CLI subpackages so missing `typer` no longer causes an import-time `SystemExit` during test collection
- keep the failure at the real `yoyoctl` invocation boundary with a short bootstrap hint to run `uv sync --extra dev`
- add regression coverage for the missing-dependency path and make the CLI-heavy test modules skip cleanly when `typer` is absent
- update the setup docs only where needed to describe the improved bootstrap recovery path

## Validation
- `uv sync --extra dev`
- `uv run pytest -q tests/test_cli_bootstrap.py tests/test_cli.py tests/test_setup_cli.py tests/test_pi_remote.py tests/test_whisplay_tune.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`

## Notes
- `uv run pytest -q` required one rerun outside the sandbox because `tests/test_mpv_ipc.py` bind Unix sockets
- this change is intentionally limited to CLI/bootstrap failure handling; it does not redesign the CLI surface
