### PR TITLE
[codex] Add VoIP reconnect and call-soak drills

### DIFF
--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -153,7 +153,7 @@ yoyoctl pi voip reconnect-drill
 yoyoctl pi voip reconnect-drill --disconnect-seconds 12
 ```
 
-If you can automate the outage on the Pi, keep it explicit:
+If you can automate the outage on the Pi, keep it explicit. The drill executes `--drop-command` and `--restore-command` with a shell, so treat them as trusted operator input for your own device only:
 
 ```bash
 yoyoctl pi voip reconnect-drill \

--- a/docs/RPI_SMOKE_VALIDATION.md
+++ b/docs/RPI_SMOKE_VALIDATION.md
@@ -84,7 +84,7 @@ What each command checks:
 - `deploy`: deploy contract files, tracked runtime config, runtime path parents, and app entrypoints without launching the app
 - `smoke`: target environment, display initialization on real hardware, matching input adapter construction and start/stop, plus optional PiSugar power and RTC checks
 - `music`: mpv music-backend startup using the composed `config/app|audio|device` topology
-- `voip`: Liblinphone startup and SIP registration using `config/communication/calling.yaml` plus local secrets/env
+- `voip`: quick Liblinphone startup and SIP registration smoke using `config/communication/calling.yaml` plus local secrets/env
 - `navigation`: repeatable one-button routed navigation with explicit idle dwells, click-driven transitions, optional playlist/shuffle playback, and a final sleep/wake pass
 - `stability`: repeated LVGL transition plus sleep/wake recovery on the active app path
 
