### PR TITLE
[codex] Make runtime loop cadence more adaptive

### DIFF
--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -131,6 +131,7 @@ When the full app is running, the coordinator-thread timing signals land in
 - `Runtime loop blocked` means the whole coordinator loop stalled between iterations.
 - `Coordinator blocking span` names the specific runtime step that blocked long enough to threaten keep-alive cadence or UI responsiveness.
 - `Runtime iteration slow` means the total loop iteration stayed on the coordinator thread too long even if the exact hot span was not obvious from a single callback.
+- `runtime_cadence_mode`, `runtime_target_sleep_seconds`, `runtime_requested_sleep_seconds`, and `voip_effective_iterate_interval_seconds` in `app.get_status()` snapshots tell you whether the loop is in a fast interactive path, awake idle, or screen-off idle and what sleep / VoIP cadence it actually requested.
 - Freeze snapshots also include `runtime_blocking_span_name`, `runtime_blocking_span_seconds`, and `runtime_blocking_span_age_seconds` so a `SIGUSR1` dump can tell you whether the last blocking span is still fresh or already stale.
 - When `diagnostics.responsiveness_watchdog_enabled=true`, the app also writes automatic evidence bundles under `logs/responsiveness/` once the loop heartbeat stops advancing past the configured threshold.
 - Those bundles include `input_activity_age_seconds` and `handled_input_activity_age_seconds` so you can tell whether input was still arriving while the coordinator/UI side stopped responding.

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -96,6 +96,7 @@ This is the startup sequence that exists on `main` today.
    - It logs a startup status snapshot.
    - It starts the watchdog cadence.
    - Each loop iteration drains queued main-thread callbacks and typed events, pumps LVGL timers and queued input, iterates the Liblinphone backend on the coordinator thread, polls recovery and power services, and refreshes active screens on the configured cadence.
+   - The outer loop adapts its next wake based on runtime state: call / recent-input paths stay fast, awake idle relaxes, and screen-off idle can relax further while still honoring the next VoIP, watchdog, power-poll, shutdown, or screen-refresh deadline.
 9. Shutdown runs through `app.stop()` and `ShutdownLifecycleService.stop()`.
    - network, VoIP, music, and input managers are stopped
    - queued main-thread work is drained one last time

--- a/src/yoyopod/runtime/loop.py
+++ b/src/yoyopod/runtime/loop.py
@@ -47,6 +47,16 @@ class _VoipIterateMetrics:
     event_drain_duration_seconds: float = 0.0
 
 
+@dataclass(frozen=True, slots=True)
+class _LoopCadenceDecision:
+    """Normalized runtime cadence decision for the next coordinator wake."""
+
+    mode: str
+    reason: str
+    loop_sleep_seconds: float
+    voip_iterate_interval_seconds: float
+
+
 def _queue_depth(queue_obj: object) -> int | None:
     """Return a best-effort queue depth for runtime diagnostics."""
 
@@ -72,6 +82,18 @@ class RuntimeLoopService:
     _MIN_RUNTIME_ITERATION_WARNING_SECONDS = 0.2
     _MIN_VOIP_SCHEDULE_DELAY_WARNING_SECONDS = 0.15
     _MIN_VOIP_ITERATE_WARNING_SECONDS = 0.15
+    _RECENT_INPUT_WINDOW_SECONDS = 0.4
+    _RELAXED_IDLE_INTERVAL_SECONDS = 0.05
+    _LATENCY_SENSITIVE_STATES = frozenset(
+        {
+            "call_incoming",
+            "call_outgoing",
+            "call_active",
+            "call_active_music_paused",
+            "paused_by_call",
+            "connecting",
+        }
+    )
 
     def __init__(self, app: "YoyoPodApp") -> None:
         self.app = app
@@ -88,6 +110,19 @@ class RuntimeLoopService:
         self._last_runtime_blocking_span_seconds = 0.0
         self._last_runtime_blocking_span_recorded_at = 0.0
         self._voip_timing_window = _VoipTimingWindow()
