### PR TITLE
[codex] Offload VoIP iterate from coordinator thread

### DIFF
--- a/src/yoyopod/communication/calling/backend.py
+++ b/src/yoyopod/communication/calling/backend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -123,6 +124,7 @@ class LiblinphoneBackend:
         self.running = False
         self.event_callbacks: list[Callable[[VoIPEvent], None]] = []
         self._last_iterate_metrics: VoIPIterateMetrics | None = None
+        self._binding_lock = threading.Lock()
 
     def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
         self.event_callbacks.append(callback)
@@ -140,50 +142,51 @@ class LiblinphoneBackend:
             conference_factory_uri = self.config.effective_conference_factory_uri()
             file_transfer_server_url = self.config.effective_file_transfer_server_url()
             lime_server_url = self.config.effective_lime_server_url()
-            self.binding.init()
-            self._configure_alsa_capture_path()
-            if not self.config.conference_factory_uri and conference_factory_uri:
-                logger.info(
-                    "Using inferred conference factory {} for hosted account {}",
-                    conference_factory_uri,
-                    self.config.sip_server,
+            with self._binding_lock:
+                self.binding.init()
+                self._configure_alsa_capture_path()
+                if not self.config.conference_factory_uri and conference_factory_uri:
+                    logger.info(
+                        "Using inferred conference factory {} for hosted account {}",
+                        conference_factory_uri,
+                        self.config.sip_server,
+                    )
+                if not self.config.file_transfer_server_url and file_transfer_server_url:
+                    logger.info(
+                        "Using inferred file-transfer server {} for hosted account {}",
+                        file_transfer_server_url,
+                        self.config.sip_server,
+                    )
+                if not self.config.lime_server_url and lime_server_url:
+                    logger.info(
+                        "Using inferred LIME server {} for hosted account {}",
+                        lime_server_url,
+                        self.config.sip_server,
+                    )
+                self.binding.start(
+                    sip_server=self.config.sip_server,
+                    sip_username=self.config.sip_username,
+                    sip_password=self.config.sip_password,
+                    sip_password_ha1=self.config.sip_password_ha1,
+                    sip_identity=self.config.sip_identity,
+                    factory_config_path=factory_config_path,
+                    transport=self.config.transport,
+                    stun_server=self.config.stun_server,
+                    conference_factory_uri=conference_factory_uri,
+                    file_transfer_server_url=file_transfer_server_url,
+                    lime_server_url=lime_server_url,
+                    auto_download_incoming_voice_recordings=(
+                        self.config.auto_download_incoming_voice_recordings
+                    ),
+                    playback_device_id=self.config.playback_dev_id,
+                    ringer_device_id=self.config.ringer_dev_id,
+                    capture_device_id=self.config.capture_dev_id,
+                    media_device_id=self.config.media_dev_id,
+                    echo_cancellation=True,
+                    mic_gain=self._linphone_software_mic_gain(),
+                    output_volume=self.config.output_volume,
+                    voice_note_store_dir=self.config.voice_note_store_dir,
                 )
-            if not self.config.file_transfer_server_url and file_transfer_server_url:
-                logger.info(
-                    "Using inferred file-transfer server {} for hosted account {}",
-                    file_transfer_server_url,
-                    self.config.sip_server,
-                )
-            if not self.config.lime_server_url and lime_server_url:
-                logger.info(
-                    "Using inferred LIME server {} for hosted account {}",
-                    lime_server_url,
-                    self.config.sip_server,
-                )
-            self.binding.start(
-                sip_server=self.config.sip_server,
-                sip_username=self.config.sip_username,
-                sip_password=self.config.sip_password,
-                sip_password_ha1=self.config.sip_password_ha1,
-                sip_identity=self.config.sip_identity,
-                factory_config_path=factory_config_path,
-                transport=self.config.transport,
-                stun_server=self.config.stun_server,
-                conference_factory_uri=conference_factory_uri,
-                file_transfer_server_url=file_transfer_server_url,
-                lime_server_url=lime_server_url,
-                auto_download_incoming_voice_recordings=(
-                    self.config.auto_download_incoming_voice_recordings
-                ),
-                playback_device_id=self.config.playback_dev_id,
-                ringer_device_id=self.config.ringer_dev_id,
-                capture_device_id=self.config.capture_dev_id,
-                media_device_id=self.config.media_dev_id,
-                echo_cancellation=True,
-                mic_gain=self._linphone_software_mic_gain(),
-                output_volume=self.config.output_volume,
-                voice_note_store_dir=self.config.voice_note_store_dir,
-            )
             self.running = True
             logger.info("Liblinphone backend started successfully")
             return True
@@ -214,9 +217,11 @@ class LiblinphoneBackend:
             return
 
         try:
-            self.binding.stop()
+            with self._binding_lock:
+                self.binding.stop()
         finally:
-            self.binding.shutdown()
+            with self._binding_lock:
+                self.binding.shutdown()
             self.running = False
 
     def get_iterate_metrics(self) -> VoIPIterateMetrics | None:
@@ -232,16 +237,21 @@ class LiblinphoneBackend:
         started_at = time.monotonic()
         native_duration_seconds = 0.0
         event_drain_started_at = started_at
+        native_events: list[LiblinphoneNativeEvent] = []
         try:
             native_started_at = time.monotonic()
-            self.binding.iterate()
-            native_duration_seconds = max(0.0, time.monotonic() - native_started_at)
-            event_drain_started_at = time.monotonic()
-            while True:
-                event = self.binding.poll_event()
-                if event is None:
-                    break
-                drained_events += 1
+            with self._binding_lock:
+                self.binding.iterate()
+                native_duration_seconds = max(0.0, time.monotonic() - native_started_at)
+                event_drain_started_at = time.monotonic()
+                while True:
+                    event = self.binding.poll_event()
+                    if event is None:
+                        break
+                    native_events.append(event)
+
+            drained_events = len(native_events)
+            for event in native_events:
                 self._emit_native_event(event)
         except Exception as exc:
             logger.error("Liblinphone iterate failed: {}", exc)
@@ -260,46 +270,72 @@ class LiblinphoneBackend:
         return drained_events
 
     def make_call(self, sip_address: str) -> bool:
-        return self._call_binding(lambda: self.binding.make_call(sip_address))
+        binding = self.binding
+        if binding is None:
+            return False
+        return self._call_binding(lambda: binding.make_call(sip_address))
 
     def answer_call(self) -> bool:
-        return self._call_binding(self.binding.answer_call)
+        binding = self.binding
+        if binding is None:
+            return False
+        return self._call_binding(binding.answer_call)
 
     def reject_call(self) -> bool:
-        return self._call_binding(self.binding.reject_call)
+        binding = self.binding
+        if binding is None:
+            return False
+        return self._call_binding(binding.reject_call)
 
     def hangup(self) -> bool:
-        return self._call_binding(self.binding.hangup)
+        binding = self.binding
+        if binding is None:
+            return False
+        return self._call_binding(binding.hangup)
 
     def mute(self) -> bool:
-        return self._call_binding(lambda: self.binding.set_muted(True))
+        binding = self.binding
+        if binding is None:
+            return False
+        return self._call_binding(lambda: binding.set_muted(True))
 
     def unmute(self) -> bool:
-        return self._call_binding(lambda: self.binding.set_muted(False))
+        binding = self.binding
+        if binding is None:
+            return False
+        return self._call_binding(lambda: binding.set_muted(False))
 
     def send_text_message(self, sip_address: str, text: str) -> str | None:
         if not self.running or self.binding is None:
             return None
         try:
-            return self.binding.send_text_message(sip_address, text)
+            with self._binding_lock:
+                return self.binding.send_text_message(sip_address, text)
         except Exception as exc:
             logger.error("Failed to send text message to {}: {}", sip_address, exc)
             return None
 
     def start_voice_note_recording(self, file_path: str) -> bool:
-        return self._call_binding(lambda: self.binding.start_voice_recording(file_path))
+        binding = self.binding
+        if binding is None:
+            return False
+        return self._call_binding(lambda: binding.start_voice_recording(file_path))
 
     def stop_voice_note_recording(self) -> int | None:
         if not self.running or self.binding is None:
             return None
         try:
-            return self.binding.stop_voice_recording()
+            with self._binding_lock:
+                return self.binding.stop_voice_recording()
         except Exception as exc:
             logger.error("Failed to stop voice-note recording: {}", exc)
             return None
 
     def cancel_voice_note_recording(self) -> bool:
-        return self._call_binding(self.binding.cancel_voice_recording)
+        binding = self.binding
+        if binding is None:
+            return False
+        return self._call_binding(binding.cancel_voice_recording)
 
     def send_voice_note(
         self,
@@ -312,12 +348,13 @@ class LiblinphoneBackend:
         if not self.running or self.binding is None:
             return None
         try:
-            return self.binding.send_voice_note(
-                sip_address,
-                file_path=file_path,
-                duration_ms=duration_ms,
-                mime_type=mime_type,
-            )
+            with self._binding_lock:
+                return self.binding.send_voice_note(
+                    sip_address,
+                    file_path=file_path,
+                    duration_ms=duration_ms,
+                    mime_type=mime_type,
+                )
         except Exception as exc:
             logger.error("Failed to send voice note to {}: {}", sip_address, exc)
             return None
@@ -327,7 +364,8 @@ class LiblinphoneBackend:
             logger.error("Cannot execute VoIP operation: Liblinphone backend not running")
             return False
         try:
-            operation()
+            with self._binding_lock:
+                operation()
             return True
         except Exception as exc:
             logger.error("Liblinphone operation failed: {}", exc)

--- a/src/yoyopod/communication/calling/manager.py
+++ b/src/yoyopod/communication/calling/manager.py
@@ -550,52 +550,61 @@ class VoIPManager:
     def _run_background_iterate_loop(self) -> None:
         """Advance the backend on a dedicated worker instead of the coordinator thread."""
 
-        next_due_at = time.monotonic()
-        while not self._iterate_stop_event.is_set():
-            wait_seconds = max(0.0, next_due_at - time.monotonic())
-            woke_early = self._iterate_wakeup_event.wait(wait_seconds)
-            if self._iterate_stop_event.is_set():
-                break
-            if woke_early:
-                self._iterate_wakeup_event.clear()
-                next_due_at = time.monotonic() + self._current_iterate_interval_seconds()
-                continue
+        try:
+            next_due_at = time.monotonic()
+            while not self._iterate_stop_event.is_set():
+                wait_seconds = max(0.0, next_due_at - time.monotonic())
+                woke_early = self._iterate_wakeup_event.wait(wait_seconds)
+                if self._iterate_stop_event.is_set():
+                    break
+                if woke_early:
+                    self._iterate_wakeup_event.clear()
+                    next_due_at = time.monotonic() + self._current_iterate_interval_seconds()
+                    continue
 
-            started_at = time.monotonic()
-            schedule_delay_seconds = max(0.0, started_at - next_due_at)
+                started_at = time.monotonic()
+                schedule_delay_seconds = max(0.0, started_at - next_due_at)
+                with self._iterate_state_lock:
+                    self._iterate_snapshot = replace(
+                        self._iterate_snapshot,
+                        last_started_at=started_at,
+                        schedule_delay_seconds=schedule_delay_seconds,
+                        in_flight=True,
+                    )
+
+                drained_events = self.backend.iterate() if self.running else 0
+                metrics = self.get_iterate_metrics()
+                completed_at = time.monotonic()
+
+                with self._iterate_state_lock:
+                    self._iterate_snapshot = VoIPIterateSnapshot(
+                        sample_id=self._iterate_snapshot.sample_id + 1,
+                        last_started_at=started_at,
+                        last_completed_at=completed_at,
+                        schedule_delay_seconds=schedule_delay_seconds,
+                        total_duration_seconds=max(0.0, completed_at - started_at),
+                        native_duration_seconds=max(
+                            0.0,
+                            float(getattr(metrics, "native_duration_seconds", 0.0) or 0.0),
+                        ),
+                        event_drain_duration_seconds=max(
+                            0.0,
+                            float(getattr(metrics, "event_drain_duration_seconds", 0.0) or 0.0),
+                        ),
+                        drained_events=max(0, int(drained_events)),
+                        interval_seconds=self._iterate_interval_seconds,
+                        in_flight=False,
+                    )
+
+                next_due_at = started_at + self._current_iterate_interval_seconds()
+        except Exception as exc:
+            if not self._iterate_stop_event.is_set():
+                reason = str(exc).strip() or exc.__class__.__name__
+                logger.exception("VoIP background iterate loop crashed: {}", reason)
+                self._dispatch_backend_event(BackendStopped(reason=reason))
+        finally:
             with self._iterate_state_lock:
-                self._iterate_snapshot = replace(
-                    self._iterate_snapshot,
-                    last_started_at=started_at,
-                    schedule_delay_seconds=schedule_delay_seconds,
-                    in_flight=True,
-                )
-
-            drained_events = self.backend.iterate() if self.running else 0
-            metrics = self.get_iterate_metrics()
-            completed_at = time.monotonic()
-
-            with self._iterate_state_lock:
-                self._iterate_snapshot = VoIPIterateSnapshot(
-                    sample_id=self._iterate_snapshot.sample_id + 1,
-                    last_started_at=started_at,
-                    last_completed_at=completed_at,
-                    schedule_delay_seconds=schedule_delay_seconds,
-                    total_duration_seconds=max(0.0, completed_at - started_at),
-                    native_duration_seconds=max(
-                        0.0,
-                        float(getattr(metrics, "native_duration_seconds", 0.0) or 0.0),
-                    ),
-                    event_drain_duration_seconds=max(
-                        0.0,
-                        float(getattr(metrics, "event_drain_duration_seconds", 0.0) or 0.0),
-                    ),
-                    drained_events=max(0, int(drained_events)),
-                    interval_seconds=self._iterate_interval_seconds,
-                    in_flight=False,
-                )
-
-            next_due_at = started_at + self._current_iterate_interval_seconds()
+                self._iterate_snapshot = replace(self._iterate_snapshot, in_flight=False)
 
     def _current_iterate_interval_seconds(self) -> float:
         """Return the currently selected iterate interval for the background worker."""
@@ -820,7 +829,10 @@ class VoIPManager:
         self.call_state = state
         logger.info("Call state: {} -> {}", old_state.value, state.value)
 
-        if state in (CallState.CONNECTED, CallState.STREAMS_RUNNING) and self.call_start_time is None:
+        if (
+            state in (CallState.CONNECTED, CallState.STREAMS_RUNNING)
+            and self.call_start_time is None
+        ):
             self._start_call_timer()
         elif state in (CallState.RELEASED, CallState.END, CallState.ERROR):
             self._clear_call_session()

--- a/src/yoyopod/communication/calling/manager.py
+++ b/src/yoyopod/communication/calling/manager.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional, cast
 
 from loguru import logger
 
@@ -53,6 +53,22 @@ class VoiceNoteDraft:
     send_started_at: float = 0.0
 
 
+@dataclass(frozen=True, slots=True)
+class VoIPIterateSnapshot:
+    """Latest iterate timing sample reported by one backend execution lane."""
+
+    sample_id: int = 0
+    last_started_at: float = 0.0
+    last_completed_at: float = 0.0
+    schedule_delay_seconds: float = 0.0
+    total_duration_seconds: float = 0.0
+    native_duration_seconds: float = 0.0
+    event_drain_duration_seconds: float = 0.0
+    drained_events: int = 0
+    interval_seconds: float = 0.0
+    in_flight: bool = False
+
+
 VOICE_NOTE_SEND_TIMEOUT_SECONDS = 15.0
 VOICE_NOTE_CONTAINER_GAIN_DB = 12.0
 
@@ -66,6 +82,8 @@ class VoIPManager:
         people_directory: "PeopleDirectory | None" = None,
         backend: Optional[VoIPBackend] = None,
         message_store: Optional[VoIPMessageStore] = None,
+        event_scheduler: Callable[[Callable[[], None]], None] | None = None,
+        background_iterate_enabled: bool = False,
     ) -> None:
         self.config = config
         self.people_directory = people_directory
@@ -95,12 +113,27 @@ class VoIPManager:
         self.message_summary_callbacks: list[
             Callable[[int, dict[str, dict[str, object]]], None]
         ] = []
+        self._event_scheduler = event_scheduler
+        self._background_iterate_enabled = bool(background_iterate_enabled and event_scheduler)
+        if background_iterate_enabled and event_scheduler is None:
+            logger.warning(
+                "VoIP background iterate requested without a main-thread scheduler; "
+                "falling back to coordinator-thread iterate"
+            )
+        self._iterate_interval_seconds = max(0.01, float(config.iterate_interval_ms) / 1000.0)
+        self._iterate_snapshot = VoIPIterateSnapshot(
+            interval_seconds=self._iterate_interval_seconds
+        )
+        self._iterate_state_lock = threading.Lock()
+        self._iterate_thread: threading.Thread | None = None
+        self._iterate_stop_event = threading.Event()
+        self._iterate_wakeup_event = threading.Event()
 
         self.duration_thread: Optional[threading.Thread] = None
         self.duration_stop_event = threading.Event()
         self._stopping = False
 
-        self.backend.on_event(self._handle_backend_event)
+        self.backend.on_event(self._dispatch_backend_event)
         logger.info("VoIPManager initialized (server: {})", config.sip_server)
 
     def _build_message_store(self) -> VoIPMessageStore:
@@ -125,6 +158,7 @@ class VoIPManager:
         logger.info("Stopping VoIP manager...")
         self._stopping = True
         try:
+            self._stop_background_iterate_loop()
             self._stop_call_timer()
             self._stop_voice_note_playback()
             self.backend.stop()
@@ -141,6 +175,56 @@ class VoIPManager:
             drained_events = self.backend.iterate()
         self._check_active_voice_note_timeout()
         return drained_events
+
+    @property
+    def background_iterate_enabled(self) -> bool:
+        """Return whether this manager owns a dedicated iterate worker."""
+
+        return self._background_iterate_enabled
+
+    def ensure_background_iterate_running(self) -> None:
+        """Start the dedicated iterate worker when app-mode background cadence is enabled."""
+
+        if not self._background_iterate_enabled or not self.running:
+            return
+        if self._iterate_thread is not None and self._iterate_thread.is_alive():
+            return
+
+        self._iterate_stop_event.clear()
+        self._iterate_wakeup_event.clear()
+        self._iterate_thread = threading.Thread(
+            target=self._run_background_iterate_loop,
+            daemon=True,
+            name="voip-iterate",
+        )
+        self._iterate_thread.start()
+
+    def set_iterate_interval_seconds(self, interval_seconds: float) -> None:
+        """Update the active background iterate cadence."""
+
+        clamped_interval_seconds = max(0.01, float(interval_seconds))
+        with self._iterate_state_lock:
+            if abs(self._iterate_interval_seconds - clamped_interval_seconds) <= 1e-9:
+                return
+            self._iterate_interval_seconds = clamped_interval_seconds
+            self._iterate_snapshot = replace(
+                self._iterate_snapshot,
+                interval_seconds=clamped_interval_seconds,
+            )
+        self._iterate_wakeup_event.set()
+
+    def get_iterate_timing_snapshot(self) -> VoIPIterateSnapshot | None:
+        """Return the latest iterate timing sample when a worker owns the backend cadence."""
+
+        if not self._background_iterate_enabled:
+            return None
+        with self._iterate_state_lock:
+            return self._iterate_snapshot
+
+    def poll_housekeeping(self) -> None:
+        """Run lightweight coordinator-thread-only maintenance alongside background iterate."""
+
+        self._check_active_voice_note_timeout()
 
     def make_call(self, sip_address: str, contact_name: str | None = None) -> bool:
         if not self.registered:
@@ -409,7 +493,7 @@ class VoIPManager:
         get_metrics = getattr(self.backend, "get_iterate_metrics", None)
         if not callable(get_metrics):
             return None
-        return get_metrics()
+        return cast(object, get_metrics())
 
     def get_call_duration(self) -> int:
         if self.call_start_time and self.call_state in (
@@ -439,6 +523,85 @@ class VoIPManager:
     def cleanup(self) -> None:
         self._stop_call_timer()
         self.stop()
+
+    def _dispatch_backend_event(self, event: VoIPEvent) -> None:
+        """Handle backend events immediately or queue them back to the coordinator thread."""
+
+        if self._event_scheduler is None:
+            self._handle_backend_event(event)
+            return
+
+        def _handle_scheduled_event(event_to_handle: VoIPEvent = event) -> None:
+            self._handle_backend_event(event_to_handle)
+
+        self._event_scheduler(_handle_scheduled_event)
+
+    def _stop_background_iterate_loop(self) -> None:
+        """Stop the dedicated iterate worker if one is active."""
+
+        self._iterate_stop_event.set()
+        self._iterate_wakeup_event.set()
+        if self._iterate_thread is not None:
+            self._iterate_thread.join(timeout=1.0)
+            self._iterate_thread = None
+        with self._iterate_state_lock:
+            self._iterate_snapshot = replace(self._iterate_snapshot, in_flight=False)
+
+    def _run_background_iterate_loop(self) -> None:
+        """Advance the backend on a dedicated worker instead of the coordinator thread."""
+
+        next_due_at = time.monotonic()
+        while not self._iterate_stop_event.is_set():
+            wait_seconds = max(0.0, next_due_at - time.monotonic())
+            woke_early = self._iterate_wakeup_event.wait(wait_seconds)
+            if self._iterate_stop_event.is_set():
+                break
+            if woke_early:
+                self._iterate_wakeup_event.clear()
+                next_due_at = time.monotonic() + self._current_iterate_interval_seconds()
+                continue
+
+            started_at = time.monotonic()
+            schedule_delay_seconds = max(0.0, started_at - next_due_at)
+            with self._iterate_state_lock:
+                self._iterate_snapshot = replace(
+                    self._iterate_snapshot,
+                    last_started_at=started_at,
+                    schedule_delay_seconds=schedule_delay_seconds,
+                    in_flight=True,
+                )
+
+            drained_events = self.backend.iterate() if self.running else 0
+            metrics = self.get_iterate_metrics()
+            completed_at = time.monotonic()
+
+            with self._iterate_state_lock:
+                self._iterate_snapshot = VoIPIterateSnapshot(
+                    sample_id=self._iterate_snapshot.sample_id + 1,
+                    last_started_at=started_at,
+                    last_completed_at=completed_at,
+                    schedule_delay_seconds=schedule_delay_seconds,
+                    total_duration_seconds=max(0.0, completed_at - started_at),
+                    native_duration_seconds=max(
+                        0.0,
+                        float(getattr(metrics, "native_duration_seconds", 0.0) or 0.0),
+                    ),
+                    event_drain_duration_seconds=max(
+                        0.0,
+                        float(getattr(metrics, "event_drain_duration_seconds", 0.0) or 0.0),
+                    ),
+                    drained_events=max(0, int(drained_events)),
+                    interval_seconds=self._iterate_interval_seconds,
+                    in_flight=False,
+                )
+
+            next_due_at = started_at + self._current_iterate_interval_seconds()
+
+    def _current_iterate_interval_seconds(self) -> float:
+        """Return the currently selected iterate interval for the background worker."""
+
+        with self._iterate_state_lock:
+            return self._iterate_interval_seconds
 
     def _handle_backend_event(self, event: VoIPEvent) -> None:
         if self._stopping:

--- a/src/yoyopod/runtime/boot.py
+++ b/src/yoyopod/runtime/boot.py
@@ -324,6 +324,8 @@ class RuntimeBootService:
             self.app.voip_manager = VoIPManager(
                 voip_config,
                 people_directory=self.app.people_directory,
+                event_scheduler=self.app._queue_main_thread_callback,
+                background_iterate_enabled=True,
             )
             self.app._voip_iterate_interval_seconds = max(
                 0.01,

--- a/src/yoyopod/runtime/loop.py
+++ b/src/yoyopod/runtime/loop.py
@@ -102,6 +102,7 @@ class RuntimeLoopService:
         self._last_runtime_loop_gap_seconds = 0.0
         self._last_runtime_iteration_duration_seconds = 0.0
         self._last_voip_iterate_started_at = 0.0
+        self._last_voip_timing_sample_id = 0
         self._last_voip_schedule_delay_seconds = 0.0
         self._last_voip_iterate_duration_seconds = 0.0
         self._last_voip_native_events = 0
@@ -188,6 +189,96 @@ class RuntimeLoopService:
             ),
         )
 
+    def _voip_background_iterate_enabled(self) -> bool:
+        """Return whether the active VoIP manager owns a dedicated iterate worker."""
+
+        return bool(
+            self.app.voip_manager is not None
+            and getattr(self.app.voip_manager, "background_iterate_enabled", False)
+        )
+
+    def _sync_background_voip_timing_sample(self) -> None:
+        """Pull the latest background iterate sample into runtime timing snapshots."""
+
+        if self.app.voip_manager is None:
+            return
+
+        get_snapshot = getattr(self.app.voip_manager, "get_iterate_timing_snapshot", None)
+        if not callable(get_snapshot):
+            return
+
+        snapshot = get_snapshot()
+        if snapshot is None:
+            return
+
+        last_started_at = max(0.0, float(getattr(snapshot, "last_started_at", 0.0) or 0.0))
+        if last_started_at > 0.0:
+            self._last_voip_iterate_started_at = last_started_at
+
+        sample_id = max(0, int(getattr(snapshot, "sample_id", 0) or 0))
+        if sample_id <= 0 or sample_id == self._last_voip_timing_sample_id:
+            return
+
+        self._last_voip_timing_sample_id = sample_id
+        self._last_voip_schedule_delay_seconds = max(
+            0.0,
+            float(getattr(snapshot, "schedule_delay_seconds", 0.0) or 0.0),
+        )
+        self._last_voip_iterate_duration_seconds = max(
+            0.0,
+            float(getattr(snapshot, "total_duration_seconds", 0.0) or 0.0),
+        )
+        self._last_voip_native_events = max(0, int(getattr(snapshot, "drained_events", 0) or 0))
+        self._last_voip_native_iterate_duration_seconds = max(
+            0.0,
+            float(getattr(snapshot, "native_duration_seconds", 0.0) or 0.0),
+        )
+        self._last_voip_event_drain_duration_seconds = max(
+            0.0,
+            float(getattr(snapshot, "event_drain_duration_seconds", 0.0) or 0.0),
+        )
+
+        delayed = (
+            self._last_voip_schedule_delay_seconds >= self._voip_schedule_delay_warning_seconds()
+        )
+        slow = self._last_voip_iterate_duration_seconds >= self._voip_iterate_warning_seconds()
+        self._record_voip_timing_sample(
+            monotonic_now=max(
+                last_started_at,
+                float(getattr(snapshot, "last_completed_at", last_started_at) or last_started_at),
+            ),
+            schedule_delay_seconds=self._last_voip_schedule_delay_seconds,
+            iterate_duration_seconds=self._last_voip_iterate_duration_seconds,
+            native_iterate_duration_seconds=self._last_voip_native_iterate_duration_seconds,
+            event_drain_duration_seconds=self._last_voip_event_drain_duration_seconds,
+            drained_events=self._last_voip_native_events,
+            delayed=delayed,
+            slow=slow,
+        )
+
+        if delayed or slow:
+            voip_logger.warning(
+                "VoIP iterate timing drift: "
+                "schedule_delay_ms={:.1f} iterate_ms={:.1f} "
+                "interval_ms={:.1f} configured_interval_ms={:.1f} "
+                "native_iterate_ms={:.1f} event_drain_ms={:.1f} "
+                "native_events={} cadence_mode={} cadence_reason={} "
+                "pending_callbacks={} pending_events={} screen={} state={}",
+                self._last_voip_schedule_delay_seconds * 1000.0,
+                self._last_voip_iterate_duration_seconds * 1000.0,
+                self._effective_voip_iterate_interval_seconds() * 1000.0,
+                self.app._voip_iterate_interval_seconds * 1000.0,
+                self._last_voip_native_iterate_duration_seconds * 1000.0,
+                self._last_voip_event_drain_duration_seconds * 1000.0,
+                self._last_voip_native_events,
+                self._current_cadence_mode,
+                self._current_cadence_reason,
+                _queue_depth(self.app._pending_main_thread_callbacks),
+                self.app.event_bus.pending_count(),
+                self._current_screen_name(),
+                self._runtime_state_name(),
+            )
+
     def process_pending_main_thread_actions(self, limit: Optional[int] = None) -> int:
         """Drain queued typed events scheduled by worker threads."""
         started_at = time.monotonic()
@@ -246,8 +337,18 @@ class RuntimeLoopService:
         )
 
     def iterate_voip_backend_if_due(self, now: float | None = None) -> None:
