### PR TITLE
docs: add YoyoPod product artifact set

### DIFF
--- a/docs/product/LANDING_PAGE_POSITIONING.md
+++ b/docs/product/LANDING_PAGE_POSITIONING.md
@@ -1,0 +1,181 @@
+# Landing-Page Positioning
+
+## Hero headline options
+Option 1:
+The first device before a smartphone
+
+Option 2:
+Safer independence for kids. Peace of mind for parents.
+
+Option 3:
+A simple connected device for kids who aren’t ready for a smartphone
+
+Best choice:
+The first device before a smartphone
+
+## Subheadline
+YoyoPod is a parent-managed companion device for kids ages 7–14, built for safe communication, live location, and everyday audio without the distraction, complexity, or screen addiction of a smartphone.
+
+## Primary CTA ideas
+- Join the waitlist
+- Get early access
+- Follow the build
+- Reserve interest
+
+Best V1 CTA:
+Join the waitlist
+
+## Secondary CTA ideas
+- See how it works
+- Why not a smartphone?
+- Built for families
+
+Best secondary CTA:
+See how it works
+
+## Core value props
+1. Safe communication
+Calls and voice messages with approved contacts only, so kids stay reachable without the chaos of an open phone.
+
+2. Live location for peace of mind
+See your child’s live-ish location when they’re out in the world, without handing them a full smartphone.
+
+3. Built for independence, not distraction
+A tiny screen, simple controls, and a focused experience help kids feel grown-up without pulling them into endless apps and notifications.
+
+4. Music and audio they actually enjoy
+At home, YoyoPod is a simple everyday audio companion for music, stories, and listening.
+
+5. Parent-managed from a mobile app
+Contacts, settings, and device controls stay in the parent’s hands, where they belong.
+
+## Three-line positioning block
+For kids, YoyoPod feels like freedom.
+For parents, it feels like reassurance.
+For both, it’s a better step before the smartphone years.
+
+## How it works
+Step 1
+Parents set up approved contacts and device settings in the mobile app.
+
+Step 2
+Kids carry YoyoPod as their simple, everyday companion for listening, calling, and getting around independently.
+
+Step 3
+Parents can reach them, hear from them, and check their location when it matters.
+
+## Why not just give them a phone?
+Because most kids don’t need the internet in their pocket before they need independence.
+
+YoyoPod is built for the stage before a smartphone:
+- communication without app overload
+- location without social media
+- independence without endless distraction
+- simplicity without giving up connection
+
+## Trust section
+What parents actually need is simple:
+- Can I reach my child?
+- Can they reach me?
+- Can I see where they are?
+
+YoyoPod is built around those questions first.
+
+## Kid/parent dual-sided section
+For kids:
+- Feels grown-up
+- Easy to carry
+- Simple to use
+- Fun for music and audio
+
+For parents:
+- Approved contacts only
+- Live location visibility
+- Less distraction than a phone
+- More confidence when kids are out on their own
+
+## Anti-positioning
+YoyoPod is not:
+- a smartphone replacement
+- a toy
+- a screen-first device
+- another addictive kids gadget
+
+It’s a simpler first step.
+
+## Homepage structure
+1. Hero
+Headline:
+The first device before a smartphone
+
+Subheadline:
+YoyoPod is a parent-managed companion device for kids ages 7–14, built for safe communication, live location, and everyday audio without the distraction, complexity, or screen addiction of a smartphone.
+
+CTA:
+Join the waitlist
+Secondary CTA:
+See how it works
+
+2. Problem section
+Smartphones solve too much too early.
+Parents want their kids to have independence, communication, and safety.
+They don’t want to hand over distraction, social media, and addictive screens to get it.
+
+3. Solution section
+YoyoPod gives kids a focused device for communication, audio, and mobility, while giving parents the confidence to stay connected.
+
+4. Value props
+- Safe communication
+- Live location
+- Low-distraction design
+- Music and audio
+- Parent mobile app
+
+5. How it works
+Simple 3-step flow
+
+6. Why not a smartphone?
+Make the contrast explicit.
+
+7. Built for both sides
+Kids want independence.
+Parents want peace of mind.
+
+8. Waitlist CTA
+Repeat the main ask clearly.
+
+## Short homepage copy draft
+Headline:
+The first device before a smartphone
+
+Subheadline:
+YoyoPod helps kids stay connected, independent, and easy to reach with simple calling, voice messages, live location, and everyday audio — all under parent control.
+
+CTA:
+Join the waitlist
+
+Supporting bullets:
+- Approved contacts only
+- Live location from a parent mobile app
+- Tiny screen, simple controls, less distraction
+- Music and audio for everyday use
+
+## Stronger emotional version
+Headline:
+Give them independence. Not a smartphone.
+
+Subheadline:
+YoyoPod is a simple connected device for kids ages 7–14 that gives families safe communication, location visibility, and peace of mind before the smartphone years.
+
+CTA:
+Join the waitlist
+
+## Blunt positioning note
+Do not market this as:
+- AI for kids
+- a new communication platform
+- a smart wearable
+- an educational device
+
+That would dilute the sharpest truth you have:
+it is the first device before a smartphone.

