### PR TITLE
[codex] Make call-state transitions backend-authoritative

### DIFF
--- a/src/yoyopod/communication/calling/manager.py
+++ b/src/yoyopod/communication/calling/manager.py
@@ -80,6 +80,7 @@ class VoIPManager:
         self.call_duration: int = 0
         self.call_start_time: Optional[float] = None
         self.is_muted = False
+        self._pending_terminal_action: str | None = None
         self._message_store = message_store or self._build_message_store()
         self._active_voice_note: VoiceNoteDraft | None = None
         self._playback_process: subprocess.Popen | None = None
@@ -149,16 +150,32 @@ class VoIPManager:
         self.caller_address = sip_address
         self.caller_name = contact_name or self._lookup_contact_name(sip_address)
         logger.info("Making call to: {} ({})", self.caller_name, sip_address)
-        return self.backend.make_call(sip_address)
+        if not self.backend.make_call(sip_address):
+            return False
+
+        self._pending_terminal_action = None
+        return True
 
     def answer_call(self) -> bool:
-        return self.backend.answer_call()
+        if not self.backend.answer_call():
+            return False
+
+        self._pending_terminal_action = None
+        return True
 
     def hangup(self) -> bool:
-        return self.backend.hangup()
+        if not self.backend.hangup():
+            return False
+
+        self._pending_terminal_action = "hangup"
+        return True
 
     def reject_call(self) -> bool:
-        return self.backend.reject_call()
+        if not self.backend.reject_call():
+            return False
+
+        self._pending_terminal_action = "reject"
+        return True
 
     def mute(self) -> bool:
         if self.is_muted:
@@ -402,6 +419,13 @@ class VoIPManager:
             return int(time.time() - self.call_start_time)
         return 0
 
+    def consume_pending_terminal_action(self) -> str | None:
+        """Return and clear the most recent local call teardown action."""
+
+        action = self._pending_terminal_action
+        self._pending_terminal_action = None
+        return action
+
     def get_caller_info(self) -> dict:
         if self.caller_address and not self.caller_name:
             self.caller_name = self._lookup_contact_name(self.caller_address)
@@ -633,7 +657,7 @@ class VoIPManager:
         self.call_state = state
         logger.info("Call state: {} -> {}", old_state.value, state.value)
 
-        if state == CallState.CONNECTED and self.call_start_time is None:
+        if state in (CallState.CONNECTED, CallState.STREAMS_RUNNING) and self.call_start_time is None:
             self._start_call_timer()
         elif state in (CallState.RELEASED, CallState.END, CallState.ERROR):
             self._clear_call_session()
@@ -690,6 +714,7 @@ class VoIPManager:
         if self.call_state not in (CallState.IDLE, CallState.RELEASED):
             self.call_state = CallState.RELEASED
         self._clear_call_session()
+        self._pending_terminal_action = None
         self.running = False
         self.registered = False
         self.registration_state = RegistrationState.NONE

--- a/src/yoyopod/coordinators/call.py
+++ b/src/yoyopod/coordinators/call.py
@@ -22,6 +22,7 @@ from yoyopod.events import (
     VoIPAvailabilityChangedEvent,
 )
 from yoyopod.communication import CallHistoryEntry, CallHistoryStore, CallState, RegistrationState
+from yoyopod.fsm import CallSessionState
 
 
 @dataclass(slots=True)
@@ -33,6 +34,8 @@ class _CallSessionDraft:
     sip_address: str
     started_at: float = field(default_factory=time.time)
     answered: bool = False
+    terminal_state: CallState | None = None
+    local_end_action: str | None = None
 
 
 class CallCoordinator:
@@ -51,11 +54,11 @@ class CallCoordinator:
         self.auto_resume_after_call = auto_resume_after_call
         self.call_history_store = call_history_store
         self.voip_registered = initial_voip_registered
-        self.handling_incoming_call = False
         self.ringing_process: Optional[subprocess.Popen] = None
         self._event_bus: Optional[EventBus] = None
         self._bound = False
         self._active_call_session: _CallSessionDraft | None = None
+        self._pending_incoming_call: tuple[str, str] | None = None
 
     def bind(self, event_bus: EventBus) -> None:
         """Bind typed event subscriptions once."""
@@ -85,8 +88,6 @@ class CallCoordinator:
             raise RuntimeError("CallCoordinator is not bound to an EventBus")
 
         self._event_bus.publish(CallStateChangedEvent(state=state))
-        if state == CallState.RELEASED:
-            self._event_bus.publish(CallEndedEvent())
 
     def publish_registration_change(self, state: RegistrationState) -> None:
         """Publish registration changes from the VoIP manager thread."""
@@ -159,7 +160,7 @@ class CallCoordinator:
         self.handle_call_state_change(event.state)
 
     def _on_call_ended_event(self, event: CallEndedEvent) -> None:
-        self.handle_call_ended()
+        self.handle_call_ended(reason=event.reason)
 
     def _on_registration_changed_event(self, event: RegistrationChangedEvent) -> None:
         self.handle_registration_change(event.state)