-        """Advance the Liblinphone core on the coordinator thread at its configured cadence."""
+        """Advance or observe VoIP keep-alive work without stalling the coordinator thread."""
         if self.app.voip_manager is None or not self.app.voip_manager.running:
+            return
+
+        if self._voip_background_iterate_enabled():
+            ensure_running = getattr(self.app.voip_manager, "ensure_background_iterate_running", None)
+            if callable(ensure_running):
+                ensure_running()
+            poll_housekeeping = getattr(self.app.voip_manager, "poll_housekeeping", None)
+            if callable(poll_housekeeping):
+                poll_housekeeping()
+            self._sync_background_voip_timing_sample()
             return
 
         monotonic_now = time.monotonic() if now is None else now
@@ -342,7 +443,11 @@ class RuntimeLoopService:
 
         sleep_seconds = max(0.0, cadence.loop_sleep_seconds)
         deadlines = [sleep_seconds]
-        if self.app.voip_manager is not None and self.app.voip_manager.running:
+        if (
+            self.app.voip_manager is not None
+            and self.app.voip_manager.running
+            and not self._voip_background_iterate_enabled()
+        ):
             if self.app._next_voip_iterate_at <= 0.0:
                 deadlines.append(self._effective_voip_iterate_interval_seconds())
             else:
