### PR TITLE
[codex] Audit and constrain offline STT/Vosk model lifecycle

### DIFF
--- a/config/voice/assistant.yaml
+++ b/config/voice/assistant.yaml
@@ -9,6 +9,7 @@ assistant:
   stt_backend: "vosk"
   tts_backend: "espeak-ng"
   vosk_model_path: "models/vosk-model-small-en-us"
+  vosk_model_keep_loaded: true
   record_seconds: 4
   sample_rate_hz: 16000
   tts_rate_wpm: 155

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -111,7 +111,9 @@ Key settings:
 - `config/network/cellular.yaml`
   - `network.*` cellular modem enablement, ports, APN, GPS, and PPP timeout
 - `config/voice/assistant.yaml`
-  - `assistant.*` local voice commands, STT, TTS, and prompt policy
+  - `assistant.*` local voice commands, STT, TTS, prompt policy, and Vosk model retention
+  - the checked-in `models/vosk-model-small-en-us` footprint is about 68 MB on disk in this repo, so keeping the model loaded trades lower repeated-command latency for a persistent RAM tax on small boards
+  - set `assistant.vosk_model_keep_loaded: false` when tighter memory bounds matter more than warm-command latency
 - `config/communication/calling.yaml`
   - SIP identity, transport, STUN, call policy, call-history path
 - `config/communication/messaging.yaml`

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ Plan docs are useful, but they are not automatically the current implementation 
 - [`SYSTEM_ARCHITECTURE.md`](SYSTEM_ARCHITECTURE.md), top-level runtime topology plus startup/bootstrap flow
 - [`CANONICAL_STRUCTURE.md`](CANONICAL_STRUCTURE.md), canonical config topology and domain package ownership
 - [`RUNTIME_EVENT_FLOW.md`](RUNTIME_EVENT_FLOW.md), current event pipeline and coordinator ownership
+- [`VOICE_STT_MODEL_LIFECYCLE.md`](VOICE_STT_MODEL_LIFECYCLE.md), offline Vosk retention policy and measured footprint
 - [`DISPLAY_HAL_ARCHITECTURE.md`](DISPLAY_HAL_ARCHITECTURE.md), display abstraction and adapters
 - [`INPUT_HAL_ARCHITECTURE.md`](INPUT_HAL_ARCHITECTURE.md), semantic input model and adapters
 - [`POWER_MODULE.md`](POWER_MODULE.md), power, battery, RTC, watchdog