@@ -168,36 +169,15 @@ class CallCoordinator:
         self.handle_availability_change(event.available, event.reason)
 
     def handle_incoming_call(self, caller_address: str, caller_name: str) -> None:
-        """Coordinate music pause and UI transitions for an incoming call."""
-        if self.handling_incoming_call:
-            logger.debug(f"Already handling call from {caller_name}")
-            return
-
-        self.handling_incoming_call = True
-        logger.info(f"Incoming call: {caller_name} ({caller_address})")
+        """Capture incoming-call metadata for the active incoming phase."""
+        logger.info(f"Incoming call metadata: {caller_name} ({caller_address})")
+        self._pending_incoming_call = (caller_address, caller_name)
         self._active_call_session = _CallSessionDraft(
             direction="incoming",
             display_name=caller_name or "Unknown",
             sip_address=caller_address,
         )
-
-        playback_state = (
-            self.runtime.music_backend.get_playback_state()
-            if self.runtime.music_backend and self.runtime.music_backend.is_connected
-            else "stopped"
-        )
-
-        if playback_state == "playing":
-            logger.info("Auto-pausing music for incoming call")
-            self.runtime.call_interruption_policy.pause_for_call(self.runtime.music_fsm)
-            if self.runtime.music_backend:
-                self.runtime.music_backend.pause()
-
-        self.runtime.call_fsm.transition("incoming")
-        self.runtime.sync_app_state("incoming_call")
-
-        self.screen_coordinator.show_incoming_call(caller_address, caller_name)
-        self.start_ringing()
+        self._present_incoming_call_if_ready()
 
     def handle_call_state_change(self, state: CallState) -> None:
         """Coordinate high-level call state updates."""
@@ -212,11 +192,28 @@ class CallCoordinator:
             self._ensure_outgoing_call_session()
             self.runtime.call_fsm.transition("dial")
             self.runtime.sync_app_state("call_outgoing")
+            if self._active_call_session is not None:
+                caller_info = self._current_caller_info()
+                if caller_info:
+                    self._active_call_session.display_name = str(
+                        caller_info.get("display_name")
+                        or caller_info.get("name")
+                        or self._active_call_session.display_name
+                    )
+                    self._active_call_session.sip_address = str(
+                        caller_info.get("address") or self._active_call_session.sip_address
+                    )
+                self.screen_coordinator.show_outgoing_call(
+                    self._active_call_session.sip_address,
+                    self._active_call_session.display_name,
+                )
             return
 
         if state == CallState.INCOMING:
+            self._pause_music_for_incoming_call()
             self.runtime.call_fsm.transition("incoming")
             self.runtime.sync_app_state("call_incoming_state")
+            self._present_incoming_call_if_ready()
             return
 
         if state in (CallState.CONNECTED, CallState.STREAMS_RUNNING):
@@ -229,20 +226,49 @@ class CallCoordinator:
                 logger.info("In call (music paused in background)")
             self.screen_coordinator.show_in_call()
             self.stop_ringing()
+            return
 
-    def handle_call_ended(self) -> None:
+        if state in (CallState.RELEASED, CallState.END, CallState.ERROR):
+            if not self._has_live_call_state():
+                logger.debug("Ignoring duplicate terminal call state {}", state.value)
+                return
+
+            local_end_action = self._consume_pending_terminal_action()
+            if self._active_call_session is not None:
+                self._active_call_session.terminal_state = state
+                self._active_call_session.local_end_action = local_end_action
+            self.handle_call_ended(reason=state.value)
+            return
+
+        logger.debug("Call state {} does not change coordinator phase", state.value)
+
+    def handle_call_ended(self, *, reason: str = "released") -> None:
         """Coordinate call cleanup and possible music resume."""
-        logger.info("Call ended")
+        if not self.runtime.call_fsm.is_active and self._active_call_session is None:
+            logger.warning(
+                "Ignoring terminal call teardown without an active session (reason: {})",
+                reason,
+            )
+            self.stop_ringing()
+            self._pending_incoming_call = None
+            self.screen_coordinator.pop_call_screens()
+            self.runtime.sync_app_state(f"call_ended:{reason}")
+            return
+
+        logger.info("Call ended ({})", reason)
 
         self.stop_ringing()
-        self.handling_incoming_call = False
+        self._pending_incoming_call = None
         self._finalize_call_history()
         self.screen_coordinator.pop_call_screens()
 
         should_resume = self.runtime.call_interruption_policy.should_auto_resume(
             self.auto_resume_after_call
         )
-        self.runtime.call_fsm.transition("end")
+        if self.runtime.call_fsm.is_active:
+            self.runtime.call_fsm.transition("end")
+        else:
+            self.runtime.call_fsm.sync(CallSessionState.IDLE)
 
         if should_resume:
             logger.info("Auto-resuming music after call")
@@ -301,8 +327,8 @@ class CallCoordinator:
         self.stop_ringing()
         self.screen_coordinator.refresh_call_screen_if_visible()
 