@@ -745,10 +850,27 @@ class RuntimeLoopService:
             self.app.voip_manager is not None
             and self.app.voip_manager.running
         ):
-            self.app._next_voip_iterate_at = self._next_voip_due_at_for_cadence(
-                monotonic_now=monotonic_now,
-                iterate_interval_seconds=decision.voip_iterate_interval_seconds,
-            )
+            if self._voip_background_iterate_enabled():
+                ensure_running = getattr(
+                    self.app.voip_manager,
+                    "ensure_background_iterate_running",
+                    None,
+                )
+                if callable(ensure_running):
+                    ensure_running()
+                set_interval = getattr(
+                    self.app.voip_manager,
+                    "set_iterate_interval_seconds",
+                    None,
+                )
+                if callable(set_interval):
+                    set_interval(decision.voip_iterate_interval_seconds)
+                self.app._next_voip_iterate_at = 0.0
+            else:
+                self.app._next_voip_iterate_at = self._next_voip_due_at_for_cadence(
+                    monotonic_now=monotonic_now,
+                    iterate_interval_seconds=decision.voip_iterate_interval_seconds,
+                )
 
         if not changed:
             return

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -212,16 +212,52 @@ class FakeRuntimeLoopVoIPManager:
         native_events: int = 0,
         native_iterate_seconds: float = 0.0,
         event_drain_seconds: float = 0.0,