+        self._current_cadence_mode = "startup"
+        self._current_cadence_reason = "startup"
+        self._current_loop_sleep_seconds = min(
+            self._RELAXED_IDLE_INTERVAL_SECONDS,
+            max(0.01, float(self.app._voip_iterate_interval_seconds)),
+        )
+        self._current_voip_iterate_interval_seconds = max(
+            0.01,
+            float(self.app._voip_iterate_interval_seconds),
+        )
+        self._last_cadence_selected_at = 0.0
+        self._last_requested_sleep_seconds = self._current_loop_sleep_seconds
+        self._last_requested_sleep_recorded_at = 0.0
 
     def _record_blocking_span(self, span_name: str, duration_seconds: float) -> None:
         """Persist and log one named coordinator-thread blocking span."""
@@ -243,7 +278,9 @@ class RuntimeLoopService:
         self._last_voip_event_drain_duration_seconds = (
             iterate_metrics.event_drain_duration_seconds if iterate_metrics is not None else 0.0
         )
-        self.app._next_voip_iterate_at = monotonic_now + self.app._voip_iterate_interval_seconds
+        self.app._next_voip_iterate_at = (
+            monotonic_now + self._effective_voip_iterate_interval_seconds()
+        )
 
         delayed = schedule_delay_seconds >= self._voip_schedule_delay_warning_seconds()
         slow = iterate_duration_seconds >= self._voip_iterate_warning_seconds()
@@ -262,15 +299,20 @@ class RuntimeLoopService:
             voip_logger.warning(
                 "VoIP iterate timing drift: "
                 "schedule_delay_ms={:.1f} iterate_ms={:.1f} since_last_ms={:.1f} "
-                "interval_ms={:.1f} native_iterate_ms={:.1f} event_drain_ms={:.1f} "
-                "native_events={} pending_callbacks={} pending_events={} screen={} state={}",
+                "interval_ms={:.1f} configured_interval_ms={:.1f} "
+                "native_iterate_ms={:.1f} event_drain_ms={:.1f} "
+                "native_events={} cadence_mode={} cadence_reason={} "
+                "pending_callbacks={} pending_events={} screen={} state={}",
                 schedule_delay_seconds * 1000.0,
                 iterate_duration_seconds * 1000.0,
                 since_last_iterate_seconds * 1000.0,
+                self._effective_voip_iterate_interval_seconds() * 1000.0,
                 self.app._voip_iterate_interval_seconds * 1000.0,
                 self._last_voip_native_iterate_duration_seconds * 1000.0,
                 self._last_voip_event_drain_duration_seconds * 1000.0,
                 native_events,
+                self._current_cadence_mode,
+                self._current_cadence_reason,
                 _queue_depth(self.app._pending_main_thread_callbacks),
                 self.app.event_bus.pending_count(),
                 self._current_screen_name(),
@@ -280,11 +322,52 @@ class RuntimeLoopService:
             "voip iterate",
             started_at=started_at,
             threshold_seconds=self._SLOW_VOIP_ITERATE_WARNING_SECONDS,
-            detail=(
-                f"screen={self._current_screen_name()} "
-                f"state={self._runtime_state_name()}"
-            ),
+            detail=(f"screen={self._current_screen_name()} " f"state={self._runtime_state_name()}"),
         )