-        if self.runtime.call_fsm.is_active:
-            self.handle_call_ended()
+        if self.runtime.call_fsm.is_active or self._active_call_session is not None:
+            self.handle_call_ended(reason=reason or "unavailable")
 
     def _is_voip_configured(self) -> bool:
         """Return whether the app has meaningful SIP identity data configured."""
@@ -328,17 +354,69 @@ class CallCoordinator:
             sip_address=str(caller_info.get("address") or ""),
         )
 
+    def _pause_music_for_incoming_call(self) -> None:
+        """Pause active playback once when a call enters the incoming phase."""
+
+        playback_state = (
+            self.runtime.music_backend.get_playback_state()
+            if self.runtime.music_backend and self.runtime.music_backend.is_connected
+            else "stopped"
+        )
+        if playback_state != "playing":
+            return
+
+        logger.info("Auto-pausing music for incoming call")
+        self.runtime.call_interruption_policy.pause_for_call(self.runtime.music_fsm)
+        if self.runtime.music_backend:
+            self.runtime.music_backend.pause()
+
+    def _present_incoming_call_if_ready(self) -> None:
+        """Show the incoming-call screen once state and caller metadata are both known."""
+
+        if self.runtime.call_fsm.state != CallSessionState.INCOMING:
+            return
+        if self._pending_incoming_call is None:
+            logger.debug("Incoming call phase entered before caller metadata arrived")
+            return
+
+        caller_address, caller_name = self._pending_incoming_call
+        self.screen_coordinator.show_incoming_call(caller_address, caller_name)
+        self.start_ringing()
+
+    def _has_live_call_state(self) -> bool:
+        """Return whether the coordinator still has a live call to tear down."""
+
+        return self.runtime.call_fsm.is_active or self._active_call_session is not None
+
+    def _consume_pending_terminal_action(self) -> str | None:
+        """Return any locally initiated teardown action awaiting terminal backend state."""
+
+        voip_manager = self._current_voip_manager()
+        consume_action = getattr(voip_manager, "consume_pending_terminal_action", None)
+        if callable(consume_action):
+            return consume_action()
+        return None
+
+    def _current_voip_manager(self) -> object | None:
+        """Return the shared VoIP manager from any registered call screen."""
+
+        for screen in (
+            self.runtime.call_screen,
+            self.runtime.outgoing_call_screen,
+            self.runtime.incoming_call_screen,
+            self.runtime.in_call_screen,
+        ):
+            voip_manager = getattr(screen, "voip_manager", None)
+            if voip_manager is not None:
+                return voip_manager
+        return None
+
     def _current_caller_info(self) -> dict[str, str]:
         """Return the current caller/callee metadata from the VoIP manager."""
 
-        call_voip_manager = getattr(self.runtime.call_screen, "voip_manager", None)
-        if call_voip_manager is not None:
-            return dict(call_voip_manager.get_caller_info())
-
-        in_call_voip_manager = getattr(self.runtime.in_call_screen, "voip_manager", None)
-        if in_call_voip_manager is not None:
-            return dict(in_call_voip_manager.get_caller_info())
-
+        voip_manager = self._current_voip_manager()
+        if voip_manager is not None:
+            return dict(voip_manager.get_caller_info())
         return {}
 
     def _finalize_call_history(self) -> None:
@@ -358,10 +436,14 @@ class CallCoordinator:
         if call_voip_manager is not None:
             call_duration = int(call_voip_manager.get_call_duration())
 
-        if draft.direction == "incoming" and not draft.answered:
-            outcome = "missed"
-        elif draft.answered:
+        if draft.answered:
             outcome = "completed"
+        elif draft.direction == "incoming" and draft.local_end_action == "reject":
+            outcome = "rejected"
+        elif draft.terminal_state == CallState.ERROR:
+            outcome = "failed"
+        elif draft.direction == "incoming":
+            outcome = "missed"
         else:
             outcome = "cancelled"
 

--- a/src/yoyopod/coordinators/screen.py
+++ b/src/yoyopod/coordinators/screen.py
@@ -101,3 +101,13 @@ class ScreenCoordinator:
         if self.runtime.screen_manager.current_screen != self.runtime.in_call_screen:
             self.runtime.screen_manager.push_screen("in_call")
             logger.info("  → Pushed in-call screen")
+
+    def show_outgoing_call(self, callee_address: str, callee_name: str) -> None:
+        """Update and show the outgoing-call screen."""
+        self.runtime.outgoing_call_screen.callee_address = callee_address
+        self.runtime.outgoing_call_screen.callee_name = callee_name or "Unknown"
+        self.runtime.outgoing_call_screen.ring_animation_frame = 0
+
+        if self.runtime.screen_manager.current_screen != self.runtime.outgoing_call_screen:
+            self.runtime.screen_manager.push_screen("outgoing_call")
+            logger.info("  → Pushed outgoing call screen")

--- a/src/yoyopod/runtime/voice.py
+++ b/src/yoyopod/runtime/voice.py
@@ -33,6 +33,7 @@ class VoiceCommandOutcome:
     body: str
     should_speak: bool = True
     route_name: str | None = None
+    auto_return: bool = True
 
 
 class VoiceSettingsResolver:
