### PR TITLE
[codex] Reduce screen-to-backend coupling with narrower facades

### DIFF
--- a/src/yoyopod/cli/pi/gallery.py
+++ b/src/yoyopod/cli/pi/gallery.py
@@ -550,6 +550,10 @@ def _build_talk_contact_screen(display: object) -> object:
 def _build_voice_note_recording_screen(display: object) -> object:
     """Build the voice-note recording state."""
     from yoyopod.ui.screens import VoiceNoteScreen
+    from yoyopod.ui.screens.voip.voice_note import (
+        build_voice_note_actions,
+        build_voice_note_state_provider,
+    )
 
     context = _build_context()
     context.set_voice_note_recipient(name="Mama", sip_address="sip:mama@example.com")  # type: ignore[union-attr]
@@ -561,16 +565,25 @@ def _build_voice_note_recording_screen(display: object) -> object:
         send_state="recording",
         status_text="Recording...",
     )
+    voip_manager = _FakeVoipManager(active_voice_note=draft)
     return VoiceNoteScreen(
         display,
         context,
-        voip_manager=_FakeVoipManager(active_voice_note=draft),
+        state_provider=build_voice_note_state_provider(
+            context=context,
+            voip_manager=voip_manager,
+        ),
+        actions=build_voice_note_actions(voip_manager=voip_manager),
     )
 
 
 def _build_voice_note_review_screen(display: object) -> object:
     """Build the voice-note review state."""
     from yoyopod.ui.screens import VoiceNoteScreen
+    from yoyopod.ui.screens.voip.voice_note import (
+        build_voice_note_actions,
+        build_voice_note_state_provider,
+    )
 
     context = _build_context()
     context.set_voice_note_recipient(name="Mama", sip_address="sip:mama@example.com")  # type: ignore[union-attr]
@@ -582,16 +595,25 @@ def _build_voice_note_review_screen(display: object) -> object:
         send_state="review",
         status_text="Ready to send",
     )
+    voip_manager = _FakeVoipManager(active_voice_note=draft)
     return VoiceNoteScreen(
         display,
         context,
-        voip_manager=_FakeVoipManager(active_voice_note=draft),
+        state_provider=build_voice_note_state_provider(
+            context=context,
+            voip_manager=voip_manager,
+        ),
+        actions=build_voice_note_actions(voip_manager=voip_manager),
     )
 
 
 def _build_voice_note_sent_screen(display: object) -> object:
     """Build the voice-note sent state."""
     from yoyopod.ui.screens import VoiceNoteScreen
+    from yoyopod.ui.screens.voip.voice_note import (
+        build_voice_note_actions,
+        build_voice_note_state_provider,
+    )
 
     context = _build_context()
     context.set_voice_note_recipient(name="Mama", sip_address="sip:mama@example.com")  # type: ignore[union-attr]
@@ -604,10 +626,15 @@ def _build_voice_note_sent_screen(display: object) -> object:
         status_text="Sent",
         message_id="demo-note",
     )
+    voip_manager = _FakeVoipManager(active_voice_note=draft)
     return VoiceNoteScreen(
         display,
         context,
-        voip_manager=_FakeVoipManager(active_voice_note=draft),
+        state_provider=build_voice_note_state_provider(
+            context=context,
+            voip_manager=voip_manager,
+        ),
+        actions=build_voice_note_actions(voip_manager=voip_manager),
     )
 
 
@@ -633,6 +660,58 @@ def _build_now_playing_backend(*, playback_state: str) -> object:
     return backend
 
 
+def _build_now_playing_screen(display: object, *, playback_state: str) -> object:
+    """Build a now-playing screen wired through the playback facade seam."""
+
+    from yoyopod.ui.screens import NowPlayingScreen
+    from yoyopod.ui.screens.music.now_playing import (
+        build_now_playing_actions,
+        build_now_playing_state_provider,
+    )
+
+    context = _build_context()
+    backend = _build_now_playing_backend(playback_state=playback_state)
+    return NowPlayingScreen(
+        display,
+        context,
+        state_provider=build_now_playing_state_provider(
+            context=context,
+            music_backend=backend,
+        ),
+        actions=build_now_playing_actions(
+            context=context,
+            music_backend=backend,
+        ),
+    )
+
+
+def _build_power_screen(
+    display: object,
+    *,
+    power_snapshot: object,
+    network_manager: object | None = None,
+) -> object:
+    """Build a Setup screen wired through the prepared power facade seam."""
+
+    from yoyopod.ui.screens import PowerScreen
+    from yoyopod.ui.screens.system.power import (
+        build_power_screen_actions,
+        build_power_screen_state_provider,
+    )
+
+    context = _build_context()
+    return PowerScreen(
+        display,
+        context,
+        state_provider=build_power_screen_state_provider(
+            power_manager=_FakePowerManager(power_snapshot),
+            network_manager=network_manager,
+            status_provider=_build_power_status,
+        ),
+        actions=build_power_screen_actions(network_manager=network_manager),
+    )
+
+
 def _advance_ask_to_response(screen: object) -> None:
     """Drive AskScreen into its response state for a second capture."""
     screen.on_select()  # type: ignore[union-attr]
@@ -650,10 +729,8 @@ def _build_capture_specs(display: object) -> list[_CaptureSpec]:
         InCallScreen,
         IncomingCallScreen,
         ListenScreen,
-        NowPlayingScreen,
         OutgoingCallScreen,
         PlaylistScreen,
-        PowerScreen,
         RecentTracksScreen,
     )
 