+
+    def next_sleep_interval_seconds(
+        self,
+        *,
+        monotonic_now: float,
+        current_time: float,
+        last_screen_update: float,
+        screen_update_interval: float,
+    ) -> float:
+        """Return the coordinator sleep for the next iteration."""
+
+        cadence = self._select_loop_cadence(monotonic_now=monotonic_now)
+        self._apply_loop_cadence(cadence, monotonic_now=monotonic_now)
+
+        sleep_seconds = max(0.0, cadence.loop_sleep_seconds)
+        deadlines = [sleep_seconds]
+        if self.app.voip_manager is not None and self.app.voip_manager.running:
+            if self.app._next_voip_iterate_at <= 0.0:
+                deadlines.append(self._effective_voip_iterate_interval_seconds())
+            else:
+                deadlines.append(max(0.0, self.app._next_voip_iterate_at - monotonic_now))
+
+        if self.app._pending_shutdown is not None:
+            deadlines.append(max(0.0, self.app._pending_shutdown.execute_at - monotonic_now))
+        if self.app._next_power_poll_at > 0.0:
+            deadlines.append(max(0.0, self.app._next_power_poll_at - monotonic_now))
+        if (
+            self.app._watchdog_active
+            and not self.app._watchdog_feed_suppressed
+            and self.app._next_watchdog_feed_at > 0.0
+        ):
+            deadlines.append(max(0.0, self.app._next_watchdog_feed_at - monotonic_now))
+        if self.app._screen_awake and screen_update_interval > 0.0:
+            deadlines.append(
+                max(
+                    0.0,
+                    screen_update_interval - max(0.0, current_time - last_screen_update),
+                )
+            )
+
+        requested_sleep_seconds = min(deadlines) if deadlines else sleep_seconds
+        self._last_requested_sleep_seconds = requested_sleep_seconds
+        self._last_requested_sleep_recorded_at = monotonic_now
+        return requested_sleep_seconds
 
     def run_iteration(
         self,
@@ -458,7 +541,16 @@ class RuntimeLoopService:
                 logger.info("")
 
             while not self.app._stopping:
-                time.sleep(min(0.05, self.app._voip_iterate_interval_seconds))
+                monotonic_now = time.monotonic()
+                current_time = time.time()
+                time.sleep(
+                    self.next_sleep_interval_seconds(
+                        monotonic_now=monotonic_now,
+                        current_time=current_time,
+                        last_screen_update=last_screen_update,
+                        screen_update_interval=screen_update_interval,
+                    )
+                )
                 monotonic_now = time.monotonic()
                 current_time = time.time()
                 last_screen_update = self.run_iteration(
@@ -502,6 +594,15 @@ class RuntimeLoopService:
                 if self._last_voip_iterate_started_at > 0.0
                 else None
             ),
+            "runtime_cadence_mode": self._current_cadence_mode,
+            "runtime_cadence_reason": self._current_cadence_reason,
+            "runtime_target_sleep_seconds": self._current_loop_sleep_seconds,
+            "runtime_requested_sleep_seconds": self._last_requested_sleep_seconds,
+            "runtime_requested_sleep_age_seconds": (
+                max(0.0, monotonic_now - self._last_requested_sleep_recorded_at)
+                if self._last_requested_sleep_recorded_at > 0.0
+                else None
+            ),
             "voip_native_iterate_duration_seconds": (
                 self._last_voip_native_iterate_duration_seconds
                 if self._last_voip_iterate_started_at > 0.0
@@ -521,6 +622,9 @@ class RuntimeLoopService:
                 else None
             ),
             "voip_iterate_interval_seconds": self.app._voip_iterate_interval_seconds,
+            "voip_effective_iterate_interval_seconds": (
+                self._current_voip_iterate_interval_seconds
+            ),
             "runtime_blocking_span_name": self._last_runtime_blocking_span_name,
             "runtime_blocking_span_seconds": (
                 self._last_runtime_blocking_span_seconds
@@ -534,6 +638,120 @@ class RuntimeLoopService:
             ),
             "voip_timing_window_samples": self._voip_timing_window.samples,
         }