@@ -285,7 +286,7 @@ class VoiceCommandExecutor:
             return VoiceCommandOutcome(
                 "Calling",
                 f"Calling {display_name}.",
-                route_name="call_started",
+                auto_return=False,
             )
 
         return VoiceCommandOutcome("Call Failed", f"I could not call {display_name}.")

--- a/src/yoyopod/ui/screens/navigation/ask_voice.py
+++ b/src/yoyopod/ui/screens/navigation/ask_voice.py
@@ -71,7 +71,7 @@ class AskScreenVoiceMixin:
         if outcome.route_name is not None:
             self.request_route(outcome.route_name)
             navigated = self._apply_pending_navigation_request()
-        if not navigated:
+        if not navigated and outcome.auto_return:
             self._schedule_auto_return()
 
     def _voice_service(self) -> "VoiceService":

--- a/src/yoyopod/ui/screens/voip/call_history.py
+++ b/src/yoyopod/ui/screens/voip/call_history.py
@@ -244,8 +244,11 @@ class CallHistoryScreen(Screen):
             return
 
         logger.info(f"Redialing recent contact: {selected.title} ({selected.sip_address})")
-        if self.voip_manager.make_call(selected.sip_address, contact_name=selected.display_name):
-            self.request_route("call_started")
+        if not self.voip_manager.make_call(
+            selected.sip_address,
+            contact_name=selected.display_name,
+        ):
+            logger.error(f"Failed to redial recent contact: {selected.title}")
 
     def on_back(self, data=None) -> None:
         """Return to the previous screen."""

--- a/src/yoyopod/ui/screens/voip/contact_list.py
+++ b/src/yoyopod/ui/screens/voip/contact_list.py
@@ -266,9 +266,7 @@ class ContactListScreen(Screen):
 
         contact = self.contacts[self.selected_index]
         logger.info(f"Calling contact: {contact.display_name} at {contact.sip_address}")
-        if self.voip_manager.make_call(contact.sip_address, contact_name=contact.display_name):
-            self.request_route("call_started")
-        else:
+        if not self.voip_manager.make_call(contact.sip_address, contact_name=contact.display_name):
             logger.error(f"Failed to initiate call to {contact.display_name}")
 
     def choose_voice_note_recipient(self) -> None:

--- a/src/yoyopod/ui/screens/voip/in_call.py
+++ b/src/yoyopod/ui/screens/voip/in_call.py
@@ -141,8 +141,8 @@ class InCallScreen(Screen):
         """End the current call."""
 
         logger.info("Ending call")
-        if self.voip_manager and self.voip_manager.hangup():
-            self.request_route("call_hangup")
+        if self.voip_manager:
+            self.voip_manager.hangup()
 
     def _toggle_mute(self) -> None:
         """Toggle microphone mute."""

--- a/src/yoyopod/ui/screens/voip/incoming_call.py
+++ b/src/yoyopod/ui/screens/voip/incoming_call.py
@@ -111,14 +111,14 @@ class IncomingCallScreen(Screen):
     def _answer_call(self) -> None:
         """Answer the incoming call."""
         logger.info("Answering incoming call")
-        if self.voip_manager and self.voip_manager.answer_call():
-            self.request_route("call_answered")
+        if self.voip_manager:
+            self.voip_manager.answer_call()
 
     def _reject_call(self) -> None:
         """Reject the incoming call."""
         logger.info("Rejecting incoming call")
-        if self.voip_manager and self.voip_manager.reject_call():
-            self.request_route("call_rejected")
+        if self.voip_manager:
+            self.voip_manager.reject_call()
 
     def on_select(self, data=None) -> None:
         """Answer the incoming call."""

--- a/src/yoyopod/ui/screens/voip/outgoing_call.py
+++ b/src/yoyopod/ui/screens/voip/outgoing_call.py
@@ -119,8 +119,8 @@ class OutgoingCallScreen(Screen):
     def _cancel_call(self) -> None:
         """Cancel the outgoing call."""
         logger.info("Canceling outgoing call")
-        if self.voip_manager and self.voip_manager.hangup():
-            self.request_route("call_hangup")
+        if self.voip_manager:
+            self.voip_manager.hangup()
 
     def on_back(self, data=None) -> None:
         """Cancel the outgoing call."""

--- a/src/yoyopod/ui/screens/voip/talk_contact.py
+++ b/src/yoyopod/ui/screens/voip/talk_contact.py
@@ -228,7 +228,6 @@ class TalkContactScreen(Screen):
             logger.error("Cannot place Talk call: no VoIP manager")
             return
         if self.voip_manager.make_call(sip_address, contact_name=contact_name):
-            self.request_route("call_started")
             return
         logger.error("Failed to place Talk call to {}", contact_name)
 

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -567,12 +567,11 @@ def test_incoming_call_pauses_playing_music_once() -> None:
     harness = OrchestrationHarness.build(playback_state="playing")
     harness.sync_runtime(music_state=MusicState.PLAYING, trigger="playback_playing")
 