@@ -680,27 +757,15 @@ def _build_capture_specs(display: object) -> list[_CaptureSpec]:
         ),
         _CaptureSpec(
             "04_now_playing",
-            lambda: NowPlayingScreen(
-                display,
-                _build_context(),
-                music_backend=_build_now_playing_backend(playback_state="playing"),
-            ),
+            lambda: _build_now_playing_screen(display, playback_state="playing"),
         ),
         _CaptureSpec(
             "04b_now_playing_paused",
-            lambda: NowPlayingScreen(
-                display,
-                _build_context(),
-                music_backend=_build_now_playing_backend(playback_state="paused"),
-            ),
+            lambda: _build_now_playing_screen(display, playback_state="paused"),
         ),
         _CaptureSpec(
             "04c_now_playing_offline",
-            lambda: NowPlayingScreen(
-                display,
-                _build_context(),
-                music_backend=_build_now_playing_backend(playback_state="offline"),
-            ),
+            lambda: _build_now_playing_screen(display, playback_state="offline"),
         ),
         _CaptureSpec(
             "05_talk",
@@ -759,42 +824,25 @@ def _build_capture_specs(display: object) -> list[_CaptureSpec]:
         ),
         _CaptureSpec(
             "12_power",
-            lambda: PowerScreen(
-                display,
-                _build_context(),
-                power_manager=_FakePowerManager(power_snapshot),
-                status_provider=_build_power_status,
-            ),
+            lambda: _build_power_screen(display, power_snapshot=power_snapshot),
         ),
         _CaptureSpec(
             "12b_gps",
-            lambda: PowerScreen(
+            lambda: _build_power_screen(
                 display,
-                _build_context(),
-                power_manager=_FakePowerManager(power_snapshot),
+                power_snapshot=power_snapshot,
                 network_manager=_FakeNetworkManager(),
-                status_provider=_build_power_status,
             ),
             prepare=lambda screen: setattr(screen, "page_index", 2),
         ),
         _CaptureSpec(
             "13_time",
-            lambda: PowerScreen(
-                display,
-                _build_context(),
-                power_manager=_FakePowerManager(power_snapshot),
-                status_provider=_build_power_status,
-            ),
+            lambda: _build_power_screen(display, power_snapshot=power_snapshot),
             prepare=lambda screen: setattr(screen, "page_index", 1),
         ),
         _CaptureSpec(
             "14_care",
-            lambda: PowerScreen(
-                display,
-                _build_context(),
-                power_manager=_FakePowerManager(power_snapshot),
-                status_provider=_build_power_status,
-            ),
+            lambda: _build_power_screen(display, power_snapshot=power_snapshot),
             prepare=lambda screen: setattr(screen, "page_index", 2),
         ),
         _CaptureSpec(

--- a/src/yoyopod/runtime/boot.py
+++ b/src/yoyopod/runtime/boot.py
@@ -57,6 +57,18 @@ from yoyopod.ui.screens import (
     TalkContactScreen,
     VoiceNoteScreen,
 )
+from yoyopod.ui.screens.music.now_playing import (
+    build_now_playing_actions,
+    build_now_playing_state_provider,
+)
+from yoyopod.ui.screens.system.power import (
+    build_power_screen_actions,
+    build_power_screen_state_provider,
+)
+from yoyopod.ui.screens.voip.voice_note import (
+    build_voice_note_actions,
+    build_voice_note_state_provider,
+)
 from yoyopod.voice import VoiceSettings
 from yoyopod.communication import CallHistoryStore, VoIPConfig, VoIPManager
 
@@ -466,9 +478,7 @@ class RuntimeBootService:
                             else 50
                         ),
                         stt_backend=(
-                            voice_cfg.assistant.stt_backend
-                            if voice_cfg is not None
-                            else "vosk"
+                            voice_cfg.assistant.stt_backend if voice_cfg is not None else "vosk"
                         ),
                         tts_backend=(
                             voice_cfg.assistant.tts_backend
@@ -523,9 +533,7 @@ class RuntimeBootService:
                         self.app.voip_manager.mute if self.app.voip_manager is not None else None
                     ),
                     unmute_action=(
-                        self.app.voip_manager.unmute
-                        if self.app.voip_manager is not None
-                        else None
+                        self.app.voip_manager.unmute if self.app.voip_manager is not None else None
                     ),
                     play_music_action=(
                         self.app.local_music_service.shuffle_all
@@ -558,46 +566,59 @@ class RuntimeBootService:
             self.app.power_screen = PowerScreen(
                 display,
                 context,
-                power_manager=self.app.power_manager,
-                status_provider=self.app.get_status,
-                refresh_voice_device_options_action=(
-                    self.app.audio_device_catalog.refresh_async
-                    if self.app.audio_device_catalog is not None
-                    else None
+                state_provider=build_power_screen_state_provider(
+                    power_manager=self.app.power_manager,
+                    network_manager=self.app.network_manager,
+                    status_provider=self.app.get_status,
+                    playback_device_options_provider=(
+                        self.app.audio_device_catalog.playback_devices
+                        if self.app.audio_device_catalog is not None
+                        else None
+                    ),
+                    capture_device_options_provider=(
+                        self.app.audio_device_catalog.capture_devices
+                        if self.app.audio_device_catalog is not None
+                        else None
+                    ),
                 ),
-                playback_device_options_provider=(
-                    self.app.audio_device_catalog.playback_devices
-                    if self.app.audio_device_catalog is not None
-                    else None
-                ),
-                capture_device_options_provider=(
-                    self.app.audio_device_catalog.capture_devices
-                    if self.app.audio_device_catalog is not None
-                    else None
-                ),
-                persist_speaker_device_action=(
-                    self.app.config_manager.set_voice_speaker_device_id
-                    if self.app.config_manager is not None
-                    else None
-                ),
-                persist_capture_device_action=(
-                    self.app.config_manager.set_voice_capture_device_id
-                    if self.app.config_manager is not None
-                    else None
-                ),
-                volume_up_action=self.app.volume_up,
-                volume_down_action=self.app.volume_down,
-                mute_action=(
-                    self.app.voip_manager.mute if self.app.voip_manager is not None else None
-                ),
-                unmute_action=(
-                    self.app.voip_manager.unmute if self.app.voip_manager is not None else None
+                actions=build_power_screen_actions(
+                    network_manager=self.app.network_manager,
+                    refresh_voice_device_options_action=(
+                        self.app.audio_device_catalog.refresh_async
+                        if self.app.audio_device_catalog is not None
+                        else None
+                    ),
+                    persist_speaker_device_action=(
+                        self.app.config_manager.set_voice_speaker_device_id
+                        if self.app.config_manager is not None
+                        else None
+                    ),
+                    persist_capture_device_action=(
+                        self.app.config_manager.set_voice_capture_device_id
+                        if self.app.config_manager is not None
+                        else None
+                    ),
+                    volume_up_action=self.app.volume_up,
+                    volume_down_action=self.app.volume_down,
+                    mute_action=(
+                        self.app.voip_manager.mute if self.app.voip_manager is not None else None
+                    ),
+                    unmute_action=(
+                        self.app.voip_manager.unmute if self.app.voip_manager is not None else None
+                    ),
                 ),
             )
             self.app.now_playing_screen = NowPlayingScreen(
                 display,
                 context,
-                music_backend=self.app.music_backend,
+                state_provider=build_now_playing_state_provider(
+                    context=context,
+                    music_backend=self.app.music_backend,
+                ),
+                actions=build_now_playing_actions(
+                    context=context,
+                    music_backend=self.app.music_backend,
+                ),
             )
             self.app.playlist_screen = PlaylistScreen(
                 display,
@@ -636,7 +657,11 @@ class RuntimeBootService:
             self.app.voice_note_screen = VoiceNoteScreen(
                 display,
                 context,
-                voip_manager=self.app.voip_manager,
+                state_provider=build_voice_note_state_provider(
+                    context=context,
+                    voip_manager=self.app.voip_manager,
+                ),
+                actions=build_voice_note_actions(voip_manager=self.app.voip_manager),
             )
             self.app.incoming_call_screen = IncomingCallScreen(
                 display,

--- a/src/yoyopod/ui/screens/music/lvgl/now_playing_view.py
+++ b/src/yoyopod/ui/screens/music/lvgl/now_playing_view.py
@@ -36,21 +36,28 @@ class LvglNowPlayingView:
         if not self._built or self.backend.binding is None:
             return
 
-        track_title, artist, progress, state_label, is_playing = self.screen._track_snapshot()
-        footer = self.screen.get_footer_text(is_playing=is_playing, state_label=state_label)
+        state = self.screen.current_state()
+        footer = self.screen.get_footer_text(
+            is_playing=state.is_playing,
+            state_label=state.state_label,
+        )
         context = self.screen.context
         sync_network_status(self.backend.binding, context)
 
         self.backend.binding.now_playing_sync(
-            title_text=track_title,
-            artist_text=artist,
-            state_text=self.screen._display_state_text(state_label),
+            title_text=state.title,
+            artist_text=state.artist,
+            state_text=self.screen._display_state_text(state.state_label),
             footer=footer,
-            progress_permille=max(0, min(1000, int(progress * 1000))),
+            progress_permille=max(0, min(1000, int(state.progress * 1000))),
             voip_state=self._voip_state(context),
             battery_percent=self._battery_percent(context),
-            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
-            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            charging=(
+                bool(getattr(context, "battery_charging", False)) if context is not None else False
+            ),
+            power_available=(
+                bool(getattr(context, "power_available", True)) if context is not None else True
+            ),
             accent=LISTEN.accent,
         )
 

--- a/src/yoyopod/ui/screens/music/now_playing.py
+++ b/src/yoyopod/ui/screens/music/now_playing.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, Optional
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
@@ -31,6 +32,136 @@ if TYPE_CHECKING:
     from yoyopod.ui.screens import ScreenView
 
 
+@dataclass(frozen=True, slots=True)
+class NowPlayingState:
+    """Prepared playback state for the now-playing screen."""
+
+    title: str
+    artist: str
+    progress: float
+    state_label: str
+    is_playing: bool
+
+
+@dataclass(frozen=True, slots=True)
+class NowPlayingActions:
+    """Focused playback actions exposed to the now-playing screen."""
+
+    toggle_playback: Callable[[], None] | None = None
+    previous_track: Callable[[], None] | None = None
+    next_track: Callable[[], None] | None = None
+
+
+def build_now_playing_state_provider(
+    *,
+    context: "AppContext | None" = None,
+    music_backend: "MusicBackend | None" = None,
+) -> Callable[[], NowPlayingState]:
+    """Build a narrow prepared-state provider for the now-playing screen."""
+
+    def provider() -> NowPlayingState:
+        if music_backend is not None:
+            if not music_backend.is_connected:
+                return NowPlayingState(
+                    title="Music Offline",
+                    artist="Trying to reconnect",
+                    progress=0.0,
+                    state_label="OFFLINE",
+                    is_playing=False,
+                )
+
+            current_track = music_backend.get_current_track()
+            playback_state = music_backend.get_playback_state()
+            if current_track is not None:
+                progress = 0.0
+                if current_track.length > 0:
+                    progress = music_backend.get_time_position() / current_track.length
+                state_label = (
+                    "PLAYING"
+                    if playback_state == "playing"
+                    else "PAUSED" if playback_state == "paused" else "READY"
+                )
+                return NowPlayingState(
+                    title=current_track.name,
+                    artist=current_track.get_artist_string() or "Unknown artist",
+                    progress=progress,
+                    state_label=state_label,
+                    is_playing=playback_state == "playing",
+                )
+
+            return NowPlayingState(
+                title="No Track Yet",
+                artist="Pick local music to begin",
+                progress=0.0,
+                state_label="READY",
+                is_playing=False,
+            )
+
+        track = context.get_current_track() if context is not None else None
+        if track is None:
+            return NowPlayingState(
+                title="No Track Yet",
+                artist="Pick local music to begin",
+                progress=0.0,
+                state_label="READY",
+                is_playing=False,
+            )
+
+        return NowPlayingState(
+            title=track.name,
+            artist=track.get_artist_string(),
+            progress=context.get_playback_progress() if context is not None else 0.0,
+            state_label=(
+                "PLAYING" if context is not None and context.playback.is_playing else "PAUSED"
+            ),
+            is_playing=bool(context is not None and context.playback.is_playing),
+        )
+
+    return provider
+
+
+def build_now_playing_actions(
+    *,
+    context: "AppContext | None" = None,
+    music_backend: "MusicBackend | None" = None,
+) -> NowPlayingActions:
+    """Build the focused playback actions for the now-playing screen."""
+
+    def toggle_playback() -> None:
+        if music_backend is not None:
+            if not music_backend.is_connected:
+                return
+            if music_backend.get_playback_state() == "playing":
+                music_backend.pause()
+            else:
+                music_backend.play()
+            return
+        if context is not None:
+            context.toggle_playback()
+
+    def previous_track() -> None:
+        if music_backend is not None:
+            if music_backend.is_connected:
+                music_backend.previous_track()
+            return
+        if context is not None:
+            context.previous_track()
+
+    def next_track() -> None:
+        if music_backend is not None:
+            if music_backend.is_connected:
+                music_backend.next_track()
+            return
+        if context is not None:
+            context.next_track()
+
+    return NowPlayingActions(
+        toggle_playback=toggle_playback,
+        previous_track=previous_track,
+        next_track=next_track,
+    )
+
+
 class NowPlayingScreen(Screen):
     """Current playback screen styled for the new Listen mode."""
 
@@ -38,10 +169,13 @@ class NowPlayingScreen(Screen):
         self,
         display: Display,
         context: Optional["AppContext"] = None,
-        music_backend: "MusicBackend | None" = None,
+        *,
+        state_provider: Callable[[], NowPlayingState] | None = None,
+        actions: NowPlayingActions | None = None,
     ) -> None:
         super().__init__(display, context, "NowPlaying")
-        self.music_backend = music_backend
+        self._state_provider = state_provider or build_now_playing_state_provider(context=context)
+        self._actions = actions or build_now_playing_actions(context=context)
         self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
@@ -81,10 +215,10 @@ class NowPlayingScreen(Screen):
             lvgl_view.sync()
             return
 
-        track_title, artist, progress, state_label, is_playing = self._track_snapshot()
-        state_text = self._display_state_text(state_label)
-        footer = self.get_footer_text(is_playing=is_playing, state_label=state_label)
-        visuals = self._state_visuals(state_label)
+        state = self.current_state()
+        state_text = self._display_state_text(state.state_label)
+        footer = self.get_footer_text(is_playing=state.is_playing, state_label=state.state_label)
+        visuals = self._state_visuals(state.state_label)
 
         render_backdrop(self.display, "listen")
         render_status_bar(self.display, self.context, show_time=True)
@@ -115,11 +249,11 @@ class NowPlayingScreen(Screen):
         title_y = halo_top + halo_height + 18
         title_lines = wrap_text(
             self.display,
-            track_title,
+            state.title,
             self.display.WIDTH - 32,
             18,
             max_lines=2,
-        ) or [text_fit(self.display, track_title, self.display.WIDTH - 32, 18)]
+        ) or [text_fit(self.display, state.title, self.display.WIDTH - 32, 18)]
         title_line_height = self.display.get_text_size("Ag", 18)[1]
         for index, line in enumerate(title_lines):
             title_width, _ = self.display.get_text_size(line, 18)
@@ -133,7 +267,7 @@ class NowPlayingScreen(Screen):
 
         title_bottom = title_y + (len(title_lines) * title_line_height)
         artist_y = title_bottom + 8
-        artist_text = text_fit(self.display, artist, self.display.WIDTH - 36, 11)
+        artist_text = text_fit(self.display, state.artist, self.display.WIDTH - 36, 11)
         artist_width, _ = self.display.get_text_size(artist_text, 11)
         self.display.text(
             artist_text,
@@ -175,7 +309,7 @@ class NowPlayingScreen(Screen):
             progress_y + 8,
             fill=mix(BACKGROUND, SURFACE_RAISED, 0.5),
         )
-        fill_width = max(0, min(progress_width, int(progress_width * progress)))
+        fill_width = max(0, min(progress_width, int(progress_width * state.progress)))
         if fill_width > 0:
             self.display.rectangle(
                 progress_x,
@@ -234,77 +368,28 @@ class NowPlayingScreen(Screen):
             "progress_fill": LISTEN.accent,
         }
 
-    def _track_snapshot(self) -> tuple[str, str, float, str, bool]:
-        """Return current track, artist, progress and state label."""
-        if self.music_backend:
-            if not self.music_backend.is_connected:
-                return ("Music Offline", "Trying to reconnect", 0.0, "OFFLINE", False)
+    def current_state(self) -> NowPlayingState:
+        """Return the prepared playback state for the current render."""
 
-            current_track = self.music_backend.get_current_track()
-            playback_state = self.music_backend.get_playback_state()
-            if current_track:
-                progress = 0.0
-                if current_track.length > 0:
-                    progress = self.music_backend.get_time_position() / current_track.length
-                state_label = (
-                    "PLAYING"
-                    if playback_state == "playing"
-                    else "PAUSED" if playback_state == "paused" else "READY"
-                )
-                return (
-                    current_track.name,
-                    current_track.get_artist_string() or "Unknown artist",
-                    progress,
-                    state_label,
-                    playback_state == "playing",
-                )
-
-            return ("No Track Yet", "Pick local music to begin", 0.0, "READY", False)
-
-        track = self.context.get_current_track() if self.context else None
-        if track is None:
-            return ("No Track Yet", "Pick local music to begin", 0.0, "READY", False)
-
-        return (
-            track.name,
-            track.get_artist_string(),
-            self.context.get_playback_progress() if self.context else 0.0,
-            "PLAYING" if self.context and self.context.playback.is_playing else "PAUSED",
-            bool(self.context and self.context.playback.is_playing),
-        )
+        return self._state_provider()
 
     def _toggle_playback(self) -> None:
-        """Toggle playback via the music backend or local app context."""
-        if self.music_backend:
-            if not self.music_backend.is_connected:
-                return
-            state = self.music_backend.get_playback_state()
-            if state == "playing":
-                self.music_backend.pause()
-            else:
-                self.music_backend.play()
-            return
+        """Toggle playback via the injected action seam."""
 
-        if self.context:
-            self.context.toggle_playback()
+        if self._actions.toggle_playback is not None:
+            self._actions.toggle_playback()
 
     def _previous_track(self) -> None:
-        """Go to the previous track."""
-        if self.music_backend:
-            if self.music_backend.is_connected:
-                self.music_backend.previous_track()
-            return
-        if self.context:
-            self.context.previous_track()
+        """Go to the previous track via the injected action seam."""
+
+        if self._actions.previous_track is not None:
+            self._actions.previous_track()
 
     def _next_track(self) -> None:
-        """Go to the next track."""
-        if self.music_backend:
-            if self.music_backend.is_connected:
-                self.music_backend.next_track()
-            return
-        if self.context:
-            self.context.next_track()
+        """Go to the next track via the injected action seam."""
+
+        if self._actions.next_track is not None:
+            self._actions.next_track()
 
     def on_select(self, data: object | None = None) -> None:
         """Toggle play/pause."""

--- a/src/yoyopod/ui/screens/system/lvgl/power_view.py
+++ b/src/yoyopod/ui/screens/system/lvgl/power_view.py
@@ -32,9 +32,8 @@ class LvglPowerView:
         if not self._built or self.backend.binding is None:
             return
 
-        snapshot = self.screen._get_snapshot()
-        status = self.screen._get_status()
-        pages = self.screen._build_pages_for_display(snapshot=snapshot, status=status)
+        state = self.screen._get_state()
+        pages = self.screen._build_pages_for_display(state=state)
         if not pages:
             return
 
@@ -64,8 +63,14 @@ class LvglPowerView:
                 total_pages=len(pages),
                 voip_state=self._voip_state(context),
                 battery_percent=self._battery_percent(context),
-                charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
-                power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+                charging=(
+                    bool(getattr(context, "battery_charging", False))
+                    if context is not None
+                    else False
+                ),
+                power_available=(
+                    bool(getattr(context, "power_available", True)) if context is not None else True
+                ),
                 accent=SETUP.accent,
             )
             return
@@ -88,8 +93,12 @@ class LvglPowerView:
             total_pages=len(pages),
             voip_state=self._voip_state(context),
             battery_percent=self._battery_percent(context),
-            charging=bool(getattr(context, "battery_charging", False)) if context is not None else False,
-            power_available=bool(getattr(context, "power_available", True)) if context is not None else True,
+            charging=(
+                bool(getattr(context, "battery_charging", False)) if context is not None else False
+            ),
+            power_available=(
+                bool(getattr(context, "power_available", True)) if context is not None else True
+            ),
             accent=SETUP.accent,
         )
 

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Callable, Optional
 
@@ -41,6 +41,193 @@ class PowerPage:
     interactive: bool = False
 
 
+@dataclass(frozen=True, slots=True)
+class PowerScreenState:
+    """Prepared power/setup state consumed by the Setup screen."""
+
+    snapshot: "PowerSnapshot | None" = None
+    status: dict[str, object] = field(default_factory=dict)
+    network_enabled: bool = False
+    network_rows: tuple[tuple[str, str], ...] = ()
+    gps_rows: tuple[tuple[str, str], ...] = ()
+    playback_devices: tuple[str, ...] = ()
+    capture_devices: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PowerScreenActions:
+    """Focused actions exposed to the Setup screen."""
+
+    refresh_voice_devices: Callable[[], None] | None = None
+    refresh_gps: Callable[[], bool] | None = None
+    persist_speaker_device: Callable[[str | None], bool] | None = None
+    persist_capture_device: Callable[[str | None], bool] | None = None
+    volume_up: Callable[[int], int | None] | None = None
+    volume_down: Callable[[int], int | None] | None = None
+    mute: Callable[[], bool] | None = None
+    unmute: Callable[[], bool] | None = None
+
+
+def _build_network_rows_from_manager(network_manager: object | None) -> list[tuple[str, str]]:
+    """Build the cellular network status rows from a backend-facing manager."""
+
+    if network_manager is None or not network_manager.config.enabled:
+        return [("Status", "Disabled")]
+
+    from yoyopod.network.models import ModemPhase
+
+    state = network_manager.modem_state
+    if state.phase == ModemPhase.ONLINE:
+        status_text = "Online"
+    elif state.phase in (
+        ModemPhase.REGISTERED,
+        ModemPhase.PPP_STARTING,
+        ModemPhase.PPP_STOPPING,
+    ):
+        status_text = "Registered"
+    elif state.phase in (ModemPhase.PROBING, ModemPhase.READY, ModemPhase.REGISTERING):
+        status_text = "Connecting"
+    else:
+        status_text = "Offline"
+
+    return [
+        ("Status", status_text),
+        ("Carrier", state.carrier or "Unknown"),
+        ("Type", state.network_type or "Unknown"),
+        ("Signal", f"{state.signal.bars}/4" if state.signal else "Unknown"),
+        ("PPP", "Up" if state.phase == ModemPhase.ONLINE else "Down"),
+    ]
+
+
+def _build_gps_rows_from_manager(network_manager: object | None) -> list[tuple[str, str]]:
+    """Build the GPS status rows from a backend-facing manager."""
+
+    if network_manager is None or not network_manager.config.enabled:
+        return [
+            ("Fix", "Disabled"),
+            ("Lat", "--"),
+            ("Lng", "--"),
+            ("Alt", "--"),
+            ("Speed", "--"),
+        ]
+    if not network_manager.config.gps_enabled:
+        return [
+            ("Fix", "Disabled"),
+            ("Lat", "--"),
+            ("Lng", "--"),
+            ("Alt", "--"),
+            ("Speed", "--"),
+        ]
+
+    from yoyopod.network.models import ModemPhase
+
+    state = network_manager.modem_state
+    if state.gps is None:
+        fix_status = "Searching"
+        if state.phase in (ModemPhase.OFF, ModemPhase.PROBING, ModemPhase.READY):
+            fix_status = "Starting"
+        elif state.phase not in (
+            ModemPhase.REGISTERING,
+            ModemPhase.REGISTERED,
+            ModemPhase.PPP_STARTING,
+            ModemPhase.PPP_STOPPING,
+            ModemPhase.ONLINE,
+        ):
+            fix_status = "Unavailable"
+        return [
+            ("Fix", fix_status),
+            ("Lat", "--"),
+            ("Lng", "--"),
+            ("Alt", "--"),
+            ("Speed", "--"),
+        ]
+
+    coord = state.gps
+    return [
+        ("Fix", "Yes"),
+        ("Lat", f"{coord.lat:.6f}"),
+        ("Lng", f"{coord.lng:.6f}"),
+        ("Alt", f"{coord.altitude:.1f}m"),
+        ("Speed", f"{coord.speed:.1f}km/h"),
+    ]
+
+
+def build_power_screen_state_provider(
+    *,
+    power_manager: "PowerManager | None" = None,
+    network_manager: object | None = None,
+    status_provider: Callable[[], dict[str, object]] | None = None,
+    playback_device_options_provider: Callable[[], list[str]] | None = None,
+    capture_device_options_provider: Callable[[], list[str]] | None = None,
+) -> Callable[[], PowerScreenState]:
+    """Build a prepared-state provider for the Setup screen."""
+
+    def provider() -> PowerScreenState:
+        snapshot = power_manager.get_snapshot() if power_manager is not None else None
+        try:
+            status = dict(status_provider() if status_provider is not None else {})
+        except Exception:
+            status = {}
+
+        return PowerScreenState(
+            snapshot=snapshot,
+            status=status,
+            network_enabled=bool(
+                network_manager is not None and getattr(network_manager.config, "enabled", False)
+            ),
+            network_rows=tuple(_build_network_rows_from_manager(network_manager)),
+            gps_rows=tuple(_build_gps_rows_from_manager(network_manager)),
+            playback_devices=tuple(
+                playback_device_options_provider()
+                if playback_device_options_provider is not None
+                else []
+            ),
+            capture_devices=tuple(
+                capture_device_options_provider()
+                if capture_device_options_provider is not None
+                else []
+            ),
+        )
+
+    return provider
+
+
+def build_power_screen_actions(
+    *,
+    network_manager: object | None = None,
+    refresh_voice_device_options_action: Callable[[], None] | None = None,
+    persist_speaker_device_action: Callable[[str | None], bool] | None = None,
+    persist_capture_device_action: Callable[[str | None], bool] | None = None,
+    volume_up_action: Callable[[int], int | None] | None = None,
+    volume_down_action: Callable[[int], int | None] | None = None,
+    mute_action: Callable[[], bool] | None = None,
+    unmute_action: Callable[[], bool] | None = None,
+) -> PowerScreenActions:
+    """Build the focused actions for the Setup screen."""
+
+    def refresh_gps() -> bool:
+        if network_manager is None or not getattr(network_manager.config, "enabled", False):
+            return False
+        if not getattr(network_manager.config, "gps_enabled", False):
+            return False
+
+        query_gps = getattr(network_manager, "query_gps", None)
+        if not callable(query_gps):
+            return False
+        return query_gps() is not None
+
+    return PowerScreenActions(
+        refresh_voice_devices=refresh_voice_device_options_action,
+        refresh_gps=refresh_gps,
+        persist_speaker_device=persist_speaker_device_action,
+        persist_capture_device=persist_capture_device_action,
+        volume_up=volume_up_action,
+        volume_down=volume_down_action,
+        mute=mute_action,
+        unmute=unmute_action,
+    )
+
+
 class PowerScreen(Screen):
     """Compact Setup screen for power and device care state."""
 
@@ -49,32 +236,12 @@ class PowerScreen(Screen):
         display: Display,
         context: Optional["AppContext"] = None,
         *,
-        power_manager: Optional["PowerManager"] = None,
-        network_manager: Optional[object] = None,
-        status_provider: Optional[Callable[[], dict[str, object]]] = None,
-        refresh_voice_device_options_action: Optional[Callable[[], None]] = None,
-        playback_device_options_provider: Optional[Callable[[], list[str]]] = None,
-        capture_device_options_provider: Optional[Callable[[], list[str]]] = None,
-        persist_speaker_device_action: Optional[Callable[[str | None], bool]] = None,
-        persist_capture_device_action: Optional[Callable[[str | None], bool]] = None,
-        volume_up_action: Optional[Callable[[int], int | None]] = None,
-        volume_down_action: Optional[Callable[[int], int | None]] = None,
-        mute_action: Optional[Callable[[], bool]] = None,
-        unmute_action: Optional[Callable[[], bool]] = None,
+        state_provider: Callable[[], PowerScreenState] | None = None,
+        actions: PowerScreenActions | None = None,
     ) -> None:
         super().__init__(display, context, "PowerStatus")
-        self.power_manager = power_manager
-        self.network_manager = network_manager
-        self.status_provider = status_provider or (lambda: {})
-        self.refresh_voice_device_options_action = refresh_voice_device_options_action
-        self.playback_device_options_provider = playback_device_options_provider
-        self.capture_device_options_provider = capture_device_options_provider
-        self.persist_speaker_device_action = persist_speaker_device_action
-        self.persist_capture_device_action = persist_capture_device_action
-        self.volume_up_action = volume_up_action
-        self.volume_down_action = volume_down_action
-        self.mute_action = mute_action
-        self.unmute_action = unmute_action
+        self._state_provider = state_provider or build_power_screen_state_provider()
+        self._actions = actions or PowerScreenActions()
         self.page_index = 0
         self.selected_row = 0
         self.in_detail = False
@@ -89,8 +256,8 @@ class PowerScreen(Screen):
         self.page_index = 0
         self.selected_row = 0
         self.in_detail = False
-        if self.refresh_voice_device_options_action is not None:
-            self.refresh_voice_device_options_action()
+        if self._actions.refresh_voice_devices is not None:
+            self._actions.refresh_voice_devices()
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
@@ -125,9 +292,8 @@ class PowerScreen(Screen):
             lvgl_view.sync()
             return
 
-        snapshot = self._get_snapshot()
-        status = self._get_status()
-        pages = self._build_pages_for_display(snapshot=snapshot, status=status)
+        state = self._get_state()
+        pages = self._build_pages_for_display(state=state)
         self.page_index %= len(pages)
         active_page = pages[self.page_index]
         picker_mode = not self.is_one_button_mode() and not self.in_detail
@@ -377,19 +543,26 @@ class PowerScreen(Screen):
     def build_pages(
         self,
         *,
-        snapshot: Optional["PowerSnapshot"],
-        status: dict[str, object],
+        snapshot: Optional["PowerSnapshot"] = None,
+        status: dict[str, object] | None = None,
+        state: PowerScreenState | None = None,
     ) -> list[PowerPage]:
         """Build compact setup pages for rendering and tests."""
-        battery_rows = self._build_battery_rows(snapshot=snapshot)
-        runtime_rows = self._build_runtime_rows(snapshot=snapshot, status=status)
+        resolved_state = state or self._get_state()
+        resolved_snapshot = snapshot if snapshot is not None else resolved_state.snapshot
+        resolved_status = status if status is not None else resolved_state.status
+        battery_rows = self._build_battery_rows(snapshot=resolved_snapshot)
+        runtime_rows = self._build_runtime_rows(
+            snapshot=resolved_snapshot,
+            status=resolved_status,
+        )
 
         pages = [
             PowerPage(title="Power", rows=battery_rows[:4]),
         ]
-        if self.network_manager is not None and self.network_manager.config.enabled:
-            pages.append(PowerPage(title="Network", rows=self._build_network_rows()))
-            pages.append(PowerPage(title="GPS", rows=self._build_gps_rows()))
+        if resolved_state.network_enabled:
+            pages.append(PowerPage(title="Network", rows=self._build_network_rows(resolved_state)))
+            pages.append(PowerPage(title="GPS", rows=self._build_gps_rows(resolved_state)))
         voice_interactive = not self.is_one_button_mode()
         pages.extend(
             [
@@ -407,12 +580,18 @@ class PowerScreen(Screen):
     def _build_pages_for_display(
         self,
         *,
-        snapshot: Optional["PowerSnapshot"],
-        status: dict[str, object],
+        snapshot: Optional["PowerSnapshot"] = None,
+        status: dict[str, object] | None = None,
+        state: PowerScreenState | None = None,
     ) -> list[PowerPage]:
         """Build pages and opportunistically refresh GPS when the GPS page is active."""
 
-        pages = self.build_pages(snapshot=snapshot, status=status)
+        resolved_state = state or self._get_state()
+        pages = self.build_pages(
+            snapshot=snapshot,
+            status=status,
+            state=resolved_state,
+        )
         if not pages:
             return pages
 
@@ -422,7 +601,7 @@ class PowerScreen(Screen):
             return pages
 
         if self._maybe_refresh_gps_page():
-            pages = self.build_pages(snapshot=snapshot, status=status)
+            pages = self.build_pages(state=self._get_state())
         return pages
 
     def _build_voice_rows(self, *, summary_mode: bool = False) -> list[tuple[str, str]]:
@@ -468,93 +647,33 @@ class PowerScreen(Screen):
             ]
         return rows
 
-    def _build_network_rows(self) -> list[tuple[str, str]]:
+    def _build_network_rows(
+        self,
+        state: PowerScreenState | None = None,
+    ) -> list[tuple[str, str]]:
         """Build the cellular network status page."""
-        if self.network_manager is None or not self.network_manager.config.enabled:
-            return [("Status", "Disabled")]
-        state = self.network_manager.modem_state
-        from yoyopod.network.models import ModemPhase
+        resolved_state = state or self._get_state()
+        return list(resolved_state.network_rows or (("Status", "Disabled"),))
 
-        if state.phase == ModemPhase.ONLINE:
-            status_text = "Online"
-        elif state.phase in (
-            ModemPhase.REGISTERED,
-            ModemPhase.PPP_STARTING,
-            ModemPhase.PPP_STOPPING,
-        ):
-            status_text = "Registered"
-        elif state.phase in (ModemPhase.PROBING, ModemPhase.READY, ModemPhase.REGISTERING):
-            status_text = "Connecting"
-        else:
-            status_text = "Offline"
-        return [
-            ("Status", status_text),
-            ("Carrier", state.carrier or "Unknown"),
-            ("Type", state.network_type or "Unknown"),
-            ("Signal", f"{state.signal.bars}/4" if state.signal else "Unknown"),
-            ("PPP", "Up" if state.phase == ModemPhase.ONLINE else "Down"),
-        ]
-
-    def _build_gps_rows(self) -> list[tuple[str, str]]:
+    def _build_gps_rows(
+        self,
+        state: PowerScreenState | None = None,
+    ) -> list[tuple[str, str]]:
         """Build the GPS status page."""
-        if self.network_manager is None or not self.network_manager.config.enabled:
-            return [
+        resolved_state = state or self._get_state()
+        return list(
+            resolved_state.gps_rows
+            or (
                 ("Fix", "Disabled"),
                 ("Lat", "--"),
                 ("Lng", "--"),
                 ("Alt", "--"),
                 ("Speed", "--"),
-            ]
-        if not self.network_manager.config.gps_enabled:
-            return [
-                ("Fix", "Disabled"),
-                ("Lat", "--"),
-                ("Lng", "--"),
-                ("Alt", "--"),
-                ("Speed", "--"),
-            ]
-        state = self.network_manager.modem_state
-        from yoyopod.network.models import ModemPhase
-
-        if state.gps is None:
-            fix_status = "Searching"
-            if state.phase in (ModemPhase.OFF, ModemPhase.PROBING, ModemPhase.READY):
-                fix_status = "Starting"
-            elif state.phase not in (
-                ModemPhase.REGISTERING,
-                ModemPhase.REGISTERED,
-                ModemPhase.PPP_STARTING,
-                ModemPhase.PPP_STOPPING,
-                ModemPhase.ONLINE,
-            ):
-                fix_status = "Unavailable"
-            return [
-                ("Fix", fix_status),
-                ("Lat", "--"),
-                ("Lng", "--"),
-                ("Alt", "--"),
-                ("Speed", "--"),
-            ]
-        coord = state.gps
-        return [
-            ("Fix", "Yes"),
-            ("Lat", f"{coord.lat:.6f}"),
-            ("Lng", f"{coord.lng:.6f}"),
-            ("Alt", f"{coord.altitude:.1f}m"),
-            ("Speed", f"{coord.speed:.1f}km/h"),
-        ]
+            )
+        )
 
     def _maybe_refresh_gps_page(self) -> bool:
         """Query GPS when the user is actively viewing the GPS page."""
-
-        if self.network_manager is None or not self.network_manager.config.enabled:
-            return False
-        if not self.network_manager.config.gps_enabled:
-            return False
-
-        query_gps = getattr(self.network_manager, "query_gps", None)
-        if not callable(query_gps):
-            return False
 
         now = time.monotonic()
         if now - self._last_gps_query_at < self._gps_refresh_interval_seconds:
@@ -562,27 +681,30 @@ class PowerScreen(Screen):
 
         self._last_gps_query_at = now
         try:
-            coord = query_gps()
+            coord = False if self._actions.refresh_gps is None else self._actions.refresh_gps()
         except Exception as exc:
             logger.warning("GPS refresh failed on Setup screen: {}", exc)
             return False
 
         if self.context is not None:
-            self.context.update_network_status(gps_has_fix=coord is not None)
-        return coord is not None
+            self.context.update_network_status(gps_has_fix=bool(coord))
+        return bool(coord)
+
+    def _get_state(self) -> PowerScreenState:
+        """Return the prepared state for the current render."""
+
+        try:
+            return self._state_provider()
+        except Exception:
+            return PowerScreenState()
 
     def _get_snapshot(self) -> Optional["PowerSnapshot"]:
         """Return the latest power snapshot."""
-        if self.power_manager is None:
-            return None
-        return self.power_manager.get_snapshot()
+        return self._get_state().snapshot
 
     def _get_status(self) -> dict[str, object]:
         """Return the latest app runtime/policy status."""
-        try:
-            return self.status_provider()
-        except Exception:
-            return {}
+        return dict(self._get_state().status)
 
     def _build_battery_rows(self, *, snapshot: Optional["PowerSnapshot"]) -> list[tuple[str, str]]:
         """Build the power-focused page."""
@@ -765,7 +887,7 @@ class PowerScreen(Screen):
     def _active_pages(self) -> list[PowerPage]:
         """Return the current page list for navigation helpers."""
 
-        return self.build_pages(snapshot=self._get_snapshot(), status=self._get_status())
+        return self.build_pages(state=self._get_state())
 
     def _active_page(self) -> PowerPage:
         """Return the current active page."""
@@ -830,10 +952,10 @@ class PowerScreen(Screen):
             self._apply_mic_state(not self.context.voice.mic_muted)
             return
         current = None
-        if direction > 0 and self.volume_up_action is not None:
-            current = self.volume_up_action(5)
-        elif direction < 0 and self.volume_down_action is not None:
-            current = self.volume_down_action(5)
+        if direction > 0 and self._actions.volume_up is not None:
+            current = self._actions.volume_up(5)
+        elif direction < 0 and self._actions.volume_down is not None:
+            current = self._actions.volume_down(5)
         else:
             volume = self.context.voice.output_volume + (5 * direction)
             self.context.set_volume(max(0, min(100, volume)))
@@ -843,18 +965,12 @@ class PowerScreen(Screen):
     def _playback_device_options(self) -> list[str | None]:
         """Return selectable playback options, with None representing Auto."""
 
-        devices = []
-        if self.playback_device_options_provider is not None:
-            devices = list(self.playback_device_options_provider())
-        return [None, *devices]
+        return [None, *self._get_state().playback_devices]
 
     def _capture_device_options(self) -> list[str | None]:
         """Return selectable capture options, with None representing Auto."""
 
-        devices = []
-        if self.capture_device_options_provider is not None:
-            devices = list(self.capture_device_options_provider())
-        return [None, *devices]
+        return [None, *self._get_state().capture_devices]
 
     @staticmethod
     def _cycle_option(
@@ -880,8 +996,8 @@ class PowerScreen(Screen):
             direction,
         )
         self.context.configure_voice(speaker_device_id=next_device)
-        if self.persist_speaker_device_action is not None:
-            self.persist_speaker_device_action(next_device)
+        if self._actions.persist_speaker_device is not None:
+            self._actions.persist_speaker_device(next_device)
 
     def _cycle_capture_device(self, direction: int) -> None:
         if self.context is None:
@@ -892,8 +1008,8 @@ class PowerScreen(Screen):
             direction,
         )
         self.context.configure_voice(capture_device_id=next_device)
-        if self.persist_capture_device_action is not None:
-            self.persist_capture_device_action(next_device)
+        if self._actions.persist_capture_device is not None:
+            self._actions.persist_capture_device(next_device)
 
     def _next_page(self) -> None:
         """Advance to the next page with wraparound."""
@@ -1008,7 +1124,7 @@ class PowerScreen(Screen):
 
         if self.context is not None:
             self.context.set_mic_muted(muted)
-        action = self.mute_action if muted else self.unmute_action
+        action = self._actions.mute if muted else self._actions.unmute
         if action is not None:
             action()
 

--- a/src/yoyopod/ui/screens/voip/voice_note.py
+++ b/src/yoyopod/ui/screens/voip/voice_note.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
@@ -26,8 +26,8 @@ from yoyopod.ui.screens.voip.lvgl.voice_note_view import LvglVoiceNoteView
 
 if TYPE_CHECKING:
     from yoyopod.app_context import AppContext
-    from yoyopod.ui.screens import ScreenView
     from yoyopod.communication import VoIPManager
+    from yoyopod.ui.screens import ScreenView
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,6 +39,136 @@ class VoiceNoteAction:
     badge: str = ""
 
 
+@dataclass(frozen=True, slots=True)
+class VoiceNoteState:
+    """Prepared state for the voice-note flow."""
+
+    recipient_name: str = "Friend"
+    recipient_address: str = ""
+    send_state: str = "idle"
+    status_text: str = ""
+    file_path: str = ""
+    duration_ms: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class VoiceNoteActions:
+    """Focused voice-note actions exposed to the screen."""
+
+    start_recording: Callable[[str, str], bool] | None = None
+    stop_recording: Callable[[], object | None] | None = None
+    cancel_recording: Callable[[], bool] | None = None
+    discard_active_draft: Callable[[], None] | None = None
+    send_active_draft: Callable[[], bool] | None = None
+    preview_draft: Callable[[str], bool] | None = None
+    set_draft_status_text: Callable[[str], None] | None = None
+
+
+def _resolve_voice_note_recipient(context: "AppContext | None") -> tuple[str, str]:
+    """Return the active voice-note recipient from the current UI context."""
+
+    if context is None:
+        return ("Friend", "")
+
+    voice_note = context.talk.active_voice_note
+    selected_contact = context.talk
+    return (
+        voice_note.recipient_name or selected_contact.selected_contact_name or "Friend",
+        voice_note.recipient_address or selected_contact.selected_contact_address,
+    )
+
+
+def build_voice_note_state_provider(
+    *,
+    context: "AppContext | None" = None,
+    voip_manager: "VoIPManager | None" = None,
+) -> Callable[[], VoiceNoteState]:
+    """Build a narrow prepared-state provider for the voice-note screen."""
+
+    def provider() -> VoiceNoteState:
+        recipient_name, recipient_address = _resolve_voice_note_recipient(context)
+        if voip_manager is None:
+            active_voice_note = context.talk.active_voice_note if context is not None else None
+            return VoiceNoteState(
+                recipient_name=recipient_name,
+                recipient_address=recipient_address,
+                send_state=(
+                    active_voice_note.send_state if active_voice_note is not None else "idle"
+                ),
+                status_text=active_voice_note.status_text if active_voice_note is not None else "",
+                file_path=active_voice_note.file_path if active_voice_note is not None else "",
+                duration_ms=active_voice_note.duration_ms if active_voice_note is not None else 0,
+            )
+
+        draft = voip_manager.get_active_voice_note()
+        if draft is None:
+            return VoiceNoteState(
+                recipient_name=recipient_name,
+                recipient_address=recipient_address,
+            )
+        if (
+            recipient_address
+            and draft.recipient_address
+            and draft.recipient_address != recipient_address
+        ):
+            return VoiceNoteState(
+                recipient_name=recipient_name,
+                recipient_address=recipient_address,
+            )
+
+        return VoiceNoteState(
+            recipient_name=draft.recipient_name or recipient_name,
+            recipient_address=draft.recipient_address or recipient_address,
+            send_state=draft.send_state or "idle",
+            status_text=draft.status_text,
+            file_path=draft.file_path,
+            duration_ms=draft.duration_ms,
+        )
+
+    return provider
+
+
+def build_voice_note_actions(
+    *,
+    voip_manager: "VoIPManager | None" = None,
+) -> VoiceNoteActions:
+    """Build the focused voice-note actions for the screen."""
+
+    def set_draft_status_text(status_text: str) -> None:
+        if voip_manager is None:
+            return
+        draft = voip_manager.get_active_voice_note()
+        if draft is not None:
+            draft.status_text = status_text
+
+    if voip_manager is None:
+        return VoiceNoteActions(set_draft_status_text=set_draft_status_text)
+
+    start_voice_note_recording = getattr(voip_manager, "start_voice_note_recording", None)
+    stop_voice_note_recording = getattr(voip_manager, "stop_voice_note_recording", None)
+    cancel_voice_note_recording = getattr(voip_manager, "cancel_voice_note_recording", None)
+    discard_active_voice_note = getattr(voip_manager, "discard_active_voice_note", None)
+    send_active_voice_note = getattr(voip_manager, "send_active_voice_note", None)
+    play_voice_note = getattr(voip_manager, "play_voice_note", None)
+
+    return VoiceNoteActions(
+        start_recording=(
+            None
+            if start_voice_note_recording is None
+            else lambda recipient_address, recipient_name: start_voice_note_recording(
+                recipient_address,
+                recipient_name=recipient_name,
+            )
+        ),
+        stop_recording=stop_voice_note_recording,
+        cancel_recording=cancel_voice_note_recording,
+        discard_active_draft=discard_active_voice_note,
+        send_active_draft=send_active_voice_note,
+        preview_draft=play_voice_note,
+        set_draft_status_text=set_draft_status_text,
+    )
+
+
 class VoiceNoteScreen(Screen):
     """Kid-facing voice-note flow with real record, review, and send states."""
 
@@ -46,10 +176,13 @@ class VoiceNoteScreen(Screen):
         self,
         display: Display,
         context: Optional["AppContext"] = None,
-        voip_manager: Optional["VoIPManager"] = None,
+        *,
+        state_provider: Callable[[], VoiceNoteState] | None = None,
+        actions: VoiceNoteActions | None = None,
     ) -> None:
         super().__init__(display, context, "VoiceNote")
