### PR TITLE
[codex] Align setup verification with power config contract

### DIFF
--- a/rules/project.md
+++ b/rules/project.md
@@ -51,6 +51,7 @@ Tracked authored config lives under `config/`:
 - `app/core.yaml` -- app shell, UI, logging, diagnostics
 - `audio/music.yaml` -- local music policy, startup volume, and media runtime paths
 - `device/hardware.yaml` -- shared hardware truth for display, input, power, communication audio, media audio, and voice audio
+- `power/backend.yaml` -- power backend transport, polling, watchdog, and shutdown policy
 - `network/cellular.yaml` -- cellular modem policy and transport settings
 - `voice/assistant.yaml` -- local voice policy and assistant defaults
 - `communication/calling.yaml` -- non-secret SIP identity and calling policy

--- a/src/yoyopod/cli/setup.py
+++ b/src/yoyopod/cli/setup.py
@@ -14,6 +14,7 @@ from typing import Annotated
 import typer
 
 from yoyopod.cli.common import REPO_ROOT
+from yoyopod.setup_contract import SETUP_TRACKED_CONFIG_FILES
 
 setup_app = typer.Typer(
     name="setup",
@@ -21,19 +22,8 @@ setup_app = typer.Typer(
     no_args_is_help=True,
 )
 
-TRACKED_CONFIG_PATHS: tuple[Path, ...] = (
-    REPO_ROOT / "config" / "app" / "core.yaml",
-    REPO_ROOT / "config" / "audio" / "music.yaml",
-    REPO_ROOT / "config" / "device" / "hardware.yaml",
-    REPO_ROOT / "config" / "network" / "cellular.yaml",
-    REPO_ROOT / "config" / "voice" / "assistant.yaml",
-    REPO_ROOT / "config" / "communication" / "calling.yaml",
-    REPO_ROOT / "config" / "communication" / "messaging.yaml",
-    REPO_ROOT / "config" / "communication" / "calling.secrets.example.yaml",
-    REPO_ROOT / "config" / "communication" / "integrations" / "liblinphone_factory.conf",
-    REPO_ROOT / "config" / "people" / "directory.yaml",
-    REPO_ROOT / "config" / "people" / "contacts.seed.yaml",
-    REPO_ROOT / "deploy" / "pi-deploy.yaml",
+TRACKED_CONFIG_PATHS: tuple[Path, ...] = tuple(
+    REPO_ROOT / relative_path for relative_path in SETUP_TRACKED_CONFIG_FILES
 )
 CORE_PI_PACKAGES: tuple[str, ...] = (
     "mpv",

--- a/src/yoyopod/main.py
+++ b/src/yoyopod/main.py
@@ -24,6 +24,7 @@ from yoyopod import __version__
 from yoyopod.app import YoyoPodApp
 from yoyopod.config import YoyoPodConfig, load_composed_app_settings
 from yoyopod.runtime import ResponsivenessWatchdog, ResponsivenessWatchdogDecision
+from yoyopod.setup_contract import RUNTIME_REQUIRED_CONFIG_FILES
 from yoyopod.utils.logger import (
     LoggingRuntimeConfig,
     build_logging_runtime_config,
@@ -260,6 +261,19 @@ def _log_signal_snapshot(
     app_log.error("Freeze diagnostics snapshot: {}", json.dumps(payload, sort_keys=True))
 
 
+def _log_setup_failure_guidance(app_log: Any) -> None:
+    """Log the shared setup contract guidance when app bootstrap fails."""
+
+    app_log.error("Check that:")
+    for relative_path in RUNTIME_REQUIRED_CONFIG_FILES:
+        app_log.error(f"  - {relative_path.as_posix()} exists")
+    app_log.error(
+        "  - data/people/contacts.yaml can be created from config/people/contacts.seed.yaml"
+    )
+    app_log.error("  - liblinphone is installed and the native shim is built")
+    app_log.error("  - mpv is installed and the configured music backend can start")
+
+
 def _resolve_responsiveness_capture_dir(app: object) -> Path:
     """Resolve the configured directory for automatic watchdog evidence files."""
 
@@ -463,20 +477,7 @@ def main() -> int:
 
         if not app.setup():
             app_log.error("Failed to setup application")
-            app_log.error("Check that:")
-            app_log.error("  - config/app/core.yaml exists")
-            app_log.error("  - config/audio/music.yaml exists")
-            app_log.error("  - config/device/hardware.yaml exists")
-            app_log.error("  - config/power/backend.yaml exists")
-            app_log.error("  - config/network/cellular.yaml exists")
-            app_log.error("  - config/voice/assistant.yaml exists")
-            app_log.error("  - config/communication/calling.yaml exists")
-            app_log.error("  - config/communication/messaging.yaml exists")
-            app_log.error(
-                "  - data/people/contacts.yaml can be created from config/people/contacts.seed.yaml"
-            )
-            app_log.error("  - liblinphone is installed and the native shim is built")
-            app_log.error("  - mpv is installed and the configured music backend can start")
+            _log_setup_failure_guidance(app_log)
             app.stop()
             return 1
 

--- a/src/yoyopod/setup_contract.py
+++ b/src/yoyopod/setup_contract.py
@@ -1,0 +1,25 @@
+"""Shared setup and boot-time config contract for YoyoPod."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+RUNTIME_REQUIRED_CONFIG_FILES: tuple[Path, ...] = (
+    Path("config/app/core.yaml"),
+    Path("config/audio/music.yaml"),
+    Path("config/device/hardware.yaml"),
+    Path("config/power/backend.yaml"),
+    Path("config/network/cellular.yaml"),
+    Path("config/voice/assistant.yaml"),
+    Path("config/communication/calling.yaml"),
+    Path("config/communication/messaging.yaml"),
+    Path("config/people/directory.yaml"),
+)
+
+SETUP_TRACKED_CONFIG_FILES: tuple[Path, ...] = (
+    *RUNTIME_REQUIRED_CONFIG_FILES,
+    Path("config/communication/calling.secrets.example.yaml"),
+    Path("config/communication/integrations/liblinphone_factory.conf"),
+    Path("config/people/contacts.seed.yaml"),
+    Path("deploy/pi-deploy.yaml"),
+)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import yoyopod.main as main_module
+from yoyopod.setup_contract import RUNTIME_REQUIRED_CONFIG_FILES
 
 
 def test_configure_logger_uses_shared_utility(monkeypatch, tmp_path) -> None:
@@ -199,6 +200,20 @@ def test_log_signal_snapshot_serializes_runtime_state() -> None:
     assert payload["status"]["current_screen"] == "hub"
     assert payload["status"]["rtc_time"] == "2026-04-16T00:09:00+00:00"
     assert payload["status"]["recent_calls"][0]["when"] == "2026-04-15T23:59:00+00:00"
+
+
+def test_log_setup_failure_guidance_uses_shared_runtime_config_contract() -> None:
+    """Bootstrap guidance should enumerate the shared runtime config surface."""
+
+    logs: list[tuple[object, ...]] = []
+    fake_log = SimpleNamespace(
+        error=lambda *args: logs.append(args),
+    )
+
+    main_module._log_setup_failure_guidance(fake_log)
+
+    for relative_path in RUNTIME_REQUIRED_CONFIG_FILES:
+        assert (f"  - {relative_path.as_posix()} exists",) in logs
 
 
 def test_capture_responsiveness_watchdog_evidence_writes_artifacts(

--- a/tests/test_setup_cli.py
+++ b/tests/test_setup_cli.py
@@ -9,6 +9,7 @@ import pytest
 pytest.importorskip("typer")
 
 import yoyopod.cli.setup as setup_cli_module
+from yoyopod.setup_contract import RUNTIME_REQUIRED_CONFIG_FILES
 from yoyopod.cli.setup import (
     SetupCheck,
     build_host_setup_commands,
@@ -88,6 +89,7 @@ def test_collect_host_setup_checks_cover_required_tools_modules_and_config(
         tmp_path / "config" / "app" / "core.yaml",
         tmp_path / "config" / "audio" / "music.yaml",
         tmp_path / "config" / "device" / "hardware.yaml",
+        tmp_path / "config" / "power" / "backend.yaml",
         tmp_path / "config" / "network" / "cellular.yaml",
         tmp_path / "config" / "voice" / "assistant.yaml",
         tmp_path / "config" / "communication" / "calling.yaml",
@@ -131,6 +133,7 @@ def test_collect_pi_setup_checks_require_packages_native_artifacts_and_service(
         tmp_path / "config" / "app" / "core.yaml",
         tmp_path / "config" / "audio" / "music.yaml",
         tmp_path / "config" / "device" / "hardware.yaml",
+        tmp_path / "config" / "power" / "backend.yaml",
         tmp_path / "config" / "network" / "cellular.yaml",
         tmp_path / "config" / "voice" / "assistant.yaml",
         tmp_path / "config" / "communication" / "calling.yaml",
@@ -172,6 +175,61 @@ def test_collect_pi_setup_checks_require_packages_native_artifacts_and_service(
     assert any(check.label == "apt:mpv" for check in checks)
     assert any(check.label == "apt:pisugar-server" for check in checks)
     assert any(check.label == "service:pisugar-server" for check in checks)
+
+
+def test_collect_host_setup_checks_fail_when_power_backend_config_is_missing(
+    tmp_path, monkeypatch
+) -> None:
+    tracked_config = (
+        tmp_path / "config" / "app" / "core.yaml",
+        tmp_path / "config" / "audio" / "music.yaml",
+        tmp_path / "config" / "device" / "hardware.yaml",
+        tmp_path / "config" / "power" / "backend.yaml",
+        tmp_path / "config" / "network" / "cellular.yaml",
+        tmp_path / "config" / "voice" / "assistant.yaml",
+        tmp_path / "config" / "communication" / "calling.yaml",
+        tmp_path / "config" / "communication" / "messaging.yaml",
+        tmp_path / "config" / "communication" / "calling.secrets.example.yaml",
+        tmp_path / "config" / "communication" / "integrations" / "liblinphone_factory.conf",
+        tmp_path / "config" / "people" / "directory.yaml",
+        tmp_path / "config" / "people" / "contacts.seed.yaml",
+        tmp_path / "deploy" / "pi-deploy.yaml",
+    )
+    for path in tracked_config:
+        if path.as_posix().endswith("config/power/backend.yaml"):
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("ok\n", encoding="utf-8")
+
+    monkeypatch.setattr(setup_cli_module, "TRACKED_CONFIG_PATHS", tracked_config)
+    monkeypatch.setattr(
+        setup_cli_module.shutil,
+        "which",
+        lambda program: f"/usr/bin/{program}" if program in {"git", "uv"} else None,
+    )
+    monkeypatch.setattr(
+        setup_cli_module.importlib.util,
+        "find_spec",
+        lambda module_name: SimpleNamespace(name=module_name),
+    )
+
+    checks = collect_host_setup_checks(with_remote_tools=False, with_github=False)
+
+    power_check = next(
+        check
+        for check in checks
+        if check.label == setup_cli_module._display_path(tracked_config[3])
+    )
+    assert power_check.ok is False
+    assert power_check.detail == "missing"
+
+
+def test_tracked_setup_config_paths_cover_runtime_required_config_contract() -> None:
+    tracked = {
+        setup_cli_module._display_path(path) for path in setup_cli_module.TRACKED_CONFIG_PATHS
+    }
+
+    assert {path.as_posix() for path in RUNTIME_REQUIRED_CONFIG_FILES}.issubset(tracked)
 
 
 def test_report_checks_returns_failure_for_missing_items() -> None:


### PR DESCRIPTION
## Summary
- centralize the runtime-required config file contract in `src/yoyopod/setup_contract.py`
- drive `yoyoctl setup verify-host` and `yoyoctl setup verify-pi` from that shared contract, including `config/power/backend.yaml`
- reuse the same runtime-required config list for bootstrap failure guidance and align the adjacent required-config messaging in `rules/project.md`

## Why
Fixes #166.

`src/yoyopod/main.py` already treated `config/power/backend.yaml` as required at boot, but `src/yoyopod/cli/setup.py` could still report setup success without it. This tightens the existing contract instead of copying file lists into more places.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_setup_cli.py tests/test_main.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/quality.py gate`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
  - in the sandbox this failed only in `tests/test_mpv_ipc.py::test_connect_and_send_command` and `tests/test_mpv_ipc.py::test_event_callback_fires` with `PermissionError: [Errno 1] Operation not permitted` while binding Unix sockets
  - reran outside the sandbox and the full suite passed: `551 passed in 13.66s`

## Notes
- adds regression coverage that setup verification fails when `config/power/backend.yaml` is missing
- adds regression coverage that setup verification and boot-time guidance stay aligned with the shared runtime config contract