+
+    def _select_loop_cadence(self, *, monotonic_now: float) -> _LoopCadenceDecision:
+        """Choose the next runtime cadence from current state and queued work."""
+
+        configured_voip_interval_seconds = max(
+            0.01,
+            float(self.app._voip_iterate_interval_seconds),
+        )
+        fast_loop_sleep_seconds = min(
+            self._RELAXED_IDLE_INTERVAL_SECONDS,
+            configured_voip_interval_seconds,
+        )
+        pending_callbacks = max(0, _queue_depth(self.app._pending_main_thread_callbacks) or 0)
+        pending_events = max(0, self.app.event_bus.pending_count())
+        if pending_callbacks > 0 or pending_events > 0:
+            return _LoopCadenceDecision(
+                mode="latency_sensitive",
+                reason="pending_work",
+                loop_sleep_seconds=0.0,
+                voip_iterate_interval_seconds=configured_voip_interval_seconds,
+            )
+
+        if self.app._pending_shutdown is not None or self.app._power_alert is not None:
+            return _LoopCadenceDecision(
+                mode="latency_sensitive",
+                reason="safety_transition",
+                loop_sleep_seconds=fast_loop_sleep_seconds,
+                voip_iterate_interval_seconds=configured_voip_interval_seconds,
+            )
+
+        if self._runtime_state_name() in self._LATENCY_SENSITIVE_STATES:
+            return _LoopCadenceDecision(
+                mode="latency_sensitive",
+                reason="call_or_connecting_state",
+                loop_sleep_seconds=fast_loop_sleep_seconds,
+                voip_iterate_interval_seconds=configured_voip_interval_seconds,
+            )
+
+        recent_input_age_seconds = (
+            max(0.0, monotonic_now - self.app._last_input_activity_at)
+            if self.app._last_input_activity_at > 0.0
+            else None
+        )
+        if (
+            recent_input_age_seconds is not None
+            and recent_input_age_seconds <= self._RECENT_INPUT_WINDOW_SECONDS
+        ):
+            return _LoopCadenceDecision(
+                mode="latency_sensitive",
+                reason="recent_input",
+                loop_sleep_seconds=fast_loop_sleep_seconds,
+                voip_iterate_interval_seconds=configured_voip_interval_seconds,
+            )
+
+        return _LoopCadenceDecision(
+            mode="idle",
+            reason="idle_state",
+            loop_sleep_seconds=self._RELAXED_IDLE_INTERVAL_SECONDS,
+            voip_iterate_interval_seconds=max(
+                configured_voip_interval_seconds,
+                self._RELAXED_IDLE_INTERVAL_SECONDS,
+            ),
+        )
+
+    def _apply_loop_cadence(
+        self,
+        decision: _LoopCadenceDecision,
+        *,
+        monotonic_now: float,
+    ) -> None:
+        """Store one cadence decision and accelerate due work when responsiveness tightens."""
+
+        previous_voip_interval_seconds = self._current_voip_iterate_interval_seconds
+        changed = (
+            self._current_cadence_mode != decision.mode
+            or self._current_cadence_reason != decision.reason
+            or abs(self._current_loop_sleep_seconds - decision.loop_sleep_seconds) > 1e-9
+            or abs(previous_voip_interval_seconds - decision.voip_iterate_interval_seconds) > 1e-9
+        )
+        self._current_cadence_mode = decision.mode
+        self._current_cadence_reason = decision.reason
+        self._current_loop_sleep_seconds = decision.loop_sleep_seconds
+        self._current_voip_iterate_interval_seconds = decision.voip_iterate_interval_seconds
+        self._last_cadence_selected_at = monotonic_now
+
+        if (
+            self.app.voip_manager is not None
+            and self.app.voip_manager.running
+            and self.app._next_voip_iterate_at > 0.0
+            and decision.voip_iterate_interval_seconds < previous_voip_interval_seconds
+        ):
+            accelerated_due = monotonic_now + decision.voip_iterate_interval_seconds
+            self.app._next_voip_iterate_at = min(self.app._next_voip_iterate_at, accelerated_due)
+
+        if not changed:
+            return
+
+        coord_logger.info(
+            "Runtime cadence: "
+            "mode={} reason={} sleep_ms={:.1f} voip_interval_ms={:.1f} "
+            "configured_voip_interval_ms={:.1f} screen={} state={}",
+            decision.mode,
+            decision.reason,
+            decision.loop_sleep_seconds * 1000.0,
+            decision.voip_iterate_interval_seconds * 1000.0,
+            self.app._voip_iterate_interval_seconds * 1000.0,
+            self._current_screen_name(),
+            self._runtime_state_name(),
+        )
+
+    def _effective_voip_iterate_interval_seconds(self) -> float:
+        """Return the currently selected VoIP iterate cadence."""
+
+        return max(0.01, self._current_voip_iterate_interval_seconds)
 
     def _observe_loop_gap(self, *, monotonic_now: float) -> None:
         """Track coordinator-loop gaps so starvation shows up in logs and snapshots."""