-        self.voip_manager = voip_manager
+        self._state_provider = state_provider or build_voice_note_state_provider(context=context)
+        self._actions = actions or VoiceNoteActions()
         self._state = "ready"
         self._selected_action_index = 0
         self._lvgl_view: "ScreenView | None" = None
@@ -59,7 +192,7 @@ class VoiceNoteScreen(Screen):
 
         super().enter()
         self._discard_terminal_draft_for_recipient()
-        self._sync_state_from_manager(default_state="ready")
+        self._sync_state_from_provider(default_state="ready")
         self._selected_action_index = 0
         self._ensure_lvgl_view()
 
@@ -96,52 +229,40 @@ class VoiceNoteScreen(Screen):
     def recipient_name(self) -> str:
         """Return the selected recipient."""
 
-        if self.context is None:
-            return "Friend"
-        voice_note = self.context.talk.active_voice_note
-        selected_contact = self.context.talk
-        return voice_note.recipient_name or selected_contact.selected_contact_name or "Friend"
+        return self.current_state().recipient_name
 
     def recipient_address(self) -> str:
         """Return the selected recipient SIP address."""
 
-        if self.context is None:
-            return ""
-        voice_note = self.context.talk.active_voice_note
-        selected_contact = self.context.talk
-        return voice_note.recipient_address or selected_contact.selected_contact_address
+        return self.current_state().recipient_address
 
     def recipient_monogram(self) -> str:
         """Return a compact label for the active recipient."""
 
         return talk_monogram(self.recipient_name())
 