--- a/docs/product/PRODUCT_DEFINITION.md
+++ b/docs/product/PRODUCT_DEFINITION.md
@@ -1,0 +1,29 @@
+# YoyoPod Product Definition
+
+YoyoPod is a parent-managed first independent device for kids ages 7–14, built for the gap before a smartphone. It gives children a focused sense of independence through simple communication, music, and mobility, while giving parents peace of mind through reliable calling and live location visibility, without the distraction, complexity, and screen addiction of a full smartphone.
+
+Short version:
+
+YoyoPod is the first device before a smartphone: a simple, walkie-talkie-like companion for kids that enables safe communication, music, and location sharing under parent control.
+
+Positioning line:
+
+Safer independence for kids. Peace of mind for parents. Before the smartphone.
+
+Core definition:
+- Buyer: parents
+- User: kids ages 7–14
+- Product type: parent-managed connected companion device
+- Form factor: walkie-talkie-like, tiny screen, minimal input
+- V1 pillars:
+  - whitelist calls and voice messages
+  - live-ish location
+  - music/audio
+  - parent mobile app
+- Anti-goal: not a smartphone replacement
+- Emotional promise:
+  - kid: independence
+  - parent: safety and peace of mind
+- Trust anchors:
+  - reliable reachability
+  - trustworthy location

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,0 +1,9 @@
+# Product Docs
+
+This folder captures the current product-definition artifacts for YoyoPod V1.
+
+Files:
+- `PRODUCT_DEFINITION.md` — crisp product definition and positioning core
+- `V1_SCOPE_MANIFESTO.md` — what V1 is, is not, and must prioritize
+- `TECHNICAL_PRIORITIES.md` — engineering priorities for YoyoPod_Core derived from product truth
+- `LANDING_PAGE_POSITIONING.md` — homepage messaging, value props, and positioning copy