+        background_iterate_enabled: bool = False,
+        sample_id: int = 0,
+        schedule_delay_seconds: float = 0.0,
+        total_duration_seconds: float | None = None,
+        last_started_at: float = 0.0,
+        last_completed_at: float = 0.0,
     ) -> None:
         self.running = True
+        self.background_iterate_enabled = background_iterate_enabled
         self.iterate_calls = 0
+        self.ensure_background_iterate_running_calls = 0
+        self.housekeeping_calls = 0
+        self.interval_updates: list[float] = []
         self.native_events = native_events
         self.native_iterate_seconds = native_iterate_seconds
         self.event_drain_seconds = event_drain_seconds
+        self._iterate_timing_snapshot = SimpleNamespace(
+            sample_id=sample_id,
+            last_started_at=last_started_at,
+            last_completed_at=last_completed_at,
+            schedule_delay_seconds=schedule_delay_seconds,
+            total_duration_seconds=(
+                native_iterate_seconds + event_drain_seconds
+                if total_duration_seconds is None
+                else total_duration_seconds
+            ),
+            native_duration_seconds=native_iterate_seconds,
+            event_drain_duration_seconds=event_drain_seconds,
+            drained_events=native_events,
+            interval_seconds=0.0,
+            in_flight=False,
+        )
 
     def iterate(self) -> int:
         self.iterate_calls += 1
         return self.native_events