-    def _sync_state_from_manager(self, default_state: str = "ready") -> None:
-        """Reflect the active voice-note draft from VoIPManager into the screen/context."""
+    def current_state(self) -> VoiceNoteState:
+        """Return the prepared voice-note state for the current render."""
 
-        if self.voip_manager is None:
-            self._state = default_state
-            return
+        return self._state_provider()
 
-        draft = self.voip_manager.get_active_voice_note()
-        recipient_address = self.recipient_address()
-        if draft is None or (
-            recipient_address
-            and draft.recipient_address
-            and draft.recipient_address != recipient_address
-        ):
+    def _sync_state_from_provider(self, default_state: str = "ready") -> None:
+        """Reflect the prepared voice-note state into the screen and shared context."""
+
+        state = self.current_state()
+        if state.send_state in {"", "idle"}:
             self._state = default_state
             if self.context is not None:
                 self.context.update_active_voice_note(send_state="idle")
             return
 
-        self._state = draft.send_state or default_state
+        self._state = state.send_state or default_state
         if self.context is not None:
             self.context.update_active_voice_note(
-                send_state=draft.send_state,
-                status_text=draft.status_text,
-                file_path=draft.file_path,
-                duration_ms=draft.duration_ms,
+                send_state=state.send_state,
+                status_text=state.status_text,
+                file_path=state.file_path,
+                duration_ms=state.duration_ms,
             )
         if self._state not in {"review", "failed"}:
             self._selected_action_index = 0