-    harness.publish(
-        IncomingCallEvent(caller_address="sip:alice@example.com", caller_name="Alice"),
-    )
+    harness.publish(CallStateChangedEvent(state=CallState.INCOMING))
+    harness.publish(IncomingCallEvent(caller_address="sip:alice@example.com", caller_name="Alice"))
 
     assert harness.music_backend.pause_calls == 0
-    assert harness.drain_events() == 1
+    assert harness.drain_events() == 2
     assert harness.music_backend.pause_calls == 1
     assert harness.music_fsm.state == MusicState.PAUSED
     assert harness.call_fsm.state == CallSessionState.INCOMING
@@ -587,6 +586,26 @@ def test_incoming_call_pauses_playing_music_once() -> None:
     assert harness.drain_events() == 1
     assert harness.music_backend.pause_calls == 1
     assert len(harness.screen_manager.screen_stack) == 2
+
+
+def test_incoming_call_metadata_waits_for_incoming_state_before_mutating_runtime() -> None:
+    """Caller metadata alone should not move the runtime into an active incoming phase."""
+    harness = OrchestrationHarness.build(playback_state="playing")
+    harness.sync_runtime(music_state=MusicState.PLAYING, trigger="playback_playing")
+
+    harness.publish(IncomingCallEvent(caller_address="sip:alice@example.com", caller_name="Alice"))
+
+    assert harness.drain_events() == 1
+    assert harness.music_backend.pause_calls == 0
+    assert harness.call_fsm.state == CallSessionState.IDLE
+    assert harness.screen_manager.current_screen is harness.screens.menu
+
+    harness.publish(CallStateChangedEvent(state=CallState.INCOMING))
+
+    assert harness.drain_events() == 1
+    assert harness.music_backend.pause_calls == 1
+    assert harness.call_fsm.state == CallSessionState.INCOMING
+    assert harness.screen_manager.current_screen is harness.screens.incoming_call
 
 
 def test_call_end_auto_resumes_only_when_enabled() -> None:
@@ -642,7 +661,7 @@ def test_outgoing_call_does_not_change_idle_or_paused_music(
     playback_state: str,
 ) -> None:
     """Outgoing call state changes should not mutate paused or idle music state."""
-    app, _, _ = _build_app(playback_state=playback_state)
+    app, _, screen_manager = _build_app(playback_state=playback_state)
     app.music_fsm.sync(music_state)
     app.coordinator_runtime.sync_app_state("test_setup")
 