+
+    def ensure_background_iterate_running(self) -> None:
+        self.ensure_background_iterate_running_calls += 1
+
+    def set_iterate_interval_seconds(self, interval_seconds: float) -> None:
+        self.interval_updates.append(interval_seconds)
+        self._iterate_timing_snapshot.interval_seconds = interval_seconds
+
+    def poll_housekeeping(self) -> None:
+        self.housekeeping_calls += 1
 
     def get_iterate_metrics(self) -> object:
         return SimpleNamespace(
@@ -230,6 +266,11 @@ class FakeRuntimeLoopVoIPManager:
             total_duration_seconds=self.native_iterate_seconds + self.event_drain_seconds,
             drained_events=self.native_events,
         )
+
+    def get_iterate_timing_snapshot(self) -> object | None:
+        if not self.background_iterate_enabled:
+            return None
+        return self._iterate_timing_snapshot
 
 
 class FakePowerManager:
@@ -1703,6 +1744,53 @@ def test_runtime_loop_keeps_fast_cadence_during_call_states() -> None:
     assert status["runtime_cadence_mode"] == "latency_sensitive"
     assert status["runtime_cadence_reason"] == "call_or_connecting_state"
     assert status["voip_effective_iterate_interval_seconds"] == pytest.approx(0.02)