@@ -149,21 +270,10 @@ class VoiceNoteScreen(Screen):
     def _discard_terminal_draft_for_recipient(self) -> None:
         """Start fresh when reopening a terminal draft for the same recipient."""
 
-        if self.voip_manager is None:
-            return
-
-        draft = self.voip_manager.get_active_voice_note()
-        recipient_address = self.recipient_address()
-        if draft is None:
-            return
-        if (
-            recipient_address
-            and draft.recipient_address
-            and draft.recipient_address != recipient_address
-        ):
-            return
-        if draft.send_state in {"sent", "failed"}:
-            self.voip_manager.discard_active_voice_note()
+        state = self.current_state()
+        if state.send_state in {"sent", "failed"}:
+            if self._actions.discard_active_draft is not None:
+                self._actions.discard_active_draft()
             if self.context is not None:
                 self.context.update_active_voice_note(send_state="idle")
 
@@ -179,9 +289,10 @@ class VoiceNoteScreen(Screen):
     def _duration_label(self) -> str:
         """Return a compact duration label for the active draft."""
 
-        if self.context is None or self.context.talk.active_voice_note.duration_ms <= 0:
+        duration_ms = self.current_state().duration_ms
+        if duration_ms <= 0:
             return ""
-        seconds = max(1, round(self.context.talk.active_voice_note.duration_ms / 1000))
+        seconds = max(1, round(duration_ms / 1000))
         return f"{seconds}s"
 
     def actions(self) -> list[VoiceNoteAction]:
@@ -348,6 +459,7 @@ class VoiceNoteScreen(Screen):
         """Return title, subtitle, footer, and icon for the current voice-note state."""
 
         recipient = self.recipient_name()
+        state = self.current_state()
         if self._state == "recording":
             return (
                 "Recording",
@@ -358,31 +470,28 @@ class VoiceNoteScreen(Screen):
         if self._state == "review":
             return (
                 "Review",
-                self.context.talk.active_voice_note.status_text
-                or f"Listen, send, or record again for {recipient}.",
+                state.status_text or f"Listen, send, or record again for {recipient}.",
                 "Tap next / Double choose" if self.is_one_button_mode() else "Select choose / Back",
                 "voice_note",
             )
         if self._state == "sending":
             return (
                 "Sending",
-                self.context.talk.active_voice_note.status_text
-                or f"Sending your note to {recipient}.",
+                state.status_text or f"Sending your note to {recipient}.",
                 "Please wait",
                 "voice_note",
             )
         if self._state == "sent":
             return (
                 "Sent",
-                self.context.talk.active_voice_note.status_text
-                or f"Your note reached {recipient}.",
+                state.status_text or f"Your note reached {recipient}.",
                 "Double done / Hold back" if self.is_one_button_mode() else "Back",
                 "voice_note",
             )
         if self._state == "failed":
             return (
                 "Couldn't Send",
-                self.context.talk.active_voice_note.status_text or f"Try {recipient}'s note again.",
+                state.status_text or f"Try {recipient}'s note again.",
                 "Tap next / Double choose" if self.is_one_button_mode() else "Select retry / Back",
                 "voice_note",
             )
@@ -396,7 +505,7 @@ class VoiceNoteScreen(Screen):
     def render(self) -> None:
         """Render the current voice-note flow state."""
 
-        self._sync_state_from_manager(default_state=self._state)
+        self._sync_state_from_provider(default_state=self._state)
         lvgl_view = self._ensure_lvgl_view()
         if lvgl_view is not None:
             lvgl_view.sync()
@@ -486,8 +595,8 @@ class VoiceNoteScreen(Screen):
     def _close_to_talk_contact(self) -> None:
         """Clear terminal draft state and return to the selected contact."""
 
-        if self.voip_manager is not None:
-            self.voip_manager.discard_active_voice_note()
+        if self._actions.discard_active_draft is not None:
+            self._actions.discard_active_draft()
         if self.context is not None:
             self.context.update_active_voice_note(send_state="idle")
         self._state = "ready"
@@ -497,33 +606,32 @@ class VoiceNoteScreen(Screen):
     def _preview_active_voice_note(self) -> None:
         """Play the current draft locally before sending it."""
 
-        if self.voip_manager is None or self.context is None:
+        if self.context is None or self._actions.preview_draft is None:
             return
 
-        file_path = self.context.talk.active_voice_note.file_path
+        state = self.current_state()
+        file_path = state.file_path
         if not file_path:
             return
 
-        if self.voip_manager.play_voice_note(file_path):
-            draft = self.voip_manager.get_active_voice_note()
-            if draft is not None:
-                draft.status_text = "Playing preview"
+        if self._actions.preview_draft(file_path):
+            if self._actions.set_draft_status_text is not None:
+                self._actions.set_draft_status_text("Playing preview")
             self.context.update_active_voice_note(
                 send_state="review",
                 status_text="Playing preview",
                 file_path=file_path,
-                duration_ms=self.context.talk.active_voice_note.duration_ms,
+                duration_ms=state.duration_ms,
             )
             return
 
-        draft = self.voip_manager.get_active_voice_note()
-        if draft is not None:
-            draft.status_text = "Couldn't play note"
+        if self._actions.set_draft_status_text is not None:
+            self._actions.set_draft_status_text("Couldn't play note")
         self.context.update_active_voice_note(
             send_state="review",
             status_text="Couldn't play note",
             file_path=file_path,
-            duration_ms=self.context.talk.active_voice_note.duration_ms,
+            duration_ms=state.duration_ms,
         )
 
     def on_select(self, data=None) -> None:
@@ -607,11 +715,11 @@ class VoiceNoteScreen(Screen):
     def _start_recording(self) -> None:
         """Start a new voice-note recording for the active recipient."""
 
-        if self.voip_manager is None:
+        if self._actions.start_recording is None:
             return
-        if not self.voip_manager.start_voice_note_recording(
+        if not self._actions.start_recording(
             self.recipient_address(),
-            recipient_name=self.recipient_name(),
+            self.recipient_name(),
         ):
             self._state = "failed"
             if self.context is not None:
@@ -621,15 +729,15 @@ class VoiceNoteScreen(Screen):
                 )
             return
         self._selected_action_index = 0
-        self._sync_state_from_manager(default_state="recording")
+        self._sync_state_from_provider(default_state="recording")
         self._refresh_input_mode()
 
     def _stop_recording(self) -> None:
         """Stop the active recording and move to review."""
 
-        if self.voip_manager is None:
+        if self._actions.stop_recording is None:
             return
-        draft = self.voip_manager.stop_voice_note_recording()
+        draft = self._actions.stop_recording()
         if draft is None:
             self._state = "failed"
             if self.context is not None:
@@ -640,14 +748,14 @@ class VoiceNoteScreen(Screen):
         else:
             self._state = "review"
             self._selected_action_index = 0
-            self._sync_state_from_manager(default_state="review")
+            self._sync_state_from_provider(default_state="review")
         self._refresh_input_mode()
 
     def _cancel_recording(self) -> None:
         """Cancel the active recording and return to the ready state."""
 
-        if self.voip_manager is not None:
-            self.voip_manager.cancel_voice_note_recording()
+        if self._actions.cancel_recording is not None:
+            self._actions.cancel_recording()
         self._state = "ready"
         self._selected_action_index = 0
         if self.context is not None:
@@ -657,8 +765,8 @@ class VoiceNoteScreen(Screen):
     def _discard_and_reset(self) -> None:
         """Discard the current draft and return to the ready state."""
 
-        if self.voip_manager is not None:
-            self.voip_manager.discard_active_voice_note()
+        if self._actions.discard_active_draft is not None:
+            self._actions.discard_active_draft()
         self._state = "ready"
         self._selected_action_index = 0
         if self.context is not None:
@@ -668,11 +776,11 @@ class VoiceNoteScreen(Screen):
     def _send_active_voice_note(self) -> None:
         """Send the recorded voice note through the VoIP manager."""
 
-        if self.voip_manager is None:
+        if self._actions.send_active_draft is None:
             return
-        if self.voip_manager.send_active_voice_note():
-            self._sync_state_from_manager(default_state="sending")
+        if self._actions.send_active_draft():
+            self._sync_state_from_provider(default_state="sending")
             self._state = "sending"
             return
-        self._sync_state_from_manager(default_state="failed")
+        self._sync_state_from_provider(default_state="failed")
         self._state = "failed"

--- a/tests/test_call_screen.py
+++ b/tests/test_call_screen.py
@@ -15,6 +15,10 @@ from yoyopod.communication.calling import VoiceNoteDraft
 from yoyopod.people import Contact
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens import CallScreen, NavigationRequest, TalkContactScreen, VoiceNoteScreen
+from yoyopod.ui.screens.voip.voice_note import (
+    build_voice_note_actions,
+    build_voice_note_state_provider,
+)
 
 
 class FakePeopleDirectory:
@@ -131,7 +135,9 @@ def test_call_screen_builds_people_deck_from_contacts(display: Display) -> None:
 def test_call_screen_select_opens_selected_contact(display: Display) -> None:
     """Selecting from Talk should store the contact and route to the action screen."""
 
-    contacts = [Contact(name="Alice", sip_address="sip:alice@example.com", favorite=True, notes="Mama")]
+    contacts = [
+        Contact(name="Alice", sip_address="sip:alice@example.com", favorite=True, notes="Mama")
+    ]
     context = AppContext()
     screen = CallScreen(
         display,
@@ -179,7 +185,9 @@ def test_talk_contact_screen_routes_to_voice_note(display: Display) -> None:
     assert screen.consume_navigation_request() == NavigationRequest.route("voice_note")
 
 
-def test_talk_contact_screen_adds_play_note_action_when_latest_note_exists(display: Display) -> None:
+def test_talk_contact_screen_adds_play_note_action_when_latest_note_exists(
+    display: Display,
+) -> None:
     """Contacts with a stored incoming voice note should expose Play Note."""
 
     context = AppContext()
@@ -216,7 +224,12 @@ def test_voice_note_screen_records_reviews_and_sends(display: Display) -> None:
     context = AppContext()
     voip_manager = FakeVoIPManager()
     context.set_voice_note_recipient(name="Mama", sip_address="sip:alice@example.com")
-    screen = VoiceNoteScreen(display, context, voip_manager=voip_manager)
+    screen = VoiceNoteScreen(
+        display,
+        context,
+        state_provider=build_voice_note_state_provider(context=context, voip_manager=voip_manager),
+        actions=build_voice_note_actions(voip_manager=voip_manager),
+    )
 
     screen.enter()
     assert screen.current_view_model()[0] == "Voice Note"
@@ -240,7 +253,12 @@ def test_voice_note_screen_can_preview_before_sending(display: Display) -> None:
     context = AppContext()
     voip_manager = FakeVoIPManager()
     context.set_voice_note_recipient(name="Mama", sip_address="sip:alice@example.com")
-    screen = VoiceNoteScreen(display, context, voip_manager=voip_manager)
+    screen = VoiceNoteScreen(
+        display,
+        context,
+        state_provider=build_voice_note_state_provider(context=context, voip_manager=voip_manager),
+        actions=build_voice_note_actions(voip_manager=voip_manager),
+    )
 
     screen.enter()
     screen.on_ptt_press({"stage": "hold_started"})
@@ -267,7 +285,12 @@ def test_voice_note_screen_reopens_clean_after_terminal_draft(display: Display) 
         duration_ms=3200,
     )
     context.set_voice_note_recipient(name="Mama", sip_address="sip:alice@example.com")
-    screen = VoiceNoteScreen(display, context, voip_manager=voip_manager)
+    screen = VoiceNoteScreen(
+        display,
+        context,
+        state_provider=build_voice_note_state_provider(context=context, voip_manager=voip_manager),
+        actions=build_voice_note_actions(voip_manager=voip_manager),
+    )
 
     screen.enter()
 
@@ -291,7 +314,12 @@ def test_voice_note_screen_render_syncs_manager_terminal_state(display: Display)
         duration_ms=3200,
     )
     context.set_voice_note_recipient(name="Mama", sip_address="sip:alice@example.com")