--- a/docs/product/TECHNICAL_PRIORITIES.md
+++ b/docs/product/TECHNICAL_PRIORITIES.md
@@ -1,0 +1,191 @@
+# Technical Priorities for YoyoPod_Core
+
+This is the translation layer from product truth to engineering reality.
+
+## Priority 0: Stop treating V1 like a platform
+YoyoPod_Core should optimize for a reliable appliance, not an extensible universe.
+
+Implications:
+- kill or defer anything that smells like framework-building for future features
+- keep Ask/AI behind the main trust-critical flows
+- prefer boring, testable paths over elegant abstractions that buy nothing for V1
+
+## Priority 1: Make calling brutally reliable
+Calling is one of the two trust anchors. If it flakes, the product story collapses.
+
+Engineering focus:
+- inbound call reliability
+- outbound call reliability
+- reconnect behavior after weak/returning network
+- call audio stability over time
+- call-state correctness in UI and runtime
+- fast recovery from VoIP backend weirdness
+- clean failure states instead of silent limbo
+
+What this means in code:
+- instrument the VoIP lifecycle heavily
+- reduce hidden state transitions
+- verify keep-alive/reconnect behavior on real hardware and real networks
+- build repeatable call soak tests, not just happy-path tests
+- treat every "call stuck," "ringing but dead," or "UI says one thing / backend says another" bug as top-tier
+
+## Priority 2: Make live location trustworthy
+Not fancy map feature. Trustworthy.
+
+Engineering focus:
+- stable GPS acquisition
+- sane update cadence
+- timestamp freshness
+- clear stale-location handling
+- robust 4G uplink path for reporting
+- parent-facing semantics: last seen, current confidence, last successful fix
+
+What this means in code/system design:
+- location data needs freshness metadata everywhere
+- never present stale data as current
+- connectivity loss must degrade honestly
+- geofencing is secondary to "where is the device right now, roughly, and when was that last updated?"
+- build logging around fix quality, send frequency, and upload failures
+
+## Priority 3: Eliminate freezes and UI deadness on hardware
+This is the current product killer in disguise.
+
+Engineering focus:
+- remove or isolate blocking work from hot UI/runtime paths
+- identify real freeze sources on Pi hardware
+- reduce rendering churn
+- reduce event-loop or coordinator overload
+- make the system recoverable if a component stalls
+
+What this means in practice:
+- profile on target hardware, not your imagination
+- add watchdog-style detection for stalled UI/runtime loops
+- log slow operations with timestamps and subsystem tags
+- stress-test navigation while music and VoIP subsystems are active
+- if a flow can freeze the device, that bug outranks almost every feature request
+
+## Priority 4: Preserve the one-button interaction contract
+Your input model is part of the product identity. If it feels inconsistent, the device feels dumb.
+
+Engineering focus:
+- tap/double/hold timing consistency
+- no ambiguous actions
+- no mode confusion around PTT/Ask/back behavior
+- screen-specific input mode changes must stay predictable
+- fast visual/audio feedback after input
+
+What this means in code:
+- centralize and test one-button grammar transitions
+- validate timing thresholds on real hardware with actual human use
+- avoid layering hidden exceptions on top of the grammar
+- ensure Ask quick-command and navigation mode never feel like conflicting personalities
+
+## Priority 5: Make audio always feel available
+Music is not just a feature. It is the daily habit-forming use case.
+
+Engineering focus:
+- fast playback start
+- no broken playback after navigation or calls
+- clear interruption/resume rules
+- no weird volume state drift
+- stable local media indexing and retrieval
+
+What this means:
+- audio interruption policy must be deterministic
+- call/audio handoff should be tested constantly
+- local playback should work even when connectivity is bad
+- playback state should survive routine UI movement without getting lost
+
+## Priority 6: Build the parent-app contract now, even if the app itself lags
+The device is only half the product. The parent app is the other half.
+
+Engineering focus:
+- define clean backend contracts for contacts, whitelist rules, location updates, device settings, and message history
+- don’t let device-side hacks hardcode assumptions that make the parent app miserable later
+- model parent-managed state clearly and minimally
+
+Strong opinion:
+if the device code grows faster than the parent control model, you’re building half a product and congratulating yourself for it.
+
+## Priority 7: Design for degraded connectivity, but don’t overbuild fallback yet
+You already said fallback is undecided and maybe not V1. Good. Keep it that way unless it becomes crisp.
+
+Engineering focus:
+- detect loss of network cleanly
+- retry sanely
+- preserve local functionality
+- report degraded state honestly
+- queue what is reasonable to queue
+
+But:
+- do not burn weeks on speculative SMS-like fallback fantasies without a tight product definition
+- first make the primary online path dependable
+
+## Priority 8: Battery and thermal behavior must be measured, not hoped for
+"One day battery" is a product requirement, not a motivational quote.
+
+Engineering focus:
+- measure idle drain
+- measure playback drain
+- measure standby with location updates
+- measure call drain
+- measure worst-case radio/audio/screen behavior
+- enforce screen and subsystem power policies
+
+Translation:
+if you cannot characterize power consumption by mode, you do not have a battery strategy, you have a prayer circle.
+
+## Priority 9: Industrial-design constraints should shape software decisions earlier
+Since hardware industrial design is your hardest open problem, software should stop assuming infinite room and ideal inputs.
+
+Engineering focus:
+- tiny-screen UX discipline
+- low-button-count discipline
+- speaker/mic constraints
+- boot/recovery UX
+- charging/power-state clarity
+- is this carryable and understandable over debug convenience
+
+## Priority 10: Product-grade observability on hardware
+You need to know what happened without guessing.
+
+Must-have telemetry/logging areas:
+- boot and shutdown
+- connectivity transitions
+- GPS fix state and send attempts
+- VoIP register/call lifecycle
+- audio backend lifecycle
+- screen transitions
+- input events and timing
+- freeze/stall warnings
+- battery and thermal snapshots
+
+This is not optional.
+Without this, hardware debugging turns into folklore.
+
+## What should be deprioritized
+These are not dead forever. Just not allowed to steal oxygen.
+
+Deprioritize for now:
+- ambitious Ask/LLM expansion
+- fancy geofence behaviors beyond the basics
+- deep customization
+- broad contact/messaging models beyond whitelist family-safe flows
+- architectural refactors that don’t directly improve reliability, clarity, or testability
+- polished extras before parent trust flows are solid
+
+## Suggested engineering order
+1. Freeze investigation and runtime stability on hardware
+2. VoIP reliability under real-world network conditions
+3. Location freshness/trust model and reporting path
+4. Audio/call interruption and resume correctness
+5. One-button interaction validation on real hardware
+6. Parent-app-facing backend contract cleanup
+7. Battery characterization and power tuning
+8. Only then broaden feature scope
+
+## Governing rule for YoyoPod_Core
+Every engineering decision should answer:
+Does this improve trust, reliability, simplicity, or daily usefulness for V1?
+
+If not, it’s probably a distraction wearing a nice jacket.