@@ -122,6 +122,75 @@ yoyoctl pi voip check
 ```
 
 Use this when you want a registration-only pass with detailed logs.
+
+### VoIP reliability drills
+
+These are the deeper real-hardware VoIP checks. They intentionally stay as a few focused commands instead of one giant wrapper, and each run writes a timestamped artifact bundle under `logs/voip-validation/` by default:
+
+- `summary.json` — pass/fail, timings, final status, and the exact thresholds used
+- `timeline.jsonl` — state changes, periodic status samples, and any network drop/restore hook results
+
+Use them after `yoyoctl pi validate voip` passes, not instead of it.
+
+#### Registration stability
+
+```bash
+yoyoctl pi voip registration-stability
+yoyoctl pi voip registration-stability --hold-seconds 120
+```
+
+What it proves:
+
+- SIP registration reached `ok`
+- SIP registration stayed `ok` for the requested hold window instead of flapping immediately after startup
+
+Fail the run if registration never reaches `ok` or if it leaves `ok` during the hold.
+
+#### Reconnect drill
+
+```bash
+yoyoctl pi voip reconnect-drill
+yoyoctl pi voip reconnect-drill --disconnect-seconds 12
+```
+
+If you can automate the outage on the Pi, keep it explicit:
+
+```bash
+yoyoctl pi voip reconnect-drill \
+  --drop-command "nmcli networking off" \
+  --restore-command "nmcli networking on"
+```
+
+What it proves:
+
+- the manager reached `ok` before the outage
+- registration actually left `ok` during the wobble or temporary loss
+- registration returned to `ok` within the recovery timeout
+
+Fail the run if the drill never sees registration leave `ok` or if recovery does not happen. That usually means the outage was too mild to prove reconnect behavior, or the backend failed to recover honestly.
+
+#### Call soak
+
+```bash
+yoyoctl pi voip call-soak --target sip:echo@example.com
+yoyoctl pi voip call-soak --target sip:echo@example.com --soak-seconds 900
+```
+
+Use a target that will actually answer, such as an echo bot or a second endpoint you control.
+
+What it proves:
+
+- registration reached `ok`
+- the outbound call connected
+- the call stayed in a connected media state for the requested soak duration
+
+Fail the run if the call never connects, if registration drops during the soak, or if the call leaves the connected media states before the soak finishes.
+
+#### Reading the artifacts
+
+- A passing reconnect drill should show an initial `registration=ok`, a later non-`ok` registration event during the outage, and then a final return to `registration=ok`.
+- A passing call soak should show the expected connect transition followed by periodic connected samples for the full soak duration.
+- If a run fails, compare `summary.json` across runs first. It makes timing drift, last seen state, and the exact failure point obvious without reading the whole timeline.
 
 When the full app is running, the coordinator-thread timing signals land in
 `logs/yoyopod.log` and through `yoyoctl remote logs --follow`.
@@ -244,6 +313,9 @@ Only use it when:
 - `input` fails: check the matching display adapter initialized correctly first
 - `music` fails: verify `mpv` is installed, the configured socket path is writable, and the provision target under `test_music_target_dir` is writable when deterministic seeding is enabled
 - `voip` fails: verify the Liblinphone shim build, `config/communication/integrations/liblinphone_factory.conf`, SIP credentials, network reachability, and audio device configuration
+- `registration-stability` fails: compare `logs/voip-validation/*/summary.json` across runs and look for whether startup never reached `ok` or whether `ok` flapped during the hold window
+- `reconnect-drill` fails: check whether the run ever recorded a non-`ok` registration state, whether the outage lasted long enough to force a drop, and whether recovery returned before the timeout
+- `call-soak` fails: check whether the target endpoint actually answered, whether registration stayed `ok`, and which non-connected call state ended the soak
 - `navigation` fails: rerun `yoyoctl pi validate navigation --verbose` or `yoyoctl remote navigation-soak --verbose` and inspect which expected screen or playback transition stalled
 - `stability` fails: rerun `yoyoctl pi validate stability --verbose` or `yoyoctl pi lvgl soak` for a deeper LVGL-only pass
 - `validate` fails before launch: check whether the branch was actually pushed and whether the Pi checkout is reachable over SSH

--- a/src/yoyopod/cli/pi/voip.py
+++ b/src/yoyopod/cli/pi/voip.py
@@ -844,6 +844,7 @@ def reconnect_drill(
                 timeout=drop_detect_timeout,
             )
         else:
+            assert first_drop_wait_seconds is not None
             drop_wait_seconds = first_drop_wait_seconds
 
         if not drop_observed:

--- a/src/yoyopod/cli/pi/voip.py
+++ b/src/yoyopod/cli/pi/voip.py
@@ -50,6 +50,11 @@ class _VoIPManagerLike(Protocol):
         callback: Callable[[CallState], None],
     ) -> None: ...
 
+    def on_incoming_call(
+        self,
+        callback: Callable[[str, str], None],
+    ) -> None: ...
+
     def make_call(self, sip_address: str, contact_name: str | None = None) -> bool: ...
 
     def hangup(self) -> bool: ...
@@ -438,6 +443,12 @@ def _run_shell_hook(
     phase: str,
     command: str,
 ) -> bool:
+    """Run an operator-supplied outage hook.
+
+    The reconnect drill treats --drop-command/--restore-command as trusted operator input
+    for a local diagnostic workflow on the device, so shell execution is intentional here.
+    """
+
     completed = subprocess.run(
         command,
         shell=True,

--- a/src/yoyopod/cli/pi/voip.py
+++ b/src/yoyopod/cli/pi/voip.py
@@ -362,6 +362,7 @@ def _wait_for_call_connection(
     deadline = started_at + timeout
     interval = _iterate_interval_seconds(manager)
     terminal_states = {
+        CallState.IDLE.value,
         CallState.RELEASED.value,
         CallState.END.value,
         CallState.ERROR.value,
@@ -843,7 +844,9 @@ def reconnect_drill(
                 timeout=drop_detect_timeout,
             )
         else:
-            drop_wait_seconds = first_drop_wait_seconds or 0.0
+            drop_wait_seconds = (
+                first_drop_wait_seconds if first_drop_wait_seconds is not None else 0.0
+            )
 
         if not drop_observed:
             result = recorder.finalize(

--- a/src/yoyopod/cli/pi/voip.py
+++ b/src/yoyopod/cli/pi/voip.py
@@ -469,13 +469,15 @@ def _print_result(result: _DrillResult) -> None:
 
 
 @voip_app.command()
-def check() -> None:
+def check(
+    config_dir: str = typer.Option(
+        "config",
+        "--config-dir",
+        help="Configuration directory to use.",
+    ),
+) -> None:
     """Run a verbose SIP registration check against the Liblinphone backend."""
     from loguru import logger
-
-    from yoyopod.config import ConfigManager
-    from yoyopod.communication import VoIPConfig, VoIPManager
-    from yoyopod.communication.integrations.liblinphone_binding import LiblinphoneBinding
 
     configure_logging(verbose=True)
 
@@ -483,15 +485,8 @@ def check() -> None:
     logger.info("Liblinphone Registration Test")
     logger.info("=" * 60)
 
-    binding = LiblinphoneBinding.try_load()
-    if binding is None:
-        logger.error(
-            "Liblinphone shim is unavailable. Build it first with yoyoctl build liblinphone."
-        )
-        raise typer.Exit(code=1)
-
-    config_manager = ConfigManager(config_dir="config")
-    voip_config = VoIPConfig.from_config_manager(config_manager)
+    voip_manager = _build_voip_manager(config_dir)
+    voip_config = voip_manager.config
 
     logger.info(f"SIP Server: {voip_config.sip_server}")
     logger.info(f"SIP Username: {voip_config.sip_username}")
@@ -500,7 +495,6 @@ def check() -> None:
     logger.info(f"STUN Server: {voip_config.stun_server}")
     logger.info(f"File transfer server: {voip_config.file_transfer_server_url or 'unset'}")
 
-    voip_manager = VoIPManager(voip_config)
     registration_states: list[RegistrationState] = []
     voip_manager.on_registration_change(lambda state: registration_states.append(state))
 
@@ -529,13 +523,15 @@ def check() -> None:
 
 
 @voip_app.command()
-def debug() -> None:
+def debug(
+    config_dir: str = typer.Option(
+        "config",
+        "--config-dir",
+        help="Configuration directory to use.",
+    ),
+) -> None:
     """Monitor for incoming SIP calls with verbose logging."""
     from loguru import logger
-
-    from yoyopod.config import ConfigManager
-    from yoyopod.communication import VoIPConfig, VoIPManager
-    from yoyopod.communication.integrations.liblinphone_binding import LiblinphoneBinding
 
     configure_logging(verbose=True)
 
@@ -543,16 +539,8 @@ def debug() -> None:
     logger.info("Incoming Call Debug Test")
     logger.info("=" * 60)
 
-    binding = LiblinphoneBinding.try_load()
-    if binding is None:
-        logger.error(
-            "Liblinphone shim is unavailable. Build it first with yoyoctl build liblinphone."
-        )
-        raise typer.Exit(code=1)
-
-    config_manager = ConfigManager(config_dir="config")
-    voip_config = VoIPConfig.from_config_manager(config_manager)
-    voip_manager = VoIPManager(voip_config)
+    voip_manager = _build_voip_manager(config_dir)
+    voip_config = voip_manager.config
     incoming_calls: list[tuple[str, str]] = []
 
     def on_incoming_call(caller_address: str, caller_name: str) -> None:
@@ -806,9 +794,11 @@ def reconnect_drill(
             logger.info(message)
             recorder.note(message)
 
-        outage_deadline = time.monotonic() + disconnect_seconds
+        outage_started_at = time.monotonic()
+        outage_deadline = outage_started_at + disconnect_seconds
         drop_observed = False
         drop_state = RegistrationState.OK.value
+        first_drop_wait_seconds: float | None = None
         while time.monotonic() <= outage_deadline:
             manager.iterate()
             recorder.sample(manager)
@@ -816,6 +806,8 @@ def reconnect_drill(
             if not _status_is_registered(status):
                 drop_observed = True
                 drop_state = str(status.get("registration_state", ""))
+                if first_drop_wait_seconds is None:
+                    first_drop_wait_seconds = max(0.0, time.monotonic() - outage_started_at)
             time.sleep(_iterate_interval_seconds(manager))
 
         if restore_command:
@@ -840,7 +832,7 @@ def reconnect_drill(
                 timeout=drop_detect_timeout,
             )
         else:
-            drop_wait_seconds = disconnect_seconds
+            drop_wait_seconds = first_drop_wait_seconds or 0.0
 
         if not drop_observed:
             result = recorder.finalize(

--- a/src/yoyopod/cli/pi/voip.py
+++ b/src/yoyopod/cli/pi/voip.py
@@ -1,14 +1,472 @@
-"""src/yoyopod/cli/pi/voip.py — VoIP diagnostic commands."""
+"""src/yoyopod/cli/pi/voip.py — VoIP diagnostic and reliability drill commands."""
 
 from __future__ import annotations
 
+import json
+import subprocess
 import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Protocol
 
 import typer
 
-from yoyopod.cli.common import configure_logging
+from yoyopod.cli.common import REPO_ROOT, configure_logging, resolve_config_dir
+from yoyopod.communication.models import CallState, RegistrationState
 
-voip_app = typer.Typer(name="voip", help="VoIP diagnostic commands.", no_args_is_help=True)
+voip_app = typer.Typer(
+    name="voip",
+    help="VoIP diagnostic and reliability drill commands.",
+    no_args_is_help=True,
+)
+
+_CONNECTED_CALL_STATES = {CallState.CONNECTED.value, CallState.STREAMS_RUNNING.value}
+
+
+class _VoIPManagerLike(Protocol):
+    """Minimal manager surface needed by the drill helpers."""
+
+    config: Any
+    running: bool
+
+    def start(self) -> bool: ...
+
+    def stop(self) -> None: ...
+
+    def iterate(self) -> int: ...
+
+    def get_status(self) -> dict[str, Any]: ...
+
+    def get_iterate_metrics(self) -> object | None: ...
+
+    def on_registration_change(
+        self,
+        callback: Callable[[RegistrationState], None],
+    ) -> None: ...
+
+    def on_call_state_change(
+        self,
+        callback: Callable[[CallState], None],
+    ) -> None: ...
+
+    def make_call(self, sip_address: str, contact_name: str | None = None) -> bool: ...
+
+    def hangup(self) -> bool: ...
+
+    def get_call_duration(self) -> int: ...
+
+
+@dataclass(slots=True)
+class _DrillResult:
+    """One drill outcome and the evidence written to disk."""
+
+    drill: str
+    passed: bool
+    reason: str
+    artifact_dir: Path
+    summary_path: Path
+    timeline_path: Path
+    extras: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def status(self) -> str:
+        return "pass" if self.passed else "fail"
+
+
+class _VoIPDrillRecorder:
+    """Collect state changes and periodic samples into one timestamped artifact bundle."""
+
+    def __init__(
+        self,
+        *,
+        drill: str,
+        config: Any,
+        artifacts_dir: str,
+        metadata: dict[str, object] | None = None,
+        sample_interval_seconds: float = 1.0,
+    ) -> None:
+        self.drill = drill
+        self.config = config
+        self.metadata = metadata or {}
+        self.started_at_monotonic = time.monotonic()
+        self.started_at_unix = time.time()
+        self.started_at_iso = self._iso_time(self.started_at_unix)
+        self.sample_interval_seconds = max(0.2, sample_interval_seconds)
+        self._next_sample_at = self.started_at_monotonic
+        artifact_root = self._resolve_artifacts_dir(artifacts_dir)
+        run_label = datetime.fromtimestamp(
+            self.started_at_unix,
+            timezone.utc,
+        ).strftime("%Y%m%dT%H%M%SZ")
+        self.artifact_dir = artifact_root / f"{drill}-{run_label}"
+        self.timeline_path = self.artifact_dir / "timeline.jsonl"
+        self.summary_path = self.artifact_dir / "summary.json"
+        self.events: list[dict[str, object]] = []
+        self.registration_states: list[str] = []
+        self.call_states: list[str] = []
+
+    @staticmethod
+    def _resolve_artifacts_dir(artifacts_dir: str) -> Path:
+        candidate = Path(artifacts_dir)
+        if not candidate.is_absolute():
+            candidate = REPO_ROOT / candidate
+        return candidate
+
+    @staticmethod
+    def _iso_time(timestamp: float) -> str:
+        return datetime.fromtimestamp(timestamp, timezone.utc).isoformat(timespec="seconds")
+
+    def attach(self, manager: _VoIPManagerLike) -> None:
+        manager.on_registration_change(self._on_registration_change)
+        manager.on_call_state_change(self._on_call_state_change)
+
+    def _emit(self, kind: str, **payload: object) -> None:
+        event = {
+            "timestamp": self._iso_time(time.time()),
+            "elapsed_seconds": round(max(0.0, time.monotonic() - self.started_at_monotonic), 3),
+            "kind": kind,
+            **payload,
+        }
+        self.events.append(event)
+
+    def note(self, message: str) -> None:
+        self._emit("note", message=message)
+
+    def checkpoint(self, name: str, **payload: object) -> None:
+        self._emit("checkpoint", name=name, **payload)
+
+    def record_command(
+        self,
+        *,
+        phase: str,
+        command: str,
+        returncode: int,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> None:
+        self._emit(
+            "command",
+            phase=phase,
+            command=command,
+            returncode=returncode,
+            stdout=stdout.strip(),
+            stderr=stderr.strip(),
+        )
+
+    def sample(self, manager: _VoIPManagerLike, *, force: bool = False) -> None:
+        now = time.monotonic()
+        if not force and now < self._next_sample_at:
+            return
+        self._emit("sample", status=self._status_snapshot(manager))
+        self._next_sample_at = now + self.sample_interval_seconds
+
+    def finalize(
+        self,
+        *,
+        passed: bool,
+        reason: str,
+        manager: _VoIPManagerLike,
+        extras: dict[str, object] | None = None,
+    ) -> _DrillResult:
+        self.artifact_dir.mkdir(parents=True, exist_ok=True)
+        with self.timeline_path.open("w", encoding="utf-8") as handle:
+            for event in self.events:
+                handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+        finished_at_unix = time.time()
+        resolved_extras: dict[str, object] = extras or {}
+        summary = {
+            "drill": self.drill,
+            "status": "pass" if passed else "fail",
+            "reason": reason,
+            "started_at": self.started_at_iso,
+            "finished_at": self._iso_time(finished_at_unix),
+            "duration_seconds": round(
+                max(0.0, time.monotonic() - self.started_at_monotonic),
+                3,
+            ),
+            "artifact_dir": str(self.artifact_dir),
+            "timeline_path": str(self.timeline_path),
+            "final_status": self._status_snapshot(manager),
+            "registration_states": self.registration_states,
+            "call_states": self.call_states,
+            "config": {
+                "sip_server": getattr(self.config, "sip_server", ""),
+                "sip_identity": getattr(self.config, "sip_identity", ""),
+                "iterate_interval_ms": getattr(self.config, "iterate_interval_ms", 0),
+            },
+            "metadata": self.metadata,
+            "extras": resolved_extras,
+        }
+        with self.summary_path.open("w", encoding="utf-8") as handle:
+            json.dump(summary, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+
+        return _DrillResult(
+            drill=self.drill,
+            passed=passed,
+            reason=reason,
+            artifact_dir=self.artifact_dir,
+            summary_path=self.summary_path,
+            timeline_path=self.timeline_path,
+            extras=resolved_extras,
+        )
+
+    def _status_snapshot(self, manager: _VoIPManagerLike) -> dict[str, object]:
+        status = dict(manager.get_status())
+        snapshot: dict[str, object] = {
+            "running": bool(status.get("running", False)),
+            "registered": bool(status.get("registered", False)),
+            "registration_state": str(status.get("registration_state", "")),
+            "call_state": str(status.get("call_state", "")),
+        }
+        get_call_duration = getattr(manager, "get_call_duration", None)
+        if callable(get_call_duration):
+            snapshot["call_duration_seconds"] = int(get_call_duration())
+        metrics = manager.get_iterate_metrics()
+        if metrics is not None:
+            snapshot["iterate_metrics"] = {
+                "native_ms": round(
+                    float(getattr(metrics, "native_duration_seconds", 0.0)) * 1000.0,
+                    1,
+                ),
+                "event_drain_ms": round(
+                    float(getattr(metrics, "event_drain_duration_seconds", 0.0)) * 1000.0,
+                    1,
+                ),
+                "total_ms": round(
+                    float(getattr(metrics, "total_duration_seconds", 0.0)) * 1000.0,
+                    1,
+                ),
+                "drained_events": int(getattr(metrics, "drained_events", 0)),
+            }
+        return snapshot
+
+    def _on_registration_change(self, state: RegistrationState) -> None:
+        self.registration_states.append(state.value)
+        self._emit("registration", state=state.value)
+
+    def _on_call_state_change(self, state: CallState) -> None:
+        self.call_states.append(state.value)
+        self._emit("call_state", state=state.value)
+
+
+def _build_voip_manager(config_dir: str) -> _VoIPManagerLike:
+    from loguru import logger
+
+    from yoyopod.communication import VoIPConfig, VoIPManager
+    from yoyopod.communication.integrations.liblinphone_binding import LiblinphoneBinding
+    from yoyopod.config import ConfigManager
+
+    binding = LiblinphoneBinding.try_load()
+    if binding is None:
+        logger.error(
+            "Liblinphone shim is unavailable. Build it first with yoyoctl build liblinphone."
+        )
+        raise typer.Exit(code=1)
+
+    config_path = resolve_config_dir(config_dir)
+    config_manager = ConfigManager(config_dir=str(config_path))
+    voip_config = VoIPConfig.from_config_manager(config_manager)
+    return VoIPManager(voip_config)
+
+
+def _iterate_interval_seconds(manager: _VoIPManagerLike) -> float:
+    return max(0.01, float(getattr(manager.config, "iterate_interval_ms", 20)) / 1000.0)
+
+
+def _status_is_registered(status: dict[str, object]) -> bool:
+    return bool(status.get("registered")) and (
+        str(status.get("registration_state")) == RegistrationState.OK.value
+    )
+
+
+def _wait_for_registration_ok(
+    manager: _VoIPManagerLike,
+    recorder: _VoIPDrillRecorder,
+    *,
+    timeout: float,
+) -> tuple[bool, float]:
+    started_at = time.monotonic()
+    deadline = started_at + timeout
+    interval = _iterate_interval_seconds(manager)
+    while time.monotonic() <= deadline:
+        manager.iterate()
+        recorder.sample(manager)
+        if _status_is_registered(manager.get_status()):
+            return True, max(0.0, time.monotonic() - started_at)
+        time.sleep(interval)
+    recorder.sample(manager, force=True)
+    return False, max(0.0, time.monotonic() - started_at)
+
+
+def _wait_for_registration_drop(
+    manager: _VoIPManagerLike,
+    recorder: _VoIPDrillRecorder,
+    *,
+    timeout: float,
+) -> tuple[bool, str, float]:
+    started_at = time.monotonic()
+    deadline = started_at + timeout
+    interval = _iterate_interval_seconds(manager)
+    while time.monotonic() <= deadline:
+        manager.iterate()
+        recorder.sample(manager)
+        status = manager.get_status()
+        if not _status_is_registered(status):
+            return (
+                True,
+                str(status.get("registration_state", "")),
+                max(0.0, time.monotonic() - started_at),
+            )
+        time.sleep(interval)
+    recorder.sample(manager, force=True)
+    return (
+        False,
+        str(manager.get_status().get("registration_state", "")),
+        max(0.0, time.monotonic() - started_at),
+    )
+
+
+def _hold_registration_ok(
+    manager: _VoIPManagerLike,
+    recorder: _VoIPDrillRecorder,
+    *,
+    hold_seconds: float,
+) -> tuple[bool, str]:
+    deadline = time.monotonic() + hold_seconds
+    interval = _iterate_interval_seconds(manager)
+    while time.monotonic() <= deadline:
+        manager.iterate()
+        recorder.sample(manager)
+        status = manager.get_status()
+        if not _status_is_registered(status):
+            return False, str(status.get("registration_state", ""))
+        time.sleep(interval)
+    recorder.sample(manager, force=True)
+    return True, RegistrationState.OK.value
+
+
+def _wait_for_call_connection(
+    manager: _VoIPManagerLike,
+    recorder: _VoIPDrillRecorder,
+    *,
+    timeout: float,
+) -> tuple[bool, str, float]:
+    started_at = time.monotonic()
+    deadline = started_at + timeout
+    interval = _iterate_interval_seconds(manager)
+    terminal_states = {
+        CallState.RELEASED.value,
+        CallState.END.value,
+        CallState.ERROR.value,
+    }
+    while time.monotonic() <= deadline:
+        manager.iterate()
+        recorder.sample(manager)
+        status = manager.get_status()
+        call_state = str(status.get("call_state", ""))
+        if call_state in _CONNECTED_CALL_STATES:
+            return True, call_state, max(0.0, time.monotonic() - started_at)
+        if call_state in terminal_states:
+            return False, call_state, max(0.0, time.monotonic() - started_at)
+        time.sleep(interval)
+    recorder.sample(manager, force=True)
+    return (
+        False,
+        str(manager.get_status().get("call_state", "")),
+        max(0.0, time.monotonic() - started_at),
+    )
+
+
+def _hold_call_connected(
+    manager: _VoIPManagerLike,
+    recorder: _VoIPDrillRecorder,
+    *,
+    soak_seconds: float,
+) -> tuple[bool, str]:
+    deadline = time.monotonic() + soak_seconds
+    interval = _iterate_interval_seconds(manager)
+    while time.monotonic() <= deadline:
+        manager.iterate()
+        recorder.sample(manager)
+        status = manager.get_status()
+        if not _status_is_registered(status):
+            return False, f"registration={status.get('registration_state', '')}"
+        call_state = str(status.get("call_state", ""))
+        if call_state not in _CONNECTED_CALL_STATES:
+            return False, f"call_state={call_state}"
+        time.sleep(interval)
+    recorder.sample(manager, force=True)
+    return True, ""
+
+
+def _wait_for_call_end(
+    manager: _VoIPManagerLike,
+    recorder: _VoIPDrillRecorder,
+    *,
+    timeout: float,
+) -> tuple[bool, str, float]:
+    started_at = time.monotonic()
+    deadline = started_at + timeout
+    interval = _iterate_interval_seconds(manager)
+    terminal_states = {
+        CallState.IDLE.value,
+        CallState.RELEASED.value,
+        CallState.END.value,
+        CallState.ERROR.value,
+    }
+    while time.monotonic() <= deadline:
+        manager.iterate()
+        recorder.sample(manager)
+        status = manager.get_status()
+        call_state = str(status.get("call_state", ""))
+        if call_state in terminal_states:
+            return True, call_state, max(0.0, time.monotonic() - started_at)
+        time.sleep(interval)
+    recorder.sample(manager, force=True)
+    return (
+        False,
+        str(manager.get_status().get("call_state", "")),
+        max(0.0, time.monotonic() - started_at),
+    )
+
+
+def _run_shell_hook(
+    *,
+    recorder: _VoIPDrillRecorder,
+    phase: str,
+    command: str,
+) -> bool:
+    completed = subprocess.run(
+        command,
+        shell=True,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    recorder.record_command(
+        phase=phase,
+        command=command,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+    return completed.returncode == 0
+
+
+def _print_result(result: _DrillResult) -> None:
+    print("")
+    print(f"VoIP drill result: {result.drill}")
+    print("=" * 48)
+    print(f"status={result.status}")
+    print(f"reason={result.reason}")
+    for key, value in sorted(result.extras.items()):
+        print(f"{key}={value}")
+    print(f"artifact_dir={result.artifact_dir}")
+    print(f"summary={result.summary_path}")
+    print(f"timeline={result.timeline_path}")
 
 
 @voip_app.command()
@@ -17,7 +475,7 @@ def check() -> None:
     from loguru import logger
 
     from yoyopod.config import ConfigManager
-    from yoyopod.communication import RegistrationState, VoIPConfig, VoIPManager
+    from yoyopod.communication import VoIPConfig, VoIPManager
     from yoyopod.communication.integrations.liblinphone_binding import LiblinphoneBinding
 
     configure_logging(verbose=True)
@@ -28,7 +486,9 @@ def check() -> None:
 
     binding = LiblinphoneBinding.try_load()
     if binding is None:
-        logger.error("Liblinphone shim is unavailable. Build it first with yoyoctl build liblinphone.")
+        logger.error(
+            "Liblinphone shim is unavailable. Build it first with yoyoctl build liblinphone."
+        )
         raise typer.Exit(code=1)
 
     config_manager = ConfigManager(config_dir="config")
@@ -86,7 +546,9 @@ def debug() -> None:
 
     binding = LiblinphoneBinding.try_load()
     if binding is None:
-        logger.error("Liblinphone shim is unavailable. Build it first with yoyoctl build liblinphone.")
+        logger.error(
+            "Liblinphone shim is unavailable. Build it first with yoyoctl build liblinphone."
+        )
         raise typer.Exit(code=1)
 
     config_manager = ConfigManager(config_dir="config")
@@ -122,3 +584,479 @@ def debug() -> None:
         logger.info(f"Total incoming calls detected: {len(incoming_calls)}")
         for address, name in incoming_calls:
             logger.info(f"  - {name} ({address})")
+
+
+@voip_app.command(name="registration-stability")
+def registration_stability(
+    config_dir: str = typer.Option(
+        "config",
+        "--config-dir",
+        help="Configuration directory to use.",
+    ),
+    registration_timeout: float = typer.Option(
+        30.0,
+        "--registration-timeout",
+        help="How long to wait for SIP registration to reach OK.",
+    ),
+    hold_seconds: float = typer.Option(
+        60.0,
+        "--hold-seconds",
+        help="How long SIP registration must remain OK after startup.",
+    ),
+    artifacts_dir: str = typer.Option(
+        "logs/voip-validation",
+        "--artifacts-dir",
+        help="Directory where timestamped drill artifacts should be written.",
+    ),
+    sample_interval: float = typer.Option(
+        1.0,
+        "--sample-interval",
+        help="How often to capture periodic status samples into the timeline.",
+    ),
+    verbose: bool = typer.Option(False, "--verbose", help="Enable DEBUG logging."),
+) -> None:
+    """Hold SIP registration open long enough to catch immediate flapping on hardware."""
+
+    from loguru import logger
+
+    configure_logging(verbose)
+    manager = _build_voip_manager(config_dir)
+    recorder = _VoIPDrillRecorder(
+        drill="registration-stability",
+        config=manager.config,
+        artifacts_dir=artifacts_dir,
+        metadata={
+            "registration_timeout": registration_timeout,
+            "hold_seconds": hold_seconds,
+        },
+        sample_interval_seconds=sample_interval,
+    )
+    recorder.attach(manager)
+
+    try:
+        if not manager.start():
+            result = recorder.finalize(
+                passed=False,
+                reason="VoIP manager failed to start",
+                manager=manager,
+            )
+            _print_result(result)
+            raise typer.Exit(code=1)
+
+        logger.info("Waiting for SIP registration to stabilize")
+        registered, registration_seconds = _wait_for_registration_ok(
+            manager,
+            recorder,
+            timeout=registration_timeout,
+        )
+        if not registered:
+            result = recorder.finalize(
+                passed=False,
+                reason="Registration never reached OK",
+                manager=manager,
+                extras={"registration_wait_seconds": round(registration_seconds, 3)},
+            )
+            _print_result(result)
+            raise typer.Exit(code=1)
+
+        recorder.checkpoint(
+            "registration_ok",
+            registration_wait_seconds=round(registration_seconds, 3),
+        )
+        stable, failed_state = _hold_registration_ok(
+            manager,
+            recorder,
+            hold_seconds=hold_seconds,
+        )
+        result = recorder.finalize(
+            passed=stable,
+            reason=(
+                f"Registration stayed OK for {hold_seconds:.1f}s"
+                if stable
+                else f"Registration left OK during stability hold: {failed_state}"
+            ),
+            manager=manager,
+            extras={
+                "registration_wait_seconds": round(registration_seconds, 3),
+                "hold_seconds": hold_seconds,
+                "failed_state": failed_state,
+            },
+        )
+        _print_result(result)
+        if not stable:
+            raise typer.Exit(code=1)
+    finally:
+        manager.stop()
+
+
+@voip_app.command(name="reconnect-drill")
+def reconnect_drill(
+    config_dir: str = typer.Option(
+        "config",
+        "--config-dir",
+        help="Configuration directory to use.",
+    ),
+    registration_timeout: float = typer.Option(
+        30.0,
+        "--registration-timeout",
+        help="How long to wait for the initial SIP registration to reach OK.",
+    ),
+    disconnect_seconds: float = typer.Option(
+        8.0,
+        "--disconnect-seconds",
+        help="How long the temporary network outage should last.",
+    ),
+    drop_detect_timeout: float = typer.Option(
+        20.0,
+        "--drop-detect-timeout",
+        help="How long to wait for registration to leave OK after the outage starts.",
+    ),
+    recovery_timeout: float = typer.Option(
+        45.0,
+        "--recovery-timeout",
+        help="How long to wait for SIP registration to recover after the outage.",
+    ),
+    drop_command: str = typer.Option(
+        "",
+        "--drop-command",
+        help="Optional shell command that intentionally drops network connectivity on the Pi.",
+    ),
+    restore_command: str = typer.Option(
+        "",
+        "--restore-command",
+        help="Optional shell command that restores network connectivity on the Pi.",
+    ),
+    artifacts_dir: str = typer.Option(
+        "logs/voip-validation",
+        "--artifacts-dir",
+        help="Directory where timestamped drill artifacts should be written.",
+    ),
+    sample_interval: float = typer.Option(
+        1.0,
+        "--sample-interval",
+        help="How often to capture periodic status samples into the timeline.",
+    ),
+    verbose: bool = typer.Option(False, "--verbose", help="Enable DEBUG logging."),
+) -> None:
+    """Verify that SIP registration drops and then recovers after a short network wobble."""
+
+    from loguru import logger
+
+    configure_logging(verbose)
+    manager = _build_voip_manager(config_dir)
+    recorder = _VoIPDrillRecorder(
+        drill="reconnect-drill",
+        config=manager.config,
+        artifacts_dir=artifacts_dir,
+        metadata={
+            "registration_timeout": registration_timeout,
+            "disconnect_seconds": disconnect_seconds,
+            "drop_detect_timeout": drop_detect_timeout,
+            "recovery_timeout": recovery_timeout,
+            "drop_command": drop_command,
+            "restore_command": restore_command,
+        },
+        sample_interval_seconds=sample_interval,
+    )
+    recorder.attach(manager)
+
+    try:
+        if not manager.start():
+            result = recorder.finalize(
+                passed=False,
+                reason="VoIP manager failed to start",
+                manager=manager,
+            )
+            _print_result(result)
+            raise typer.Exit(code=1)
+
+        registered, registration_seconds = _wait_for_registration_ok(
+            manager,
+            recorder,
+            timeout=registration_timeout,
+        )
+        if not registered:
+            result = recorder.finalize(
+                passed=False,
+                reason="Initial registration never reached OK",
+                manager=manager,
+                extras={"registration_wait_seconds": round(registration_seconds, 3)},
+            )
+            _print_result(result)
+            raise typer.Exit(code=1)
+
+        recorder.checkpoint(
+            "initial_registration_ok",
+            registration_wait_seconds=round(registration_seconds, 3),
+        )
+        if drop_command:
+            logger.info("Running network drop hook")
+            if not _run_shell_hook(recorder=recorder, phase="drop", command=drop_command):
+                result = recorder.finalize(
+                    passed=False,
+                    reason="The configured network drop command failed",
+                    manager=manager,
+                )
+                _print_result(result)
+                raise typer.Exit(code=1)
+        else:
+            message = (
+                f"Drop network connectivity now for about {disconnect_seconds:.1f}s, "
+                "then restore it. The drill is recording registration loss and recovery."
+            )
+            logger.info(message)
+            recorder.note(message)
+
+        outage_deadline = time.monotonic() + disconnect_seconds
+        drop_observed = False
+        drop_state = RegistrationState.OK.value
+        while time.monotonic() <= outage_deadline:
+            manager.iterate()
+            recorder.sample(manager)
+            status = manager.get_status()
+            if not _status_is_registered(status):
+                drop_observed = True
+                drop_state = str(status.get("registration_state", ""))
+            time.sleep(_iterate_interval_seconds(manager))
+
+        if restore_command:
+            logger.info("Running network restore hook")
+            if not _run_shell_hook(recorder=recorder, phase="restore", command=restore_command):
+                result = recorder.finalize(
+                    passed=False,
+                    reason="The configured network restore command failed",
+                    manager=manager,
+                    extras={"drop_observed": drop_observed, "drop_state": drop_state},
+                )
+                _print_result(result)
+                raise typer.Exit(code=1)
+        elif drop_command:
+            logger.info("Restore network connectivity now so SIP registration can recover")
+            recorder.note("Restore network connectivity now so SIP registration can recover.")
+
+        if not drop_observed:
+            drop_observed, drop_state, drop_wait_seconds = _wait_for_registration_drop(
+                manager,
+                recorder,
+                timeout=drop_detect_timeout,
+            )
+        else:
+            drop_wait_seconds = disconnect_seconds
+
+        if not drop_observed:
+            result = recorder.finalize(
+                passed=False,
+                reason="Registration never left OK during the reconnect drill",
+                manager=manager,
+                extras={
+                    "registration_wait_seconds": round(registration_seconds, 3),
+                    "drop_wait_seconds": round(drop_wait_seconds, 3),
+                    "drop_state": drop_state,
+                },
+            )
+            _print_result(result)
+            raise typer.Exit(code=1)
+
+        recorder.checkpoint(
+            "registration_dropped",
+            drop_wait_seconds=round(drop_wait_seconds, 3),
+            drop_state=drop_state,
+        )
+        recovered, recovery_seconds = _wait_for_registration_ok(
+            manager,
+            recorder,
+            timeout=recovery_timeout,
+        )
+        result = recorder.finalize(
+            passed=recovered,
+            reason=(
+                "Registration recovered after the temporary outage"
+                if recovered
+                else "Registration did not recover after the temporary outage"
+            ),
+            manager=manager,
+            extras={
+                "registration_wait_seconds": round(registration_seconds, 3),
+                "drop_wait_seconds": round(drop_wait_seconds, 3),
+                "drop_state": drop_state,
+                "recovery_wait_seconds": round(recovery_seconds, 3),
+            },
+        )
+        _print_result(result)
+        if not recovered:
+            raise typer.Exit(code=1)
+    finally:
+        manager.stop()
+
+
+@voip_app.command(name="call-soak")
+def call_soak(
+    target: str = typer.Option(
+        ...,
+        "--target",
+        help="SIP address to call for the soak drill, for example sip:echo@example.com.",
+    ),
+    contact_name: str = typer.Option(
+        "",
+        "--contact-name",
+        help="Optional contact label used for log output while making the call.",
+    ),
+    config_dir: str = typer.Option(
+        "config",
+        "--config-dir",
+        help="Configuration directory to use.",
+    ),
+    registration_timeout: float = typer.Option(
+        30.0,
+        "--registration-timeout",
+        help="How long to wait for SIP registration to reach OK before calling.",
+    ),
+    connect_timeout: float = typer.Option(
+        60.0,
+        "--connect-timeout",
+        help="How long to wait for the target call to reach a connected media state.",
+    ),
+    soak_seconds: float = typer.Option(
+        300.0,
+        "--soak-seconds",
+        help="How long the call must remain connected once media is up.",
+    ),
+    hangup_timeout: float = typer.Option(
+        15.0,
+        "--hangup-timeout",
+        help="How long to wait for the call to tear down cleanly after the soak.",
+    ),
+    artifacts_dir: str = typer.Option(
+        "logs/voip-validation",
+        "--artifacts-dir",
+        help="Directory where timestamped drill artifacts should be written.",
+    ),
+    sample_interval: float = typer.Option(
+        1.0,
+        "--sample-interval",
+        help="How often to capture periodic status samples into the timeline.",
+    ),
+    verbose: bool = typer.Option(False, "--verbose", help="Enable DEBUG logging."),
+) -> None:
+    """Place one real call, wait for connection, and hold it long enough to catch drift."""
+
+    from loguru import logger
+
+    configure_logging(verbose)
+    manager = _build_voip_manager(config_dir)
+    recorder = _VoIPDrillRecorder(
+        drill="call-soak",
+        config=manager.config,
+        artifacts_dir=artifacts_dir,
+        metadata={
+            "target": target,
+            "contact_name": contact_name,
+            "registration_timeout": registration_timeout,
+            "connect_timeout": connect_timeout,
+            "soak_seconds": soak_seconds,
+            "hangup_timeout": hangup_timeout,
+        },
+        sample_interval_seconds=sample_interval,
+    )
+    recorder.attach(manager)
+
+    try:
+        if not manager.start():
+            result = recorder.finalize(
+                passed=False,
+                reason="VoIP manager failed to start",
+                manager=manager,
+            )
+            _print_result(result)
+            raise typer.Exit(code=1)
+
+        registered, registration_seconds = _wait_for_registration_ok(
+            manager,
+            recorder,
+            timeout=registration_timeout,
+        )
+        if not registered:
+            result = recorder.finalize(
+                passed=False,
+                reason="Registration never reached OK before the call soak",
+                manager=manager,
+                extras={"registration_wait_seconds": round(registration_seconds, 3)},
+            )
+            _print_result(result)
+            raise typer.Exit(code=1)
+
+        if not manager.make_call(target, contact_name or None):
+            result = recorder.finalize(
+                passed=False,
+                reason=f"Failed to initiate call to {target}",
+                manager=manager,
+                extras={"registration_wait_seconds": round(registration_seconds, 3)},
+            )
+            _print_result(result)
+            raise typer.Exit(code=1)
+
+        logger.info("Waiting for the call to connect: {}", target)
+        connected, connected_state, connect_seconds = _wait_for_call_connection(
+            manager,
+            recorder,
+            timeout=connect_timeout,
+        )
+        if not connected:
+            result = recorder.finalize(
+                passed=False,
+                reason=f"Call never reached a connected state (last_state={connected_state})",
+                manager=manager,
+                extras={
+                    "target": target,
+                    "registration_wait_seconds": round(registration_seconds, 3),
+                    "connect_wait_seconds": round(connect_seconds, 3),
+                    "last_call_state": connected_state,
+                },
+            )
+            _print_result(result)
+            raise typer.Exit(code=1)
+
+        recorder.checkpoint(
+            "call_connected",
+            target=target,
+            connect_wait_seconds=round(connect_seconds, 3),
+            connected_state=connected_state,
+        )
+        soaked, soak_failure = _hold_call_connected(
+            manager,
+            recorder,
+            soak_seconds=soak_seconds,
+        )
+        cleanup_reason = "cleanup_skipped"
+        if manager.hangup():
+            hangup_ok, hangup_state, hangup_seconds = _wait_for_call_end(
+                manager,
+                recorder,
+                timeout=hangup_timeout,
+            )
+            cleanup_reason = (
+                f"hangup_wait_seconds={round(hangup_seconds, 3)} last_state={hangup_state}"
+                if not hangup_ok
+                else "hangup_clean"
+            )
+        result = recorder.finalize(
+            passed=soaked,
+            reason=(
+                f"Call stayed connected for {soak_seconds:.1f}s"
+                if soaked
+                else f"Call soak failed: {soak_failure}"
+            ),
+            manager=manager,
+            extras={
+                "target": target,
+                "registration_wait_seconds": round(registration_seconds, 3),
+                "connect_wait_seconds": round(connect_seconds, 3),
+                "soak_seconds": soak_seconds,
+                "cleanup": cleanup_reason,
+            },
+        )
+        _print_result(result)
+        if not soaked:
+            raise typer.Exit(code=1)
+    finally:
+        manager.stop()

--- a/src/yoyopod/cli/pi/voip.py
+++ b/src/yoyopod/cli/pi/voip.py
@@ -844,9 +844,7 @@ def reconnect_drill(
                 timeout=drop_detect_timeout,
             )
         else:
-            drop_wait_seconds = (
-                first_drop_wait_seconds if first_drop_wait_seconds is not None else 0.0
-            )
+            drop_wait_seconds = first_drop_wait_seconds
 
         if not drop_observed:
             result = recorder.finalize(

--- a/src/yoyopod/cli/pi/voip.py
+++ b/src/yoyopod/cli/pi/voip.py
@@ -259,8 +259,7 @@ def _build_voip_manager(config_dir: str) -> _VoIPManagerLike:
     from yoyopod.communication.integrations.liblinphone_binding import LiblinphoneBinding
     from yoyopod.config import ConfigManager
 
-    binding = LiblinphoneBinding.try_load()
-    if binding is None:
+    if LiblinphoneBinding.try_load() is None:
         logger.error(
             "Liblinphone shim is unavailable. Build it first with yoyoctl build liblinphone."
         )
@@ -393,7 +392,7 @@ def _hold_call_connected(
         recorder.sample(manager)
         status = manager.get_status()
         if not _status_is_registered(status):
-            return False, f"registration={status.get('registration_state', '')}"
+            return False, f"registration_state={status.get('registration_state', '')}"
         call_state = str(status.get("call_state", ""))
         if call_state not in _CONNECTED_CALL_STATES:
             return False, f"call_state={call_state}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,11 +103,13 @@ def test_build_liblinphone_help():
 def test_pi_voip_check_help():
     result = runner.invoke(app, ["pi", "voip", "check", "--help"])
     assert result.exit_code == 0
+    assert "--config-dir" in _plain(result.output)
 
 
 def test_pi_voip_debug_help():
     result = runner.invoke(app, ["pi", "voip", "debug", "--help"])
     assert result.exit_code == 0
+    assert "--config-dir" in _plain(result.output)
 
 
 def test_pi_voip_registration_stability_help():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,6 +110,35 @@ def test_pi_voip_debug_help():
     assert result.exit_code == 0
 
 
+def test_pi_voip_registration_stability_help():
+    result = runner.invoke(app, ["pi", "voip", "registration-stability", "--help"])
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "--registration-timeout" in output
+    assert "--hold-seconds" in output
+    assert "--artifacts-dir" in output
+
+
+def test_pi_voip_reconnect_drill_help():
+    result = runner.invoke(app, ["pi", "voip", "reconnect-drill", "--help"])
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "--disconnect-seconds" in output
+    assert "--drop-command" in output
+    assert "--restore-command" in output
+    assert "--artifacts-dir" in output
+
+
+def test_pi_voip_call_soak_help():
+    result = runner.invoke(app, ["pi", "voip", "call-soak", "--help"])
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "--target" in output
+    assert "--connect-timeout" in output
+    assert "--soak-seconds" in output
+    assert "--artifacts-dir" in output
+
+
 def test_pi_power_battery_help():
     result = runner.invoke(app, ["pi", "power", "battery", "--help"])
     assert result.exit_code == 0
@@ -154,18 +183,6 @@ def test_pi_smoke_help():
     assert "--with-power" in _plain(result.output)
     assert "--with-lvgl-soak" in _plain(result.output)
     assert "--test-music-dir" in _plain(result.output)
-
-
-def test_pi_music_help():
-    result = runner.invoke(app, ["pi", "music", "--help"])
-    assert result.exit_code == 0
-    assert "provision-test-library" in _plain(result.output)
-
-
-def test_pi_music_provision_test_library_help():
-    result = runner.invoke(app, ["pi", "music", "provision-test-library", "--help"])
-    assert result.exit_code == 0
-    assert "--target-dir" in _plain(result.output)
 
 
 def test_pi_validate_help():

--- a/tests/test_voip_cli.py
+++ b/tests/test_voip_cli.py
@@ -152,9 +152,21 @@ def _patch_clock(monkeypatch: pytest.MonkeyPatch, clock: FakeClock) -> None:
     monkeypatch.setattr(voip_cli.time, "sleep", clock.sleep)
 
 
+def _run_dir(artifacts_dir: Path) -> Path:
+    return next(artifacts_dir.iterdir())
+
+
 def _load_summary(artifacts_dir: Path) -> dict[str, object]:
-    run_dir = next(artifacts_dir.iterdir())
+    run_dir = _run_dir(artifacts_dir)
     return json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+
+
+def _load_timeline(artifacts_dir: Path) -> list[dict[str, object]]:
+    run_dir = _run_dir(artifacts_dir)
+    return [
+        json.loads(line)
+        for line in (run_dir / "timeline.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
 
 
 def test_registration_stability_writes_pass_artifacts(
@@ -398,6 +410,126 @@ def test_reconnect_drill_recovers_after_temporary_drop(
     assert summary["extras"]["drop_wait_seconds"] == pytest.approx(0.1)
     assert summary["registration_states"] == ["ok", "failed", "ok"]
 
+    timeline = _load_timeline(tmp_path)
+    assert any(event["kind"] == "command" and event["phase"] == "drop" for event in timeline)
+    assert any(event["kind"] == "command" and event["phase"] == "restore" for event in timeline)
+    assert any(
+        event["kind"] == "checkpoint" and event.get("name") == "registration_dropped"
+        for event in timeline
+    )
+    assert any(event["kind"] == "registration" and event.get("state") == "failed" for event in timeline)
+
+
+def test_reconnect_drill_without_hooks_exercises_manual_operator_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The reconnect drill should still pass when an operator drops/restores connectivity manually."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.1, RegistrationState.OK)
+    manager.schedule_registration(0.3, RegistrationState.FAILED)
+    manager.schedule_registration(0.6, RegistrationState.OK)
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "reconnect-drill",
+            "--registration-timeout",
+            "1",
+            "--disconnect-seconds",
+            "0.4",
+            "--drop-detect-timeout",
+            "0.5",
+            "--recovery-timeout",
+            "1",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "pass"
+    assert summary["extras"]["drop_state"] == "failed"
+    timeline = _load_timeline(tmp_path)
+    notes = [event["message"] for event in timeline if event["kind"] == "note"]
+    assert any("Drop network connectivity now" in message for message in notes)
+
+
+@pytest.mark.parametrize(
+    ("phase", "option"),
+    [
+        ("drop", "--drop-command"),
+        ("restore", "--restore-command"),
+    ],
+)
+def test_reconnect_drill_fails_when_hook_command_returns_non_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    phase: str,
+    option: str,
+) -> None:
+    """The reconnect drill should fail honestly when an outage hook exits non-zero."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.1, RegistrationState.OK)
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+    phase_under_test = phase
+
+    def fake_hook(*, recorder, phase: str, command: str) -> bool:
+        returncode = 23 if phase == phase_under_test else 0
+        recorder.record_command(
+            phase=phase,
+            command=command,
+            returncode=returncode,
+            stdout="",
+            stderr="boom" if returncode else "",
+        )
+        return returncode == 0
+
+    monkeypatch.setattr(voip_cli, "_run_shell_hook", fake_hook)
+
+    args = [
+        "reconnect-drill",
+        "--registration-timeout",
+        "1",
+        "--disconnect-seconds",
+        "0.4",
+        "--drop-detect-timeout",
+        "0.5",
+        "--recovery-timeout",
+        "1",
+        option,
+        f"{phase}-net",
+        "--artifacts-dir",
+        str(tmp_path),
+    ]
+    if phase == "restore":
+        args[args.index("--artifacts-dir"):args.index("--artifacts-dir")] = [
+            "--drop-command",
+            "drop-net",
+        ]
+
+    result = runner.invoke(voip_cli.voip_app, args)
+
+    assert result.exit_code == 1
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "fail"
+    assert summary["reason"] == f"The configured network {phase} command failed"
+    timeline = _load_timeline(tmp_path)
+    assert any(
+        event["kind"] == "command"
+        and event["phase"] == phase
+        and event["returncode"] == 23
+        for event in timeline
+    )
+
 
 @pytest.mark.parametrize(
     ("schedule_failure", "expected_reason"),
@@ -527,6 +659,112 @@ def test_call_soak_fails_when_call_never_reaches_connected_media(
     assert summary["status"] == "fail"
     assert summary["reason"] == "Call never reached a connected state (last_state=end)"
     assert summary["extras"]["last_call_state"] == "end"
+
+
+def test_call_soak_fails_fast_when_call_returns_to_idle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The connect wait should treat a rejected/unanswered call returning to IDLE as terminal."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.1, RegistrationState.OK)
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    def fake_make_call(sip_address: str, contact_name: str | None = None) -> bool:
+        manager._set_call_state(CallState.OUTGOING_RINGING)
+        manager.schedule_call_state(0.2, CallState.IDLE)
+        return True
+
+    monkeypatch.setattr(manager, "make_call", fake_make_call)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "call-soak",
+            "--target",
+            "sip:echo@example.com",
+            "--registration-timeout",
+            "1",
+            "--connect-timeout",
+            "5",
+            "--soak-seconds",
+            "1",
+            "--hangup-timeout",
+            "0.5",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "fail"
+    assert summary["extras"]["last_call_state"] == "idle"
+    assert summary["extras"]["connect_wait_seconds"] < 1.0
+
+
+def test_call_soak_fails_when_manager_start_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The call soak should fail honestly when the VoIP manager cannot start."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.start_result = False
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "call-soak",
+            "--target",
+            "sip:echo@example.com",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "fail"
+    assert summary["reason"] == "VoIP manager failed to start"
+
+
+def test_call_soak_fails_when_call_cannot_be_initiated(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The call soak should fail honestly when make_call returns False."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.1, RegistrationState.OK)
+    manager.make_call_result = False
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "call-soak",
+            "--target",
+            "sip:echo@example.com",
+            "--registration-timeout",
+            "1",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "fail"
+    assert summary["reason"] == "Failed to initiate call to sip:echo@example.com"
 
 
 def test_check_uses_custom_config_dir(

--- a/tests/test_voip_cli.py
+++ b/tests/test_voip_cli.py
@@ -42,7 +42,11 @@ class FakeVoIPManager:
         self.config = SimpleNamespace(
             iterate_interval_ms=100,
             sip_server="sip.example.com",
+            sip_username="alice",
             sip_identity="sip:alice@example.com",
+            transport="udp",
+            stun_server="stun.example.com",
+            file_transfer_server_url="https://uploads.example.com",
         )
         self.running = False
         self.registered = False
@@ -50,8 +54,11 @@ class FakeVoIPManager:
         self.call_state = CallState.IDLE
         self._registration_callbacks: list[object] = []
         self._call_state_callbacks: list[object] = []
+        self._incoming_call_callbacks: list[object] = []
         self._scheduled: list[tuple[float, object]] = []
         self.call_connected_at: float | None = None
+        self.start_result = True
+        self.make_call_result = True
 
     def schedule_registration(self, delay_seconds: float, state: RegistrationState) -> None:
         self._scheduled.append((self.clock.now + delay_seconds, ("registration", state)))
@@ -65,9 +72,12 @@ class FakeVoIPManager:
     def on_call_state_change(self, callback) -> None:
         self._call_state_callbacks.append(callback)
 
+    def on_incoming_call(self, callback) -> None:
+        self._incoming_call_callbacks.append(callback)
+
     def start(self) -> bool:
         self.running = True
-        return True
+        return self.start_result
 
     def stop(self) -> None:
         self.running = False
@@ -102,6 +112,8 @@ class FakeVoIPManager:
         )
 
     def make_call(self, sip_address: str, contact_name: str | None = None) -> bool:
+        if not self.make_call_result:
+            return False
         self._set_call_state(CallState.OUTGOING_RINGING)
         self.schedule_call_state(0.2, CallState.CONNECTED)
         return True
@@ -179,6 +191,39 @@ def test_registration_stability_writes_pass_artifacts(
     assert summary["extras"]["hold_seconds"] == 1.0
 
 
+def test_registration_stability_fails_when_registration_flaps_during_hold(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The registration drill should exit non-zero when registration leaves OK during the hold."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.1, RegistrationState.OK)
+    manager.schedule_registration(0.4, RegistrationState.FAILED)
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "registration-stability",
+            "--registration-timeout",
+            "1",
+            "--hold-seconds",
+            "1",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "fail"
+    assert summary["reason"] == "Registration left OK during stability hold: failed"
+    assert summary["extras"]["failed_state"] == "failed"
+
+
 def test_reconnect_drill_fails_when_registration_never_recovers(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -231,6 +276,7 @@ def test_reconnect_drill_fails_when_registration_never_recovers(
     assert summary["status"] == "fail"
     assert "did not recover" in summary["reason"]
     assert summary["extras"]["drop_state"] == "failed"
+    assert summary["extras"]["drop_wait_seconds"] == pytest.approx(0.1)
 
 
 def test_reconnect_drill_recovers_after_temporary_drop(
@@ -287,6 +333,7 @@ def test_reconnect_drill_recovers_after_temporary_drop(
     assert summary["status"] == "pass"
     assert summary["reason"] == "Registration recovered after the temporary outage"
     assert summary["extras"]["drop_state"] == "failed"
+    assert summary["extras"]["drop_wait_seconds"] == pytest.approx(0.1)
     assert summary["registration_states"] == ["ok", "failed", "ok"]
 
 
@@ -373,3 +420,103 @@ def test_call_soak_writes_pass_summary(
     assert summary["status"] == "pass"
     assert summary["metadata"]["target"] == "sip:echo@example.com"
     assert summary["extras"]["cleanup"] == "hangup_clean"
+
+
+def test_call_soak_fails_when_call_never_reaches_connected_media(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The call soak should exit non-zero when the target call terminates before media connects."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.1, RegistrationState.OK)
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    def fake_make_call(sip_address: str, contact_name: str | None = None) -> bool:
+        manager._set_call_state(CallState.OUTGOING_RINGING)
+        manager.schedule_call_state(0.2, CallState.END)
+        return True
+
+    monkeypatch.setattr(manager, "make_call", fake_make_call)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "call-soak",
+            "--target",
+            "sip:echo@example.com",
+            "--registration-timeout",
+            "1",
+            "--connect-timeout",
+            "1",
+            "--soak-seconds",
+            "1",
+            "--hangup-timeout",
+            "0.5",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "fail"
+    assert summary["reason"] == "Call never reached a connected state (last_state=end)"
+    assert summary["extras"]["last_call_state"] == "end"
+
+
+def test_check_uses_custom_config_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The verbose registration check should honor the shared config-dir option."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.1, RegistrationState.OK)
+    _patch_clock(monkeypatch, clock)
+    called_with: list[str] = []
+
+    def fake_build(config_dir: str) -> FakeVoIPManager:
+        called_with.append(config_dir)
+        return manager
+
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", fake_build)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        ["check", "--config-dir", "/tmp/custom-config"],
+    )
+
+    assert result.exit_code == 0
+    assert called_with == ["/tmp/custom-config"]
+
+
+def test_debug_uses_custom_config_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The incoming-call debug loop should honor the shared config-dir option."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    _patch_clock(monkeypatch, clock)
+    called_with: list[str] = []
+
+    def fake_build(config_dir: str) -> FakeVoIPManager:
+        called_with.append(config_dir)
+        return manager
+
+    def interrupting_iterate() -> int:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", fake_build)
+    monkeypatch.setattr(manager, "iterate", interrupting_iterate)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        ["debug", "--config-dir", "/tmp/custom-config"],
+    )
+
+    assert result.exit_code == 0
+    assert called_with == ["/tmp/custom-config"]

--- a/tests/test_voip_cli.py
+++ b/tests/test_voip_cli.py
@@ -224,6 +224,68 @@ def test_registration_stability_fails_when_registration_flaps_during_hold(
     assert summary["extras"]["failed_state"] == "failed"
 
 
+def test_registration_stability_fails_when_manager_start_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The registration drill should fail honestly when the VoIP manager never starts."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.start_result = False
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "registration-stability",
+            "--registration-timeout",
+            "1",
+            "--hold-seconds",
+            "1",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "fail"
+    assert summary["reason"] == "VoIP manager failed to start"
+
+
+def test_registration_stability_fails_when_registration_never_reaches_ok(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The registration drill should fail honestly when SIP never reaches OK."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "registration-stability",
+            "--registration-timeout",
+            "0.5",
+            "--hold-seconds",
+            "1",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "fail"
+    assert summary["reason"] == "Registration never reached OK"
+    assert summary["extras"]["registration_wait_seconds"] >= 0.5
+
+
 def test_reconnect_drill_fails_when_registration_never_recovers(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_voip_cli.py
+++ b/tests/test_voip_cli.py
@@ -233,6 +233,108 @@ def test_reconnect_drill_fails_when_registration_never_recovers(
     assert summary["extras"]["drop_state"] == "failed"
 
 
+def test_reconnect_drill_recovers_after_temporary_drop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The reconnect drill should pass when registration drops and then recovers."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.1, RegistrationState.OK)
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    def fake_hook(*, recorder, phase: str, command: str) -> bool:
+        if phase == "drop":
+            manager.schedule_registration(0.1, RegistrationState.FAILED)
+        elif phase == "restore":
+            manager.schedule_registration(0.1, RegistrationState.OK)
+        recorder.record_command(
+            phase=phase,
+            command=command,
+            returncode=0,
+            stdout="ok",
+            stderr="",
+        )
+        return True
+
+    monkeypatch.setattr(voip_cli, "_run_shell_hook", fake_hook)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "reconnect-drill",
+            "--registration-timeout",
+            "1",
+            "--disconnect-seconds",
+            "0.4",
+            "--drop-detect-timeout",
+            "0.5",
+            "--recovery-timeout",
+            "1",
+            "--drop-command",
+            "drop-net",
+            "--restore-command",
+            "restore-net",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "pass"
+    assert summary["reason"] == "Registration recovered after the temporary outage"
+    assert summary["extras"]["drop_state"] == "failed"
+    assert summary["registration_states"] == ["ok", "failed", "ok"]
+
+
+@pytest.mark.parametrize(
+    ("schedule_failure", "expected_reason"),
+    [
+        (
+            lambda manager: manager.schedule_registration(0.2, RegistrationState.FAILED),
+            "registration_state=failed",
+        ),
+        (
+            lambda manager: manager.schedule_call_state(0.2, CallState.END),
+            "call_state=end",
+        ),
+    ],
+)
+def test_hold_call_connected_returns_machine_friendly_failure_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    schedule_failure,
+    expected_reason: str,
+) -> None:
+    """The soak helper should report registration and call failures with stable key=value reasons."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager._set_registration(RegistrationState.OK)
+    manager._set_call_state(CallState.CONNECTED)
+    schedule_failure(manager)
+    _patch_clock(monkeypatch, clock)
+
+    recorder = voip_cli._VoIPDrillRecorder(
+        drill="call-soak",
+        config=manager.config,
+        artifacts_dir=str(tmp_path),
+    )
+    recorder.attach(manager)
+
+    soaked, reason = voip_cli._hold_call_connected(
+        manager,
+        recorder,
+        soak_seconds=1.0,
+    )
+
+    assert soaked is False
+    assert reason == expected_reason
+
+
 def test_call_soak_writes_pass_summary(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_voip_cli.py
+++ b/tests/test_voip_cli.py
@@ -1,0 +1,273 @@
+"""Tests for the focused VoIP reliability drill commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("typer")
+
+from typer.testing import CliRunner
+
+from yoyopod.cli.pi import voip as voip_cli
+from yoyopod.communication.models import CallState, RegistrationState
+
+runner = CliRunner()
+
+
+class FakeClock:
+    """Deterministic clock for time-driven drill loops."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def time(self) -> float:
+        return 1_700_000_000.0 + self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += max(0.0, seconds)
+
+
+class FakeVoIPManager:
+    """Small manager double that can schedule registration and call transitions."""
+
+    def __init__(self, clock: FakeClock) -> None:
+        self.clock = clock
+        self.config = SimpleNamespace(
+            iterate_interval_ms=100,
+            sip_server="sip.example.com",
+            sip_identity="sip:alice@example.com",
+        )
+        self.running = False
+        self.registered = False
+        self.registration_state = RegistrationState.NONE
+        self.call_state = CallState.IDLE
+        self._registration_callbacks: list[object] = []
+        self._call_state_callbacks: list[object] = []
+        self._scheduled: list[tuple[float, object]] = []
+        self.call_connected_at: float | None = None
+
+    def schedule_registration(self, delay_seconds: float, state: RegistrationState) -> None:
+        self._scheduled.append((self.clock.now + delay_seconds, ("registration", state)))
+
+    def schedule_call_state(self, delay_seconds: float, state: CallState) -> None:
+        self._scheduled.append((self.clock.now + delay_seconds, ("call", state)))
+
+    def on_registration_change(self, callback) -> None:
+        self._registration_callbacks.append(callback)
+
+    def on_call_state_change(self, callback) -> None:
+        self._call_state_callbacks.append(callback)
+
+    def start(self) -> bool:
+        self.running = True
+        return True
+
+    def stop(self) -> None:
+        self.running = False
+
+    def iterate(self) -> int:
+        drained = 0
+        due = [item for item in self._scheduled if item[0] <= self.clock.now]
+        self._scheduled = [item for item in self._scheduled if item[0] > self.clock.now]
+        for _at, payload in sorted(due, key=lambda item: item[0]):
+            drained += 1
+            kind, state = payload
+            if kind == "registration":
+                self._set_registration(state)
+            else:
+                self._set_call_state(state)
+        return drained
+
+    def get_status(self) -> dict[str, object]:
+        return {
+            "running": self.running,
+            "registered": self.registered,
+            "registration_state": self.registration_state.value,
+            "call_state": self.call_state.value,
+        }
+
+    def get_iterate_metrics(self) -> object | None:
+        return SimpleNamespace(
+            native_duration_seconds=0.01,
+            event_drain_duration_seconds=0.0,
+            total_duration_seconds=0.01,
+            drained_events=0,
+        )
+
+    def make_call(self, sip_address: str, contact_name: str | None = None) -> bool:
+        self._set_call_state(CallState.OUTGOING_RINGING)
+        self.schedule_call_state(0.2, CallState.CONNECTED)
+        return True
+
+    def hangup(self) -> bool:
+        self.schedule_call_state(0.1, CallState.END)
+        return True
+
+    def get_call_duration(self) -> int:
+        if self.call_connected_at is None:
+            return 0
+        return int(max(0.0, self.clock.now - self.call_connected_at))
+
+    def _set_registration(self, state: RegistrationState) -> None:
+        self.registration_state = state
+        self.registered = state == RegistrationState.OK
+        for callback in self._registration_callbacks:
+            callback(state)
+
+    def _set_call_state(self, state: CallState) -> None:
+        self.call_state = state
+        if (
+            state in {CallState.CONNECTED, CallState.STREAMS_RUNNING}
+            and self.call_connected_at is None
+        ):
+            self.call_connected_at = self.clock.now
+        if state in {CallState.END, CallState.RELEASED, CallState.IDLE, CallState.ERROR}:
+            self.call_connected_at = None
+        for callback in self._call_state_callbacks:
+            callback(state)
+
+
+def _patch_clock(monkeypatch: pytest.MonkeyPatch, clock: FakeClock) -> None:
+    monkeypatch.setattr(voip_cli.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(voip_cli.time, "time", clock.time)
+    monkeypatch.setattr(voip_cli.time, "sleep", clock.sleep)
+
+
+def _load_summary(artifacts_dir: Path) -> dict[str, object]:
+    run_dir = next(artifacts_dir.iterdir())
+    return json.loads((run_dir / "summary.json").read_text(encoding="utf-8"))
+
+
+def test_registration_stability_writes_pass_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The registration drill should pass and persist a summary when SIP stays stable."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.2, RegistrationState.OK)
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "registration-stability",
+            "--registration-timeout",
+            "1",
+            "--hold-seconds",
+            "1",
+            "--sample-interval",
+            "0.5",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "pass"
+    assert summary["registration_states"] == ["ok"]
+    assert summary["extras"]["hold_seconds"] == 1.0
+
+
+def test_reconnect_drill_fails_when_registration_never_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The reconnect drill should fail honestly when the network comes back but SIP does not."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.1, RegistrationState.OK)
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    def fake_hook(*, recorder, phase: str, command: str) -> bool:
+        if phase == "drop":
+            manager.schedule_registration(0.1, RegistrationState.FAILED)
+        recorder.record_command(
+            phase=phase,
+            command=command,
+            returncode=0,
+            stdout="ok",
+            stderr="",
+        )
+        return True
+
+    monkeypatch.setattr(voip_cli, "_run_shell_hook", fake_hook)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "reconnect-drill",
+            "--registration-timeout",
+            "1",
+            "--disconnect-seconds",
+            "0.4",
+            "--drop-detect-timeout",
+            "0.5",
+            "--recovery-timeout",
+            "0.5",
+            "--drop-command",
+            "drop-net",
+            "--restore-command",
+            "restore-net",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "fail"
+    assert "did not recover" in summary["reason"]
+    assert summary["extras"]["drop_state"] == "failed"
+
+
+def test_call_soak_writes_pass_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The call soak should pass when the call connects and remains up for the soak window."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.1, RegistrationState.OK)
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager", lambda _config_dir: manager)
+
+    result = runner.invoke(
+        voip_cli.voip_app,
+        [
+            "call-soak",
+            "--target",
+            "sip:echo@example.com",
+            "--registration-timeout",
+            "1",
+            "--connect-timeout",
+            "1",
+            "--soak-seconds",
+            "1",
+            "--hangup-timeout",
+            "0.5",
+            "--sample-interval",
+            "0.5",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "pass"
+    assert summary["metadata"]["target"] == "sip:echo@example.com"
+    assert summary["extras"]["cleanup"] == "hangup_clean"

--- a/tests/test_voip_cli.py
+++ b/tests/test_voip_cli.py
@@ -505,16 +505,17 @@ def test_reconnect_drill_fails_when_hook_command_returns_non_zero(
         "0.5",
         "--recovery-timeout",
         "1",
-        option,
-        f"{phase}-net",
-        "--artifacts-dir",
-        str(tmp_path),
     ]
     if phase == "restore":
-        args[args.index("--artifacts-dir"):args.index("--artifacts-dir")] = [
-            "--drop-command",
-            "drop-net",
+        args.extend(["--drop-command", "drop-net"])
+    args.extend(
+        [
+            option,
+            f"{phase}-net",
+            "--artifacts-dir",
+            str(tmp_path),
         ]
+    )
 
     result = runner.invoke(voip_cli.voip_app, args)
 


### PR DESCRIPTION
## Summary
- add three focused real-hardware VoIP drill commands under `yoyoctl pi voip`: `registration-stability`, `reconnect-drill`, and `call-soak`
- make each drill write a timestamped artifact bundle under `logs/voip-validation/` with `summary.json` and `timeline.jsonl`
- document how contributors should run the deeper VoIP drills, what pass/fail means, and how to triage failures
- address the repair follow-ups by making `check` and `debug` honor `--config-dir`, recording the first observed registration drop time during `reconnect-drill`, and adding CLI-level negative-path coverage for registration stability and call soak failures

## Why
Issue #182 asks for repeatable, reviewable real-hardware VoIP validation instead of short happy-path checks. This PR keeps that slice focused on drill-style commands for registration stability, temporary network-loss recovery, and longer-running call soak behavior, with artifact-first evidence and contributor guidance.

## Validation
- `env UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_voip_cli.py`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_cli.py`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run python -m ruff check src/yoyopod/cli/pi/voip.py tests/test_voip_cli.py tests/test_cli.py`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/quality.py gate`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q` inside the sandbox hit two unrelated `tests/test_mpv_ipc.py` AF_UNIX bind permission failures
- `env UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q` rerun outside the sandbox passed: `580 passed in 14.61s`

## Limitations
- the reconnect drill does not pretend to automate every network stack; it supports explicit drop/restore commands when available and otherwise records a manual outage/recovery window honestly
- the call soak verifies registration and call-state continuity from the YoyoPod side; it does not claim to detect every RTP or audio-quality defect
- this PR adds repeatable drills and reviewable evidence, not a full observability platform or a claim that every VoIP reliability bug is solved

Closes #182