+
+
+def test_runtime_loop_offloads_voip_iterate_to_background_manager() -> None:
+    """App-mode VoIP cadence should no longer call the backend iterate on the coordinator."""
+
+    app, _, _ = _build_app_with_power(
+        FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+    voip_manager = FakeRuntimeLoopVoIPManager(
+        background_iterate_enabled=True,
+        native_events=2,
+        native_iterate_seconds=0.003,
+        event_drain_seconds=0.001,
+        sample_id=1,
+        schedule_delay_seconds=0.004,
+        last_started_at=0.96,
+        last_completed_at=0.964,
+    )
+    app.voip_manager = voip_manager
+    app._voip_iterate_interval_seconds = 0.02
+
+    sleep_seconds = app.runtime_loop.next_sleep_interval_seconds(
+        monotonic_now=1.0,
+        current_time=1.0,
+        last_screen_update=1.0,
+        screen_update_interval=1.0,
+    )
+    updated_at = app.runtime_loop.run_iteration(
+        monotonic_now=1.0,
+        current_time=1.0,
+        last_screen_update=0.0,
+        screen_update_interval=10.0,
+    )
+
+    status = app.get_status()
+    assert sleep_seconds == pytest.approx(0.05)
+    assert updated_at == 0.0
+    assert voip_manager.iterate_calls == 0
+    assert voip_manager.ensure_background_iterate_running_calls >= 1
+    assert voip_manager.housekeeping_calls == 1
+    assert voip_manager.interval_updates[-1] == pytest.approx(0.05)
+    assert status["voip_schedule_delay_seconds"] == pytest.approx(0.004)
+    assert status["voip_iterate_duration_seconds"] == pytest.approx(0.004)
+    assert status["voip_native_iterate_duration_seconds"] == pytest.approx(0.003)
+    assert status["voip_event_drain_duration_seconds"] == pytest.approx(0.001)
+    assert status["voip_iterate_native_events"] == 2
+    assert status["voip_iterate_age_seconds"] is not None
 
 
 def test_runtime_loop_logs_voip_timing_drift_and_exposes_snapshot(

--- a/tests/test_voip_backend.py
+++ b/tests/test_voip_backend.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import queue
 import subprocess
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -27,6 +29,7 @@ from yoyopod.communication import (
     RegistrationState,
     RegistrationStateChanged,
     VoIPConfig,
+    VoIPEvent,
     VoIPManager,
     VoIPMessageRecord,
 )
@@ -115,6 +118,38 @@ class FakePeopleDirectory:
         return SimpleNamespace(display_name=contact_name)
 
 
+class BackgroundIterateMockVoIPBackend(MockVoIPBackend):
+    """Mock backend that cooperates with the manager's real background iterate thread."""
+
+    def __init__(
+        self,
+        *,
+        event_to_emit: VoIPEvent | None = None,
+        metrics_error: Exception | None = None,
+    ) -> None:
+        super().__init__()
+        self.event_to_emit = event_to_emit
+        self.metrics_error = metrics_error
+        self.iterate_calls = 0
+        self.iterate_started = threading.Event()
+
+    def iterate(self) -> int:
+        self.iterate_started.set()
+        self.iterate_calls += 1
+        if self.iterate_calls == 1 and self.event_to_emit is not None:
+            self.emit(self.event_to_emit)
+            return 1
+        return 0
+
+    def get_iterate_metrics(self) -> object | None:
+        if self.metrics_error is not None:
+            raise self.metrics_error
+        return SimpleNamespace(
+            native_duration_seconds=0.0,
+            event_drain_duration_seconds=0.0,
+        )
+
+
 def build_config() -> VoIPConfig:
     """Create a small test configuration."""
 
@@ -152,6 +187,17 @@ def native_event(**overrides) -> SimpleNamespace:
     }
     base.update(overrides)
     return SimpleNamespace(**base)
+
+
+def wait_for_condition(predicate: Callable[[], bool], *, timeout_seconds: float = 1.0) -> bool:
+    """Poll a test condition until it becomes true or the timeout expires."""
+
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
 
 
 def test_liblinphone_backend_starts_and_drains_native_events() -> None:
@@ -235,7 +281,9 @@ def test_liblinphone_backend_records_native_iterate_timings(monkeypatch) -> None
     warnings: list[tuple[object, ...]] = []
     monotonic_values = iter([10.0, 10.0, 10.18, 10.18, 10.29, 10.31])
 
-    monkeypatch.setattr("yoyopod.communication.calling.backend.time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(
+        "yoyopod.communication.calling.backend.time.monotonic", lambda: next(monotonic_values)
+    )
     monkeypatch.setattr(
         "yoyopod.communication.calling.backend.logger.warning",
         lambda *args: warnings.append(args),
@@ -496,6 +544,96 @@ def test_voip_manager_queues_backend_events_back_to_main_thread(tmp_path: Path) 
     assert manager.call_state == CallState.CONNECTED
 
 
+def test_voip_manager_background_iterate_thread_queues_events_and_stops_cleanly(
+    tmp_path: Path,
+) -> None:
+    """The dedicated iterate worker should queue callbacks back to the coordinator thread."""
+
+    backend = BackgroundIterateMockVoIPBackend(
+        event_to_emit=CallStateChanged(state=CallState.CONNECTED)
+    )
+    config = build_config()
+    config.message_store_dir = str(tmp_path / "messages")
+    config.voice_note_store_dir = str(tmp_path / "voice_notes")
+    scheduled_callbacks: queue.Queue[Callable[[], None]] = queue.Queue()
+    manager = VoIPManager(
+        config,
+        backend=backend,
+        event_scheduler=scheduled_callbacks.put,
+        background_iterate_enabled=True,
+    )
+
+    assert manager.start()
+    try:
+        manager.ensure_background_iterate_running()
+
+        assert wait_for_condition(backend.iterate_started.is_set)
+        assert manager._iterate_thread is not None
+        worker_thread = manager._iterate_thread
+
+        assert wait_for_condition(lambda: not scheduled_callbacks.empty())
+        assert manager.call_state == CallState.IDLE
+
+        scheduled_callbacks.get_nowait()()
+
+        assert manager.call_state == CallState.CONNECTED
+        assert backend.iterate_calls >= 1
+
+        manager._stop_background_iterate_loop()
+
+        assert manager._iterate_thread is None
+        assert worker_thread is not None
+        assert worker_thread.is_alive() is False
+    finally:
+        manager.stop(notify_events=False)
+
+
+def test_voip_manager_background_iterate_worker_surfaces_unexpected_failure(
+    tmp_path: Path,
+) -> None:
+    """Unexpected worker-loop failures should be converted into a backend-stopped event."""
+
+    backend = BackgroundIterateMockVoIPBackend(metrics_error=RuntimeError("metrics exploded"))
+    config = build_config()
+    config.message_store_dir = str(tmp_path / "messages")
+    config.voice_note_store_dir = str(tmp_path / "voice_notes")
+    scheduled_callbacks: queue.Queue[Callable[[], None]] = queue.Queue()
+    availability_changes: list[tuple[bool, str]] = []
+    manager = VoIPManager(
+        config,
+        backend=backend,
+        event_scheduler=scheduled_callbacks.put,
+        background_iterate_enabled=True,
+    )
+    manager.on_availability_change(
+        lambda available, reason: availability_changes.append((available, reason))
+    )
+
+    assert manager.start()
+    try:
+        manager.ensure_background_iterate_running()
+
+        assert wait_for_condition(backend.iterate_started.is_set)
+        assert wait_for_condition(lambda: not scheduled_callbacks.empty())
+
+        scheduled_callbacks.get_nowait()()
+
+        assert manager.running is False
+        assert manager.registered is False
+        assert manager.registration_state == RegistrationState.FAILED
+        assert availability_changes[-1] == (False, "metrics exploded")
+
+        worker_thread = manager._iterate_thread
+        assert worker_thread is not None
+        assert wait_for_condition(lambda: worker_thread.is_alive() is False)
+
+        manager._stop_background_iterate_loop()
+
+        assert manager._iterate_thread is None
+    finally:
+        manager.stop(notify_events=False)
+
+
 def test_voip_manager_surfaces_voice_note_failure_reason() -> None:
     """Voice-note send failures should preserve the backend reason for the UI."""
 
@@ -640,9 +778,7 @@ def test_liblinphone_shim_records_voice_notes_as_wav() -> None:
 
     shim_source = Path(
         "src/yoyopod/communication/integrations/liblinphone_binding/native/liblinphone_shim.c"
-    ).read_text(
-        encoding="utf-8"
-    )
+    ).read_text(encoding="utf-8")
 
     assert (
         "linphone_recorder_params_set_file_format(params, LinphoneRecorderFileFormatWav);"
@@ -655,9 +791,7 @@ def test_liblinphone_shim_wires_incoming_message_debug_paths() -> None:
 
     shim_source = Path(
         "src/yoyopod/communication/integrations/liblinphone_binding/native/liblinphone_shim.c"
-    ).read_text(
-        encoding="utf-8"
-    )
+    ).read_text(encoding="utf-8")
 
     assert (
         "linphone_core_cbs_set_messages_received(g_state.core_cbs, yoyopod_on_messages_received);"

--- a/tests/test_voip_backend.py
+++ b/tests/test_voip_backend.py
@@ -6,6 +6,7 @@ import subprocess
 import time
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Callable
 
 import pytest
 from cffi import FFI
@@ -467,6 +468,32 @@ def test_voip_manager_times_out_stuck_voice_note_send() -> None:
     assert manager.get_active_voice_note().send_state == "failed"
     assert manager.get_active_voice_note().status_text == "Send timed out"
     assert drained_events == 0
+
+
+def test_voip_manager_queues_backend_events_back_to_main_thread(tmp_path: Path) -> None:
+    """App-mode VoIP events should be marshaled back through the main-thread scheduler."""
+
+    backend = MockVoIPBackend()
+    config = build_config()
+    config.message_store_dir = str(tmp_path / "messages")
+    config.voice_note_store_dir = str(tmp_path / "voice_notes")
+    queued_callbacks: list[Callable[[], None]] = []
+    manager = VoIPManager(
+        config,
+        backend=backend,
+        event_scheduler=queued_callbacks.append,
+        background_iterate_enabled=True,
+    )
+
+    backend.emit(CallStateChanged(state=CallState.CONNECTED))
+
+    assert manager.background_iterate_enabled is True
+    assert manager.call_state == CallState.IDLE
+    assert len(queued_callbacks) == 1
+
+    queued_callbacks.pop()()
+
+    assert manager.call_state == CallState.CONNECTED
 
 
 def test_voip_manager_surfaces_voice_note_failure_reason() -> None:


### PR DESCRIPTION
## Summary
- move app-mode VoIP iterate execution into a dedicated `VoIPManager` worker instead of running Liblinphone iterate directly on the coordinator loop
- marshal backend events back through the existing main-thread callback queue so call and message state mutations still stay on the coordinator thread
- harden the background iterate worker so unexpected loop-body failures are logged and surfaced as `BackendStopped` instead of silently killing the daemon thread
- add real threaded manager coverage for background iterate startup, callback queue handoff, unexpected worker failure, and clean shutdown

## Why
Issue #237 calls out coordinator-thread starvation from running Liblinphone iterate and native event draining on the single Python runtime loop. The main implementation in this PR moves that hot path off the coordinator in the app runtime while preserving the existing cadence decisions and diagnostics.

The repair pass on top of that implementation addresses the review brief directly: if code around one worker iteration raises outside `backend.iterate()`, the worker now logs the failure and reports it through the existing `BackendStopped` path, and the tests now exercise the real background iterate thread rather than only synchronous callback dispatch.

## Validation
- `uv sync --extra dev`
- `uv run pytest -q tests/test_voip_backend.py -k "background_iterate or backend_stop_event or queues_backend_events_back_to_main_thread" -o cache_dir=/tmp/yoyopod-pytest-cache`
- `uv run black --check src/yoyopod/communication/calling/manager.py tests/test_voip_backend.py`
- `uv run ruff check src/yoyopod/communication/calling/manager.py tests/test_voip_backend.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q -o cache_dir=/tmp/yoyopod-pytest-cache`

## Reviewer Notes
- background iterate is enabled only for the app runtime path wired in `RuntimeBootService`; CLI and manual `VoIPManager.iterate()` behavior stays synchronous
- this repair pass is intentionally narrow and does not widen the PR into broader VoIP or runtime refactors
- issue: #237