@@ -556,9 +774,12 @@ class RuntimeLoopService:
 
         coord_logger.warning(
             "Runtime loop blocked: "
-            "gap_ms={:.1f} interval_ms={:.1f} pending_callbacks={} pending_events={} screen={} state={}",
+            "gap_ms={:.1f} interval_ms={:.1f} cadence_mode={} cadence_reason={} "
+            "pending_callbacks={} pending_events={} screen={} state={}",
             loop_gap_seconds * 1000.0,
-            self.app._voip_iterate_interval_seconds * 1000.0,
+            self._effective_voip_iterate_interval_seconds() * 1000.0,
+            self._current_cadence_mode,
+            self._current_cadence_reason,
             _queue_depth(self.app._pending_main_thread_callbacks),
             self.app.event_bus.pending_count(),
             self._current_screen_name(),
@@ -638,7 +859,8 @@ class RuntimeLoopService:
             "delayed_samples={} slow_samples={} max_native_iterate_ms={:.1f} "
             "max_event_drain_ms={:.1f} max_native_events={} "
             "max_blocking_span={} max_blocking_span_ms={:.1f} "
-            "interval_ms={:.1f} screen={} state={}",
+            "interval_ms={:.1f} configured_interval_ms={:.1f} "
+            "cadence_mode={} cadence_reason={} screen={} state={}",
             window.samples,
             average_schedule_delay_ms,
             window.max_schedule_delay_seconds * 1000.0,
@@ -652,7 +874,10 @@ class RuntimeLoopService:
             window.max_drained_events,
             window.max_blocking_span_name or "none",
             window.max_blocking_span_seconds * 1000.0,
+            self._effective_voip_iterate_interval_seconds() * 1000.0,
             self.app._voip_iterate_interval_seconds * 1000.0,
+            self._current_cadence_mode,
+            self._current_cadence_reason,
             self._current_screen_name(),
             self._runtime_state_name(),
         )
@@ -663,7 +888,7 @@ class RuntimeLoopService:
 
         return max(
             self._MIN_RUNTIME_LOOP_GAP_WARNING_SECONDS,
-            self.app._voip_iterate_interval_seconds * 6.0,
+            self._effective_voip_iterate_interval_seconds() * 6.0,
         )
 
     def _runtime_iteration_warning_seconds(self) -> float:
@@ -671,7 +896,7 @@ class RuntimeLoopService:
 
         return max(
             self._MIN_RUNTIME_ITERATION_WARNING_SECONDS,
-            self.app._voip_iterate_interval_seconds * 6.0,
+            self._effective_voip_iterate_interval_seconds() * 6.0,
         )
 
     def _runtime_blocking_span_warning_seconds(self) -> float:
@@ -679,7 +904,7 @@ class RuntimeLoopService:
 
         return max(
             self._MIN_RUNTIME_BLOCKING_SPAN_WARNING_SECONDS,
-            self.app._voip_iterate_interval_seconds * 6.0,
+            self._effective_voip_iterate_interval_seconds() * 6.0,
         )
 
     def _voip_schedule_delay_warning_seconds(self) -> float:
@@ -687,7 +912,7 @@ class RuntimeLoopService:
 
         return max(
             self._MIN_VOIP_SCHEDULE_DELAY_WARNING_SECONDS,
-            self.app._voip_iterate_interval_seconds * 4.0,
+            self._effective_voip_iterate_interval_seconds() * 4.0,
         )
 
     def _voip_iterate_warning_seconds(self) -> float:
@@ -695,7 +920,7 @@ class RuntimeLoopService:
 
         return max(
             self._MIN_VOIP_ITERATE_WARNING_SECONDS,
-            self.app._voip_iterate_interval_seconds * 4.0,
+            self._effective_voip_iterate_interval_seconds() * 4.0,
         )
 
     def _current_screen_name(self) -> str:

--- a/src/yoyopod/runtime/loop.py
+++ b/src/yoyopod/runtime/loop.py
@@ -84,6 +84,7 @@ class RuntimeLoopService:
     _MIN_VOIP_ITERATE_WARNING_SECONDS = 0.15
     _RECENT_INPUT_WINDOW_SECONDS = 0.4
     _RELAXED_IDLE_INTERVAL_SECONDS = 0.05