-    screen = VoiceNoteScreen(display, context, voip_manager=voip_manager)
+    screen = VoiceNoteScreen(
+        display,
+        context,
+        state_provider=build_voice_note_state_provider(context=context, voip_manager=voip_manager),
+        actions=build_voice_note_actions(voip_manager=voip_manager),
+    )
 
     screen.enter()
     voip_manager.active_voice_note.send_state = "failed"
@@ -316,7 +344,12 @@ def test_voice_note_screen_ignores_stale_draft_for_different_recipient(display: 
         message_id="note-alice",
     )
     context.set_voice_note_recipient(name="Dad", sip_address="sip:bob@example.com")
-    screen = VoiceNoteScreen(display, context, voip_manager=voip_manager)
+    screen = VoiceNoteScreen(
+        display,
+        context,
+        state_provider=build_voice_note_state_provider(context=context, voip_manager=voip_manager),
+        actions=build_voice_note_actions(voip_manager=voip_manager),
+    )
 
     screen.enter()
 

--- a/tests/test_network_ui.py
+++ b/tests/test_network_ui.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from yoyopod.ui.screens.system.power import PowerScreen
 from yoyopod.network.models import GpsCoordinate, ModemPhase, ModemState, SignalInfo
+from yoyopod.ui.screens.system.power import (
+    PowerScreen,
+    build_power_screen_actions,
+    build_power_screen_state_provider,
+)
 
 
 class FakeDisplay:
@@ -62,7 +66,10 @@ class FakeNetworkManager:
 def test_network_page_online():
     """Network page should show Online status with carrier info."""
     nm = FakeNetworkManager(phase=ModemPhase.ONLINE)
-    screen = PowerScreen(FakeDisplay(), network_manager=nm)
+    screen = PowerScreen(
+        FakeDisplay(),
+        state_provider=build_power_screen_state_provider(network_manager=nm),
+    )
     rows = screen._build_network_rows()
     assert ("Status", "Online") in rows
     assert ("Carrier", "Telekom.de") in rows
@@ -73,7 +80,10 @@ def test_network_page_online():
 def test_network_page_disabled():
     """Network page should show Disabled when network is off."""
     nm = FakeNetworkManager(enabled=False)
-    screen = PowerScreen(FakeDisplay(), network_manager=nm)
+    screen = PowerScreen(
+        FakeDisplay(),
+        state_provider=build_power_screen_state_provider(network_manager=nm),
+    )
     rows = screen._build_network_rows()
     assert rows == [("Status", "Disabled")]
 
@@ -89,7 +99,10 @@ def test_gps_page_with_fix():
     """GPS page should show coordinates when fix is available."""
     nm = FakeNetworkManager()
     nm._state.gps = GpsCoordinate(lat=48.8738, lng=2.3522, altitude=349.6, speed=0.0)
-    screen = PowerScreen(FakeDisplay(), network_manager=nm)
+    screen = PowerScreen(
+        FakeDisplay(),
+        state_provider=build_power_screen_state_provider(network_manager=nm),
+    )
     rows = screen._build_gps_rows()
     assert ("Fix", "Yes") in rows
     assert any("48.8738" in v for _, v in rows)
@@ -99,7 +112,10 @@ def test_gps_page_with_fix():
 def test_gps_page_no_fix():
     """GPS page should show a searching state when GPS has no fix yet."""
     nm = FakeNetworkManager()
-    screen = PowerScreen(FakeDisplay(), network_manager=nm)
+    screen = PowerScreen(
+        FakeDisplay(),
+        state_provider=build_power_screen_state_provider(network_manager=nm),
+    )
     rows = screen._build_gps_rows()
     assert ("Fix", "Searching") in rows
     assert ("Lat", "--") in rows
@@ -110,10 +126,14 @@ def test_active_gps_page_refreshes_coordinates_before_render():
 
     nm = FakeNetworkManager()
     nm._state.gps = GpsCoordinate(lat=48.8738, lng=2.3522, altitude=349.6, speed=0.0)
-    screen = PowerScreen(FakeDisplay(), network_manager=nm)
+    screen = PowerScreen(
+        FakeDisplay(),
+        state_provider=build_power_screen_state_provider(network_manager=nm),
+        actions=build_power_screen_actions(network_manager=nm),
+    )
     screen.page_index = 2
 
-    pages = screen._build_pages_for_display(snapshot=None, status={})
+    pages = screen._build_pages_for_display()
 
     assert nm.query_gps_calls == 1
     gps_page = pages[2]
@@ -125,8 +145,11 @@ def test_active_gps_page_refreshes_coordinates_before_render():
 def test_build_pages_includes_network_when_enabled():
     """build_pages should include Network and GPS pages when network is enabled."""
     nm = FakeNetworkManager()
-    screen = PowerScreen(FakeDisplay(), network_manager=nm)
-    pages = screen.build_pages(snapshot=None, status={})
+    screen = PowerScreen(
+        FakeDisplay(),
+        state_provider=build_power_screen_state_provider(network_manager=nm),
+    )
+    pages = screen.build_pages()
     titles = [p.title for p in pages]
     assert "Network" in titles
     assert "GPS" in titles
@@ -137,7 +160,7 @@ def test_build_pages_includes_network_when_enabled():
 def test_build_pages_excludes_network_when_disabled():
     """build_pages should omit Network and GPS pages when network is disabled."""
     screen = PowerScreen(FakeDisplay())
-    pages = screen.build_pages(snapshot=None, status={})
+    pages = screen.build_pages()
     titles = [p.title for p in pages]
     assert "Network" not in titles
     assert "GPS" not in titles

--- a/tests/test_now_playing_lvgl_view.py
+++ b/tests/test_now_playing_lvgl_view.py
@@ -6,6 +6,10 @@ from yoyopod.app_context import AppContext
 from yoyopod.audio import MockMusicBackend, Track
 from yoyopod.ui.input import InteractionProfile
 from yoyopod.ui.screens import NowPlayingScreen
+from yoyopod.ui.screens.music.now_playing import (
+    build_now_playing_actions,
+    build_now_playing_state_provider,
+)
 
 
 class FakeLvglBinding:
@@ -67,7 +71,12 @@ def test_now_playing_screen_builds_syncs_and_destroys_lvgl_view() -> None:
     )
     backend.time_position = 50000
     backend.play()
-    screen = NowPlayingScreen(display, context, music_backend=backend)
+    screen = NowPlayingScreen(
+        display,
+        context,
+        state_provider=build_now_playing_state_provider(context=context, music_backend=backend),
+        actions=build_now_playing_actions(context=context, music_backend=backend),
+    )
 
     screen.enter()
     screen.render()
@@ -95,10 +104,18 @@ def test_now_playing_screen_syncs_offline_state_through_lvgl() -> None:
     binding = FakeLvglBinding()
     display = FakeLvglDisplay(binding)
     context = AppContext(interaction_profile=InteractionProfile.ONE_BUTTON)
+    backend = MockMusicBackend()
     screen = NowPlayingScreen(
         display,
         context,
-        music_backend=MockMusicBackend(),
+        state_provider=build_now_playing_state_provider(
+            context=context,
+            music_backend=backend,
+        ),
+        actions=build_now_playing_actions(
+            context=context,
+            music_backend=backend,
+        ),
     )
 
     screen.enter()
@@ -130,7 +147,12 @@ def test_now_playing_screen_syncs_paused_state_through_lvgl() -> None:
     backend.time_position = 74000
     backend.pause()
 
-    screen = NowPlayingScreen(display, context, music_backend=backend)
+    screen = NowPlayingScreen(
+        display,
+        context,
+        state_provider=build_now_playing_state_provider(context=context, music_backend=backend),
+        actions=build_now_playing_actions(context=context, music_backend=backend),
+    )
 
     screen.enter()
     screen.render()

--- a/tests/test_power_screen.py
+++ b/tests/test_power_screen.py
@@ -8,7 +8,11 @@ from yoyopod.app_context import AppContext
 from yoyopod.power import BatteryState, PowerDeviceInfo, PowerSnapshot, RTCState, ShutdownState
 from yoyopod.ui.display import Display
 from yoyopod.ui.input import InteractionProfile
-from yoyopod.ui.screens.system.power import PowerScreen
+from yoyopod.ui.screens.system.power import (
+    PowerScreen,
+    build_power_screen_actions,
+    build_power_screen_state_provider,
+)
 
 
 class StubPowerManager:
@@ -66,11 +70,16 @@ def test_power_screen_builds_battery_and_runtime_pages() -> None:
         screen = PowerScreen(
             display,
             AppContext(),
-            power_manager=StubPowerManager(_snapshot()),
-            status_provider=lambda: status,
+            state_provider=build_power_screen_state_provider(
+                power_manager=StubPowerManager(_snapshot()),
+                status_provider=lambda: status,
+            ),
         )
 
-        pages = screen.build_pages(snapshot=screen.power_manager.get_snapshot(), status=status)
+        pages = screen.build_pages(
+            snapshot=screen._get_snapshot(),
+            status=status,
+        )
 
         assert [page.title for page in pages] == ["Power", "Time", "Care", "Voice"]
         assert ("Model", "PiSugar 3") in pages[0].rows
@@ -100,8 +109,10 @@ def test_power_screen_formats_unavailable_snapshot() -> None:
         screen = PowerScreen(
             display,
             AppContext(),
-            power_manager=StubPowerManager(snapshot),
-            status_provider=lambda: {},
+            state_provider=build_power_screen_state_provider(
+                power_manager=StubPowerManager(snapshot),
+                status_provider=lambda: {},
+            ),
         )
 
         pages = screen.build_pages(snapshot=snapshot, status={})
@@ -137,12 +148,16 @@ def test_power_screen_voice_page_toggles_runtime_voice_settings() -> None:
         screen = PowerScreen(
             display,
             context,
-            power_manager=StubPowerManager(_snapshot()),
-            status_provider=lambda: {},
-            volume_up_action=volume_up,
-            volume_down_action=volume_down,
-            mute_action=lambda: mute_calls.append("mute") or True,
-            unmute_action=lambda: mute_calls.append("unmute") or True,
+            state_provider=build_power_screen_state_provider(
+                power_manager=StubPowerManager(_snapshot()),
+                status_provider=lambda: {},
+            ),
+            actions=build_power_screen_actions(
+                volume_up_action=volume_up,
+                volume_down_action=volume_down,
+                mute_action=lambda: mute_calls.append("mute") or True,
+                unmute_action=lambda: mute_calls.append("unmute") or True,
+            ),
         )
 
         screen.page_index = 3