--- a/docs/VOICE_STT_MODEL_LIFECYCLE.md
+++ b/docs/VOICE_STT_MODEL_LIFECYCLE.md
@@ -1,0 +1,104 @@
+# Offline STT / Vosk Model Lifecycle
+
+This document is the source of truth for how YoyoPod keeps, drops, and
+measures offline Vosk speech-to-text models.
+
+## Current lifecycle
+
+- `VoiceRuntimeCoordinator` keeps one cached `VoiceService` for the current
+  `VoiceSettings`.
+- `VoiceService` uses `VoskSpeechToTextBackend` by default for offline STT.
+- `VoskSpeechToTextBackend` retains at most one loaded Vosk model path per
+  backend instance.
+- When runtime settings change enough to require a new `VoiceService`, the old
+  service explicitly clears its STT backend cache before replacement.
+
+That makes the supported steady-state path explicit:
+
+- one runtime voice service
+- one Vosk backend under that service
+- zero or one retained Vosk model under that backend
+
+## Config knob
+
+`config/voice/assistant.yaml` now exposes:
+
+```yaml
+assistant:
+  vosk_model_keep_loaded: true
+```
+
+Equivalent env var:
+
+```bash
+YOYOPOD_VOSK_MODEL_KEEP_LOADED=true
+```
+
+Behavior:
+
+- `true` keeps the currently selected Vosk model loaded after first use. This is
+  the latency-optimized default and matches the current voice product direction.
+- `false` loads the model for each transcription request and drops the backend's
+  retained reference immediately afterward. This is a best-effort lower-idle-RAM
+  mode, not a hard RSS guarantee.
+
+## Measured footprint
+
+Measurements below were captured from this repo checkout with the tracked small
+English model at `models/vosk-model-small-en-us`.
+
+### Storage
+
+Command:
+
+```bash
+du -sh models/vosk-model-small-en-us
+du -sk models/vosk-model-small-en-us
+find models/vosk-model-small-en-us -type f | wc -l
+```
+
+Observed result:
+
+- on-disk size: `68M`
+- on-disk size (KiB): `69300`
+- tracked files in the model directory: `14`
+
+### Process memory
+
+Command summary:
+
+- baseline Python process
+- import `vosk`
+- construct `vosk.Model("models/vosk-model-small-en-us")`
+- delete the Python reference and run `gc.collect()`
+- read `VmRSS` and `VmSize` from `/proc/self/status`
+
+Observed result:
+
+| Stage | VmRSS | VmSize |
+| --- | ---: | ---: |
+| before import | 14,000 kB | 28,380 kB |
+| after `from vosk import Model` | 39,008 kB | 54,620 kB |
+| after `Model(...)` | 157,576 kB | 2,075,196 kB |
+| after `del model; gc.collect()` | 89,488 kB | 2,000,164 kB |
+
+Practical takeaway:
+
+- the shipped small model is already a meaningful storage payload on disk
+- loading it in-process raised RSS by roughly `118 MB` in this environment
+- dropping Python references recovered some memory, but did not return the
+  process to its pre-load baseline
+
+That is why `vosk_model_keep_loaded=false` is documented as best effort only.
+For a long-lived process, clearing the cache removes YoyoPod's retained model
+reference, but native allocator behavior can still leave RSS above baseline.
+
+## Operational guidance
+
+- Leave `vosk_model_keep_loaded=true` when fast repeated voice interactions are
+  more important than idle-memory pressure.
+- Consider `false` only on constrained hardware where voice commands are used
+  infrequently and reload latency is acceptable.
+- Do not expect `false` to behave like a hard memory cap. It bounds YoyoPod's
+  retained model references; it does not force the OS to reclaim all native
+  allocations immediately.

--- a/src/yoyopod/config/models.py
+++ b/src/yoyopod/config/models.py
@@ -224,6 +224,10 @@ class VoiceAssistantConfig:
         default="models/vosk-model-small-en-us",
         env="YOYOPOD_VOSK_MODEL_PATH",
     )
+    vosk_model_keep_loaded: bool = config_value(
+        default=True,
+        env="YOYOPOD_VOSK_MODEL_KEEP_LOADED",
+    )
     record_seconds: int = config_value(default=4, env="YOYOPOD_VOICE_RECORD_SECONDS")
     sample_rate_hz: int = config_value(default=16000, env="YOYOPOD_VOICE_SAMPLE_RATE_HZ")
     tts_rate_wpm: int = config_value(default=155, env="YOYOPOD_TTS_RATE_WPM")

--- a/src/yoyopod/runtime/boot.py
+++ b/src/yoyopod/runtime/boot.py
@@ -490,6 +490,11 @@ class RuntimeBootService:
                             if voice_cfg is not None
                             else "models/vosk-model-small-en-us"
                         ),