--- a/docs/product/V1_SCOPE_MANIFESTO.md
+++ b/docs/product/V1_SCOPE_MANIFESTO.md
@@ -1,0 +1,93 @@
+# YoyoPod V1 Scope Manifesto
+
+YoyoPod V1 is not a smartphone for kids.
+It is the first independent device before a smartphone.
+
+## What V1 is for
+- Help kids feel independent
+- Help parents reliably reach them
+- Help parents see their live-ish location
+- Give kids simple audio they actually enjoy using
+- Do all of that with less distraction, less complexity, and less addiction than a phone
+
+## Who it is for
+- Buyer: parents
+- User: kids ages 7–14
+
+## Core product promise
+- For kids: independence
+- For parents: peace of mind
+
+## V1 must do these things well
+1. Whitelist-only calling
+   - Approved contacts only
+   - Fast, obvious, trustworthy call flow
+
+2. Voice messages
+   - Simple send/listen flow
+   - Family-safe, async communication
+
+3. Live-ish location
+   - Parent can see where the kid roughly is
+   - Good enough to build trust, not fake precision theater
+
+4. Music and audio
+   - Local and/or streaming playback
+   - Simple enough that the kid actually uses it daily
+
+5. Parent mobile app
+   - Contacts
+   - Device settings
+   - Location view
+   - Parent control surface, not optional admin garnish
+
+6. Focused hardware interaction
+   - Walkie-talkie-like form
+   - Tiny screen
+   - Minimal controls
+   - One-button PTT-style grammar that stays learnable
+
+## What V1 must not become
+- Not a smartphone replacement
+- Not an app platform
+- Not a toy
+- Not an AI gadget demo
+- Not a surveillance fetish object
+- Not a fragile hacker project pretending to be a product
+
+## What is explicitly not V1-critical
+- Fancy AI Ask ambitions
+- Over-designed fallback messaging schemes
+- Feature sprawl
+- Cute but low-trust geofence complexity before calling/location basics are solid
+- Anything that hurts reliability, battery, or simplicity
+
+## Trust anchors for V1
+If these fail, the product fails:
+- Calling reachability
+- Location trustworthiness
+
+## Daily-use anchors for V1
+If these fail, the kid stops caring:
+- Feeling independent
+- Easy audio/music use
+- Device feels carryable and believable
+
+## Design principles
+- Safety over openness
+- Simplicity over cleverness
+- Reliability over feature count
+- Honest state over fake magic
+- Focus over flexibility
+
+## Hard product truth
+Parents will buy the dream once.
+They will only keep using YoyoPod if calling and location are dependable in real life.
+
+## V1 success test
+A parent should be able to say:
+
+"My child can carry this instead of a smartphone for now, I can reach them, I can see where they are, and they actually like using it."
+
+## One-line V1 definition
+YoyoPod V1 is a parent-managed, walkie-talkie-like first device for kids that delivers safe communication, live location, and simple audio before the smartphone years.


### PR DESCRIPTION
## Summary
- add a dedicated docs/product/ folder for YoyoPod product artifacts
- split the generated product work into separate docs for definition, V1 scope, technical priorities, and landing-page positioning
- keep the PR scoped to docs/product/* only

## Files
- docs/product/README.md
- docs/product/PRODUCT_DEFINITION.md
- docs/product/V1_SCOPE_MANIFESTO.md
- docs/product/TECHNICAL_PRIORITIES.md
- docs/product/LANDING_PAGE_POSITIONING.md

## Test Plan
- not applicable (documentation only)