### PR TITLE
[codex] Restore cloud provisioning alongside MQTT telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ deploy/pi-deploy.local.yaml
 .cache/
 data/*.json
 data/communication/
+data/cloud/
 data/media/
 data/people/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # YoyoPod - Agent Instructions
 
-**Last Updated:** 2026-04-16
+**Last Updated:** 2026-04-18
 **Target Hardware:** Raspberry Pi Zero 2W
 **Project:** iPod-inspired communication, local music, modem, and voice device with a small-screen button UI
 
@@ -69,7 +69,7 @@ When asked to deploy, sync, restart, check status, view logs, or take a screensh
   - screen timeout and usage tracking
   - RTC helpers
   - PiSugar software watchdog support
-- Production Raspberry Pi deployment now has a committed systemd unit template under `deploy/systemd/`.
+- Production Raspberry Pi deployment runs as `yoyopod@raouf.service` (systemd unit template at `deploy/systemd/yoyopod@.service`).
 - Whisplay now runs on the LVGL rendering path in production under `src/yoyopod/ui/lvgl_binding/`.
 - Production local music now runs through the app-managed mpv backend under `src/yoyopod/audio/music/`.
 - Production communication now runs through Liblinphone under `src/yoyopod/communication/integrations/liblinphone_binding/` and `src/yoyopod/communication/calling/backend.py`.
@@ -149,6 +149,9 @@ yoyopod.py / yoyopod.main
      -> PowerManager
         -> PiSugarBackend
         -> PiSugarWatchdog
+     -> CloudManager
+        -> DeviceMqttClient (transport: websockets via Cloudflare)
+        -> cloud config sync, telemetry, remote command handling
      -> NetworkManager
      -> VoiceRuntimeCoordinator
 ```
@@ -236,6 +239,12 @@ Key design points:
 - `src/yoyopod/cli/pi/` - on-Pi hardware and diagnostic commands
 - `src/yoyopod/cli/remote/` - SSH-based remote Pi operations
 
+### Cloud Integration
+
+- `src/yoyopod/cloud/manager.py` — CloudManager: provisioning, HTTPS auth/refresh, config polling, MQTT telemetry
+- `src/yoyopod/cloud/mqtt_client.py` — DeviceMqttClient with configurable transport (tcp/websockets)
+- `config/cloud/backend.yaml` — MQTT broker host, port, TLS, transport, REST API base URL
+
 ### Configuration
 
 - `config/app/core.yaml`
@@ -279,6 +288,7 @@ Useful env overrides:
 - `YOYOPOD_PI_HOST`
 - `YOYOPOD_PI_PROJECT_DIR`
 - `YOYOPOD_PI_BRANCH`
+- `YOYOPOD_CLOUD_MQTT_TRANSPORT` (websockets/tcp, default tcp)
 
 ---
 

--- a/config/cloud/backend.yaml
+++ b/config/cloud/backend.yaml
@@ -8,9 +8,10 @@ backend:
   claim_retry_seconds: 60
   cache_file: "data/cloud/config_cache.json"
   status_file: "data/cloud/status.json"
-  mqtt_broker_host: "yoyopod.moraouf.net"
-  mqtt_broker_port: 1883
-  mqtt_use_tls: false
+  mqtt_broker_host: "mqtt-yoyopod.moraouf.net"
+  mqtt_broker_port: 443
+  mqtt_use_tls: true
+  mqtt_transport: "websockets"
   mqtt_username: ""
   mqtt_password: ""
   battery_report_interval_seconds: 60

--- a/config/cloud/backend.yaml
+++ b/config/cloud/backend.yaml
@@ -1,4 +1,13 @@
 backend:
+  api_base_url: "https://yoyopod.moraouf.net"
+  auth_path: "/v1/auth/device"
+  refresh_path: "/v1/auth/device/refresh"
+  config_path_template: "/v1/devices/{device_id}/config"
+  timeout_seconds: 3.0
+  config_poll_interval_seconds: 300
+  claim_retry_seconds: 60
+  cache_file: "data/cloud/config_cache.json"
+  status_file: "data/cloud/status.json"
   mqtt_broker_host: "yoyopod.moraouf.net"
   mqtt_broker_port: 1883
   mqtt_use_tls: false

--- a/config/cloud/backend.yaml
+++ b/config/cloud/backend.yaml
@@ -1,0 +1,7 @@
+backend:
+  mqtt_broker_host: "yoyopod.moraouf.net"
+  mqtt_broker_port: 1883
+  mqtt_use_tls: false
+  mqtt_username: ""
+  mqtt_password: ""
+  battery_report_interval_seconds: 60

--- a/config/cloud/device.secrets.example.yaml
+++ b/config/cloud/device.secrets.example.yaml
@@ -1,0 +1,3 @@
+secrets:
+  device_id: "replace-with-claimed-device-id"
+  device_secret: "replace-with-issued-device-secret"

--- a/docs/DEPLOYED_PI_DEPENDENCIES.md
+++ b/docs/DEPLOYED_PI_DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # Deployed Pi Dependency Snapshot
 
-**Last Verified:** 2026-04-10  
+**Last Verified:** 2026-04-18  
 **Target Device:** `rpi-zero`  
 **SSH User:** `tifo`
 
@@ -10,7 +10,7 @@ This document is a live deployment snapshot of the Raspberry Pi environment curr
 
 These services were running when this snapshot was taken:
 
-- `yoyopod@tifo.service`
+- `yoyopod@raouf.service`
 - `pisugar-server.service`
 
 What that means in practice:
@@ -36,7 +36,7 @@ No separate Mopidy process or music daemon is part of the stack anymore.
 
 - `python3`
 - `uv`
-- YoyoPod virtual environment under `/home/tifo/YoyoPod_Core/.venv`
+- YoyoPod virtual environment under `/home/raouf/yoyo-py/.venv`
 
 ### Music playback
 
@@ -162,10 +162,40 @@ Current product direction is local-first music via `mpv`, not a general music-se
 
 At the time of capture:
 
-- `yoyopod@tifo.service` was healthy
+- `yoyopod@raouf.service` was healthy
 - `pisugar-server.service` was healthy
 - memory usage was approximately `231 MB / 416 MB`
 - YoyoPod had one long-lived `python3` process and one long-lived `mpv` child
+
+
+## Cloud Integration Dependencies
+
+### Cloudflare Tunnel
+
+The backend is exposed through a Cloudflare tunnel (token-based, managed via  systemd service). The MQTT broker WebSocket endpoint is routed through Cloudflare:
+
+- Cloudflare route:  → 
+- Mosquitto listens on port 8083 with WebSocket protocol enabled
+
+### Mosquitto MQTT Broker
+
+Mosquitto runs as a snap service on the host machine with two listeners:
+
+- Port 1883: plain TCP (LAN access)
+- Port 8083: WebSocket (routed via Cloudflare tunnel for Pi access over the internet)
+
+Config at: 
+
+### Pi MQTT Transport
+
+The Pi connects to the MQTT broker using WebSocket transport over WSS:443 via Cloudflare. Config in :
+
+- 
+- 
+- 
+- 
+
+Env override: 
 
 ## Source Of Truth For This Snapshot
 

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # YoyoPod System Architecture
 
-**Last updated:** 2026-04-14
+**Last updated:** 2026-04-18
 **Status:** Current implementation
 
 This document describes the architecture that exists on `main`.
@@ -311,7 +311,8 @@ needs selected-track state.
 
 The current code still includes a few environment-specific assumptions:
 
-- Whisplay driver path: `/home/tifo/Whisplay/Driver/WhisPlay.py`
+- Whisplay driver path: `/home/raouf/Whisplay/Driver/WhisPlay.py`
+- MQTT transport: device connects over WebSocket (WSS:443) via Cloudflare tunnel to `mqtt-yoyopod.moraouf.net`; Mosquitto listens on port 8083 with WebSocket protocol
 - audio device defaults for Liblinphone and mpv: `ALSA: wm8960-soundcard` / `alsa/default`
 - simulation server defaults to port `5000`
 - call negotiation on the Pi currently depends on the tracked Liblinphone factory config at `config/communication/integrations/liblinphone_factory.conf`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "tinytag>=2.2.1",
     "pyserial>=3.5",
     "typer>=0.12.0",
+    "paho-mqtt>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/yoyopod/app.py
+++ b/src/yoyopod/app.py
@@ -85,7 +85,7 @@ from yoyopod.ui.screens import (
     TalkContactScreen,
     VoiceNoteScreen,
 )
-from yoyopod.cloud import TelemetryManager
+from yoyopod.cloud import CloudManager
 from yoyopod.communication import CallHistoryStore, VoIPManager
 
 
@@ -168,8 +168,8 @@ class YoyoPodApp:
         self._voip_registered = False
         self._ui_state = AppRuntimeState.IDLE
 
-        # Telemetry
-        self.telemetry_manager: Optional[TelemetryManager] = None
+        # Cloud / backend runtime
+        self.cloud_manager: Optional[CloudManager] = None
 
         # Extracted coordinators
         self.coordinator_runtime: Optional[CoordinatorRuntime] = None
@@ -535,6 +535,8 @@ class YoyoPodApp:
 
     def _handle_network_ppp_up(self, event: NetworkPppUpEvent) -> None:
         """Refresh network connectivity state when PPP comes online."""
+        if self.cloud_manager is not None:
+            self.cloud_manager.note_network_change(connected=True)
         if self.network_manager is not None:
             self._sync_network_context_from_manager()
             return
@@ -585,6 +587,8 @@ class YoyoPodApp:
 
     def _handle_network_ppp_down(self, _event: NetworkPppDownEvent) -> None:
         """Reset network state in AppContext when PPP drops."""
+        if self.cloud_manager is not None:
+            self.cloud_manager.note_network_change(connected=False)
         if self.network_manager is not None:
             self._sync_network_context_from_manager()
             return

--- a/src/yoyopod/app.py
+++ b/src/yoyopod/app.py
@@ -85,6 +85,7 @@ from yoyopod.ui.screens import (
     TalkContactScreen,
     VoiceNoteScreen,
 )
+from yoyopod.cloud import TelemetryManager
 from yoyopod.communication import CallHistoryStore, VoIPManager
 
 
@@ -166,6 +167,9 @@ class YoyoPodApp:
         self.auto_resume_after_call = True
         self._voip_registered = False
         self._ui_state = AppRuntimeState.IDLE
+
+        # Telemetry
+        self.telemetry_manager: Optional[TelemetryManager] = None
 
         # Extracted coordinators
         self.coordinator_runtime: Optional[CoordinatorRuntime] = None

--- a/src/yoyopod/app_context.py
+++ b/src/yoyopod/app_context.py
@@ -79,6 +79,17 @@ class AppContext:
 
         # Navigation history remains screen-manager-adjacent scratch state.
         self.navigation_history: list[str] = []
+        self.cloud_status: dict[str, object] = {
+            "device_id": "",
+            "provisioning_state": "unprovisioned",
+            "cloud_state": "offline",
+            "config_source": "none",
+            "config_version": 0,
+            "backend_reachable": None,
+            "last_successful_sync": None,
+            "last_error_summary": "",
+            "unapplied_keys": [],
+        }
 
         logger.info("AppContext initialized")
 
@@ -650,6 +661,33 @@ class AppContext:
         """Cache the latest spoken response text."""
 
         self.voice.last_spoken_text = text.strip()
+
+    def update_cloud_status(
+        self,
+        *,
+        device_id: str,
+        provisioning_state: str,
+        cloud_state: str,
+        config_source: str,
+        config_version: int,
+        backend_reachable: bool | None,
+        last_successful_sync: str | None,
+        last_error_summary: str,
+        unapplied_keys: list[str],
+    ) -> None:
+        """Cache backend/provisioning state for UI and diagnostics."""
+
+        self.cloud_status = {
+            "device_id": device_id,
+            "provisioning_state": provisioning_state,
+            "cloud_state": cloud_state,
+            "config_source": config_source,
+            "config_version": int(config_version),
+            "backend_reachable": backend_reachable,
+            "last_successful_sync": last_successful_sync,
+            "last_error_summary": last_error_summary,
+            "unapplied_keys": list(unapplied_keys),
+        }
 
     def update_voice_interaction(
         self,

--- a/src/yoyopod/cloud/__init__.py
+++ b/src/yoyopod/cloud/__init__.py
@@ -1,5 +1,15 @@
-"""Cloud telemetry module — publishes device events to the backend via MQTT."""
+"""Cloud runtime, backend client, and MQTT transport helpers."""
 
-from yoyopod.cloud.manager import TelemetryManager
+from yoyopod.cloud.client import CloudClientError, CloudDeviceClient
+from yoyopod.cloud.manager import CloudManager
+from yoyopod.cloud.models import CloudAccessToken, CloudStatusSnapshot
+from yoyopod.cloud.mqtt_client import DeviceMqttClient
 
-__all__ = ["TelemetryManager"]
+__all__ = [
+    "CloudAccessToken",
+    "CloudClientError",
+    "CloudDeviceClient",
+    "CloudManager",
+    "CloudStatusSnapshot",
+    "DeviceMqttClient",
+]

--- a/src/yoyopod/cloud/__init__.py
+++ b/src/yoyopod/cloud/__init__.py
@@ -1,0 +1,5 @@
+"""Cloud telemetry module — publishes device events to the backend via MQTT."""
+
+from yoyopod.cloud.manager import TelemetryManager
+
+__all__ = ["TelemetryManager"]

--- a/src/yoyopod/cloud/client.py
+++ b/src/yoyopod/cloud/client.py
@@ -1,0 +1,127 @@
+"""HTTP client for claimed-device cloud auth and config fetches."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+from yoyopod.cloud.models import CloudAccessToken
+
+
+@dataclass(slots=True)
+class CloudClientError(RuntimeError):
+    """Structured cloud/backend failure surfaced to the coordinator."""
+
+    message: str
+    status_code: int | None = None
+    error_code: str | None = None
+    payload: dict[str, Any] | None = None
+
+    def __str__(self) -> str:
+        code = f" [{self.error_code}]" if self.error_code else ""
+        status = f" ({self.status_code})" if self.status_code is not None else ""
+        return f"{self.message}{code}{status}"
+
+
+class CloudDeviceClient:
+    """Small HTTP client for device auth, refresh, and config fetch."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        auth_path: str,
+        refresh_path: str,
+        config_path_template: str,
+        timeout_seconds: float = 3.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.auth_path = auth_path
+        self.refresh_path = refresh_path
+        self.config_path_template = config_path_template
+        self.timeout_seconds = max(0.1, float(timeout_seconds))
+
+    def authenticate(self, *, device_id: str, device_secret: str) -> CloudAccessToken:
+        payload = self._request_json(
+            "POST",
+            self._url(self.auth_path),
+            json={
+                "device_id": device_id,
+                "device_secret": device_secret,
+            },
+        )
+        return CloudAccessToken.from_payload(payload)
+
+    def refresh(self, *, access_token: str) -> CloudAccessToken:
+        payload = self._request_json(
+            "POST",
+            self._url(self.refresh_path),
+            headers=self._auth_headers(access_token),
+        )
+        return CloudAccessToken.from_payload(payload)
+
+    def fetch_config(self, *, access_token: str, device_id: str) -> dict[str, Any]:
+        payload = self._request_json(
+            "GET",
+            self._url(self.config_path_template.format(device_id=device_id)),
+            headers=self._auth_headers(access_token),
+        )
+        if not isinstance(payload, dict):
+            raise CloudClientError("Malformed cloud config payload", payload={"payload": payload})
+        return payload
+
+    def _request_json(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        try:
+            response = requests.request(
+                method,
+                url,
+                headers=headers,
+                json=json,
+                timeout=self.timeout_seconds,
+            )
+        except requests.RequestException as exc:
+            raise CloudClientError(str(exc)) from exc
+
+        payload: dict[str, Any] | None
+        try:
+            decoded = response.json()
+            payload = decoded if isinstance(decoded, dict) else {"payload": decoded}
+        except ValueError:
+            payload = None
+
+        if response.status_code >= 400:
+            error_code = None
+            message = response.reason or "Cloud request failed"
+            if payload is not None:
+                error_code = str(payload.get("error_code") or payload.get("code") or "").strip() or None
+                message = str(payload.get("message") or payload.get("detail") or message)
+            raise CloudClientError(
+                message=message,
+                status_code=response.status_code,
+                error_code=error_code,
+                payload=payload,
+            )
+
+        if payload is None:
+            raise CloudClientError(
+                message="Cloud response was not valid JSON",
+                status_code=response.status_code,
+            )
+        return payload
+
+    @staticmethod
+    def _auth_headers(access_token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {access_token}"}
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}/{path.lstrip('/')}"

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -721,6 +721,7 @@ class CloudManager:
             username=backend.mqtt_username or None,
             password=backend.mqtt_password or None,
             use_tls=backend.mqtt_use_tls,
+            transport=backend.mqtt_transport,
             command_callback=self._handle_mqtt_command,
         )
         self._mqtt.start()

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -1,87 +1,765 @@
-"""Telemetry manager — publishes device state to the backend via MQTT."""
+"""Cloud manager for device auth, remote config, cache, and operator status."""
 
 from __future__ import annotations
 
+import json
+import threading
 import time
-from typing import TYPE_CHECKING
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
 
 from loguru import logger
 
+from yoyopod.cloud.client import CloudClientError, CloudDeviceClient
+from yoyopod.cloud.models import CloudAccessToken, CloudStatusSnapshot
 from yoyopod.cloud.mqtt_client import DeviceMqttClient
 
 if TYPE_CHECKING:
-    from yoyopod.config.models import BackendTelemetryConfig
+    from yoyopod.app import YoyoPodApp
+    from yoyopod.config import ConfigManager
 
 
-class TelemetryManager:
-    """Own MQTT-based device telemetry publishing (battery, heartbeat, connectivity).
+class CloudManager:
+    """Own device provisioning, auth refresh, config sync, and MQTT telemetry."""
 
-    This is intentionally decoupled from the runtime loop — it runs its MQTT
-    client on a background daemon thread and exposes simple fire-and-forget
-    publish helpers that the coordinator layer calls directly.
-    """
+    _NETWORK_RETRY_DELAYS_SECONDS = (30.0, 60.0, 120.0, 300.0)
+    _INVALID_CREDENTIALS_CODES = {"invalid_credentials", "invalid_device"}
+    _TOKEN_RETRY_CODES = {"unauthorized", "token_revoked"}
 
-    def __init__(self, *, config: "BackendTelemetryConfig", device_id: str) -> None:
-        self._config = config
-        self._device_id = device_id
+    def __init__(
+        self,
+        *,
+        app: "YoyoPodApp",
+        config_manager: "ConfigManager",
+        client: CloudDeviceClient | None = None,
+    ) -> None:
+        self.app = app
+        self.config_manager = config_manager
+        backend = config_manager.get_cloud_settings().backend
+        self._custom_client = client is not None
+        self.client = client or CloudDeviceClient(
+            base_url=backend.api_base_url,
+            auth_path=backend.auth_path,
+            refresh_path=backend.refresh_path,
+            config_path_template=backend.config_path_template,
+            timeout_seconds=backend.timeout_seconds,
+        )
+        self.status = CloudStatusSnapshot()
+        self._access_token: CloudAccessToken | None = None
+        self._next_auth_attempt_at = 0.0
+        self._next_refresh_at = 0.0
+        self._next_config_poll_at = 0.0
+        self._network_retry_index = 0
+        self._secrets_fingerprint: tuple[bool, int, int] | None = None
+        self._last_persisted_status_payload: dict[str, Any] | None = None
+        self._request_in_flight = False
+        self._provisioning_generation = 0
         self._mqtt: DeviceMqttClient | None = None
-        self._next_battery_report_at: float = 0.0
+        self._next_battery_report_at = 0.0
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
+    def prepare_boot(self) -> None:
+        """Load secrets/cache and start MQTT before the runtime loop begins."""
 
-    def start(self) -> None:
-        """Create and connect the MQTT client."""
-        cfg = self._config
-        if not cfg.mqtt_broker_host:
-            logger.info("Telemetry: no MQTT broker configured — skipping")
+        self._reload_provisioning(force=True, now=time.monotonic())
+        self._start_mqtt()
+
+    def tick(self, now: float | None = None) -> None:
+        """Advance auth/config sync on the coordinator loop."""
+
+        monotonic_now = time.monotonic() if now is None else now
+        self._reload_provisioning(force=False, now=monotonic_now)
+
+        if not self._is_backend_configured():
+            self.status.cloud_state = "offline"
+            self.status.backend_reachable = None
+            self._persist_status()
+            self._sync_context_state()
             return
 
-        self._mqtt = DeviceMqttClient(
-            broker_host=cfg.mqtt_broker_host,
-            device_id=self._device_id,
-            port=cfg.mqtt_broker_port,
-            username=cfg.mqtt_username or None,
-            password=cfg.mqtt_password or None,
-            use_tls=cfg.mqtt_use_tls,
-        )
-        self._mqtt.start()
-        logger.info(
-            "Telemetry: MQTT client started (broker={}:{})",
-            cfg.mqtt_broker_host,
-            cfg.mqtt_broker_port,
-        )
+        if self.status.provisioning_state != "provisioned":
+            self._persist_status()
+            self._sync_context_state()
+            return
+
+        if self._request_in_flight:
+            return
+
+        if self._access_token is None:
+            if monotonic_now >= self._next_auth_attempt_at:
+                self._start_authentication(monotonic_now)
+            return
+
+        if monotonic_now >= self._next_refresh_at:
+            self._start_refresh_token(monotonic_now)
+            return
+
+        if monotonic_now >= self._next_config_poll_at:
+            self._start_fetch_remote_config(monotonic_now)
+
+    def note_network_change(self, *, connected: bool) -> None:
+        """Wake auth/config work when connectivity changes."""
+
+        if not connected:
+            self.status.cloud_state = "offline"
+            self.status.backend_reachable = False
+            self._sync_context_state()
+            self._persist_status()
+            return
+
+        if self.status.provisioning_state != "provisioned":
+            return
+
+        now = time.monotonic()
+        if self._access_token is None:
+            self._next_auth_attempt_at = now
+        else:
+            self._next_config_poll_at = now
+        self._persist_status()
+
+    def request_immediate_poll(self) -> None:
+        """Reset the config-poll timer so the next tick polls immediately."""
+
+        self._next_config_poll_at = 0.0
+
+    def publish_battery(self, *, level: int, charging: bool, now: float) -> None:
+        """Send a battery telemetry event via MQTT if the interval has elapsed."""
+
+        if self._mqtt is None or not self._mqtt.is_connected:
+            return
+        if now < self._next_battery_report_at:
+            return
+        interval = self.config_manager.get_cloud_settings().backend.battery_report_interval_seconds
+        if self._mqtt.publish_battery(level=level, charging=charging):
+            self._next_battery_report_at = now + max(1, interval)
+
+    def publish_heartbeat(self, *, firmware_version: str | None = None) -> None:
+        """Send a heartbeat event via MQTT."""
+
+        if self._mqtt is not None and self._mqtt.is_connected:
+            self._mqtt.publish_heartbeat(firmware_version=firmware_version)
+
+    def sync_context_state(self) -> None:
+        """Push the latest cloud/max-volume state into AppContext when available."""
+
+        self._sync_context_state()
+
+    def export_status(self) -> dict[str, Any]:
+        """Return the current redacted cloud status as a dict."""
+
+        return self.status.to_dict()
 
     def stop(self) -> None:
-        """Disconnect the MQTT client."""
+        """Persist the latest status and stop MQTT on shutdown."""
+
+        self._persist_status()
+        if self._mqtt is not None:
+            self._mqtt.stop()
+
+    def _reload_provisioning(self, *, force: bool, now: float) -> None:
+        """Reload runtime secrets when the provisioning file changes."""
+
+        fingerprint = self._current_secrets_fingerprint()
+        if not force and fingerprint == self._secrets_fingerprint:
+            return
+
+        previous_device_id = self.status.device_id
+        self._secrets_fingerprint = fingerprint
+        self._provisioning_generation += 1
+        self.config_manager.load_cloud_config()
+        if not self._custom_client:
+            backend = self.config_manager.get_cloud_settings().backend
+            self.client = CloudDeviceClient(
+                base_url=backend.api_base_url,
+                auth_path=backend.auth_path,
+                refresh_path=backend.refresh_path,
+                config_path_template=backend.config_path_template,
+                timeout_seconds=backend.timeout_seconds,
+            )
+
+        device_id = self.config_manager.get_cloud_device_id().strip()
+        device_secret = self.config_manager.get_cloud_device_secret().strip()
+        self.status.device_id = device_id
+        self.status.backend_reachable = None
+        self.status.last_error_summary = ""
+        self.status.updated_at = self._utc_now()
+        self._access_token = None
+        self._next_refresh_at = 0.0
+        self._next_config_poll_at = 0.0
+        self._network_retry_index = 0
+        self._start_mqtt()
+
+        if self.config_manager.cloud_secrets_error:
+            self.status.provisioning_state = "invalid_provisioning"
+            self.status.cloud_state = "degraded"
+            self.status.config_source = "none"
+            self.status.last_error_summary = self.config_manager.cloud_secrets_error
+            self.status.unapplied_keys = []
+            self.status.config_version = 0
+            self._sync_context_state()
+            self._persist_status()
+            return
+
+        if not device_id and not device_secret:
+            self.status.provisioning_state = "unprovisioned"
+            self.status.cloud_state = "offline"
+            self.status.config_source = "none"
+            self.status.unapplied_keys = []
+            self.status.config_version = 0
+            self._sync_context_state()
+            self._persist_status()
+            return
+
+        if not device_id or not device_secret:
+            self.status.provisioning_state = "invalid_provisioning"
+            self.status.cloud_state = "degraded"
+            self.status.config_source = "none"
+            self.status.last_error_summary = "Provisioning file must contain device_id and device_secret"
+            self.status.unapplied_keys = []
+            self.status.config_version = 0
+            self._sync_context_state()
+            self._persist_status()
+            return
+
+        self.status.provisioning_state = "provisioned"
+        self.status.cloud_state = "offline"
+        if device_id != previous_device_id:
+            self.status.config_source = "none"
+            self.status.unapplied_keys = []
+            self.status.config_version = 0
+            self.status.last_successful_sync = None
+
+        self._load_cached_config()
+        self._next_auth_attempt_at = now
+        self._sync_context_state()
+        self._persist_status()
+
+    def _start_authentication(self, now: float) -> None:
+        self.status.cloud_state = "authenticating"
+        self.status.updated_at = self._utc_now()
+        self._sync_context_state()
+        self._persist_status()
+
+        self._request_in_flight = True
+        self._start_worker(
+            name="cloud-auth",
+            work=lambda: self._run_authentication(
+                device_id=self.config_manager.get_cloud_device_id().strip(),
+                device_secret=self.config_manager.get_cloud_device_secret().strip(),
+                generation=self._provisioning_generation,
+            ),
+        )
+
+    def _start_refresh_token(self, now: float) -> None:
+        if self._access_token is None:
+            self._next_auth_attempt_at = now
+            return
+
+        access_token = self._access_token.access_token
+        self._request_in_flight = True
+        self._start_worker(
+            name="cloud-refresh",
+            work=lambda: self._run_refresh_token(
+                access_token=access_token,
+                generation=self._provisioning_generation,
+            ),
+        )
+
+    def _start_fetch_remote_config(self, now: float) -> None:
+        if self._access_token is None:
+            self._next_auth_attempt_at = now
+            return
+
+        access_token = self._access_token.access_token
+        device_id = self.config_manager.get_cloud_device_id().strip()
+        self._request_in_flight = True
+        self._start_worker(
+            name="cloud-config-fetch",
+            work=lambda: self._run_fetch_remote_config(
+                access_token=access_token,
+                device_id=device_id,
+                generation=self._provisioning_generation,
+            ),
+        )
+
+    def _run_authentication(self, *, device_id: str, device_secret: str, generation: int) -> None:
+        try:
+            token = self.client.authenticate(device_id=device_id, device_secret=device_secret)
+        except CloudClientError as exc:
+            self.app._queue_main_thread_callback(
+                lambda exc=exc, generation=generation, device_id=device_id, completed_at=time.monotonic(): self._complete_authentication(
+                    device_id=device_id,
+                    generation=generation,
+                    completed_at=completed_at,
+                    error=exc,
+                )
+            )
+            return
+        except Exception as exc:
+            error = CloudClientError(str(exc))
+            self.app._queue_main_thread_callback(
+                lambda error=error, generation=generation, device_id=device_id, completed_at=time.monotonic(): self._complete_authentication(
+                    device_id=device_id,
+                    generation=generation,
+                    completed_at=completed_at,
+                    error=error,
+                )
+            )
+            return
+
+        self.app._queue_main_thread_callback(
+            lambda token=token, generation=generation, device_id=device_id, completed_at=time.monotonic(): self._complete_authentication(
+                device_id=device_id,
+                generation=generation,
+                completed_at=completed_at,
+                token=token,
+            )
+        )
+
+    def _complete_authentication(
+        self,
+        *,
+        device_id: str,
+        generation: int,
+        completed_at: float,
+        token: CloudAccessToken | None = None,
+        error: CloudClientError | None = None,
+    ) -> None:
+        self._request_in_flight = False
+        if not self._matches_current_provisioning(device_id=device_id, generation=generation):
+            return
+
+        if error is not None:
+            self._handle_auth_error(error, now=completed_at)
+            return
+
+        assert token is not None
+        self._access_token = token
+        self.status.backend_reachable = True
+        self.status.cloud_state = "ready" if self.status.config_source != "none" else "authenticating"
+        self._schedule_refresh(token, now=completed_at)
+        self._next_config_poll_at = completed_at
+        self._network_retry_index = 0
+        self.status.last_error_summary = ""
+        self._persist_status()
+        self._sync_context_state()
+
+    def _run_refresh_token(self, *, access_token: str, generation: int) -> None:
+        try:
+            token = self.client.refresh(access_token=access_token)
+        except CloudClientError as exc:
+            self.app._queue_main_thread_callback(
+                lambda exc=exc, generation=generation, access_token=access_token, completed_at=time.monotonic(): self._complete_refresh_token(
+                    access_token=access_token,
+                    generation=generation,
+                    completed_at=completed_at,
+                    error=exc,
+                )
+            )
+            return
+        except Exception as exc:
+            error = CloudClientError(str(exc))
+            self.app._queue_main_thread_callback(
+                lambda error=error, generation=generation, access_token=access_token, completed_at=time.monotonic(): self._complete_refresh_token(
+                    access_token=access_token,
+                    generation=generation,
+                    completed_at=completed_at,
+                    error=error,
+                )
+            )
+            return
+
+        self.app._queue_main_thread_callback(
+            lambda token=token, generation=generation, access_token=access_token, completed_at=time.monotonic(): self._complete_refresh_token(
+                access_token=access_token,
+                generation=generation,
+                completed_at=completed_at,
+                token=token,
+            )
+        )
+
+    def _complete_refresh_token(
+        self,
+        *,
+        access_token: str,
+        generation: int,
+        completed_at: float,
+        token: CloudAccessToken | None = None,
+        error: CloudClientError | None = None,
+    ) -> None:
+        self._request_in_flight = False
+        if not self._matches_current_request(access_token=access_token, generation=generation):
+            return
+
+        if error is not None:
+            if error.error_code in self._TOKEN_RETRY_CODES:
+                self._access_token = None
+                self._next_auth_attempt_at = completed_at
+                self.status.cloud_state = "authenticating"
+                self.status.last_error_summary = ""
+                self._persist_status()
+                self._sync_context_state()
+                return
+            self._handle_network_or_backend_error(error, now=completed_at)
+            return
+
+        assert token is not None
+        self._access_token = token
+        self.status.backend_reachable = True
+        self.status.cloud_state = "ready"
+        self.status.last_error_summary = ""
+        self._schedule_refresh(token, now=completed_at)
+        self._persist_status()
+        self._sync_context_state()
+
+    def _run_fetch_remote_config(self, *, access_token: str, device_id: str, generation: int) -> None:
+        try:
+            payload = self.client.fetch_config(access_token=access_token, device_id=device_id)
+        except CloudClientError as exc:
+            self.app._queue_main_thread_callback(
+                lambda exc=exc, generation=generation, access_token=access_token, device_id=device_id, completed_at=time.monotonic(): self._complete_fetch_remote_config(
+                    access_token=access_token,
+                    device_id=device_id,
+                    generation=generation,
+                    completed_at=completed_at,
+                    error=exc,
+                )
+            )
+            return
+        except Exception as exc:
+            error = CloudClientError(str(exc))
+            self.app._queue_main_thread_callback(
+                lambda error=error, generation=generation, access_token=access_token, device_id=device_id, completed_at=time.monotonic(): self._complete_fetch_remote_config(
+                    access_token=access_token,
+                    device_id=device_id,
+                    generation=generation,
+                    completed_at=completed_at,
+                    error=error,
+                )
+            )
+            return
+
+        self.app._queue_main_thread_callback(
+            lambda payload=payload, generation=generation, access_token=access_token, device_id=device_id, completed_at=time.monotonic(): self._complete_fetch_remote_config(
+                access_token=access_token,
+                device_id=device_id,
+                generation=generation,
+                completed_at=completed_at,
+                payload=payload,
+            )
+        )
+
+    def _complete_fetch_remote_config(
+        self,
+        *,
+        access_token: str,
+        device_id: str,
+        generation: int,
+        completed_at: float,
+        payload: dict[str, Any] | None = None,
+        error: CloudClientError | None = None,
+    ) -> None:
+        self._request_in_flight = False
+        if not self._matches_current_request(
+            access_token=access_token,
+            generation=generation,
+            device_id=device_id,
+        ):
+            return
+
+        if error is not None:
+            if error.error_code in self._TOKEN_RETRY_CODES:
+                self._access_token = None
+                self._next_auth_attempt_at = completed_at
+                self.status.cloud_state = "authenticating"
+                self._persist_status()
+                self._sync_context_state()
+                return
+            self._handle_network_or_backend_error(error, now=completed_at)
+            return
+
+        assert payload is not None
+        config_version = int(payload.get("config_version") or 0)
+        unapplied_keys = self.config_manager.apply_cloud_overrides(payload)
+        self._apply_runtime_side_effects(payload)
+        self.status.backend_reachable = True
+        self.status.cloud_state = "ready"
+        self.status.config_source = "live"
+        self.status.config_version = config_version
+        self.status.last_successful_sync = self._utc_now()
+        self.status.last_error_summary = ""
+        self.status.unapplied_keys = unapplied_keys
+        self._next_config_poll_at = completed_at + max(
+            1,
+            self.config_manager.get_cloud_settings().backend.config_poll_interval_seconds,
+        )
+        self._network_retry_index = 0
+        self._write_cache(
+            payload=payload,
+            config_version=config_version,
+            source="live",
+            unapplied_keys=unapplied_keys,
+        )
+        self._persist_status()
+        self._sync_context_state()
+        from yoyopod import __version__
+        self.publish_heartbeat(firmware_version=__version__)
+
+    def _start_worker(self, *, name: str, work: Callable[[], None]) -> None:
+        threading.Thread(target=work, daemon=True, name=name).start()
+
+    def _matches_current_provisioning(self, *, device_id: str, generation: int) -> bool:
+        return (
+            generation == self._provisioning_generation
+            and device_id == self.config_manager.get_cloud_device_id().strip()
+            and self.status.provisioning_state == "provisioned"
+        )
+
+    def _matches_current_request(
+        self,
+        *,
+        access_token: str,
+        generation: int,
+        device_id: str | None = None,
+    ) -> bool:
+        if not self._matches_current_provisioning(
+            device_id=device_id or self.config_manager.get_cloud_device_id().strip(),
+            generation=generation,
+        ):
+            return False
+        return self._access_token is not None and self._access_token.access_token == access_token
+
+    def _handle_auth_error(self, exc: CloudClientError, *, now: float) -> None:
+        if exc.error_code == "device_unclaimed":
+            self.status.backend_reachable = True
+            self.status.cloud_state = "unclaimed"
+            self.status.last_error_summary = "Device has not been claimed yet"
+            self._next_auth_attempt_at = now + max(
+                1,
+                self.config_manager.get_cloud_settings().backend.claim_retry_seconds,
+            )
+        elif exc.error_code in self._INVALID_CREDENTIALS_CODES:
+            self.status.backend_reachable = True
+            self.status.cloud_state = "degraded"
+            self.status.last_error_summary = "Invalid device credentials"
+            self._next_auth_attempt_at = float("inf")
+        else:
+            self._handle_network_or_backend_error(exc, now=now)
+            return
+
+        self._persist_status()
+        self._sync_context_state()
+
+    def _handle_network_or_backend_error(self, exc: CloudClientError, *, now: float) -> None:
+        status_code = exc.status_code or 0
+        reachable = exc.status_code is not None
+        self.status.backend_reachable = True if status_code >= 400 else False
+        self.status.cloud_state = "offline" if not reachable or status_code >= 500 else "degraded"
+        self.status.last_error_summary = str(exc)
+        delay = self._NETWORK_RETRY_DELAYS_SECONDS[
+            min(self._network_retry_index, len(self._NETWORK_RETRY_DELAYS_SECONDS) - 1)
+        ]
+        self._network_retry_index = min(
+            self._network_retry_index + 1,
+            len(self._NETWORK_RETRY_DELAYS_SECONDS) - 1,
+        )
+        if self._access_token is None:
+            self._next_auth_attempt_at = now + delay
+        else:
+            self._next_refresh_at = now + delay
+            self._next_config_poll_at = now + delay
+        self._persist_status()
+        self._sync_context_state()
+
+    def _schedule_refresh(self, token: CloudAccessToken, *, now: float) -> None:
+        threshold_seconds = min(token.lifetime_seconds * 0.2, 2 * 60 * 60)
+        refresh_at_epoch = max(token.issued_at_epoch, token.expires_at_epoch - threshold_seconds)
+        seconds_until_refresh = max(0.0, refresh_at_epoch - time.time())
+        self._next_refresh_at = now + seconds_until_refresh
+
+    def _apply_runtime_side_effects(self, payload: dict[str, Any]) -> None:
+        audio = payload.get("audio", {})
+        if not isinstance(audio, dict):
+            audio = {}
+
+        if self.app.context is not None:
+            self.app.context.settings["max_volume"] = self.config_manager.get_max_output_volume()
+
+        if "max_volume" in audio:
+            max_volume = self.config_manager.get_max_output_volume()
+            current = self.app.get_output_volume(refresh_system=False)
+            if current is not None and current > max_volume:
+                self.app.set_output_volume(max_volume)
+            elif self.app.context is not None and self.app.context.voice.output_volume > max_volume:
+                self.app.context.set_volume(max_volume)
+
+        if "default_volume" in audio:
+            self.app.set_output_volume(self.config_manager.get_default_output_volume())
+
+        if self.app.voip_manager is not None:
+            self.app.voip_manager.config.voice_note_max_duration_seconds = (
+                self.config_manager.get_voice_note_max_duration_seconds()
+            )
+            current_volume = self.app.get_output_volume(refresh_system=False)
+            if current_volume is not None:
+                self.app.voip_manager.config.output_volume = current_volume
+
+        self._sync_context_state()
+
+    def _load_cached_config(self) -> None:
+        cache_path = self._cache_path()
+        if not cache_path.exists():
+            return
+
+        try:
+            payload = json.loads(cache_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            logger.warning("Failed to read cloud config cache {}: {}", cache_path, exc)
+            return
+
+        if not isinstance(payload, dict):
+            logger.warning("Ignoring malformed cloud config cache {}", cache_path)
+            return
+
+        cached_device_id = str(payload.get("device_id") or "")
+        current_device_id = self.config_manager.get_cloud_device_id().strip()
+        if cached_device_id != current_device_id:
+            logger.warning(
+                "Ignoring cloud config cache for mismatched device id (cache={}, current={})",
+                cached_device_id,
+                current_device_id,
+            )
+            return
+
+        raw_payload = payload.get("raw_payload", {})
+        if not isinstance(raw_payload, dict):
+            logger.warning("Ignoring malformed cloud config cache payload {}", cache_path)
+            return
+
+        unapplied_keys = self.config_manager.apply_cloud_overrides(raw_payload)
+        self._apply_runtime_side_effects(raw_payload)
+        self.status.config_source = "cache"
+        self.status.config_version = int(payload.get("config_version") or 0)
+        self.status.unapplied_keys = unapplied_keys
+
+    def _write_cache(
+        self,
+        *,
+        payload: dict[str, Any],
+        config_version: int,
+        source: str,
+        unapplied_keys: list[str],
+    ) -> None:
+        cache_path = self._cache_path()
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_payload = {
+            "device_id": self.config_manager.get_cloud_device_id().strip(),
+            "config_version": config_version,
+            "fetched_at": self._utc_now(),
+            "source": source,
+            "raw_payload": payload,
+            "unapplied_keys": list(unapplied_keys),
+        }
+        try:
+            cache_path.write_text(
+                json.dumps(cache_payload, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning("Failed to persist cloud config cache {}: {}", cache_path, exc)
+
+    def _persist_status(self) -> None:
+        status_path = self._status_path()
+        status_path.parent.mkdir(parents=True, exist_ok=True)
+        status_payload = self.status.to_dict()
+        status_payload["updated_at"] = None
+        if status_payload == self._last_persisted_status_payload:
+            return
+        self.status.updated_at = self._utc_now()
+        status_json = json.dumps(self.status.to_dict(), indent=2, sort_keys=True)
+        try:
+            status_path.write_text(status_json, encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Failed to persist cloud status {}: {}", status_path, exc)
+            return
+        self._last_persisted_status_payload = status_payload
+
+    def _sync_context_state(self) -> None:
+        if self.app.context is None:
+            return
+        self.app.context.settings["max_volume"] = self.config_manager.get_max_output_volume()
+        self.app.context.update_cloud_status(
+            device_id=self.status.device_id,
+            provisioning_state=self.status.provisioning_state,
+            cloud_state=self.status.cloud_state,
+            config_source=self.status.config_source,
+            config_version=self.status.config_version,
+            backend_reachable=self.status.backend_reachable,
+            last_successful_sync=self.status.last_successful_sync,
+            last_error_summary=self.status.last_error_summary,
+            unapplied_keys=self.status.unapplied_keys,
+        )
+
+    def _start_mqtt(self) -> None:
+        backend = self.config_manager.get_cloud_settings().backend
         if self._mqtt is not None:
             self._mqtt.stop()
             self._mqtt = None
-
-    # ------------------------------------------------------------------
-    # Publishing
-    # ------------------------------------------------------------------
-
-    def publish_battery(self, *, level: int, charging: bool, now: float | None = None) -> None:
-        """Publish a battery event, rate-limited by config interval."""
-        if self._mqtt is None:
+        if not backend.mqtt_broker_host.strip():
+            logger.info("MQTT broker host not configured — telemetry events disabled")
             return
 
-        monotonic_now = time.monotonic() if now is None else now
-        if monotonic_now < self._next_battery_report_at:
+        device_id = self.config_manager.get_cloud_device_id().strip()
+        if not device_id:
+            logger.info("Device not provisioned — MQTT telemetry deferred")
             return
 
-        if self._mqtt.publish_battery(level=level, charging=charging):
-            self._next_battery_report_at = (
-                monotonic_now + self._config.battery_report_interval_seconds
-            )
+        self._mqtt = DeviceMqttClient(
+            broker_host=backend.mqtt_broker_host,
+            device_id=device_id,
+            port=backend.mqtt_broker_port,
+            username=backend.mqtt_username or None,
+            password=backend.mqtt_password or None,
+            use_tls=backend.mqtt_use_tls,
+            command_callback=self._handle_mqtt_command,
+        )
+        self._mqtt.start()
+        logger.info(
+            "MQTT client started -> {}:{} (device={})",
+            backend.mqtt_broker_host,
+            backend.mqtt_broker_port,
+            device_id,
+        )
 
-    def publish_heartbeat(self, *, firmware_version: str | None = None) -> None:
-        """Publish a heartbeat event (e.g. on screen wake or periodic tick)."""
-        if self._mqtt is not None:
-            self._mqtt.publish_heartbeat(firmware_version=firmware_version)
+    def _handle_mqtt_command(self, command: dict[str, Any]) -> None:
+        cmd_type = command.get("type", "unknown")
+        logger.info("MQTT command received from backend: {}", cmd_type)
+        self.app._queue_main_thread_callback(lambda cmd=command: self._apply_mqtt_command(cmd))
 
-    @property
-    def is_connected(self) -> bool:
-        return self._mqtt is not None and self._mqtt.is_connected
+    def _apply_mqtt_command(self, command: dict[str, Any]) -> None:
+        cmd_type = command.get("type", "")
+        if cmd_type == "fetch_config":
+            self._next_config_poll_at = 0.0
+            logger.info("MQTT: backend requested immediate config fetch")
+        else:
+            logger.info("MQTT: unhandled command type '{}'", cmd_type)
+
+    def _is_backend_configured(self) -> bool:
+        return bool(self.config_manager.get_cloud_settings().backend.api_base_url.strip())
+
+    def _current_secrets_fingerprint(self) -> tuple[bool, int, int]:
+        path = self.config_manager.cloud_secrets_runtime_file
+        if not path.exists():
+            return (False, 0, 0)
+        stat = path.stat()
+        return (True, stat.st_mtime_ns, stat.st_size)
+
+    def _cache_path(self) -> Path:
+        return self.config_manager.resolve_runtime_path(self.config_manager.get_cloud_cache_file())
+
+    def _status_path(self) -> Path:
+        return self.config_manager.resolve_runtime_path(self.config_manager.get_cloud_status_file())
+
+    @staticmethod
+    def _utc_now() -> str:
+        return datetime.now(timezone.utc).isoformat()

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -187,7 +187,9 @@ class CloudManager:
         self._next_refresh_at = 0.0
         self._next_config_poll_at = 0.0
         self._network_retry_index = 0
-        self._start_mqtt()
+        if self._mqtt is not None:
+            self._mqtt.stop()
+            self._mqtt = None
 
         if self.config_manager.cloud_secrets_error:
             self.status.provisioning_state = "invalid_provisioning"
@@ -223,6 +225,7 @@ class CloudManager:
 
         self.status.provisioning_state = "provisioned"
         self.status.cloud_state = "offline"
+        self._start_mqtt()
         if device_id != previous_device_id:
             self.status.config_source = "none"
             self.status.unapplied_keys = []
@@ -599,7 +602,9 @@ class CloudManager:
                 self.app.context.set_volume(max_volume)
 
         if "default_volume" in audio:
-            self.app.set_output_volume(self.config_manager.get_default_output_volume())
+            max_volume = self.config_manager.get_max_output_volume()
+            default_volume = min(self.config_manager.get_default_output_volume(), max_volume)
+            self.app.set_output_volume(default_volume)
 
         if self.app.voip_manager is not None:
             self.app.voip_manager.config.voice_note_max_duration_seconds = (

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -392,7 +392,9 @@ class CloudManager:
             return
 
         if error is not None:
-            if error.error_code in self._TOKEN_RETRY_CODES:
+            if error.error_code in self._TOKEN_RETRY_CODES or (
+                error.status_code == 401 and not error.error_code
+            ):
                 self._access_token = None
                 self._next_auth_attempt_at = completed_at
                 self.status.cloud_state = "authenticating"
@@ -468,10 +470,13 @@ class CloudManager:
             return
 
         if error is not None:
-            if error.error_code in self._TOKEN_RETRY_CODES:
+            if error.error_code in self._TOKEN_RETRY_CODES or (
+                error.status_code == 401 and not error.error_code
+            ):
                 self._access_token = None
                 self._next_auth_attempt_at = completed_at
                 self.status.cloud_state = "authenticating"
+                self.status.last_error_summary = ""
                 self._persist_status()
                 self._sync_context_state()
                 return

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -1,0 +1,87 @@
+"""Telemetry manager — publishes device state to the backend via MQTT."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from yoyopod.cloud.mqtt_client import DeviceMqttClient
+
+if TYPE_CHECKING:
+    from yoyopod.config.models import BackendTelemetryConfig
+
+
+class TelemetryManager:
+    """Own MQTT-based device telemetry publishing (battery, heartbeat, connectivity).
+
+    This is intentionally decoupled from the runtime loop — it runs its MQTT
+    client on a background daemon thread and exposes simple fire-and-forget
+    publish helpers that the coordinator layer calls directly.
+    """
+
+    def __init__(self, *, config: "BackendTelemetryConfig", device_id: str) -> None:
+        self._config = config
+        self._device_id = device_id
+        self._mqtt: DeviceMqttClient | None = None
+        self._next_battery_report_at: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Create and connect the MQTT client."""
+        cfg = self._config
+        if not cfg.mqtt_broker_host:
+            logger.info("Telemetry: no MQTT broker configured — skipping")
+            return
+
+        self._mqtt = DeviceMqttClient(
+            broker_host=cfg.mqtt_broker_host,
+            device_id=self._device_id,
+            port=cfg.mqtt_broker_port,
+            username=cfg.mqtt_username or None,
+            password=cfg.mqtt_password or None,
+            use_tls=cfg.mqtt_use_tls,
+        )
+        self._mqtt.start()
+        logger.info(
+            "Telemetry: MQTT client started (broker={}:{})",
+            cfg.mqtt_broker_host,
+            cfg.mqtt_broker_port,
+        )
+
+    def stop(self) -> None:
+        """Disconnect the MQTT client."""
+        if self._mqtt is not None:
+            self._mqtt.stop()
+            self._mqtt = None
+
+    # ------------------------------------------------------------------
+    # Publishing
+    # ------------------------------------------------------------------
+
+    def publish_battery(self, *, level: int, charging: bool, now: float | None = None) -> None:
+        """Publish a battery event, rate-limited by config interval."""
+        if self._mqtt is None:
+            return
+
+        monotonic_now = time.monotonic() if now is None else now
+        if monotonic_now < self._next_battery_report_at:
+            return
+
+        if self._mqtt.publish_battery(level=level, charging=charging):
+            self._next_battery_report_at = (
+                monotonic_now + self._config.battery_report_interval_seconds
+            )
+
+    def publish_heartbeat(self, *, firmware_version: str | None = None) -> None:
+        """Publish a heartbeat event (e.g. on screen wake or periodic tick)."""
+        if self._mqtt is not None:
+            self._mqtt.publish_heartbeat(firmware_version=firmware_version)
+
+    @property
+    def is_connected(self) -> bool:
+        return self._mqtt is not None and self._mqtt.is_connected

--- a/src/yoyopod/cloud/models.py
+++ b/src/yoyopod/cloud/models.py
@@ -1,0 +1,72 @@
+"""Typed models for cloud auth and backend status."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class CloudAccessToken:
+    """Normalized bearer token metadata returned by the backend."""
+
+    access_token: str
+    issued_at_epoch: float
+    expires_at_epoch: float
+    lifetime_seconds: float
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "CloudAccessToken":
+        access_token = str(payload.get("access_token") or payload.get("token") or "").strip()
+        if not access_token:
+            raise ValueError("Cloud auth payload did not include an access token")
+
+        issued_at_epoch = float(payload.get("issued_at_epoch") or time.time())
+
+        expires_at_epoch_raw = payload.get("expires_at_epoch")
+        expires_in_raw = payload.get("expires_in_seconds", payload.get("expires_in"))
+        if expires_at_epoch_raw is not None:
+            expires_at_epoch = float(expires_at_epoch_raw)
+        elif expires_in_raw is not None:
+            expires_at_epoch = issued_at_epoch + max(1.0, float(expires_in_raw))
+        else:
+            expires_at_epoch = issued_at_epoch + 3600.0
+
+        lifetime_seconds = max(1.0, expires_at_epoch - issued_at_epoch)
+        return cls(
+            access_token=access_token,
+            issued_at_epoch=issued_at_epoch,
+            expires_at_epoch=expires_at_epoch,
+            lifetime_seconds=lifetime_seconds,
+        )
+
+
+@dataclass(slots=True)
+class CloudStatusSnapshot:
+    """Redacted backend/provisioning state mirrored into files and context."""
+
+    device_id: str = ""
+    provisioning_state: str = "unprovisioned"
+    cloud_state: str = "offline"
+    config_source: str = "none"
+    config_version: int = 0
+    backend_reachable: bool | None = None
+    last_successful_sync: str | None = None
+    last_error_summary: str = ""
+    unapplied_keys: list[str] = field(default_factory=list)
+    updated_at: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "device_id": self.device_id,
+            "provisioning_state": self.provisioning_state,
+            "cloud_state": self.cloud_state,
+            "config_source": self.config_source,
+            "config_version": self.config_version,
+            "backend_reachable": self.backend_reachable,
+            "last_successful_sync": self.last_successful_sync,
+            "last_error_summary": self.last_error_summary,
+            "unapplied_keys": list(self.unapplied_keys),
+            "updated_at": self.updated_at,
+        }

--- a/src/yoyopod/cloud/mqtt_client.py
+++ b/src/yoyopod/cloud/mqtt_client.py
@@ -31,6 +31,7 @@ class DeviceMqttClient:
         username: str | None = None,
         password: str | None = None,
         use_tls: bool = False,
+        transport: str = "tcp",
         command_callback: Any | None = None,
     ) -> None:
         self._broker_host = broker_host
@@ -39,6 +40,7 @@ class DeviceMqttClient:
         self._username = username
         self._password = password
         self._use_tls = use_tls
+        self._transport = transport
         self._command_callback = command_callback
 
         self._client: Any = None
@@ -61,7 +63,7 @@ class DeviceMqttClient:
             )
             return
 
-        client = mqtt.Client(client_id=f"yoyopod-{self._device_id}", clean_session=True)
+        client = mqtt.Client(client_id=f"yoyopod-{self._device_id}", clean_session=True, transport=self._transport)
 
         if self._username:
             client.username_pw_set(self._username, self._password)

--- a/src/yoyopod/cloud/mqtt_client.py
+++ b/src/yoyopod/cloud/mqtt_client.py
@@ -146,8 +146,6 @@ class DeviceMqttClient:
                     break
 
                 client.connect(self._broker_host, self._port, keepalive=_KEEPALIVE_SECONDS)
-                cmd_topic = f"yoyopod/{self._device_id}/cmd"
-                client.subscribe(cmd_topic, qos=1)
                 client.loop_forever()
 
             except OSError as exc:
@@ -171,6 +169,7 @@ class DeviceMqttClient:
         if rc == 0:
             with self._lock:
                 self._connected = True
+            client.subscribe(f"yoyopod/{self._device_id}/cmd", qos=1)
             logger.info(
                 "MQTT connected to {}:{} (device={})", self._broker_host, self._port, self._device_id
             )

--- a/src/yoyopod/cloud/mqtt_client.py
+++ b/src/yoyopod/cloud/mqtt_client.py
@@ -1,0 +1,197 @@
+"""MQTT publisher for device telemetry events sent to the YoYoPod backend."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any
+
+from loguru import logger
+
+
+_RECONNECT_DELAY_SECONDS = 10.0
+_KEEPALIVE_SECONDS = 60
+
+
+class DeviceMqttClient:
+    """Publish device telemetry events to the backend MQTT broker.
+
+    The device publishes to  ``yoyopod/{device_id}/evt``.
+    The backend sends commands on ``yoyopod/{device_id}/cmd``; those are
+    forwarded to the registered command callback.
+    """
+
+    def __init__(
+        self,
+        *,
+        broker_host: str,
+        device_id: str,
+        port: int = 1883,
+        username: str | None = None,
+        password: str | None = None,
+        use_tls: bool = False,
+        command_callback: Any | None = None,
+    ) -> None:
+        self._broker_host = broker_host
+        self._device_id = device_id
+        self._port = port
+        self._username = username
+        self._password = password
+        self._use_tls = use_tls
+        self._command_callback = command_callback
+
+        self._client: Any = None
+        self._connected = False
+        self._stopped = False
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the MQTT client and connect in the background."""
+        try:
+            import paho.mqtt.client as mqtt  # type: ignore[import-untyped]
+        except ImportError:
+            logger.warning(
+                "paho-mqtt not installed — device telemetry events will not be sent. "
+                "Install with: pip install paho-mqtt"
+            )
+            return
+
+        client = mqtt.Client(client_id=f"yoyopod-{self._device_id}", clean_session=True)
+
+        if self._username:
+            client.username_pw_set(self._username, self._password)
+
+        if self._use_tls:
+            client.tls_set()
+
+        client.on_connect = self._on_connect
+        client.on_disconnect = self._on_disconnect
+        client.on_message = self._on_message
+
+        self._client = client
+        self._stopped = False
+
+        # Connect in background thread so it doesn't block the boot sequence.
+        threading.Thread(target=self._connect_loop, daemon=True, name="mqtt-connect").start()
+
+    def stop(self) -> None:
+        """Disconnect and stop reconnect attempts."""
+        self._stopped = True
+        client = self._client
+        if client is not None:
+            try:
+                client.disconnect()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # Publishing
+    # ------------------------------------------------------------------
+
+    def publish_battery(self, *, level: int, charging: bool) -> bool:
+        """Publish a battery telemetry event."""
+        return self._publish("battery", {"level": level, "charging": charging})
+
+    def publish_heartbeat(self, *, firmware_version: str | None = None) -> bool:
+        """Publish a device heartbeat event."""
+        payload: dict[str, Any] = {}
+        if firmware_version is not None:
+            payload["firmware_version"] = firmware_version
+        return self._publish("heartbeat", payload)
+
+    def publish_connectivity(self, *, connection_type: str) -> bool:
+        """Publish a connectivity change (wifi / 4g)."""
+        return self._publish("connectivity", {"type": connection_type})
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _publish(self, event_type: str, payload: dict[str, Any]) -> bool:
+        """Publish one event envelope to ``yoyopod/{device_id}/evt``."""
+        with self._lock:
+            client = self._client
+            connected = self._connected
+
+        if client is None or not connected:
+            logger.debug("MQTT not connected — skipping {} event", event_type)
+            return False
+
+        topic = f"yoyopod/{self._device_id}/evt"
+        message = json.dumps({"type": event_type, "payload": payload, "ts": int(time.time())})
+        try:
+            result = client.publish(topic, message, qos=1)
+            if result.rc != 0:
+                logger.warning("MQTT publish failed for {}: rc={}", event_type, result.rc)
+                return False
+            logger.debug("MQTT published {} event", event_type)
+            return True
+        except Exception as exc:
+            logger.warning("MQTT publish error for {}: {}", event_type, exc)
+            return False
+
+    def _connect_loop(self) -> None:
+        """Attempt to connect (and reconnect) to the broker."""
+        while not self._stopped:
+            try:
+                client = self._client
+                if client is None:
+                    break
+
+                client.connect(self._broker_host, self._port, keepalive=_KEEPALIVE_SECONDS)
+                cmd_topic = f"yoyopod/{self._device_id}/cmd"
+                client.subscribe(cmd_topic, qos=1)
+                client.loop_forever()
+
+            except OSError as exc:
+                logger.warning(
+                    "MQTT connection failed: {} — retrying in {}s",
+                    exc,
+                    _RECONNECT_DELAY_SECONDS,
+                )
+                if not self._stopped:
+                    time.sleep(_RECONNECT_DELAY_SECONDS)
+            except Exception as exc:
+                logger.warning(
+                    "MQTT unexpected error: {} — retrying in {}s",
+                    exc,
+                    _RECONNECT_DELAY_SECONDS,
+                )
+                if not self._stopped:
+                    time.sleep(_RECONNECT_DELAY_SECONDS)
+
+    def _on_connect(self, client: Any, userdata: Any, flags: Any, rc: int) -> None:
+        if rc == 0:
+            with self._lock:
+                self._connected = True
+            logger.info(
+                "MQTT connected to {}:{} (device={})", self._broker_host, self._port, self._device_id
+            )
+        else:
+            logger.warning("MQTT connect refused: rc={}", rc)
+
+    def _on_disconnect(self, client: Any, userdata: Any, rc: int) -> None:
+        with self._lock:
+            self._connected = False
+        if rc != 0 and not self._stopped:
+            logger.warning("MQTT disconnected unexpectedly: rc={}", rc)
+
+    def _on_message(self, client: Any, userdata: Any, msg: Any) -> None:
+        """Handle an incoming command from the backend."""
+        try:
+            payload = json.loads(msg.payload.decode())
+            logger.info("MQTT command received: {}", payload.get("type", "unknown"))
+            if self._command_callback is not None:
+                self._command_callback(payload)
+        except Exception as exc:
+            logger.warning("MQTT command parse error: {}", exc)
+
+    @property
+    def is_connected(self) -> bool:
+        with self._lock:
+            return self._connected

--- a/src/yoyopod/config/__init__.py
+++ b/src/yoyopod/config/__init__.py
@@ -3,6 +3,9 @@
 from yoyopod.config.manager import ConfigManager, load_composed_app_settings
 from yoyopod.config.models import (
     BackendTelemetryConfig,
+    CloudBackendConfig,
+    CloudConfig,
+    CloudSecretsConfig,
     CommunicationConfig,
     MediaConfig,
     NetworkConfig,
@@ -17,6 +20,9 @@ from yoyopod.config.models import (
 
 __all__ = [
     "BackendTelemetryConfig",
+    "CloudBackendConfig",
+    "CloudConfig",
+    "CloudSecretsConfig",
     "ConfigManager",
     "CommunicationConfig",
     "MediaConfig",

--- a/src/yoyopod/config/__init__.py
+++ b/src/yoyopod/config/__init__.py
@@ -2,6 +2,7 @@
 
 from yoyopod.config.manager import ConfigManager, load_composed_app_settings
 from yoyopod.config.models import (
+    BackendTelemetryConfig,
     CommunicationConfig,
     MediaConfig,
     NetworkConfig,
@@ -15,6 +16,7 @@ from yoyopod.config.models import (
 )
 
 __all__ = [
+    "BackendTelemetryConfig",
     "ConfigManager",
     "CommunicationConfig",
     "MediaConfig",

--- a/src/yoyopod/config/manager.py
+++ b/src/yoyopod/config/manager.py
@@ -9,7 +9,8 @@ from loguru import logger
 
 from yoyopod.config.layers import resolve_config_board, resolve_config_layers
 from yoyopod.config.models import (
-    BackendTelemetryConfig,
+    CloudConfig,
+    CloudSecretsConfig,
     CommunicationConfig,
     MediaConfig,
     NetworkConfig,
@@ -38,7 +39,9 @@ COMMUNICATION_CALLING_CONFIG = Path("communication/calling.yaml")
 COMMUNICATION_MESSAGING_CONFIG = Path("communication/messaging.yaml")
 COMMUNICATION_SECRETS_CONFIG = Path("communication/calling.secrets.yaml")
 PEOPLE_DIRECTORY_CONFIG = Path("people/directory.yaml")
-BACKEND_TELEMETRY_CONFIG = Path("cloud/backend.yaml")
+CLOUD_BACKEND_CONFIG = Path("cloud/backend.yaml")
+CLOUD_SECRETS_CONFIG = Path("cloud/device.secrets.yaml")
+SYSTEM_CLOUD_SECRETS_FILE = Path("/etc/yoyopod/cloud/device.secrets.yaml")
 _SECRET_KEYS = ("sip_password", "sip_password_ha1")
 
 
@@ -129,12 +132,18 @@ class ConfigManager:
             self.config_board,
             PEOPLE_DIRECTORY_CONFIG,
         )
-        self.backend_telemetry_layers = resolve_config_layers(
+        self.cloud_backend_layers = resolve_config_layers(
             self.config_dir,
             self.config_board,
-            BACKEND_TELEMETRY_CONFIG,
+            CLOUD_BACKEND_CONFIG,
         )
         self.communication_secrets_file = self.config_dir / COMMUNICATION_SECRETS_CONFIG
+        self.cloud_secrets_file = self.config_dir / CLOUD_SECRETS_CONFIG
+        self.cloud_secrets_runtime_file = (
+            self.cloud_secrets_file
+            if self.cloud_secrets_file.exists()
+            else SYSTEM_CLOUD_SECRETS_FILE
+        )
 
         self.app_config_file = self.app_core_layers[-1]
         self.device_hardware_file = self.device_hardware_layers[-1]
@@ -145,7 +154,7 @@ class ConfigManager:
         self.communication_calling_file = self.communication_calling_layers[-1]
         self.communication_messaging_file = self.communication_messaging_layers[-1]
         self.people_directory_file = self.people_directory_layers[-1]
-        self.backend_telemetry_file = self.backend_telemetry_layers[-1]
+        self.cloud_backend_file = self.cloud_backend_layers[-1]
 
         self.app_settings = YoyoPodConfig()
         self.media_settings = MediaConfig()
@@ -154,7 +163,7 @@ class ConfigManager:
         self.voice_settings = VoiceConfig()
         self.communication_settings = CommunicationConfig()
         self.people_settings = PeopleDirectoryConfig()
-        self.backend_settings = BackendTelemetryConfig()
+        self.cloud_settings = CloudConfig()
         self.runtime_settings = YoyoPodRuntimeConfig()
 
         self.app_config: dict[str, Any] = config_to_dict(self.app_settings)
@@ -173,7 +182,10 @@ class ConfigManager:
         self.communication_config_loaded = False
         self.communication_secrets_loaded = False
         self.people_config_loaded = False
-        self.backend_config_loaded = False
+        self.cloud_config_loaded = False
+        self.cloud_secrets_loaded = False
+        self.cloud_secrets_error = ""
+        self._cloud_override_values: dict[str, Any] = {}
 
         logger.info(
             "ConfigManager initialized (config_dir={}, config_board={})",
@@ -188,7 +200,7 @@ class ConfigManager:
         self.load_voice_config()
         self.load_communication_config()
         self.load_people_config()
-        self.load_backend_config()
+        self.load_cloud_config()
         self._refresh_runtime_settings()
 
     def _refresh_runtime_settings(self) -> None:
@@ -202,7 +214,7 @@ class ConfigManager:
             voice=self.voice_settings,
             communication=self.communication_settings,
             people=self.people_settings,
-            backend=self.backend_settings,
+            cloud=self.cloud_settings,
         )
         self.runtime_config = config_to_dict(self.runtime_settings)
 
@@ -528,34 +540,138 @@ class ConfigManager:
             self._refresh_runtime_settings()
             return False
 
-    def load_backend_config(self) -> bool:
-        """Load backend telemetry config (MQTT broker settings)."""
+    def load_cloud_config(self) -> bool:
+        """Load cloud/backend tracked config plus runtime-only device secrets."""
 
-        self.backend_config_loaded = _config_loaded(self.backend_telemetry_layers)
+        self.cloud_config_loaded = _config_loaded(self.cloud_backend_layers)
+        self.cloud_secrets_runtime_file = (
+            self.cloud_secrets_file
+            if self.cloud_secrets_file.exists()
+            else SYSTEM_CLOUD_SECRETS_FILE
+        )
+        self.cloud_secrets_loaded = self.cloud_secrets_runtime_file.exists()
+        self.cloud_secrets_error = ""
         try:
-            payload = load_yaml_layers(self.backend_telemetry_layers)
-            self.backend_settings = build_config_model(
-                BackendTelemetryConfig, payload.get("backend", payload)
-            )
+            backend_payload = load_yaml_layers(self.cloud_backend_layers)
+            secrets_payload: dict[str, Any] = {}
+            if self.cloud_secrets_loaded:
+                secrets_payload = load_yaml_mapping(self.cloud_secrets_runtime_file)
+
+            merged_payload = {
+                "backend": backend_payload.get("backend", backend_payload),
+                "secrets": secrets_payload.get("secrets", secrets_payload),
+            }
+            self.cloud_settings = build_config_model(CloudConfig, merged_payload)
+
+            device_id = self.cloud_settings.secrets.device_id.strip()
+            device_secret = self.cloud_settings.secrets.device_secret.strip()
+            if (device_id and not device_secret) or (device_secret and not device_id):
+                self.cloud_secrets_error = (
+                    "Provisioning file must contain both device_id and device_secret"
+                )
+
             self._refresh_runtime_settings()
 
-            if self.backend_config_loaded:
-                logger.info("Backend telemetry configuration loaded successfully")
+            if self.cloud_config_loaded:
+                logger.info("Cloud backend configuration loaded successfully")
             else:
-                logger.info("No backend telemetry config found; MQTT telemetry disabled")
+                logger.info("No cloud backend config found; backend connectivity disabled")
+            if self.cloud_secrets_loaded:
+                logger.info(
+                    "Cloud provisioning secrets loaded successfully from {}",
+                    self.cloud_secrets_runtime_file,
+                )
 
-            return self.backend_config_loaded
+            return self.cloud_config_loaded or self.cloud_secrets_loaded
         except Exception:
-            logger.exception("Error loading backend telemetry config")
-            self.backend_settings = BackendTelemetryConfig()
-            self.backend_config_loaded = False
+            logger.exception("Error loading cloud config")
+            self.cloud_settings = CloudConfig()
+            self.cloud_config_loaded = False
+            self.cloud_secrets_loaded = False
+            self.cloud_secrets_error = "Failed to load cloud configuration"
             self._refresh_runtime_settings()
             return False
 
-    def get_backend_settings(self) -> BackendTelemetryConfig:
-        """Return the typed backend telemetry settings."""
+    def load_backend_config(self) -> bool:
+        """Compatibility alias for older telemetry-only callers."""
 
-        return self.backend_settings
+        return self.load_cloud_config()
+
+    def get_cloud_settings(self) -> CloudConfig:
+        """Return the typed cloud settings."""
+
+        return self.cloud_settings
+
+    def get_backend_settings(self) -> Any:
+        """Compatibility alias returning just the backend subsection."""
+
+        return self.cloud_settings.backend
+
+    def get_cloud_device_id(self) -> str:
+        return self.cloud_settings.secrets.device_id
+
+    def get_cloud_device_secret(self) -> str:
+        return self.cloud_settings.secrets.device_secret
+
+    def get_cloud_cache_file(self) -> str:
+        return self.cloud_settings.backend.cache_file
+
+    def get_cloud_status_file(self) -> str:
+        return self.cloud_settings.backend.status_file
+
+    def get_max_output_volume(self) -> int:
+        value = self._cloud_override_values.get("audio.max_volume", 80)
+        return max(0, min(100, int(value)))
+
+    def apply_cloud_overrides(self, payload: dict[str, Any]) -> list[str]:
+        """Apply recognized runtime-only cloud overrides and return unapplied keys."""
+
+        if not isinstance(payload, dict):
+            return ["<invalid-payload>"]
+
+        unapplied: list[str] = []
+
+        audio_payload = payload.get("audio", {})
+        if isinstance(audio_payload, dict):
+            if "max_volume" in audio_payload:
+                try:
+                    self._cloud_override_values["audio.max_volume"] = max(
+                        0,
+                        min(100, int(audio_payload["max_volume"])),
+                    )
+                except (TypeError, ValueError):
+                    unapplied.append("audio.max_volume")
+            if "default_volume" in audio_payload:
+                try:
+                    self.media_settings.music.default_volume = max(
+                        0,
+                        min(100, int(audio_payload["default_volume"])),
+                    )
+                except (TypeError, ValueError):
+                    unapplied.append("audio.default_volume")
+        elif "audio" in payload:
+            unapplied.append("audio")
+
+        messaging_payload = payload.get("messaging", {})
+        if isinstance(messaging_payload, dict):
+            if "voice_note_max_duration_seconds" in messaging_payload:
+                try:
+                    self.communication_settings.messaging.voice_note_max_duration_seconds = max(
+                        1,
+                        int(messaging_payload["voice_note_max_duration_seconds"]),
+                    )
+                except (TypeError, ValueError):
+                    unapplied.append("messaging.voice_note_max_duration_seconds")
+        elif "messaging" in payload:
+            unapplied.append("messaging")
+
+        recognized_top_level = {"audio", "messaging", "config_version"}
+        for key in payload:
+            if key not in recognized_top_level:
+                unapplied.append(str(key))
+
+        self._refresh_runtime_settings()
+        return sorted(set(unapplied))
 
     def get_app_settings(self) -> YoyoPodConfig:
         """Return the composed typed app settings."""
@@ -777,7 +893,9 @@ class ConfigManager:
         logger.info("Reloading configuration...")
         self.load_app_config()
         self.load_media_config()
+        self.load_power_config()
         self.load_network_config()
         self.load_voice_config()
         self.load_communication_config()
         self.load_people_config()
+        self.load_cloud_config()

--- a/src/yoyopod/config/manager.py
+++ b/src/yoyopod/config/manager.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from yoyopod.config.layers import resolve_config_board, resolve_config_layers
 from yoyopod.config.models import (
+    BackendTelemetryConfig,
     CommunicationConfig,
     MediaConfig,
     NetworkConfig,
@@ -37,6 +38,7 @@ COMMUNICATION_CALLING_CONFIG = Path("communication/calling.yaml")
 COMMUNICATION_MESSAGING_CONFIG = Path("communication/messaging.yaml")
 COMMUNICATION_SECRETS_CONFIG = Path("communication/calling.secrets.yaml")
 PEOPLE_DIRECTORY_CONFIG = Path("people/directory.yaml")
+BACKEND_TELEMETRY_CONFIG = Path("cloud/backend.yaml")
 _SECRET_KEYS = ("sip_password", "sip_password_ha1")
 
 
@@ -127,6 +129,11 @@ class ConfigManager:
             self.config_board,
             PEOPLE_DIRECTORY_CONFIG,
         )
+        self.backend_telemetry_layers = resolve_config_layers(
+            self.config_dir,
+            self.config_board,
+            BACKEND_TELEMETRY_CONFIG,
+        )
         self.communication_secrets_file = self.config_dir / COMMUNICATION_SECRETS_CONFIG
 
         self.app_config_file = self.app_core_layers[-1]
@@ -138,6 +145,7 @@ class ConfigManager:
         self.communication_calling_file = self.communication_calling_layers[-1]
         self.communication_messaging_file = self.communication_messaging_layers[-1]
         self.people_directory_file = self.people_directory_layers[-1]
+        self.backend_telemetry_file = self.backend_telemetry_layers[-1]
 
         self.app_settings = YoyoPodConfig()
         self.media_settings = MediaConfig()
@@ -146,6 +154,7 @@ class ConfigManager:
         self.voice_settings = VoiceConfig()
         self.communication_settings = CommunicationConfig()
         self.people_settings = PeopleDirectoryConfig()
+        self.backend_settings = BackendTelemetryConfig()
         self.runtime_settings = YoyoPodRuntimeConfig()
 
         self.app_config: dict[str, Any] = config_to_dict(self.app_settings)
@@ -164,6 +173,7 @@ class ConfigManager:
         self.communication_config_loaded = False
         self.communication_secrets_loaded = False
         self.people_config_loaded = False
+        self.backend_config_loaded = False
 
         logger.info(
             "ConfigManager initialized (config_dir={}, config_board={})",
@@ -178,6 +188,7 @@ class ConfigManager:
         self.load_voice_config()
         self.load_communication_config()
         self.load_people_config()
+        self.load_backend_config()
         self._refresh_runtime_settings()
 
     def _refresh_runtime_settings(self) -> None:
@@ -191,6 +202,7 @@ class ConfigManager:
             voice=self.voice_settings,
             communication=self.communication_settings,
             people=self.people_settings,
+            backend=self.backend_settings,
         )
         self.runtime_config = config_to_dict(self.runtime_settings)
 
@@ -515,6 +527,35 @@ class ConfigManager:
             self.people_config_loaded = False
             self._refresh_runtime_settings()
             return False
+
+    def load_backend_config(self) -> bool:
+        """Load backend telemetry config (MQTT broker settings)."""
+
+        self.backend_config_loaded = _config_loaded(self.backend_telemetry_layers)
+        try:
+            payload = load_yaml_layers(self.backend_telemetry_layers)
+            self.backend_settings = build_config_model(
+                BackendTelemetryConfig, payload.get("backend", payload)
+            )
+            self._refresh_runtime_settings()
+
+            if self.backend_config_loaded:
+                logger.info("Backend telemetry configuration loaded successfully")
+            else:
+                logger.info("No backend telemetry config found; MQTT telemetry disabled")
+
+            return self.backend_config_loaded
+        except Exception:
+            logger.exception("Error loading backend telemetry config")
+            self.backend_settings = BackendTelemetryConfig()
+            self.backend_config_loaded = False
+            self._refresh_runtime_settings()
+            return False
+
+    def get_backend_settings(self) -> BackendTelemetryConfig:
+        """Return the typed backend telemetry settings."""
+
+        return self.backend_settings
 
     def get_app_settings(self) -> YoyoPodConfig:
         """Return the composed typed app settings."""

--- a/src/yoyopod/config/models.py
+++ b/src/yoyopod/config/models.py
@@ -639,6 +639,10 @@ class CloudBackendConfig:
         default="",
         env="YOYOPOD_CLOUD_MQTT_PASSWORD",
     )
+    mqtt_transport: str = config_value(
+        default="tcp",
+        env="YOYOPOD_CLOUD_MQTT_TRANSPORT",
+    )
     battery_report_interval_seconds: int = config_value(
         default=60,
         env="YOYOPOD_CLOUD_BATTERY_REPORT_INTERVAL_SECONDS",

--- a/src/yoyopod/config/models.py
+++ b/src/yoyopod/config/models.py
@@ -592,6 +592,76 @@ class PeopleDirectoryConfig:
 
 
 @dataclass(slots=True)
+class CloudBackendConfig:
+    """Tracked cloud/backend endpoints, polling, cache, and MQTT transport."""
+
+    api_base_url: str = config_value(
+        default="https://yoyopod.moraouf.net",
+        env="YOYOPOD_CLOUD_API_BASE_URL",
+    )
+    auth_path: str = "/v1/auth/device"
+    refresh_path: str = "/v1/auth/device/refresh"
+    config_path_template: str = "/v1/devices/{device_id}/config"
+    timeout_seconds: float = config_value(default=3.0, env="YOYOPOD_CLOUD_TIMEOUT_SECONDS")
+    config_poll_interval_seconds: int = config_value(
+        default=300,
+        env="YOYOPOD_CLOUD_CONFIG_POLL_INTERVAL_SECONDS",
+    )
+    claim_retry_seconds: int = config_value(
+        default=60,
+        env="YOYOPOD_CLOUD_CLAIM_RETRY_SECONDS",
+    )
+    cache_file: str = config_value(
+        default="data/cloud/config_cache.json",
+        env="YOYOPOD_CLOUD_CACHE_FILE",
+    )
+    status_file: str = config_value(
+        default="data/cloud/status.json",
+        env="YOYOPOD_CLOUD_STATUS_FILE",
+    )
+    mqtt_broker_host: str = config_value(
+        default="yoyopod.moraouf.net",
+        env="YOYOPOD_CLOUD_MQTT_BROKER_HOST",
+    )
+    mqtt_broker_port: int = config_value(
+        default=1883,
+        env="YOYOPOD_CLOUD_MQTT_BROKER_PORT",
+    )
+    mqtt_use_tls: bool = config_value(
+        default=False,
+        env="YOYOPOD_CLOUD_MQTT_USE_TLS",
+    )
+    mqtt_username: str = config_value(
+        default="",
+        env="YOYOPOD_CLOUD_MQTT_USERNAME",
+    )
+    mqtt_password: str = config_value(
+        default="",
+        env="YOYOPOD_CLOUD_MQTT_PASSWORD",
+    )
+    battery_report_interval_seconds: int = config_value(
+        default=60,
+        env="YOYOPOD_CLOUD_BATTERY_REPORT_INTERVAL_SECONDS",
+    )
+
+
+@dataclass(slots=True)
+class CloudSecretsConfig:
+    """Runtime-only device claim credentials."""
+
+    device_id: str = config_value(default="", env="YOYOPOD_CLOUD_DEVICE_ID")
+    device_secret: str = config_value(default="", env="YOYOPOD_CLOUD_DEVICE_SECRET")
+
+
+@dataclass(slots=True)
+class CloudConfig:
+    """Composed cloud config built from tracked backend settings plus runtime secrets."""
+
+    backend: CloudBackendConfig = config_value(default_factory=CloudBackendConfig)
+    secrets: CloudSecretsConfig = config_value(default_factory=CloudSecretsConfig)
+
+
+@dataclass(slots=True)
 class VoiceConfig:
     """Composed voice domain config built from voice and device-owned layers."""
 
@@ -599,35 +669,7 @@ class VoiceConfig:
     audio: VoiceAudioConfig = config_value(default_factory=VoiceAudioConfig)
 
 
-@dataclass(slots=True)
-class BackendTelemetryConfig:
-    """MQTT broker settings for sending device telemetry to the backend."""
-
-    mqtt_broker_host: str = config_value(
-        default="",
-        env="YOYOPOD_MQTT_BROKER_HOST",
-    )
-    mqtt_broker_port: int = config_value(
-        default=1883,
-        env="YOYOPOD_MQTT_BROKER_PORT",
-    )
-    mqtt_use_tls: bool = config_value(
-        default=False,
-        env="YOYOPOD_MQTT_USE_TLS",
-    )
-    mqtt_username: str = config_value(
-        default="",
-        env="YOYOPOD_MQTT_USERNAME",
-    )
-    mqtt_password: str = config_value(
-        default="",
-        env="YOYOPOD_MQTT_PASSWORD",
-    )
-    battery_report_interval_seconds: int = config_value(
-        default=60,
-        env="YOYOPOD_BATTERY_REPORT_INTERVAL",
-    )
-
+BackendTelemetryConfig = CloudBackendConfig
 
 @dataclass(slots=True)
 class YoyoPodRuntimeConfig:
@@ -640,4 +682,4 @@ class YoyoPodRuntimeConfig:
     voice: VoiceConfig = config_value(default_factory=VoiceConfig)
     communication: CommunicationConfig = config_value(default_factory=CommunicationConfig)
     people: PeopleDirectoryConfig = config_value(default_factory=PeopleDirectoryConfig)
-    backend: BackendTelemetryConfig = config_value(default_factory=BackendTelemetryConfig)
+    cloud: CloudConfig = config_value(default_factory=CloudConfig)

--- a/src/yoyopod/config/models.py
+++ b/src/yoyopod/config/models.py
@@ -139,6 +139,7 @@ class AppMetadataConfig:
     name: str = "YoyoPod"
     version: str = "1.0.0"
     simulate: bool = config_value(default=False, env="YOYOPOD_SIMULATE")
+    device_id: str = config_value(default="", env="YOYOPOD_DEVICE_ID")
 
 
 @dataclass(slots=True)
@@ -599,6 +600,36 @@ class VoiceConfig:
 
 
 @dataclass(slots=True)
+class BackendTelemetryConfig:
+    """MQTT broker settings for sending device telemetry to the backend."""
+
+    mqtt_broker_host: str = config_value(
+        default="",
+        env="YOYOPOD_MQTT_BROKER_HOST",
+    )
+    mqtt_broker_port: int = config_value(
+        default=1883,
+        env="YOYOPOD_MQTT_BROKER_PORT",
+    )
+    mqtt_use_tls: bool = config_value(
+        default=False,
+        env="YOYOPOD_MQTT_USE_TLS",
+    )
+    mqtt_username: str = config_value(
+        default="",
+        env="YOYOPOD_MQTT_USERNAME",
+    )
+    mqtt_password: str = config_value(
+        default="",
+        env="YOYOPOD_MQTT_PASSWORD",
+    )
+    battery_report_interval_seconds: int = config_value(
+        default=60,
+        env="YOYOPOD_BATTERY_REPORT_INTERVAL",
+    )
+
+
+@dataclass(slots=True)
 class YoyoPodRuntimeConfig:
     """One typed runtime model composed from the canonical authored config topology."""
 
@@ -609,3 +640,4 @@ class YoyoPodRuntimeConfig:
     voice: VoiceConfig = config_value(default_factory=VoiceConfig)
     communication: CommunicationConfig = config_value(default_factory=CommunicationConfig)
     people: PeopleDirectoryConfig = config_value(default_factory=PeopleDirectoryConfig)
+    backend: BackendTelemetryConfig = config_value(default_factory=BackendTelemetryConfig)

--- a/src/yoyopod/coordinators/power.py
+++ b/src/yoyopod/coordinators/power.py
@@ -24,7 +24,7 @@ from yoyopod.power import (
 )
 
 if TYPE_CHECKING:
-    from yoyopod.cloud import TelemetryManager
+    from yoyopod.cloud import CloudManager
 
 
 class PowerCoordinator:
@@ -36,12 +36,12 @@ class PowerCoordinator:
         screen_coordinator: ScreenCoordinator,
         context: AppContext,
         now_provider: Callable[[], float] | None = None,
-        telemetry_manager: "TelemetryManager | None" = None,
+        cloud_manager: "CloudManager | None" = None,
     ) -> None:
         self.runtime = runtime
         self.screen_coordinator = screen_coordinator
         self.context = context
-        self.telemetry_manager = telemetry_manager
+        self.cloud_manager = cloud_manager
         power_config = runtime.power_manager.config if runtime.power_manager is not None else None
         self.policy = PowerSafetyPolicy(power_config) if power_config is not None else None
         self.now_provider = now_provider or time.monotonic
@@ -96,11 +96,11 @@ class PowerCoordinator:
         if current_signature != previous_signature or current_route_name == "power":
             self.screen_coordinator.refresh_current_screen()
 
-        if self.telemetry_manager is not None:
+        if self.cloud_manager is not None:
             level = snapshot.battery.level_percent
             charging = snapshot.battery.charging
             if level is not None:
-                self.telemetry_manager.publish_battery(
+                self.cloud_manager.publish_battery(
                     level=round(level),
                     charging=bool(charging),
                     now=self.now_provider(),

--- a/src/yoyopod/coordinators/power.py
+++ b/src/yoyopod/coordinators/power.py
@@ -5,7 +5,7 @@ Power telemetry coordination for YoyoPod.
 from __future__ import annotations
 
 import time
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from loguru import logger
 
@@ -23,6 +23,9 @@ from yoyopod.power import (
     PowerSnapshotUpdated,
 )
 
+if TYPE_CHECKING:
+    from yoyopod.cloud import TelemetryManager
+
 
 class PowerCoordinator:
     """Own power event publishing and UI/runtime power sync."""
@@ -33,10 +36,12 @@ class PowerCoordinator:
         screen_coordinator: ScreenCoordinator,
         context: AppContext,
         now_provider: Callable[[], float] | None = None,
+        telemetry_manager: "TelemetryManager | None" = None,
     ) -> None:
         self.runtime = runtime
         self.screen_coordinator = screen_coordinator
         self.context = context
+        self.telemetry_manager = telemetry_manager
         power_config = runtime.power_manager.config if runtime.power_manager is not None else None
         self.policy = PowerSafetyPolicy(power_config) if power_config is not None else None
         self.now_provider = now_provider or time.monotonic
@@ -90,6 +95,16 @@ class PowerCoordinator:
 
         if current_signature != previous_signature or current_route_name == "power":
             self.screen_coordinator.refresh_current_screen()
+
+        if self.telemetry_manager is not None:
+            level = snapshot.battery.level_percent
+            charging = snapshot.battery.charging
+            if level is not None:
+                self.telemetry_manager.publish_battery(
+                    level=round(level),
+                    charging=bool(charging),
+                    now=self.now_provider(),
+                )
 
         if self.policy is None or self._event_bus is None:
             return

--- a/src/yoyopod/runtime/boot.py
+++ b/src/yoyopod/runtime/boot.py
@@ -278,15 +278,12 @@ class RuntimeBootService:
                 logger.info("    No input hardware available")
 
             logger.info("  - ScreenManager")
-            action_scheduler = (
-                self.app.runtime_loop.queue_main_thread_callback
-                if getattr(display, "backend_kind", "pil") == "lvgl"
-                else None
-            )
             self.app.screen_manager = ScreenManager(
                 display,
                 self.app.input_manager,
-                action_scheduler=action_scheduler,
+                # Screen/input callbacks may originate from worker or polling threads.
+                # Route all UI actions through the runtime loop to keep display I/O serialized.
+                action_scheduler=self.app.runtime_loop.queue_main_thread_callback,
             )
             return True
         except Exception:

--- a/src/yoyopod/runtime/boot.py
+++ b/src/yoyopod/runtime/boot.py
@@ -69,7 +69,7 @@ from yoyopod.ui.screens.voip.voice_note import (
     build_voice_note_actions,
     build_voice_note_state_provider,
 )
-from yoyopod.cloud import TelemetryManager
+from yoyopod.cloud import CloudManager
 from yoyopod.voice import VoiceSettings
 from yoyopod.communication import CallHistoryStore, VoIPConfig, VoIPManager
 
@@ -397,21 +397,12 @@ class RuntimeBootService:
                         gps_has_fix=False,
                     )
 
-            logger.info("  - TelemetryManager")
-            backend_cfg = config_manager.get_backend_settings()
-            configured_device_id = (
-                self.app.app_settings.app.device_id.strip()
-                if self.app.app_settings is not None
-                else ""
+            logger.info("  - CloudManager")
+            self.app.cloud_manager = CloudManager(
+                app=self.app,
+                config_manager=config_manager,
             )
-            if not configured_device_id:
-                import socket as _socket
-                configured_device_id = _socket.gethostname()
-            self.app.telemetry_manager = TelemetryManager(
-                config=backend_cfg,
-                device_id=configured_device_id,
-            )
-            self.app.telemetry_manager.start()
+            self.app.cloud_manager.prepare_boot()
 
             return True
         except Exception:
@@ -867,7 +858,7 @@ class RuntimeBootService:
             runtime=self.app.coordinator_runtime,
             screen_coordinator=self.app.screen_coordinator,
             context=self.app.context,
-            telemetry_manager=self.app.telemetry_manager,
+            cloud_manager=self.app.cloud_manager,
         )
         if self.app.screen_manager is not None:
             self.app.screen_manager.on_screen_changed = self.app._handle_screen_changed

--- a/src/yoyopod/runtime/boot.py
+++ b/src/yoyopod/runtime/boot.py
@@ -69,6 +69,7 @@ from yoyopod.ui.screens.voip.voice_note import (
     build_voice_note_actions,
     build_voice_note_state_provider,
 )
+from yoyopod.cloud import TelemetryManager
 from yoyopod.voice import VoiceSettings
 from yoyopod.communication import CallHistoryStore, VoIPConfig, VoIPManager
 
@@ -398,6 +399,22 @@ class RuntimeBootService:
                         connected=False,
                         gps_has_fix=False,
                     )
+
+            logger.info("  - TelemetryManager")
+            backend_cfg = config_manager.get_backend_settings()
+            configured_device_id = (
+                self.app.app_settings.app.device_id.strip()
+                if self.app.app_settings is not None
+                else ""
+            )
+            if not configured_device_id:
+                import socket as _socket
+                configured_device_id = _socket.gethostname()
+            self.app.telemetry_manager = TelemetryManager(
+                config=backend_cfg,
+                device_id=configured_device_id,
+            )
+            self.app.telemetry_manager.start()
 
             return True
         except Exception:
@@ -853,6 +870,7 @@ class RuntimeBootService:
             runtime=self.app.coordinator_runtime,
             screen_coordinator=self.app.screen_coordinator,
             context=self.app.context,
+            telemetry_manager=self.app.telemetry_manager,
         )
         if self.app.screen_manager is not None:
             self.app.screen_manager.on_screen_changed = self.app._handle_screen_changed

--- a/src/yoyopod/runtime/loop.py
+++ b/src/yoyopod/runtime/loop.py
@@ -400,6 +400,11 @@ class RuntimeLoopService:
                 "power_poll",
                 lambda: self.app.power_runtime.poll_status(now=monotonic_now),
             )
+            if self.app.cloud_manager is not None:
+                self._measure_blocking_span(
+                    "cloud_tick",
+                    lambda: self.app.cloud_manager.tick(monotonic_now),
+                )
             self._measure_blocking_span(
                 "lvgl_pump",
                 lambda: self.pump_lvgl_backend(monotonic_now),

--- a/src/yoyopod/runtime/screen_power.py
+++ b/src/yoyopod/runtime/screen_power.py
@@ -128,10 +128,10 @@ class ScreenPowerService:
 
         self.update_screen_runtime_metrics(now)
 
-        # Publish a heartbeat so the backend learns the device is online again
-        # without waiting for the next scheduled battery report.
-        if self.app.telemetry_manager is not None:
-            self.app.telemetry_manager.publish_heartbeat()
+        if self.app.cloud_manager is not None:
+            # Wake both the config-poll path and MQTT liveness path on screen wake.
+            self.app.cloud_manager.request_immediate_poll()
+            self.app.cloud_manager.publish_heartbeat()
 
         logger.debug("Screen woke from inactivity")
 

--- a/src/yoyopod/runtime/screen_power.py
+++ b/src/yoyopod/runtime/screen_power.py
@@ -127,6 +127,12 @@ class ScreenPowerService:
             self.app._lvgl_backend.force_refresh()
 
         self.update_screen_runtime_metrics(now)
+
+        # Publish a heartbeat so the backend learns the device is online again
+        # without waiting for the next scheduled battery report.
+        if self.app.telemetry_manager is not None:
+            self.app.telemetry_manager.publish_heartbeat()
+
         logger.debug("Screen woke from inactivity")
 
     def sleep_screen(self, now: float) -> None:

--- a/src/yoyopod/runtime/shutdown.py
+++ b/src/yoyopod/runtime/shutdown.py
@@ -204,9 +204,9 @@ class ShutdownLifecycleService:
                 if cleanup is not None:
                     cleanup()
 
-        if self.app.telemetry_manager is not None:
-            logger.info("  - Stopping telemetry manager")
-            self.app.telemetry_manager.stop()
+        if self.app.cloud_manager is not None:
+            logger.info("  - Stopping cloud manager")
+            self.app.cloud_manager.stop()
 
         if self.app.input_manager:
             logger.info("  - Stopping input manager")

--- a/src/yoyopod/runtime/shutdown.py
+++ b/src/yoyopod/runtime/shutdown.py
@@ -204,6 +204,10 @@ class ShutdownLifecycleService:
                 if cleanup is not None:
                     cleanup()
 
+        if self.app.telemetry_manager is not None:
+            logger.info("  - Stopping telemetry manager")
+            self.app.telemetry_manager.stop()
+
         if self.app.input_manager:
             logger.info("  - Stopping input manager")
             self.app.input_manager.stop()

--- a/tests/test_cloud_config_manager.py
+++ b/tests/test_cloud_config_manager.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import yoyopod.cloud.manager as cloud_manager_module
+from yoyopod.cloud.client import CloudClientError
+from yoyopod.cloud.manager import CloudManager
+from yoyopod.cloud.models import CloudAccessToken
+from yoyopod.config.manager import ConfigManager
+
+
+def _write_yaml(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_config_manager_loads_cloud_backend_and_secrets(tmp_path: Path) -> None:
+    _write_yaml(
+        tmp_path / "cloud" / "backend.yaml",
+        "\n".join(
+            [
+                "backend:",
+                '  api_base_url: "https://backend.example.test"',
+                '  auth_path: "/auth/device"',
+                '  refresh_path: "/auth/refresh"',
+                '  config_path_template: "/devices/{device_id}/config"',
+                "  timeout_seconds: 5.0",
+                "  mqtt_broker_port: 2883",
+            ]
+        ),
+    )
+    _write_yaml(
+        tmp_path / "cloud" / "device.secrets.yaml",
+        "\n".join(
+            [
+                "secrets:",
+                '  device_id: "device-123"',
+                '  device_secret: "secret-456"',
+            ]
+        ),
+    )
+
+    manager = ConfigManager(config_dir=str(tmp_path))
+
+    cloud = manager.get_cloud_settings()
+    assert cloud.backend.api_base_url == "https://backend.example.test"
+    assert cloud.backend.auth_path == "/auth/device"
+    assert cloud.backend.mqtt_broker_port == 2883
+    assert cloud.secrets.device_id == "device-123"
+    assert cloud.secrets.device_secret == "secret-456"
+    assert manager.get_cloud_device_id() == "device-123"
+    assert manager.get_cloud_device_secret() == "secret-456"
+
+
+def test_apply_cloud_overrides_updates_runtime_values(tmp_path: Path) -> None:
+    manager = ConfigManager(config_dir=str(tmp_path))
+
+    unapplied = manager.apply_cloud_overrides(
+        {
+            "audio": {
+                "max_volume": 65,
+                "default_volume": 42,
+            },
+            "messaging": {
+                "voice_note_max_duration_seconds": 55,
+            },
+            "unknown_section": {
+                "ignored": True,
+            },
+        }
+    )
+
+    assert manager.get_max_output_volume() == 65
+    assert manager.get_default_output_volume() == 42
+    assert manager.get_voice_note_max_duration_seconds() == 55
+    assert "unknown_section" in unapplied
+
+
+class _FakeMqttClient:
+    def __init__(self, **_kwargs) -> None:
+        self.is_connected = False
+
+    def start(self) -> None:
+        return None
+
+    def stop(self) -> None:
+        return None
+
+
+class _FakeApp:
+    def __init__(self) -> None:
+        self.context = None
+
+    def _queue_main_thread_callback(self, callback) -> None:
+        callback()
+
+
+def test_cloud_manager_backs_off_refresh_after_network_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _write_yaml(
+        tmp_path / "cloud" / "backend.yaml",
+        "\n".join(
+            [
+                "backend:",
+                '  api_base_url: "https://backend.example.test"',
+                "  claim_retry_seconds: 60",
+                "  config_poll_interval_seconds: 300",
+            ]
+        ),
+    )
+    _write_yaml(
+        tmp_path / "cloud" / "device.secrets.yaml",
+        "\n".join(
+            [
+                "secrets:",
+                '  device_id: "device-123"',
+                '  device_secret: "secret-456"',
+            ]
+        ),
+    )
+
+    monkeypatch.setattr(cloud_manager_module, "DeviceMqttClient", _FakeMqttClient)
+
+    config_manager = ConfigManager(config_dir=str(tmp_path))
+    manager = CloudManager(
+        app=_FakeApp(),
+        config_manager=config_manager,
+        client=SimpleNamespace(),
+    )
+    manager.prepare_boot()
+    manager._access_token = CloudAccessToken(
+        access_token="token-123",
+        issued_at_epoch=0.0,
+        expires_at_epoch=3600.0,
+        lifetime_seconds=3600.0,
+    )
+    manager._next_refresh_at = 0.0
+    manager._next_config_poll_at = 0.0
+
+    manager._complete_refresh_token(
+        access_token="token-123",
+        generation=manager._provisioning_generation,
+        completed_at=100.0,
+        error=CloudClientError("network down"),
+    )
+
+    assert manager.status.cloud_state == "offline"
+    assert manager.status.backend_reachable is False
+    assert manager._next_refresh_at == 130.0
+    assert manager._next_config_poll_at == 130.0

--- a/tests/test_runtime_boot.py
+++ b/tests/test_runtime_boot.py
@@ -1,0 +1,168 @@
+"""Regression tests for boot-time runtime wiring."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import yoyopod.runtime.boot as boot_module
+from yoyopod.runtime.boot import RuntimeBootService
+
+
+class _FakeDisplay:
+    WIDTH = 240
+    HEIGHT = 240
+    ORIENTATION = 0
+    COLOR_BLACK = 0
+    COLOR_WHITE = 1
+
+    def __init__(
+        self,
+        *,
+        hardware: str,
+        simulate: bool,
+        whisplay_renderer: str,
+        whisplay_lvgl_buffer_lines: int,
+    ) -> None:
+        self.hardware = hardware
+        self.simulate = simulate
+        self.whisplay_renderer = whisplay_renderer
+        self.whisplay_lvgl_buffer_lines = whisplay_lvgl_buffer_lines
+        self.backend_kind = "pil"
+
+    def get_ui_backend(self):
+        return None
+
+    def refresh_backend_kind(self) -> str:
+        return self.backend_kind
+
+    def clear(self, *_args, **_kwargs) -> None:
+        return None
+
+    def text(self, *_args, **_kwargs) -> None:
+        return None
+
+    def update(self) -> None:
+        return None
+
+    def get_adapter(self) -> object:
+        return object()
+
+
+class _FakeInputManager:
+    def __init__(self) -> None:
+        self.interaction_profile = "one_button"
+        self.activity_callbacks = []
+        self.started = False
+
+    def on_activity(self, callback) -> None:
+        self.activity_callbacks.append(callback)
+
+    def start(self) -> None:
+        self.started = True
+
+
+class _FakeConfigManager:
+    def get_max_output_volume(self) -> int:
+        return 80
+
+    def get_sip_identity(self) -> str:
+        return ""
+
+    def get_sip_username(self) -> str:
+        return ""
+
+    def get_voice_settings(self):
+        return SimpleNamespace(
+            assistant=SimpleNamespace(
+                commands_enabled=False,
+                ai_requests_enabled=False,
+                screen_read_enabled=True,
+                stt_enabled=False,
+                tts_enabled=False,
+            ),
+            audio=SimpleNamespace(
+                speaker_device_id="",
+                capture_device_id="",
+            ),
+        )
+
+
+class _FakeScreenPowerService:
+    def configure_screen_power(self, *, initial_now: float) -> None:
+        return None
+
+    def update_screen_runtime_metrics(self, _now: float) -> None:
+        return None
+
+    def queue_user_activity_event(self, _data=None) -> None:
+        return None
+
+
+class _FakeApp:
+    def __init__(self, scheduler) -> None:
+        self.app_settings = SimpleNamespace(
+            display=SimpleNamespace(
+                hardware="auto",
+                whisplay_renderer="pil",
+                lvgl_buffer_lines=40,
+            ),
+            input=SimpleNamespace(),
+        )
+        self.simulate = True
+        self.config_manager = _FakeConfigManager()
+        self.screen_power_service = _FakeScreenPowerService()
+        self.runtime_loop = SimpleNamespace(
+            queue_main_thread_callback=scheduler,
+            queue_lvgl_input_action=lambda _data=None: None,
+        )
+        self.cloud_manager = SimpleNamespace(sync_context_state=lambda: None)
+        self.call_history_store = None
+        self.voip_manager = None
+        self.context = None
+        self.display = None
+        self.input_manager = None
+        self.screen_manager = None
+        self.music_fsm = None
+        self.call_fsm = None
+        self.call_interruption_policy = None
+        self._lvgl_backend = None
+        self._lvgl_input_bridge = None
+
+    def note_input_activity(self, _data=None) -> None:
+        return None
+
+
+def test_init_core_components_schedules_screen_actions_for_pil_backend(monkeypatch) -> None:
+    """Boot wiring should serialize screen actions on the runtime loop for pil displays too."""
+
+    scheduled_callback = object()
+    fake_input_manager = _FakeInputManager()
+    captured = {}
+
+    monkeypatch.setattr(boot_module, "Display", _FakeDisplay)
+    monkeypatch.setattr(
+        boot_module,
+        "get_input_manager",
+        lambda **_kwargs: fake_input_manager,
+    )
+
+    def _capture_screen_manager(display, input_manager, action_scheduler=None):
+        captured["display"] = display
+        captured["input_manager"] = input_manager
+        captured["action_scheduler"] = action_scheduler
+        return SimpleNamespace(
+            display=display,
+            input_manager=input_manager,
+            action_scheduler=action_scheduler,
+        )
+
+    monkeypatch.setattr(boot_module, "ScreenManager", _capture_screen_manager)
+
+    app = _FakeApp(scheduler=scheduled_callback)
+
+    assert RuntimeBootService(app).init_core_components() is True
+    assert captured["display"].backend_kind == "pil"
+    assert captured["input_manager"] is fake_input_manager
+    assert captured["action_scheduler"] is scheduled_callback
+    assert fake_input_manager.started is True
+


### PR DESCRIPTION
## What changed
This branch keeps the MQTT telemetry work and restores the broader cloud runtime that the device still depends on for provisioning, claim/auth flows, remote config polling, cached config/status persistence, and backend connectivity reporting. It also preserves the runtime-loop screen action serialization work already on the branch.

## Why
MQTT telemetry by itself is not sufficient for a fresh or unclaimed device. The device must first load its provisioned identity from the runtime secrets file, authenticate with the backend, fetch/apply config, and expose claim/connection state for operators before MQTT telemetry becomes meaningful.

## Impact
- Adds `paho-mqtt` as a runtime dependency.
- Replaces the telemetry-only manager with `CloudManager` for lifecycle wiring.
- Loads device secrets from `/etc/yoyopod/cloud/device.secrets.yaml` when no repo-local secrets file is present.
- Restores remote config/cache/status handling under `data/cloud/` and ignores those runtime files in git.
- Mirrors cloud/provisioning state into `AppContext` for UI and diagnostics.
- Keeps MQTT battery and heartbeat publishing active, with backend-triggered config refresh support.
- Serializes `ScreenManager` actions through the runtime loop for PIL and LVGL paths.

## Root cause
The telemetry branch replaced the old cloud runtime with an MQTT-only manager, which removed the provisioning and backend-auth/config path that the device still requires before telemetry can be used reliably.

## Validation
- `uv run pytest tests/test_cloud_config_manager.py tests/test_runtime_boot.py tests/test_config_models.py tests/test_config_manager.py -q`
- `python3 -m py_compile src/yoyopod/cloud/manager.py tests/test_cloud_config_manager.py`
- Verified on the Pi that the provisioned device loads `/etc/yoyopod/cloud/device.secrets.yaml`, reaches the backend, reports `cloud_state: ready`, and runs a single app instance with the screen rendering again.

## Review note
While reviewing the merged branch, I fixed a refresh-backoff bug so refresh failures now delay both token refresh and config polling instead of allowing an immediate retry loop.