+                        vosk_model_keep_loaded=(
+                            voice_cfg.assistant.vosk_model_keep_loaded
+                            if voice_cfg is not None
+                            else True
+                        ),
                         speaker_device_id=(
                             self.app.context.voice.speaker_device_id
                             if self.app.context is not None

--- a/src/yoyopod/runtime/voice.py
+++ b/src/yoyopod/runtime/voice.py
@@ -153,6 +153,11 @@ class VoiceSettingsResolver:
             stt_backend=assistant_cfg.stt_backend,
             tts_backend=assistant_cfg.tts_backend,
             vosk_model_path=assistant_cfg.vosk_model_path,
+            vosk_model_keep_loaded=getattr(
+                assistant_cfg,
+                "vosk_model_keep_loaded",
+                defaults.vosk_model_keep_loaded,
+            ),
             speaker_device_id=speaker_device_id,
             capture_device_id=capture_device_id,
             sample_rate_hz=assistant_cfg.sample_rate_hz,
@@ -581,7 +586,11 @@ class VoiceRuntimeCoordinator:
         settings = self._settings_resolver.current()
         if self._voice_service_factory is not None:
             return self._voice_service_factory(settings)
-        if self._cached_voice_service is None or self._cached_voice_service.settings != settings:
+        if self._cached_voice_service is None:
+            self._cached_voice_service = VoiceService(settings=settings)
+            return self._cached_voice_service
+        if self._cached_voice_service.settings != settings:
+            self._cached_voice_service.release_resources()
             self._cached_voice_service = VoiceService(settings=settings)
         return self._cached_voice_service
 

--- a/src/yoyopod/voice/models.py
+++ b/src/yoyopod/voice/models.py
@@ -21,6 +21,7 @@ class VoiceSettings:
     stt_backend: str = "vosk"
     tts_backend: str = "espeak-ng"
     vosk_model_path: str = "models/vosk-model-small-en-us"
+    vosk_model_keep_loaded: bool = True
     speaker_device_id: str | None = None
     capture_device_id: str | None = None
     sample_rate_hz: int = 16000

--- a/src/yoyopod/voice/service.py
+++ b/src/yoyopod/voice/service.py
@@ -79,3 +79,10 @@ class VoiceService:
         """Speak text using the configured TTS backend."""
 
         return self.tts_backend.speak(text, self.settings)
+
+    def release_resources(self) -> None:
+        """Drop backend-owned caches when this service is being replaced."""
+
+        clear_cache = getattr(self.stt_backend, "clear_cache", None)
+        if callable(clear_cache):
+            clear_cache()

--- a/src/yoyopod/voice/stt.py
+++ b/src/yoyopod/voice/stt.py
@@ -76,7 +76,11 @@ class VoskSpeechToTextBackend:
         from vosk import Model
 
         model_path = str(self._resolve_model_path(settings))
+        if not settings.vosk_model_keep_loaded:
+            self._model_cache.clear()
+            return Model(model_path)
         if model_path not in self._model_cache:
+            self._model_cache.clear()
             self._model_cache[model_path] = Model(model_path)
         return self._model_cache[model_path]
 

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -123,6 +123,7 @@ def test_voice_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> N
 
     monkeypatch.delenv("YOYOPOD_VOICE_COMMANDS_ENABLED", raising=False)
     monkeypatch.delenv("YOYOPOD_VOSK_MODEL_PATH", raising=False)
+    monkeypatch.delenv("YOYOPOD_VOSK_MODEL_KEEP_LOADED", raising=False)
     monkeypatch.delenv("YOYOPOD_VOICE_SPEAKER_DEVICE", raising=False)
 
     config_file = tmp_path / "voice" / "assistant.yaml"
@@ -135,6 +136,7 @@ def test_voice_config_defaults_do_not_require_a_file(tmp_path, monkeypatch) -> N
     assert settings.assistant.stt_backend == "vosk"
     assert settings.assistant.tts_backend == "espeak-ng"
     assert settings.assistant.vosk_model_path == "models/vosk-model-small-en-us"
+    assert settings.assistant.vosk_model_keep_loaded is True
     assert settings.assistant.sample_rate_hz == 16000
     assert settings.assistant.tts_rate_wpm == 155
     assert settings.audio.speaker_device_id == ""
@@ -225,6 +227,7 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     monkeypatch.setenv("YOYOPOD_VOICE_COMMANDS_ENABLED", "false")
     monkeypatch.setenv("YOYOPOD_SCREEN_READ_ENABLED", "true")
     monkeypatch.setenv("YOYOPOD_VOSK_MODEL_PATH", "/srv/models/vosk-small")
+    monkeypatch.setenv("YOYOPOD_VOSK_MODEL_KEEP_LOADED", "false")
     monkeypatch.setenv("YOYOPOD_LOG_FILE", "/var/log/yoyopod.log")
     monkeypatch.setenv("YOYOPOD_ERROR_LOG_FILE", "/var/log/yoyopod_errors.log")
     monkeypatch.setenv("YOYOPOD_PID_FILE", "/run/yoyopod.pid")
@@ -271,6 +274,7 @@ def test_config_manager_app_config_merges_yaml_and_env(tmp_path, monkeypatch) ->
     assert voice_settings.assistant.commands_enabled is False
     assert voice_settings.assistant.screen_read_enabled is True
     assert voice_settings.assistant.vosk_model_path == "/srv/models/vosk-small"
+    assert voice_settings.assistant.vosk_model_keep_loaded is False
     assert settings.logging.level == "DEBUG"
     assert settings.logging.file == "/var/log/yoyopod.log"
     assert settings.logging.error_file == "/var/log/yoyopod_errors.log"

--- a/tests/test_runtime_voice.py
+++ b/tests/test_runtime_voice.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from types import SimpleNamespace
@@ -27,6 +28,27 @@ class _FakeContact:
 class _FakeConfigManager:
     def __init__(self, contacts: list[_FakeContact]) -> None:
         self._contacts = contacts
+        self._voice_settings = SimpleNamespace(
+            assistant=SimpleNamespace(
+                commands_enabled=True,
+                ai_requests_enabled=True,
+                screen_read_enabled=False,
+                stt_enabled=True,
+                tts_enabled=True,
+                stt_backend="dummy-stt",
+                tts_backend="dummy-tts",
+                vosk_model_path="models/custom-model",
+                vosk_model_keep_loaded=False,
+                sample_rate_hz=22050,
+                record_seconds=6,
+                tts_rate_wpm=180,
+                tts_voice="en-us",
+            ),
+            audio=SimpleNamespace(
+                speaker_device_id="",
+                capture_device_id="",
+            )
+        )
 
     def get_contacts(self) -> list[_FakeContact]:
         return list(self._contacts)
@@ -41,26 +63,7 @@ class _FakeConfigManager:
         return 61
 
     def get_voice_settings(self):
-        return SimpleNamespace(
-            assistant=SimpleNamespace(
-                commands_enabled=True,
-                ai_requests_enabled=True,
-                screen_read_enabled=False,
-                stt_enabled=True,
-                tts_enabled=True,
-                stt_backend="dummy-stt",
-                tts_backend="dummy-tts",
-                vosk_model_path="models/custom-model",
-                sample_rate_hz=22050,
-                record_seconds=6,
-                tts_rate_wpm=180,
-                tts_voice="en-us",
-            ),
-            audio=SimpleNamespace(
-                speaker_device_id="",
-                capture_device_id="",
-            )
-        )
+        return self._voice_settings
 
 
 class _FakeVoipManager:
@@ -88,6 +91,7 @@ class _FakeVoiceService:
         self.transcript = transcript
         self.capture_calls = 0
         self.speak_calls: list[str] = []
+        self.release_calls = 0
 
     def capture_available(self) -> bool:
         return True
@@ -115,6 +119,9 @@ class _FakeVoiceService:
     def speak(self, text: str) -> bool:
         self.speak_calls.append(text)
         return True
+
+    def release_resources(self) -> None:
+        self.release_calls += 1
 
 
 class _NoAudioVoiceService(_FakeVoiceService):
@@ -262,3 +269,39 @@ def test_voice_runtime_coordinator_ptt_no_audio_resolves_to_no_speech() -> None:
     assert context.voice.interaction.phase == "reply"
     assert context.voice.interaction.headline == "No Speech"
     assert context.voice.interaction.capture_in_flight is False
+
+
+def test_voice_runtime_coordinator_releases_cached_service_when_settings_change(monkeypatch) -> None:
+    """Replacing the cached service should drop backend-owned resources explicitly."""
+
+    current_settings = VoiceSettings(vosk_model_keep_loaded=True)
+    created_services: list[object] = []
+
+    class _TrackingVoiceService:
+        def __init__(self, *, settings: VoiceSettings) -> None:
+            self.settings = settings
+            self.released = False
+            created_services.append(self)
+
+        def release_resources(self) -> None:
+            self.released = True
+
+    monkeypatch.setattr("yoyopod.runtime.voice.VoiceService", _TrackingVoiceService)
+    coordinator = VoiceRuntimeCoordinator(
+        context=None,
+        settings_resolver=VoiceSettingsResolver(
+            context=None,
+            settings_provider=lambda: current_settings,
+        ),
+        command_executor=VoiceCommandExecutor(context=None),
+    )
+
+    first = coordinator._voice_service()
+    current_settings = replace(current_settings, vosk_model_keep_loaded=False)
+    second = coordinator._voice_service()
+
+    assert len(created_services) == 2
+    assert first is created_services[0]
+    assert second is created_services[1]
+    assert created_services[0].released is True
+    assert created_services[1].released is False

--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -302,6 +302,7 @@ class _FakeConfigManager:
                 stt_backend="dummy-stt",
                 tts_backend="dummy-tts",
                 vosk_model_path="models/custom-model",
+                vosk_model_keep_loaded=False,
                 sample_rate_hz=22050,
                 record_seconds=6,
                 tts_rate_wpm=180,
@@ -325,6 +326,7 @@ class _FakeConfigManagerWithSpeaker(_FakeConfigManager):
                 stt_backend="dummy-stt",
                 tts_backend="dummy-tts",
                 vosk_model_path="models/custom-model",
+                vosk_model_keep_loaded=False,
                 speaker_device_id="plughw:CARD=wm8960soundcard,DEV=0",
                 capture_device_id="plughw:CARD=wm8960soundcard,DEV=0",
                 sample_rate_hz=22050,
@@ -586,6 +588,7 @@ def test_ask_screen_fallback_settings_keep_configured_voice_defaults() -> None:
     assert settings.stt_backend == "dummy-stt"
     assert settings.tts_backend == "dummy-tts"
     assert settings.vosk_model_path == "models/custom-model"
+    assert settings.vosk_model_keep_loaded is False
     assert settings.capture_device_id is None
     assert settings.sample_rate_hz == 22050
     assert settings.record_seconds == 6

--- a/tests/test_voice_service.py
+++ b/tests/test_voice_service.py
@@ -7,7 +7,9 @@ import math
 import struct
 from pathlib import Path
 import subprocess
+import sys
 import threading
+import types
 
 from yoyopod.voice import (
     AlsaOutputPlayer,
@@ -29,6 +31,7 @@ class FakeSttBackend:
 
     def __init__(self) -> None:
         self.calls: list[tuple[Path, VoiceSettings]] = []
+        self.clear_cache_calls = 0
 
     def is_available(self, settings: VoiceSettings) -> bool:
         return settings.stt_enabled
@@ -36,6 +39,9 @@ class FakeSttBackend:
     def transcribe(self, audio_path: Path, settings: VoiceSettings) -> VoiceTranscript:
         self.calls.append((audio_path, settings))
         return VoiceTranscript(text="call mom", confidence=0.91)
+
+    def clear_cache(self) -> None:
+        self.clear_cache_calls += 1
 
 
 class FakeTtsBackend:
@@ -124,6 +130,17 @@ def test_voice_service_uses_injected_backends() -> None:
     assert command.contact_name == "mom"
     assert spoken is True
     assert tts_backend.calls == [("Calling mom", settings)]
+
+
+def test_voice_service_release_resources_clears_stt_backend_cache() -> None:
+    """Replacing a voice service should clear any backend-owned STT cache."""
+
+    stt_backend = FakeSttBackend()
+    service = VoiceService(settings=VoiceSettings(), stt_backend=stt_backend)
+
+    service.release_resources()
+
+    assert stt_backend.clear_cache_calls == 1
 
 
 def test_voice_capture_request_defaults_to_short_local_capture() -> None:
@@ -539,3 +556,74 @@ def test_vosk_backend_can_clear_cached_models() -> None:
     backend.clear_cache()
 
     assert backend._model_cache == {}
+
+
+def test_vosk_backend_replaces_stale_cached_model_when_path_changes(tmp_path) -> None:
+    """Retained-model mode should cap the cache to one loaded model path."""
+
+    load_calls: list[str] = []
+
+    class FakeModel:
+        def __init__(self, model_path: str) -> None:
+            load_calls.append(model_path)
+
+    original_vosk = sys.modules.get("vosk")
+    vosk_module = types.ModuleType("vosk")
+    vosk_module.Model = FakeModel
+    sys.modules["vosk"] = vosk_module
+    try:
+        backend = VoskSpeechToTextBackend()
+        first_path = str(tmp_path / "model-a")
+        second_path = str(tmp_path / "model-b")
+
+        first_model = backend._load_model(VoiceSettings(vosk_model_path=first_path))
+        second_model = backend._load_model(VoiceSettings(vosk_model_path=second_path))
+    finally:
+        if original_vosk is None:
+            sys.modules.pop("vosk", None)
+        else:
+            sys.modules["vosk"] = original_vosk
+
+    assert load_calls == [first_path, second_path]
+    assert list(backend._model_cache) == [second_path]
+    assert backend._model_cache[second_path] is second_model
+    assert first_model is not second_model
+
+
+def test_vosk_backend_can_disable_model_retention(tmp_path) -> None:
+    """Best-effort low-memory mode should avoid retaining a loaded model reference."""
+
+    load_calls: list[str] = []
+
+    class FakeModel:
+        def __init__(self, model_path: str) -> None:
+            load_calls.append(model_path)
+
+    original_vosk = sys.modules.get("vosk")
+    vosk_module = types.ModuleType("vosk")
+    vosk_module.Model = FakeModel
+    sys.modules["vosk"] = vosk_module
+    try:
+        backend = VoskSpeechToTextBackend()
+        model_path = str(tmp_path / "model-a")
+        first_model = backend._load_model(
+            VoiceSettings(
+                vosk_model_path=model_path,
+                vosk_model_keep_loaded=False,
+            )
+        )
+        second_model = backend._load_model(
+            VoiceSettings(
+                vosk_model_path=model_path,
+                vosk_model_keep_loaded=False,
+            )
+        )
+    finally:
+        if original_vosk is None:
+            sys.modules.pop("vosk", None)
+        else:
+            sys.modules["vosk"] = original_vosk
+
+    assert load_calls == [model_path, model_path]
+    assert backend._model_cache == {}
+    assert first_model is not second_model


### PR DESCRIPTION
## Summary
- make the offline Vosk model retention policy explicit with an `assistant.vosk_model_keep_loaded` config/env knob
- cap each Vosk backend instance to a single retained model path and clear stale STT caches when runtime voice settings force a new `VoiceService`
- document the actual lifecycle plus measured storage and RSS tradeoffs for the tracked small English model
- add focused tests covering config wiring, runtime/screen propagation, cache clearing, single-model retention, and best-effort non-retained mode

## Validation
- `uv run pytest -q tests/test_voice_service.py tests/test_runtime_voice.py tests/test_screen_routing.py tests/test_config_models.py` ✅
- `uv run python scripts/quality.py gate` ✅
- `uv run pytest -q` ✅

## Notes / limitations
- `vosk_model_keep_loaded=false` removes YoyoPod's retained model reference, but it is only a best-effort idle-memory reduction; native allocator behavior can still leave RSS above the original baseline after a model load
- the measured footprint doc uses this repo checkout's tracked `models/vosk-model-small-en-us` and the local process numbers captured for this lane
- full `pytest -q` needed one unrestricted rerun because the sandbox blocks the mpv IPC tests' Unix-socket binds with `PermissionError: [Errno 1] Operation not permitted`