+    _SCREEN_SLEEP_IDLE_INTERVAL_SECONDS = 0.1
     _LATENCY_SENSITIVE_STATES = frozenset(
         {
             "call_incoming",
@@ -278,8 +279,9 @@ class RuntimeLoopService:
         self._last_voip_event_drain_duration_seconds = (
             iterate_metrics.event_drain_duration_seconds if iterate_metrics is not None else 0.0
         )
-        self.app._next_voip_iterate_at = (
-            monotonic_now + self._effective_voip_iterate_interval_seconds()
+        self.app._next_voip_iterate_at = self._next_voip_due_at_for_cadence(
+            monotonic_now=monotonic_now,
+            iterate_interval_seconds=self._effective_voip_iterate_interval_seconds(),
         )
 
         delayed = schedule_delay_seconds >= self._voip_schedule_delay_warning_seconds()
@@ -598,6 +600,11 @@ class RuntimeLoopService:
             "runtime_cadence_reason": self._current_cadence_reason,
             "runtime_target_sleep_seconds": self._current_loop_sleep_seconds,
             "runtime_requested_sleep_seconds": self._last_requested_sleep_seconds,
+            "runtime_cadence_age_seconds": (
+                max(0.0, monotonic_now - self._last_cadence_selected_at)
+                if self._last_cadence_selected_at > 0.0
+                else None
+            ),
             "runtime_requested_sleep_age_seconds": (
                 max(0.0, monotonic_now - self._last_requested_sleep_recorded_at)
                 if self._last_requested_sleep_recorded_at > 0.0
@@ -692,9 +699,20 @@ class RuntimeLoopService:
                 voip_iterate_interval_seconds=configured_voip_interval_seconds,
             )
 
+        if not self.app._screen_awake:
+            return _LoopCadenceDecision(
+                mode="idle_sleeping",
+                reason="screen_sleeping",
+                loop_sleep_seconds=self._SCREEN_SLEEP_IDLE_INTERVAL_SECONDS,
+                voip_iterate_interval_seconds=max(
+                    configured_voip_interval_seconds,
+                    self._SCREEN_SLEEP_IDLE_INTERVAL_SECONDS,
+                ),
+            )
+
         return _LoopCadenceDecision(
-            mode="idle",
-            reason="idle_state",
+            mode="idle_awake",
+            reason="screen_awake_idle",
             loop_sleep_seconds=self._RELAXED_IDLE_INTERVAL_SECONDS,
             voip_iterate_interval_seconds=max(
                 configured_voip_interval_seconds,
@@ -726,11 +744,11 @@ class RuntimeLoopService:
         if (
             self.app.voip_manager is not None
             and self.app.voip_manager.running
-            and self.app._next_voip_iterate_at > 0.0
-            and decision.voip_iterate_interval_seconds < previous_voip_interval_seconds
         ):
-            accelerated_due = monotonic_now + decision.voip_iterate_interval_seconds
-            self.app._next_voip_iterate_at = min(self.app._next_voip_iterate_at, accelerated_due)
+            self.app._next_voip_iterate_at = self._next_voip_due_at_for_cadence(
+                monotonic_now=monotonic_now,
+                iterate_interval_seconds=decision.voip_iterate_interval_seconds,
+            )
 
         if not changed:
             return
@@ -752,6 +770,22 @@ class RuntimeLoopService:
         """Return the currently selected VoIP iterate cadence."""
 
         return max(0.01, self._current_voip_iterate_interval_seconds)
+
+    def _next_voip_due_at_for_cadence(
+        self,
+        *,
+        monotonic_now: float,
+        iterate_interval_seconds: float,
+    ) -> float:
+        """Return the next VoIP iterate deadline aligned to the current cadence."""
+
+        effective_interval_seconds = max(0.01, iterate_interval_seconds)
+        if self._last_voip_iterate_started_at <= 0.0:
+            return monotonic_now + effective_interval_seconds
+        return max(
+            monotonic_now,
+            self._last_voip_iterate_started_at + effective_interval_seconds,
+        )
 
     def _observe_loop_gap(self, *, monotonic_now: float) -> None:
         """Track coordinator-loop gaps so starvation shows up in logs and snapshots."""

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -1509,6 +1509,91 @@ def test_runtime_loop_service_refreshes_visible_power_screen() -> None:
     assert app.power_screen.render_calls > render_calls_before
 
 
+def test_runtime_loop_relaxes_idle_cadence_and_exposes_snapshot() -> None:
+    """Idle coordinator state should publish the relaxed cadence instead of the fast loop."""
+
+    app, _, _ = _build_app_with_power(
+        FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+    app.voip_manager = FakeRuntimeLoopVoIPManager()
+    app._voip_iterate_interval_seconds = 0.02
+
+    sleep_seconds = app.runtime_loop.next_sleep_interval_seconds(
+        monotonic_now=1.0,
+        current_time=1.0,
+        last_screen_update=1.0,
+        screen_update_interval=1.0,
+    )
+
+    status = app.get_status()
+    assert sleep_seconds == pytest.approx(0.05)
+    assert status["runtime_cadence_mode"] == "idle"
+    assert status["runtime_cadence_reason"] == "idle_state"
+    assert status["runtime_target_sleep_seconds"] == pytest.approx(0.05)
+    assert status["runtime_requested_sleep_seconds"] == pytest.approx(0.05)
+    assert status["voip_iterate_interval_seconds"] == pytest.approx(0.02)
+    assert status["voip_effective_iterate_interval_seconds"] == pytest.approx(0.05)
+
+
+def test_runtime_loop_restores_fast_cadence_for_recent_input() -> None:
+    """Fresh input should immediately pull the runtime loop back to the fast cadence."""
+
+    app, _, _ = _build_app_with_power(
+        FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+    app.voip_manager = FakeRuntimeLoopVoIPManager()
+    app._voip_iterate_interval_seconds = 0.02
+
+    idle_sleep_seconds = app.runtime_loop.next_sleep_interval_seconds(
+        monotonic_now=1.0,
+        current_time=1.0,
+        last_screen_update=1.0,
+        screen_update_interval=1.0,
+    )
+    assert idle_sleep_seconds == pytest.approx(0.05)
+
+    app._next_voip_iterate_at = 1.05
+    app._last_input_activity_at = 0.9
+    fast_sleep_seconds = app.runtime_loop.next_sleep_interval_seconds(
+        monotonic_now=1.0,
+        current_time=1.0,
+        last_screen_update=1.0,
+        screen_update_interval=1.0,
+    )
+
+    status = app.get_status()
+    assert fast_sleep_seconds == pytest.approx(0.02)
+    assert app._next_voip_iterate_at == pytest.approx(1.02)
+    assert status["runtime_cadence_mode"] == "latency_sensitive"
+    assert status["runtime_cadence_reason"] == "recent_input"
+    assert status["voip_effective_iterate_interval_seconds"] == pytest.approx(0.02)
+
+
+def test_runtime_loop_keeps_fast_cadence_during_call_states() -> None:
+    """Call-active coordinator states should not relax the runtime cadence."""
+
+    harness = OrchestrationHarness.build(
+        power_manager=FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+    harness.app.voip_manager = FakeRuntimeLoopVoIPManager()
+    harness.app._voip_iterate_interval_seconds = 0.02
+    harness.sync_runtime(call_state=CallSessionState.ACTIVE, trigger="call_active")
+
+    sleep_seconds = harness.app.runtime_loop.next_sleep_interval_seconds(
+        monotonic_now=1.0,
+        current_time=1.0,
+        last_screen_update=1.0,
+        screen_update_interval=1.0,
+    )
+
+    status = harness.app.get_status()
+    assert sleep_seconds == pytest.approx(0.02)
+    assert status["state"] == AppRuntimeState.CALL_ACTIVE.value
+    assert status["runtime_cadence_mode"] == "latency_sensitive"
+    assert status["runtime_cadence_reason"] == "call_or_connecting_state"
+    assert status["voip_effective_iterate_interval_seconds"] == pytest.approx(0.02)
+
+
 def test_runtime_loop_logs_voip_timing_drift_and_exposes_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -1527,12 +1527,41 @@ def test_runtime_loop_relaxes_idle_cadence_and_exposes_snapshot() -> None:
 
     status = app.get_status()
     assert sleep_seconds == pytest.approx(0.05)
-    assert status["runtime_cadence_mode"] == "idle"
-    assert status["runtime_cadence_reason"] == "idle_state"
+    assert status["runtime_cadence_mode"] == "idle_awake"
+    assert status["runtime_cadence_reason"] == "screen_awake_idle"
     assert status["runtime_target_sleep_seconds"] == pytest.approx(0.05)
     assert status["runtime_requested_sleep_seconds"] == pytest.approx(0.05)
     assert status["voip_iterate_interval_seconds"] == pytest.approx(0.02)
     assert status["voip_effective_iterate_interval_seconds"] == pytest.approx(0.05)
+    assert status["runtime_cadence_age_seconds"] is not None
+
+
+def test_runtime_loop_uses_slower_screen_off_idle_cadence() -> None:
+    """Screen-off idle should stretch both the loop sleep and the VoIP deadline."""
+
+    app, _, _ = _build_app_with_power(
+        FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+    app.voip_manager = FakeRuntimeLoopVoIPManager()
+    app._voip_iterate_interval_seconds = 0.02
+    app._screen_awake = False
+    app._next_voip_iterate_at = 1.05
+
+    sleep_seconds = app.runtime_loop.next_sleep_interval_seconds(
+        monotonic_now=1.0,
+        current_time=1.0,
+        last_screen_update=1.0,
+        screen_update_interval=1.0,
+    )
+
+    status = app.get_status()
+    assert sleep_seconds == pytest.approx(0.1)
+    assert app._next_voip_iterate_at == pytest.approx(1.1)
+    assert status["runtime_cadence_mode"] == "idle_sleeping"
+    assert status["runtime_cadence_reason"] == "screen_sleeping"
+    assert status["runtime_target_sleep_seconds"] == pytest.approx(0.1)
+    assert status["runtime_requested_sleep_seconds"] == pytest.approx(0.1)
+    assert status["voip_effective_iterate_interval_seconds"] == pytest.approx(0.1)
 
 
 def test_runtime_loop_restores_fast_cadence_for_recent_input() -> None:


### PR DESCRIPTION
## Summary
- split the relaxed runtime cadence into explicit `idle_awake` and `idle_sleeping` paths so screen-off idle can sleep longer than awake idle without changing fast call/recent-input behavior
- realign the next VoIP iterate deadline whenever cadence changes so the loop immediately stretches or tightens its wake schedule instead of waiting one extra fast cycle
- expose cadence age in runtime snapshots, add a focused orchestration test for screen-off idle, and document the new cadence snapshot fields for Pi validation work

## Why
Issue #167 asks for state-aware runtime cadence with measurable before/after behavior. The branch already had a first-pass fast-vs-idle planner; this update narrows it further so truly low-activity screen-off states back off more aggressively while latency-sensitive states stay fast.

Closes #167.

## Validation
- `UV_CACHE_DIR=/tmp/yoyopod-uv-cache uv run pytest -q tests/test_app_orchestration.py`
- `UV_CACHE_DIR=/tmp/yoyopod-uv-cache uv run python scripts/quality.py gate`
- `UV_CACHE_DIR=/tmp/yoyopod-uv-cache uv run pytest -q`

## Validation notes
- The first sandboxed full-suite run hit `PermissionError` on the AF_UNIX socket tests in `tests/test_mpv_ipc.py`; rerunning the full suite outside the sandbox passed.
- I could not run target-hardware or Pi validation from this environment, so the PR only includes host-side validation plus the runtime/status instrumentation needed to compare cadence behavior on hardware.

## Reviewer notes
- awake idle now reports `runtime_cadence_mode=idle_awake` / `runtime_cadence_reason=screen_awake_idle`
- screen-off idle now reports `runtime_cadence_mode=idle_sleeping` / `runtime_cadence_reason=screen_sleeping`
- `app.get_status()` now includes `runtime_cadence_age_seconds` alongside the existing cadence and timing fields

## Limitations
- No Raspberry Pi or `yoyoctl remote` validation was possible from this workspace, so reviewers should treat hardware cadence / responsiveness confirmation as follow-up validation rather than something this lane already proved.
- The relaxed screen-off cadence is still intentionally conservative at 100ms; this lane does not try to push deeper sleep intervals without target measurements.