@@ -651,6 +670,46 @@ def test_outgoing_call_does_not_change_idle_or_paused_music(
     assert app.event_bus.drain() == 1
     assert app.call_fsm.state == CallSessionState.OUTGOING
     assert app.music_fsm.state == music_state
+    assert screen_manager.current_screen is app.outgoing_call_screen
+
+
+def test_terminal_error_state_ends_incoming_call_without_waiting_for_released() -> None:
+    """Terminal backend errors should unwind the incoming-call flow immediately."""
+
+    harness = OrchestrationHarness.build(playback_state="playing", auto_resume=True)
+    harness.sync_runtime(music_state=MusicState.PLAYING, trigger="playback_playing")
+
+    harness.publish(
+        IncomingCallEvent(caller_address="sip:alice@example.com", caller_name="Alice"),
+    )
+    assert harness.drain_events() == 1
+
+    harness.publish(CallStateChangedEvent(state=CallState.INCOMING))
+    assert harness.drain_events() == 1
+
+    harness.publish(CallStateChangedEvent(state=CallState.ERROR))
+
+    assert harness.drain_events() == 1
+    assert harness.call_fsm.state == CallSessionState.IDLE
+    assert harness.music_fsm.state == MusicState.PLAYING
+    assert harness.music_backend.play_calls == 1
+    assert harness.screen_manager.current_screen is harness.screens.menu
+
+
+def test_terminal_end_state_clears_outgoing_call_without_waiting_for_released() -> None:
+    """Cancelled or rejected call terminals should clear the outgoing phase directly."""
+
+    harness = OrchestrationHarness.build(playback_state="stopped")
+
+    harness.publish(CallStateChangedEvent(state=CallState.OUTGOING))
+    assert harness.drain_events() == 1
+    assert harness.screen_manager.current_screen is harness.screens.outgoing_call
+
+    harness.publish(CallStateChangedEvent(state=CallState.END))
+
+    assert harness.drain_events() == 1
+    assert harness.call_fsm.state == CallSessionState.IDLE
+    assert harness.screen_manager.current_screen is harness.screens.menu
 
 
 def test_background_events_wait_for_drain_before_mutating_state() -> None:
@@ -712,6 +771,29 @@ def test_voip_unavailable_event_ends_call_and_restores_music() -> None:
     harness.publish(
         VoIPAvailabilityChangedEvent(available=False, reason="backend_stopped"),
     )
+
+    assert harness.drain_events() == 1
+    assert harness.call_fsm.state == CallSessionState.IDLE
+    assert harness.music_fsm.state == MusicState.PLAYING
+    assert harness.music_backend.play_calls == 1
+    assert harness.screen_manager.current_screen is harness.screens.menu
+
+
+@pytest.mark.parametrize(
+    "terminal_state",
+    [CallState.RELEASED, CallState.END, CallState.ERROR],
+)
+def test_terminal_call_states_end_call_and_restore_music(terminal_state: CallState) -> None:
+    """Every terminal backend call state should follow the same teardown path."""
+    harness = OrchestrationHarness.build(playback_state="paused", auto_resume=True)
+    harness.sync_runtime(
+        music_state=MusicState.PAUSED,
+        call_state=CallSessionState.ACTIVE,
+        music_interrupted_by_call=True,
+    )
+    harness.push_screens("in_call")
+
+    harness.publish(CallStateChangedEvent(state=terminal_state))
 
     assert harness.drain_events() == 1
     assert harness.call_fsm.state == CallSessionState.IDLE

--- a/tests/test_call_coordinator.py
+++ b/tests/test_call_coordinator.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
+
 from yoyopod.app_context import AppContext
-from yoyopod.communication import RegistrationState
+from yoyopod.communication import CallHistoryStore, CallState, RegistrationState
 from yoyopod.coordinators.call import CallCoordinator
 from yoyopod.coordinators.runtime import CoordinatorRuntime
 from yoyopod.fsm import CallFSM, CallInterruptionPolicy, MusicFSM
@@ -17,6 +20,21 @@ class _ScreenCoordinatorStub:
 
     def refresh_call_screen_if_visible(self) -> None:
         self.refresh_calls += 1
+
+    def show_incoming_call(self, caller_address: str, caller_name: str) -> None:
+        return
+
+    def show_outgoing_call(self, callee_address: str, callee_name: str) -> None:
+        return
+
+    def show_in_call(self) -> None:
+        return
+
+    def pop_call_screens(self) -> None:
+        return
+
+    def refresh_now_playing_screen(self) -> None:
+        return
 
 
 class _ConfigManagerStub:
@@ -33,8 +51,47 @@ class _ConfigManagerStub:
         return self._sip_username
 
 
-def _build_runtime(*, config_manager: _ConfigManagerStub, context: AppContext) -> CoordinatorRuntime:
+class _VoipManagerStub:
+    """Tiny VoIP manager surface used for call-history classification tests."""
+
+    def __init__(self) -> None:
+        self._caller_info = {
+            "address": "sip:friend@example.com",
+            "name": "Friend",
+            "display_name": "Friend",
+        }
+        self._call_duration = 0
+        self._pending_terminal_action: str | None = None
+
+    def get_caller_info(self) -> dict[str, str]:
+        return dict(self._caller_info)
+
+    def get_call_duration(self) -> int:
+        return self._call_duration
+
+    def consume_pending_terminal_action(self) -> str | None:
+        action = self._pending_terminal_action
+        self._pending_terminal_action = None
+        return action
+
+
+@dataclass
+class _ScreenStub:
+    voip_manager: _VoipManagerStub
+
+
+def _build_runtime(
+    *,
+    config_manager: _ConfigManagerStub,
+    context: AppContext,
+    voip_manager: _VoipManagerStub | None = None,
+) -> CoordinatorRuntime:
     """Create the minimal coordinator runtime required by CallCoordinator."""
+
+    call_screen = _ScreenStub(voip_manager) if voip_manager is not None else None
+    incoming_call_screen = _ScreenStub(voip_manager) if voip_manager is not None else None
+    outgoing_call_screen = _ScreenStub(voip_manager) if voip_manager is not None else None
+    in_call_screen = _ScreenStub(voip_manager) if voip_manager is not None else None
 
     return CoordinatorRuntime(
         music_fsm=MusicFSM(),
@@ -44,11 +101,11 @@ def _build_runtime(*, config_manager: _ConfigManagerStub, context: AppContext) -
         music_backend=None,
         power_manager=None,
         now_playing_screen=None,
-        call_screen=None,
+        call_screen=call_screen,
         power_screen=None,
-        incoming_call_screen=None,
-        outgoing_call_screen=None,
-        in_call_screen=None,
+        incoming_call_screen=incoming_call_screen,
+        outgoing_call_screen=outgoing_call_screen,
+        in_call_screen=in_call_screen,
         config_manager=config_manager,
         context=context,
     )
@@ -75,3 +132,38 @@ def test_registration_change_uses_config_manager_for_voip_configured_status() ->
     assert context.voip.ready is True
     assert runtime.voip_ready is True
     assert screen_coordinator.refresh_calls == 1
+
+
+def test_terminal_call_states_record_rejected_and_failed_history(tmp_path: Path) -> None:
+    """Terminal backend states should classify rejected and failed calls explicitly."""
+
+    context = AppContext()
+    voip_manager = _VoipManagerStub()
+    runtime = _build_runtime(
+        config_manager=_ConfigManagerStub(sip_username="kid@example.com"),
+        context=context,
+        voip_manager=voip_manager,
+    )
+    coordinator = CallCoordinator(
+        runtime=runtime,
+        screen_coordinator=_ScreenCoordinatorStub(),
+        auto_resume_after_call=True,
+        call_history_store=CallHistoryStore(tmp_path / "call_history.json"),
+    )
+
+    coordinator.handle_incoming_call("sip:mama@example.com", "Mama")
+    coordinator.handle_call_state_change(CallState.INCOMING)
+    voip_manager._pending_terminal_action = "reject"
+    coordinator.handle_call_state_change(CallState.END)
+
+    voip_manager._caller_info = {
+        "address": "sip:dad@example.com",
+        "name": "Dad",
+        "display_name": "Dad",
+    }
+    coordinator.handle_call_state_change(CallState.OUTGOING)
+    coordinator.handle_call_state_change(CallState.ERROR)
+
+    recent = coordinator.call_history_store.list_recent(2)  # type: ignore[union-attr]
+    assert recent[0].outcome == "failed"
+    assert recent[1].outcome == "rejected"

--- a/tests/test_call_screen.py
+++ b/tests/test_call_screen.py
@@ -155,7 +155,7 @@ def test_call_screen_select_opens_selected_contact(display: Display) -> None:
 
 
 def test_talk_contact_screen_calls_selected_person(display: Display) -> None:
-    """The contact action screen should call the selected person when Call is chosen."""
+    """The contact action screen should delegate dialing without owning navigation."""
 
     context = AppContext()
     context.set_talk_contact(name="Mama", sip_address="sip:alice@example.com")
@@ -166,7 +166,7 @@ def test_talk_contact_screen_calls_selected_person(display: Display) -> None:
     screen.on_select()
 
     assert voip_manager.make_calls == [("sip:alice@example.com", "Mama")]
-    assert screen.consume_navigation_request() == NavigationRequest.route("call_started")
+    assert screen.consume_navigation_request() is None
 
 
 def test_talk_contact_screen_routes_to_voice_note(display: Display) -> None:

--- a/tests/test_runtime_voice.py
+++ b/tests/test_runtime_voice.py
@@ -175,7 +175,7 @@ def test_voice_command_executor_routes_call_and_updates_context() -> None:
     assert outcome == VoiceCommandOutcome(
         "Calling",
         "Calling Mama.",
-        route_name="call_started",
+        auto_return=False,
     )
     assert context.talk_contact_name == "Mama"
     assert voip_manager.make_calls == [("sip:mama@example.com", "Mama")]

--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -452,7 +452,7 @@ def test_ask_screen_can_start_music_from_local_hook() -> None:
 
 
 def test_ask_screen_can_place_call_for_named_contact() -> None:
-    """Call commands should resolve child-facing labels and trigger VoIP dialing."""
+    """Call commands should resolve labels and let call-state events own navigation."""
 
     context = AppContext()
     voip_manager = _FakeVoipManager()
@@ -472,11 +472,12 @@ def test_ask_screen_can_place_call_for_named_contact() -> None:
 
     assert context.talk_contact_name == "Mama"
     assert voip_manager.make_calls == [("sip:mama@example.com", "Mama")]
-    assert screen.consume_navigation_request() == NavigationRequest.route("call_started")
+    assert screen.consume_navigation_request() is None
+    assert screen._auto_return_timer is None
 
 
 def test_ask_screen_can_place_call_for_parent_aliases() -> None:
-    """Parent aliases like mom and dad should resolve against kid-facing labels."""
+    """Parent aliases should not force a local navigation request for call start."""
 
     context = AppContext()
     voip_manager = _FakeVoipManager()
@@ -500,11 +501,13 @@ def test_ask_screen_can_place_call_for_parent_aliases() -> None:
 
     screen.on_voice_command({"transcript": "call mom"})
     assert voip_manager.make_calls == [("sip:mama@example.com", "Mama")]
-    assert screen.consume_navigation_request() == NavigationRequest.route("call_started")
+    assert screen.consume_navigation_request() is None
+    assert screen._auto_return_timer is None
 
     screen.on_voice_command({"transcript": "call dad"})
     assert voip_manager.make_calls[-1] == ("sip:dad@example.com", "Dad")
-    assert screen.consume_navigation_request() == NavigationRequest.route("call_started")
+    assert screen.consume_navigation_request() is None
+    assert screen._auto_return_timer is None
 
 
 def test_ask_screen_default_voice_settings_keep_saved_speaker_device() -> None:

--- a/tests/test_voip_backend.py
+++ b/tests/test_voip_backend.py
@@ -355,16 +355,35 @@ def test_voip_manager_applies_backend_events_and_resolves_contact_names() -> Non
 
 
 def test_voip_manager_delegates_outgoing_commands_to_backend() -> None:
-    """Outgoing call commands should be delegated through the backend boundary."""
+    """Outgoing commands should not invent local call phases before backend events arrive."""
 
     backend = MockVoIPBackend()
     manager = VoIPManager(build_config(), backend=backend)
+    call_states: list[CallState] = []
 
     backend.emit(RegistrationStateChanged(state=RegistrationState.OK))
+    manager.on_call_state_change(call_states.append)
 
     assert manager.make_call("sip:bob@example.com", contact_name="Bob")
     assert backend.commands == ["call sip:bob@example.com"]
+    assert call_states == []
+    assert manager.call_state == CallState.IDLE
     assert manager.get_caller_info()["display_name"] == "Bob"
+
+
+def test_voip_manager_starts_timer_on_streams_running_without_connected() -> None:
+    """Streams-running callbacks should start live duration tracking on their own."""
+
+    backend = MockVoIPBackend()
+    manager = VoIPManager(build_config(), backend=backend)
+    started: list[bool] = []
+    manager._start_call_timer = lambda: started.append(True)  # type: ignore[method-assign]
+
+    assert manager.start()
+
+    backend.emit(CallStateChanged(state=CallState.STREAMS_RUNNING))
+
+    assert started == [True]
 
 
 def test_voip_manager_tracks_voice_note_send_and_delivery() -> None:

--- a/tests/test_whisplay_one_button.py
+++ b/tests/test_whisplay_one_button.py
@@ -557,25 +557,25 @@ def test_incoming_call_select_answers_and_back_rejects(
     display: Display,
     one_button_context: AppContext,
 ) -> None:
-    """Incoming calls should answer on SELECT and reject on BACK."""
+    """Incoming-call actions should defer navigation to coordinator call-state events."""
     voip_manager = FakeVoIPManager()
     screen = IncomingCallScreen(display, one_button_context, voip_manager=voip_manager)
 
     screen.on_advance()
     screen.on_select()
     assert voip_manager.answer_calls == 1
-    assert screen.consume_navigation_request() == NavigationRequest.route("call_answered")
+    assert screen.consume_navigation_request() is None
 
     screen.on_back()
     assert voip_manager.reject_calls == 1
-    assert screen.consume_navigation_request() == NavigationRequest.route("call_rejected")
+    assert screen.consume_navigation_request() is None
 
 
 def test_outgoing_call_back_cancels_call(
     display: Display,
     one_button_context: AppContext,
 ) -> None:
-    """Outgoing calls should cancel on BACK in one-button mode."""
+    """Outgoing-call cancel should wait for backend teardown before navigation."""
     voip_manager = FakeVoIPManager()
     screen = OutgoingCallScreen(display, one_button_context, voip_manager=voip_manager)
 
@@ -584,14 +584,14 @@ def test_outgoing_call_back_cancels_call(
     screen.on_back()
 
     assert voip_manager.hangup_calls == 1
-    assert screen.consume_navigation_request() == NavigationRequest.route("call_hangup")
+    assert screen.consume_navigation_request() is None
 
 
 def test_in_call_advance_toggles_mute_and_back_hangs_up(
     display: Display,
     one_button_context: AppContext,
 ) -> None:
-    """In-call view should use ADVANCE for mute and BACK for hangup."""
+    """In-call actions should leave teardown navigation to the coordinator."""
     voip_manager = FakeVoIPManager()
     screen = InCallScreen(display, one_button_context, voip_manager=voip_manager)
 
@@ -600,4 +600,4 @@ def test_in_call_advance_toggles_mute_and_back_hangs_up(
 
     assert voip_manager.toggle_mute_calls == 1
     assert voip_manager.hangup_calls == 1
-    assert screen.consume_navigation_request() == NavigationRequest.route("call_hangup")
+    assert screen.consume_navigation_request() is None


### PR DESCRIPTION
## Summary
- route outbound, inbound, active, and terminal call UI transitions through backend call-state events instead of optimistic local screen navigation
- treat `END`, `ERROR`, and `RELEASED` as explicit terminal backend states in the call coordinator, with one teardown path for runtime and UI cleanup
- track local reject and hangup intent just long enough to classify rejected vs failed vs cancelled call history entries
- start in-call duration tracking on `STREAMS_RUNNING` as well as `CONNECTED`

## What Changed
- removed optimistic local call-phase transitions from `VoIPManager.make_call()` and from Talk, incoming-call, outgoing-call, and in-call screen action handlers
- made `CallCoordinator` own the visible outgoing, incoming, active, and terminal call transitions, including duplicate-terminal guarding and explicit teardown reasons
- kept Ask voice call commands from forcing local navigation, while also suppressing quick-command auto-return for that path so call-state events remain authoritative
- added focused regression coverage for terminal call states, call-history outcome classification, backend-owned outgoing state, and `STREAMS_RUNNING` timer startup

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_voip_backend.py tests/test_call_coordinator.py tests/test_app_orchestration.py tests/test_call_screen.py tests/test_screen_routing.py tests/test_whisplay_one_button.py tests/test_runtime_voice.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/quality.py gate`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
  - this passed all but 2 tests in the sandbox; the remaining failures were `tests/test_mpv_ipc.py::test_connect_and_send_command` and `tests/test_mpv_ipc.py::test_event_callback_fires`, both failing because the sandbox blocks the Unix-socket bind they exercise
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_mpv_ipc.py::test_connect_and_send_command tests/test_mpv_ipc.py::test_event_callback_fires`
  - rerun outside the sandbox to confirm the remaining Unix-socket tests pass

## Notes
- this stays scoped to the call-state correctness seam; it does not redesign the broader call UX or replace the backend
- `gh auth status` reports an invalid local token in this environment, so PR creation and updates used the GitHub app path instead of `gh pr create`

Refs #181