### PR TITLE
[codex] Speed up Whisplay RGB565 full-frame refresh

### DIFF
--- a/src/yoyopod/ui/display/adapters/whisplay.py
+++ b/src/yoyopod/ui/display/adapters/whisplay.py
@@ -23,13 +23,17 @@ from types import ModuleType
 from typing import Optional, Tuple
 
 from loguru import logger
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageChops, ImageDraw, ImageFont
 
 from yoyopod.ui.display.adapters.whisplay_paths import ensure_whisplay_driver_on_path
 from yoyopod.ui.display.hal import DisplayHAL
 
 DRIVER_PATH = ensure_whisplay_driver_on_path()
 DEFAULT_FONT_PATH = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+_RGB565_HIGH_RED_LUT = tuple(value & 0xF8 for value in range(256))
+_RGB565_HIGH_GREEN_LUT = tuple(value >> 5 for value in range(256))
+_RGB565_LOW_GREEN_LUT = tuple((value & 0x1C) << 3 for value in range(256))
+_RGB565_LOW_BLUE_LUT = tuple(value >> 3 for value in range(256))
 
 
 def _normalize_gpiochip_path(candidate: object) -> object:
@@ -409,24 +413,19 @@ class WhisplayDisplayAdapter(DisplayHAL):
         if self.buffer is None:
             return b""
 
-        rgb_bytes = self.buffer.tobytes()
-        pixel_count = self.WIDTH * self.HEIGHT
-        pixel_data = bytearray(pixel_count * 2)
+        red, green, blue = self.buffer.split()
+        high = ImageChops.add(
+            red.point(_RGB565_HIGH_RED_LUT),
+            green.point(_RGB565_HIGH_GREEN_LUT),
+        )
+        low = ImageChops.add(
+            green.point(_RGB565_LOW_GREEN_LUT),
+            blue.point(_RGB565_LOW_BLUE_LUT),
+        )
 
-        src_index = 0
-        dst_index = 0
-        for _ in range(pixel_count):
-            red = rgb_bytes[src_index]
-            green = rgb_bytes[src_index + 1]
-            blue = rgb_bytes[src_index + 2]
-            src_index += 3
-
-            rgb565 = ((red & 0xF8) << 8) | ((green & 0xFC) << 3) | (blue >> 3)
-            pixel_data[dst_index] = (rgb565 >> 8) & 0xFF
-            pixel_data[dst_index + 1] = rgb565 & 0xFF
-            dst_index += 2
-
-        return bytes(pixel_data)
+        # ``LA`` stores two 8-bit channels interleaved, which matches the
+        # adapter's big-endian RGB565 byte contract without a Python pixel loop.
+        return Image.merge("LA", (high, low)).tobytes()
 
     def _paste_rgb565_region(
         self,

--- a/tests/test_whisplay_adapter.py
+++ b/tests/test_whisplay_adapter.py
@@ -292,6 +292,30 @@ def test_rgb565_conversion_matches_expected_byte_order() -> None:
     assert adapter._convert_to_rgb565() == bytes.fromhex("f80007e0")
 
 
+def test_rgb565_conversion_matches_reference_for_mixed_pixels() -> None:
+    """The bulk conversion should match the historical RGB565 packing rules."""
+
+    adapter = WhisplayDisplayAdapter(simulate=True, renderer="pil")
+    adapter.WIDTH = 4
+    adapter.HEIGHT = 1
+    adapter.buffer = Image.new("RGB", (4, 1))
+    adapter.draw = ImageDraw.Draw(adapter.buffer)
+    pixels = [
+        (255, 255, 255),
+        (0, 0, 255),
+        (17, 34, 51),
+        (123, 231, 45),
+    ]
+    adapter.buffer.putdata(pixels)
+
+    expected = bytearray()
+    for red, green, blue in pixels:
+        rgb565 = ((red & 0xF8) << 8) | ((green & 0xFC) << 3) | (blue >> 3)
+        expected.extend(((rgb565 >> 8) & 0xFF, rgb565 & 0xFF))
+
+    assert adapter._convert_to_rgb565() == bytes(expected)
+
+
 def test_paste_rgb565_region_decodes_into_shadow_buffer() -> None:
     """Shadow-buffer region pastes should decode RGB565 bytes back into RGB pixels."""
 


### PR DESCRIPTION
## Summary
- replace the Whisplay full-frame PIL `RGB888 -> RGB565` per-pixel Python loop with a Pillow bulk-pack path built from channel LUTs and `Image.merge("LA", ...)`
- preserve the existing big-endian RGB565 byte contract used by `device.draw_image()`
- add focused coverage that compares the new packed bytes against the historical RGB565 reference math for mixed pixels

## Why
Issue #236 calls out the full-frame Whisplay fallback spending hundreds of milliseconds in Python pixel loops on Pi Zero 2W refreshes. The old `_convert_to_rgb565()` implementation iterated every pixel in Python before each full-frame refresh.

This change keeps the adapter API the same but moves the heavy lifting into Pillow image ops, which avoids per-pixel Python work on the full-frame update path.

## Impact
- improves the performance-sensitive Whisplay full-frame refresh path without changing partial flush behavior
- keeps correctness explicit via focused byte-level tests
- leaves simulation and LVGL partial flush paths unchanged

## Validation
- `uv run pytest -q tests/test_whisplay_adapter.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`

## Notes
- A quick local spot check on a 240x280 image in this lane produced identical bytes with roughly `57.65 ms -> 2.27 ms` conversion time for the old reference loop versus the new bulk-pack path. This was an ad hoc measurement, not a CI benchmark.
- An in-sandbox `uv run pytest -q` attempt hit `PermissionError` binding AF_UNIX sockets in `tests/test_mpv_ipc.py`; rerunning the same command outside the sandbox passed (`568 passed`).