@@ -194,8 +209,10 @@ def test_power_screen_one_button_voice_page_stays_in_fast_page_mode() -> None:
         screen = PowerScreen(
             display,
             context,
-            power_manager=StubPowerManager(_snapshot()),
-            status_provider=lambda: {},
+            state_provider=build_power_screen_state_provider(
+                power_manager=StubPowerManager(_snapshot()),
+                status_provider=lambda: {},
+            ),
         )
 
         screen.page_index = 3
@@ -233,16 +250,20 @@ def test_power_screen_uses_injected_voice_device_hooks() -> None:
         screen = PowerScreen(
             display,
             context,
-            power_manager=StubPowerManager(_snapshot()),
-            status_provider=lambda: {},
-            refresh_voice_device_options_action=lambda: refresh_calls.append("refresh"),
-            playback_device_options_provider=lambda: ["plughw:CARD=wm8960soundcard,DEV=0"],
-            capture_device_options_provider=lambda: ["plughw:CARD=USB,DEV=0"],
-            persist_speaker_device_action=(
-                lambda device_id: persisted_devices.append(("speaker", device_id)) or True
+            state_provider=build_power_screen_state_provider(
+                power_manager=StubPowerManager(_snapshot()),
+                status_provider=lambda: {},
+                playback_device_options_provider=lambda: ["plughw:CARD=wm8960soundcard,DEV=0"],
+                capture_device_options_provider=lambda: ["plughw:CARD=USB,DEV=0"],
             ),
-            persist_capture_device_action=(
-                lambda device_id: persisted_devices.append(("capture", device_id)) or True
+            actions=build_power_screen_actions(
+                refresh_voice_device_options_action=lambda: refresh_calls.append("refresh"),
+                persist_speaker_device_action=(
+                    lambda device_id: persisted_devices.append(("speaker", device_id)) or True
+                ),
+                persist_capture_device_action=(
+                    lambda device_id: persisted_devices.append(("capture", device_id)) or True
+                ),
             ),
         )
 

--- a/tests/test_remaining_lvgl_views.py
+++ b/tests/test_remaining_lvgl_views.py
@@ -470,11 +470,20 @@ def test_voice_note_screen_uses_talk_actions_scene_for_voice_note_states() -> No
     """VoiceNoteScreen should delegate to the Talk actions scene on LVGL."""
 
     from yoyopod.ui.screens.voip.voice_note import VoiceNoteScreen
+    from yoyopod.ui.screens.voip.voice_note import (
+        build_voice_note_actions,
+        build_voice_note_state_provider,
+    )
 
     binding = FakeLvglBinding()
     context = make_one_button_context()
     context.set_voice_note_recipient(name="Hagar", sip_address="sip:hagar@example.com")
-    screen = VoiceNoteScreen(FakeLvglDisplay(binding), context)
+    screen = VoiceNoteScreen(
+        FakeLvglDisplay(binding),
+        context,
+        state_provider=build_voice_note_state_provider(context=context),
+        actions=build_voice_note_actions(),
+    )
 
     screen.enter()
     screen.render()
@@ -494,25 +503,28 @@ def test_voice_note_screen_uses_talk_actions_scene_for_voice_note_states() -> No
 def test_power_screen_cycles_four_lvgl_pages() -> None:
     """PowerScreen should use the picker/detail Setup flow on standard controls."""
 
+    from yoyopod.ui.screens.system.power import build_power_screen_state_provider
+
     binding = FakeLvglBinding()
     screen = PowerScreen(
         FakeLvglDisplay(binding),
         AppContext(),
-        power_manager=None,
-        status_provider=lambda: {
-            "app_uptime_seconds": 99,
-            "screen_awake": True,
-            "screen_on_seconds": 42,
-            "screen_idle_seconds": 3,
-            "screen_timeout_seconds": 60,
-            "warning_threshold_percent": 20,
-            "critical_shutdown_percent": 10,
-            "shutdown_delay_seconds": 15,
-            "shutdown_pending": False,
-            "watchdog_enabled": True,
-            "watchdog_active": True,
-            "watchdog_feed_suppressed": False,
-        },
+        state_provider=build_power_screen_state_provider(
+            status_provider=lambda: {
+                "app_uptime_seconds": 99,
+                "screen_awake": True,
+                "screen_on_seconds": 42,
+                "screen_idle_seconds": 3,
+                "screen_timeout_seconds": 60,
+                "warning_threshold_percent": 20,
+                "critical_shutdown_percent": 10,
+                "shutdown_delay_seconds": 15,
+                "shutdown_pending": False,
+                "watchdog_enabled": True,
+                "watchdog_active": True,
+                "watchdog_feed_suppressed": False,
+            },
+        ),
     )
 
     screen.enter()
@@ -591,12 +603,13 @@ def test_power_screen_cycles_four_lvgl_pages() -> None:
 def test_power_screen_one_button_voice_page_wraps_immediately() -> None:
     """The Whisplay Voice page should stay in the normal page-to-page loop."""
 
+    from yoyopod.ui.screens.system.power import build_power_screen_state_provider
+
     binding = FakeLvglBinding()
     screen = PowerScreen(
         FakeLvglDisplay(binding),
         make_one_button_context(),
-        power_manager=None,
-        status_provider=lambda: {},
+        state_provider=build_power_screen_state_provider(status_provider=lambda: {}),
     )
 
     screen.enter()
@@ -625,6 +638,10 @@ def test_power_screen_reports_full_network_page_count_through_lvgl() -> None:
     """Network-enabled Setup pages should preserve the full page count in LVGL payloads."""
 
     from yoyopod.network.models import ModemPhase, ModemState, SignalInfo
+    from yoyopod.ui.screens.system.power import (
+        build_power_screen_actions,
+        build_power_screen_state_provider,
+    )
 
     class _FakeNetworkManager:
         def __init__(self) -> None:
@@ -647,11 +664,15 @@ def test_power_screen_reports_full_network_page_count_through_lvgl() -> None:
             return None
 
     binding = FakeLvglBinding()
+    network_manager = _FakeNetworkManager()
     screen = PowerScreen(
         FakeLvglDisplay(binding),
         make_one_button_context(),
-        network_manager=_FakeNetworkManager(),
-        status_provider=lambda: {},
+        state_provider=build_power_screen_state_provider(
+            network_manager=network_manager,
+            status_provider=lambda: {},
+        ),
+        actions=build_power_screen_actions(network_manager=network_manager),
     )
 
     screen.enter()

--- a/tests/test_whisplay_one_button.py
+++ b/tests/test_whisplay_one_button.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import pytest
 
 from yoyopod.app_context import AppContext
-from yoyopod.audio import LocalMusicService, MockMusicBackend, Playlist, RecentTrackHistoryStore, Track
+from yoyopod.audio import (
+    LocalMusicService,
+    MockMusicBackend,
+    Playlist,
+    RecentTrackHistoryStore,
+    Track,
+)
 from yoyopod.communication.calling import VoiceNoteDraft
 from yoyopod.ui.display import Display
 from yoyopod.ui.input import InteractionProfile
@@ -24,6 +30,14 @@ from yoyopod.ui.screens import (
     TalkContactScreen,
     VoiceNoteScreen,
 )
+from yoyopod.ui.screens.music.now_playing import (
+    build_now_playing_actions,
+    build_now_playing_state_provider,
+)
+from yoyopod.ui.screens.voip.voice_note import (
+    build_voice_note_actions,
+    build_voice_note_state_provider,
+)
 
 
 class FakeMusicBackend(MockMusicBackend):
@@ -32,7 +46,9 @@ class FakeMusicBackend(MockMusicBackend):
     def __init__(self) -> None:
         super().__init__()
         self.start()
-        self.current_track = Track(uri="/music/track.mp3", name="Track", artists=["Artist"], length=120000)
+        self.current_track = Track(
+            uri="/music/track.mp3", name="Track", artists=["Artist"], length=120000
+        )
         self.next_track_calls = 0
         self.play_calls = 0
         self.pause_calls = 0
@@ -70,7 +86,9 @@ class FakeMusicBackend(MockMusicBackend):
 class FakeContact:
     """Minimal contact record for VoIP screen tests."""
 
-    def __init__(self, name: str, sip_address: str, favorite: bool = False, notes: str = "") -> None:
+    def __init__(
+        self, name: str, sip_address: str, favorite: bool = False, notes: str = ""
+    ) -> None:
         self.name = name
         self.sip_address = sip_address
         self.favorite = favorite
@@ -263,6 +281,7 @@ def test_listen_screen_select_opens_recent_tracks(
 
     assert screen.consume_navigation_request() == NavigationRequest.route("open_recent")
 
+
 def test_hub_select_requests_setup_route_for_setup_card(
     display: Display,
     one_button_context: AppContext,
@@ -337,7 +356,18 @@ def test_now_playing_advance_and_select_follow_one_button_mapping(
 ) -> None:
     """Now Playing should map ADVANCE to next track and SELECT to play/pause."""
     backend = FakeMusicBackend()
-    screen = NowPlayingScreen(display, one_button_context, music_backend=backend)
+    screen = NowPlayingScreen(
+        display,
+        one_button_context,
+        state_provider=build_now_playing_state_provider(
+            context=one_button_context,
+            music_backend=backend,
+        ),
+        actions=build_now_playing_actions(
+            context=one_button_context,
+            music_backend=backend,
+        ),
+    )
 
     screen.on_advance()
     screen.on_select()
@@ -470,7 +500,15 @@ def test_voice_note_screen_uses_hold_to_record_in_one_button_mode(
 
     one_button_context.set_voice_note_recipient(name="Mama", sip_address="sip:alice@example.com")
     voip_manager = FakeVoIPManager()
-    screen = VoiceNoteScreen(display, one_button_context, voip_manager=voip_manager)
+    screen = VoiceNoteScreen(
+        display,
+        one_button_context,
+        state_provider=build_voice_note_state_provider(
+            context=one_button_context,
+            voip_manager=voip_manager,
+        ),
+        actions=build_voice_note_actions(voip_manager=voip_manager),
+    )
 
     screen.enter()
     assert screen.wants_ptt_passthrough()


### PR DESCRIPTION
## Summary
- introduce prepared state/action facades for `PowerScreen`, `NowPlayingScreen`, and `VoiceNoteScreen`
- wire runtime boot through the narrower screen seams instead of passing broad managers/backends directly into the touched screens
- update the affected screen tests to exercise the new seams, including a compatibility fallback for voice-note preview actions when the injected VoIP double does not expose playback

## Validation
- `uv run pytest -q tests/test_call_screen.py tests/test_network_ui.py tests/test_now_playing_lvgl_view.py tests/test_power_screen.py tests/test_remaining_lvgl_views.py tests/test_whisplay_one_button.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`

## Notes
- preserved the unrelated dirty `data/test_messages/messages.json` file outside the commit
- no `.codex` artifacts included

Closes #168
