### PR TITLE
[codex] Reduce button adapter polling churn

### DIFF
--- a/src/yoyopod/ui/gpiod_compat.py
+++ b/src/yoyopod/ui/gpiod_compat.py
@@ -108,20 +108,33 @@ def request_input_events(chip: Any, line_offset: int, consumer: str) -> Any:
     raise RuntimeError("gpiod edge-event requests are unavailable")
 
 
+def _normalize_event_fd(candidate: Any) -> int | None:
+    """Return a waitable GPIO event fd or ``None`` when the runtime reports none."""
+    try:
+        event_fd = int(candidate)
+    except Exception as exc:
+        logger.debug("Failed to normalize GPIO event fd: {}", exc)
+        return None
+
+    if event_fd < 0:
+        logger.debug("Ignoring invalid negative GPIO event fd: {}", event_fd)
+        return None
+
+    return event_fd
+
+
 def get_event_fd(line: Any) -> int | None:
     """Return the file descriptor used for waiting on GPIO edge events."""
     getter = getattr(line, "event_get_fd", None)
     if callable(getter):
         try:
-            return int(getter())
+            return _normalize_event_fd(getter())
         except Exception as exc:
             logger.debug("Failed to read GPIO event fd: {}", exc)
             return None
 
     fd = getattr(line, "fd", None)
-    if isinstance(fd, int):
-        return fd
-    return None
+    return _normalize_event_fd(fd)
 
 
 def read_edge_events(line: Any) -> list[Any]:

--- a/src/yoyopod/ui/gpiod_compat.py
+++ b/src/yoyopod/ui/gpiod_compat.py
@@ -10,6 +10,7 @@ are available.
 
 from __future__ import annotations
 
+import select
 from typing import Any
 
 from loguru import logger
@@ -146,6 +147,32 @@ def read_edge_events(line: Any) -> list[Any]:
 
     reader = getattr(line, "event_read", None)
     if callable(reader):
-        return [reader()]
+        events: list[Any] = []
+        event_fd = get_event_fd(line)
+
+        while True:
+            event = reader()
+            if event is None:
+                break
+
+            events.append(event)
+
+            if event_fd is None:
+                break
+
+            try:
+                ready, _, _ = select.select([event_fd], [], [], 0.0)
+            except (OSError, ValueError) as exc:
+                logger.debug(
+                    "Failed to drain legacy GPIO edge queue from fd {}: {}",
+                    event_fd,
+                    exc,
+                )
+                break
+
+            if not ready:
+                break
+
+        return events
 
     raise RuntimeError("Requested line does not expose edge-event reads")

--- a/src/yoyopod/ui/gpiod_compat.py
+++ b/src/yoyopod/ui/gpiod_compat.py
@@ -1,11 +1,11 @@
 """
-gpiod API compatibility layer for gpiod 1.x and 2.x.
+gpiod API compatibility layer for the legacy Python bindings used by YoyoPod.
 
-gpiod 1.x (Debian Bullseye): lowercase ``gpiod.chip()``, ``gpiod.line_request``
-gpiod 2.x (newer distros): uppercase ``gpiod.Chip()``, ``gpiod.LINE_REQ_DIR_OUT``
-
-This module normalizes both APIs behind a minimal interface used by the
-ST7789 SPI driver and gpiod button adapter.
+The project primarily targets the historical Python gpiod layouts that expose
+``chip()/line_request`` or ``Chip()/LINE_REQ_*`` with line-level requests.
+Some environments also provide the official libgpiod Python bindings, so this
+module keeps the interface narrow and feature-detects when edge-event requests
+are available.
 """
 
 from __future__ import annotations
@@ -80,3 +80,59 @@ def request_input(chip: Any, line_offset: int, consumer: str) -> Any:
         )
 
     return line
+
+
+def request_input_events(chip: Any, line_offset: int, consumer: str) -> Any:
+    """Request a GPIO line for both-edge events when the runtime supports it."""
+    if not HAS_GPIOD:
+        raise RuntimeError("gpiod module is required but not installed")
+
+    line = chip.get_line(line_offset)
+
+    if _is_v1():
+        config = _gpiod.line_request()
+        config.consumer = consumer
+        config.request_type = _gpiod.line_request.EVENT_BOTH_EDGES
+        config.flags = _gpiod.line_request.FLAG_BIAS_DISABLE
+        line.request(config)
+        return line
+
+    if hasattr(_gpiod, "LINE_REQ_EV_BOTH_EDGES"):
+        line.request(
+            consumer=consumer,
+            type=_gpiod.LINE_REQ_EV_BOTH_EDGES,
+            flags=_gpiod.LINE_REQ_FLAG_BIAS_DISABLE,
+        )
+        return line
+
+    raise RuntimeError("gpiod edge-event requests are unavailable")
+
+
+def get_event_fd(line: Any) -> int | None:
+    """Return the file descriptor used for waiting on GPIO edge events."""
+    getter = getattr(line, "event_get_fd", None)
+    if callable(getter):
+        try:
+            return int(getter())
+        except Exception as exc:
+            logger.debug("Failed to read GPIO event fd: {}", exc)
+            return None
+
+    fd = getattr(line, "fd", None)
+    if isinstance(fd, int):
+        return fd
+    return None
+
+
+def read_edge_events(line: Any) -> list[Any]:
+    """Drain the currently queued edge events for one requested line."""
+    reader = getattr(line, "read_edge_events", None)
+    if callable(reader):
+        events = reader()
+        return list(events) if events is not None else []
+
+    reader = getattr(line, "event_read", None)
+    if callable(reader):
+        return [reader()]
+
+    raise RuntimeError("Requested line does not expose edge-event reads")

--- a/src/yoyopod/ui/input/adapters/four_button.py
+++ b/src/yoyopod/ui/input/adapters/four_button.py
@@ -4,11 +4,12 @@ Four-button input adapter for Pimoroni Display HAT Mini.
 Maps physical buttons (A, B, X, Y) to semantic input actions.
 """
 
-import time
 from collections import defaultdict
 from enum import Enum
-from typing import Callable, Dict, Optional, Any, List
-from threading import Thread, Event
+from threading import Event, Thread
+from typing import Any, Callable, Dict, List, Optional
+
+import time
 from loguru import logger
 
 from yoyopod.ui.input.hal import InputHAL, InputAction
@@ -69,6 +70,7 @@ class FourButtonInputAdapter(InputHAL):
     DEBOUNCE_TIME = 0.05      # 50ms debounce
     LONG_PRESS_TIME = 1.0     # 1 second for long press
     DOUBLE_PRESS_TIME = 0.3   # 300ms window for double press
+    POLL_INTERVAL = 0.03      # 30ms idle poll to reduce GIL churn
 
     def __init__(
         self,
@@ -102,6 +104,18 @@ class FourButtonInputAdapter(InputHAL):
             Button.B: False,
             Button.X: False,
             Button.Y: False,
+        }
+        self.raw_button_states: Dict[Button, bool] = {
+            Button.A: False,
+            Button.B: False,
+            Button.X: False,
+            Button.Y: False,
+        }
+        self.button_transition_times: Dict[Button, Optional[float]] = {
+            Button.A: None,
+            Button.B: None,
+            Button.X: None,
+            Button.Y: None,
         }
 
         # Press time tracking for long press detection
@@ -219,6 +233,81 @@ class FourButtonInputAdapter(InputHAL):
                 except Exception as e:
                     logger.error(f"Error in button callback: {e}")
 
+    def _observe_raw_state(
+        self,
+        button: Button,
+        current_state: bool,
+        observed_at: float,
+    ) -> None:
+        """Track a raw edge and start a debounce window when the signal changes."""
+        if current_state == self.raw_button_states[button]:
+            return
+
+        self.raw_button_states[button] = current_state
+        self.button_transition_times[button] = observed_at
+
+    def _advance_button_state(self, button: Button, current_time: float) -> None:
+        """Promote debounced edges into semantic press, release, and long-hold state."""
+        transition_started_at = self.button_transition_times[button]
+        stable_state = self.button_states[button]
+        raw_state = self.raw_button_states[button]
+
+        if transition_started_at is not None:
+            if (current_time - transition_started_at) >= self.DEBOUNCE_TIME:
+                self.button_transition_times[button] = None
+                if raw_state != stable_state:
+                    if raw_state:
+                        self.button_press_times[button] = transition_started_at
+                        self.button_states[button] = True
+                        self.long_press_fired[button] = False
+                        logger.trace(f"Button {button.value} pressed")
+                    else:
+                        press_time = self.button_press_times[button]
+                        self.button_states[button] = False
+                        if press_time is not None:
+                            press_duration = transition_started_at - press_time
+                            if not self.long_press_fired[button]:
+                                action = self.mapping.get(button)
+                                if action:
+                                    self._fire_action(action, {"button": button.value})
+                            logger.trace(
+                                f"Button {button.value} released after {press_duration:.2f}s"
+                            )
+                        self.button_press_times[button] = None
+
+        press_time = self.button_press_times[button]
+        if self.button_states[button] and press_time is not None and not self.long_press_fired[button]:
+            hold_duration = current_time - press_time
+            if hold_duration >= self.LONG_PRESS_TIME:
+                long_action = self.LONG_PRESS_MAPPING.get(button)
+                if long_action:
+                    self._fire_action(
+                        long_action,
+                        {"button": button.value, "long_press": True},
+                    )
+                self.long_press_fired[button] = True
+
+    def _next_wait_timeout(self, current_time: float) -> float:
+        """Return the shortest relevant wait for polling, debounce, or long-hold deadlines."""
+        deadlines = [self.POLL_INTERVAL]
+
+        for transition_started_at in self.button_transition_times.values():
+            if transition_started_at is None:
+                continue
+            deadlines.append(
+                max(0.0, self.DEBOUNCE_TIME - (current_time - transition_started_at))
+            )
+
+        for button in Button:
+            press_time = self.button_press_times[button]
+            if press_time is None or not self.button_states[button] or self.long_press_fired[button]:
+                continue
+            deadlines.append(
+                max(0.0, self.LONG_PRESS_TIME - (current_time - press_time))
+            )
+
+        return min(deadlines)
+
     def _poll_buttons(self) -> None:
         """
         Poll button states in a loop.
@@ -229,57 +318,13 @@ class FourButtonInputAdapter(InputHAL):
         logger.debug("Button polling started")
 
         while not self.stop_event.is_set():
-            current_time = time.time()
+            current_time = time.monotonic()
 
             for button in Button:
                 current_state = self._get_button_state(button)
-                previous_state = self.button_states[button]
+                self._observe_raw_state(button, current_state, current_time)
+                self._advance_button_state(button, current_time)
 
-                # Button just pressed (transition from False to True)
-                if current_state and not previous_state:
-                    # Debounce
-                    time.sleep(self.DEBOUNCE_TIME)
-                    current_state = self._get_button_state(button)
-
-                    if current_state:  # Still pressed after debounce
-                        self.button_press_times[button] = current_time
-                        self.button_states[button] = True
-                        self.long_press_fired[button] = False
-                        logger.trace(f"Button {button.value} pressed")
-
-                # Button released (transition from True to False)
-                elif not current_state and previous_state:
-                    press_time = self.button_press_times[button]
-                    self.button_states[button] = False
-
-                    if press_time:
-                        press_duration = current_time - press_time
-
-                        # Don't fire PRESS if LONG_PRESS already fired
-                        if not self.long_press_fired[button]:
-                            # Map button to action and fire
-                            action = self.mapping.get(button)
-                            if action:
-                                self._fire_action(action, {"button": button.value})
-
-                        self.button_press_times[button] = None
-                        logger.trace(f"Button {button.value} released after {press_duration:.2f}s")
-
-                # Button held down - check for long press
-                elif current_state and previous_state:
-                    press_time = self.button_press_times[button]
-                    if press_time and not self.long_press_fired[button]:
-                        hold_duration = current_time - press_time
-                        if hold_duration >= self.LONG_PRESS_TIME:
-                            # Check for long press mapping
-                            long_action = self.LONG_PRESS_MAPPING.get(button)
-                            if long_action:
-                                self._fire_action(long_action, {
-                                    "button": button.value,
-                                    "long_press": True
-                                })
-                            self.long_press_fired[button] = True
-
-            time.sleep(0.01)  # 10ms polling rate
+            self.stop_event.wait(self._next_wait_timeout(current_time))
 
         logger.debug("Button polling stopped")

--- a/src/yoyopod/ui/input/adapters/gpiod_buttons.py
+++ b/src/yoyopod/ui/input/adapters/gpiod_buttons.py
@@ -333,6 +333,10 @@ class GpiodButtonAdapter(InputHAL):
                 self._polling_loop()
                 return
 
+            # Some buttons may have new edges while others only need their existing
+            # debounce or long-press deadlines advanced. Reusing one monotonic
+            # timestamp keeps every button in this wake cycle ordered against the
+            # same "now", so unready buttons can safely advance without a fresh read.
             observed_at = time.monotonic()
             for fd in ready:
                 button = fd_to_button.get(fd)
@@ -345,11 +349,10 @@ class GpiodButtonAdapter(InputHAL):
                     read_edge_events(line)
                 except Exception as exc:
                     logger.debug(
-                        "Failed to drain GPIO edge events for button {}: {}",
+                        "Failed to drain GPIO edge events for button {}; sampling level directly: {}",
                         button.value,
                         exc,
                     )
-                    continue
 
                 self._observe_raw_state(button, self._read_button(button), observed_at)
 

--- a/src/yoyopod/ui/input/adapters/gpiod_buttons.py
+++ b/src/yoyopod/ui/input/adapters/gpiod_buttons.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import select
 import time
 from collections import defaultdict
+from datetime import datetime
 from enum import Enum
 from threading import Event, Thread
 from typing import Any, Callable, Dict, List, Optional
@@ -58,8 +59,8 @@ _DEBOUNCE_TIME = 0.05
 _LONG_PRESS_TIME = 1.0
 _POLL_INTERVAL = 0.03
 _EDGE_IDLE_WAIT_TIMEOUT = 0.5
-_EDGE_EVENT_RISING = {"rising", "rising_edge", "line_event_rising_edge", "edge_rising"}
-_EDGE_EVENT_FALLING = {"falling", "falling_edge", "line_event_falling_edge", "edge_falling"}
+_EDGE_EVENT_RISING = {"rising", "rising_edge", "line_event_rising_edge", "edge_rising", "1"}
+_EDGE_EVENT_FALLING = {"falling", "falling_edge", "line_event_falling_edge", "edge_falling", "2"}
 
 
 class GpiodButtonAdapter(InputHAL):
@@ -357,13 +358,15 @@ class GpiodButtonAdapter(InputHAL):
 
         return None
 
-    def _edge_event_observed_at(self, event: object, fallback: float) -> float:
-        """Prefer event timestamps when available so drained edges keep their ordering."""
+    def _edge_event_timestamp_seconds(self, event: object) -> float | None:
+        """Extract an event timestamp as seconds without assuming a clock domain."""
         timestamp_ns = getattr(event, "timestamp_ns", None)
         if isinstance(timestamp_ns, int):
             return timestamp_ns / 1_000_000_000
 
         timestamp = getattr(event, "timestamp", None)
+        if isinstance(timestamp, datetime):
+            return timestamp.timestamp()
         if isinstance(timestamp, (int, float)):
             return float(timestamp)
 
@@ -372,7 +375,20 @@ class GpiodButtonAdapter(InputHAL):
         if isinstance(sec, int) and isinstance(nsec, int):
             return sec + (nsec / 1_000_000_000)
 
-        return fallback
+        return None
+
+    def _edge_event_observed_at(
+        self,
+        event: object,
+        fallback: float,
+        first_timestamp: float | None,
+    ) -> float:
+        """Project event ordering onto the local monotonic clock used by the FSM."""
+        timestamp_seconds = self._edge_event_timestamp_seconds(event)
+        if timestamp_seconds is None or first_timestamp is None:
+            return fallback
+
+        return fallback + max(0.0, timestamp_seconds - first_timestamp)
 
     def _edge_type_to_pressed_state(self, edge_type: object) -> bool | None:
         """Map gpiod edge direction identifiers onto active-low pressed state."""
@@ -393,8 +409,15 @@ class GpiodButtonAdapter(InputHAL):
             self._observe_raw_state(button, self._read_button(button), observed_at)
             return
 
+        first_timestamp = None
         for event in events:
-            event_at = self._edge_event_observed_at(event, observed_at)
+            timestamp_seconds = self._edge_event_timestamp_seconds(event)
+            if timestamp_seconds is not None:
+                first_timestamp = timestamp_seconds
+                break
+
+        for event in events:
+            event_at = self._edge_event_observed_at(event, observed_at, first_timestamp)
             self._advance_button_state(button, event_at)
             event_state = self._edge_event_state(event)
             if event_state is None:

--- a/src/yoyopod/ui/input/adapters/gpiod_buttons.py
+++ b/src/yoyopod/ui/input/adapters/gpiod_buttons.py
@@ -58,6 +58,8 @@ _DEBOUNCE_TIME = 0.05
 _LONG_PRESS_TIME = 1.0
 _POLL_INTERVAL = 0.03
 _EDGE_IDLE_WAIT_TIMEOUT = 0.5
+_EDGE_EVENT_RISING = {"rising", "rising_edge", "line_event_rising_edge", "edge_rising"}
+_EDGE_EVENT_FALLING = {"falling", "falling_edge", "line_event_falling_edge", "edge_falling"}
 
 
 class GpiodButtonAdapter(InputHAL):
@@ -318,9 +320,92 @@ class GpiodButtonAdapter(InputHAL):
             self._observe_raw_state(button, current_state, current_time)
             self._advance_button_state(button, current_time)
 
+    def _seed_event_loop_states(self, observed_at: float) -> None:
+        """Prime raw/stable state from live GPIO levels before waiting on edges."""
+        for button in Button:
+            if button not in self._lines:
+                continue
+
+            current_state = self._read_button(button)
+            self._raw_button_states[button] = current_state
+            self._button_states[button] = current_state
+            self._transition_times[button] = None
+            self._long_fired[button] = False
+            self._press_times[button] = observed_at if current_state else None
+
+    def _edge_event_state(self, event: object) -> bool | None:
+        """Translate a gpiod edge-event object into the adapter's pressed state."""
+        for attr_name in ("event_type", "type"):
+            edge_type = getattr(event, attr_name, None)
+            state = self._edge_type_to_pressed_state(edge_type)
+            if state is not None:
+                return state
+
+        for attr_name in ("rising_edge", "is_rising_edge"):
+            value = getattr(event, attr_name, None)
+            if value is True:
+                return False
+            if value is False:
+                return True
+
+        for attr_name in ("falling_edge", "is_falling_edge"):
+            value = getattr(event, attr_name, None)
+            if value is True:
+                return True
+            if value is False:
+                return False
+
+        return None
+
+    def _edge_event_observed_at(self, event: object, fallback: float) -> float:
+        """Prefer event timestamps when available so drained edges keep their ordering."""
+        timestamp_ns = getattr(event, "timestamp_ns", None)
+        if isinstance(timestamp_ns, int):
+            return timestamp_ns / 1_000_000_000
+
+        timestamp = getattr(event, "timestamp", None)
+        if isinstance(timestamp, (int, float)):
+            return float(timestamp)
+
+        sec = getattr(event, "sec", None)
+        nsec = getattr(event, "nsec", None)
+        if isinstance(sec, int) and isinstance(nsec, int):
+            return sec + (nsec / 1_000_000_000)
+
+        return fallback
+
+    def _edge_type_to_pressed_state(self, edge_type: object) -> bool | None:
+        """Map gpiod edge direction identifiers onto active-low pressed state."""
+        if edge_type is None:
+            return None
+
+        normalized = str(edge_type).rsplit(".", 1)[-1].lower()
+        if normalized in _EDGE_EVENT_RISING:
+            return False
+        if normalized in _EDGE_EVENT_FALLING:
+            return True
+        return None
+
+    def _apply_edge_events(self, button: Button, line: object, observed_at: float) -> None:
+        """Replay drained edge transitions without collapsing them into one sampled level."""
+        events = read_edge_events(line)
+        if not events:
+            self._observe_raw_state(button, self._read_button(button), observed_at)
+            return
+
+        for event in events:
+            event_at = self._edge_event_observed_at(event, observed_at)
+            self._advance_button_state(button, event_at)
+            event_state = self._edge_event_state(event)
+            if event_state is None:
+                event_state = self._read_button(button)
+            self._observe_raw_state(button, event_state, event_at)
+            self._advance_button_state(button, event_at)
+
     def _event_wait_loop(self) -> None:
         """Block on GPIO edge file descriptors so idle threads stay asleep."""
         fd_to_button = {fd: button for button, fd in self._line_event_fds.items()}
+        self._seed_event_loop_states(time.monotonic())
 
         while not self._stop_event.is_set():
             current_time = time.monotonic()
@@ -346,15 +431,14 @@ class GpiodButtonAdapter(InputHAL):
                 if line is None:
                     continue
                 try:
-                    read_edge_events(line)
+                    self._apply_edge_events(button, line, observed_at)
                 except Exception as exc:
                     logger.debug(
                         "Failed to drain GPIO edge events for button {}; sampling level directly: {}",
                         button.value,
                         exc,
                     )
-
-                self._observe_raw_state(button, self._read_button(button), observed_at)
+                    self._observe_raw_state(button, self._read_button(button), observed_at)
 
             for button in Button:
                 self._advance_button_state(button, observed_at)

--- a/src/yoyopod/ui/input/adapters/gpiod_buttons.py
+++ b/src/yoyopod/ui/input/adapters/gpiod_buttons.py
@@ -11,6 +11,7 @@ Button mapping matches FourButtonInputAdapter:
 
 from __future__ import annotations
 
+import select
 import time
 from collections import defaultdict
 from enum import Enum
@@ -21,7 +22,14 @@ from loguru import logger
 
 from yoyopod.ui.input.hal import InputAction, InputHAL
 
-from yoyopod.ui.gpiod_compat import HAS_GPIOD, open_chip, request_input
+from yoyopod.ui.gpiod_compat import (
+    HAS_GPIOD,
+    get_event_fd,
+    open_chip,
+    read_edge_events,
+    request_input,
+    request_input_events,
+)
 
 
 class Button(Enum):
@@ -48,6 +56,8 @@ _LONG_PRESS_MAPPING: dict[Button, InputAction] = {
 # Timing constants (seconds)
 _DEBOUNCE_TIME = 0.05
 _LONG_PRESS_TIME = 1.0
+_POLL_INTERVAL = 0.03
+_EDGE_IDLE_WAIT_TIMEOUT = 0.5
 
 
 class GpiodButtonAdapter(InputHAL):
@@ -67,8 +77,11 @@ class GpiodButtonAdapter(InputHAL):
         # GPIO line handles keyed by Button
         self._lines: dict[Button, object] = {}
         self._chips: list[object] = []
+        self._line_event_fds: dict[Button, int] = {}
 
         # Button state tracking
+        self._raw_button_states: dict[Button, bool] = {b: False for b in Button}
+        self._transition_times: dict[Button, Optional[float]] = {b: None for b in Button}
         self._button_states: dict[Button, bool] = {b: False for b in Button}
         self._press_times: dict[Button, Optional[float]] = {b: None for b in Button}
         self._long_fired: dict[Button, bool] = {b: False for b in Button}
@@ -112,7 +125,7 @@ class GpiodButtonAdapter(InputHAL):
             try:
                 chip = open_chip(chip_name)
                 self._chips.append(chip)
-                line = request_input(chip, line_offset, f"pimoroni-btn-{button.value}")
+                line = self._request_line(chip, line_offset, button)
                 self._lines[button] = line
                 logger.debug(
                     "Button {} on {}:{}", button.value, chip_name, line_offset
@@ -125,6 +138,31 @@ class GpiodButtonAdapter(InputHAL):
         logger.info(
             "GpiodButtonAdapter: {} of 4 buttons acquired", len(self._lines)
         )
+
+    def _request_line(self, chip: object, line_offset: int, button: Button) -> object:
+        """Request one GPIO line, preferring both-edge events when supported."""
+        consumer = f"pimoroni-btn-{button.value}"
+
+        try:
+            line = request_input_events(chip, line_offset, consumer)
+        except Exception as exc:
+            logger.debug(
+                "Falling back to polled GPIO input for button {}: {}",
+                button.value,
+                exc,
+            )
+            return request_input(chip, line_offset, consumer)
+
+        event_fd = get_event_fd(line)
+        if event_fd is None:
+            logger.debug(
+                "GPIO edge events unavailable for button {}; using polling loop",
+                button.value,
+            )
+            return line
+
+        self._line_event_fds[button] = event_fd
+        return line
 
     def start(self) -> None:
         if self.running:
@@ -186,50 +224,149 @@ class GpiodButtonAdapter(InputHAL):
         except Exception:
             return False
 
-    def _poll_loop(self) -> None:
-        """Poll button states at 10ms intervals with debounce and long-press."""
-        while not self._stop_event.is_set():
-            now = time.time()
+    def _observe_raw_state(self, button: Button, current_state: bool, observed_at: float) -> None:
+        """Track raw GPIO edges and start a debounce window when the level changes."""
+        if current_state == self._raw_button_states[button]:
+            return
 
-            for button in Button:
-                if self.simulate and button not in self._lines:
-                    continue
+        self._raw_button_states[button] = current_state
+        self._transition_times[button] = observed_at
 
-                current = self._read_button(button)
-                previous = self._button_states[button]
+    def _advance_button_state(self, button: Button, current_time: float) -> None:
+        """Promote debounced raw state changes into semantic button actions."""
+        transition_started_at = self._transition_times[button]
+        stable_state = self._button_states[button]
+        raw_state = self._raw_button_states[button]
 
-                # Press detected
-                if current and not previous:
-                    time.sleep(_DEBOUNCE_TIME)
-                    current = self._read_button(button)
-                    if current:
-                        self._button_states[button] = True
-                        self._press_times[button] = now
-                        self._long_fired[button] = False
-
-                # Release detected
-                elif not current and previous:
+        if transition_started_at is not None and (current_time - transition_started_at) >= _DEBOUNCE_TIME:
+            self._transition_times[button] = None
+            if raw_state != stable_state:
+                if raw_state:
+                    self._button_states[button] = True
+                    self._press_times[button] = transition_started_at
+                    self._long_fired[button] = False
+                else:
                     self._button_states[button] = False
-                    if (
-                        self._press_times[button] is not None
-                        and not self._long_fired[button]
-                    ):
+                    press_time = self._press_times[button]
+                    if press_time is not None and not self._long_fired[button]:
                         action = _PRESS_MAPPING.get(button)
                         if action:
                             self._fire_action(action, {"button": button.value})
                     self._press_times[button] = None
 
-                # Held — check long press
-                elif current and previous:
-                    pt = self._press_times[button]
-                    if pt is not None and not self._long_fired[button]:
-                        if now - pt >= _LONG_PRESS_TIME:
-                            long_action = _LONG_PRESS_MAPPING.get(button)
-                            if long_action:
-                                self._fire_action(
-                                    long_action,
-                                    {"button": button.value, "long_press": True},
-                                )
-                            self._long_fired[button] = True
+        press_time = self._press_times[button]
+        if self._button_states[button] and press_time is not None and not self._long_fired[button]:
+            if current_time - press_time >= _LONG_PRESS_TIME:
+                long_action = _LONG_PRESS_MAPPING.get(button)
+                if long_action:
+                    self._fire_action(
+                        long_action,
+                        {"button": button.value, "long_press": True},
+                    )
+                self._long_fired[button] = True
 
-            time.sleep(0.01)
+    def _next_poll_timeout(self, current_time: float) -> float:
+        """Return the next timeout for the fallback polling loop."""
+        deadlines = [_POLL_INTERVAL]
+
+        for transition_started_at in self._transition_times.values():
+            if transition_started_at is None:
+                continue
+            deadlines.append(
+                max(0.0, _DEBOUNCE_TIME - (current_time - transition_started_at))
+            )
+
+        for button in Button:
+            press_time = self._press_times[button]
+            if press_time is None or not self._button_states[button] or self._long_fired[button]:
+                continue
+            deadlines.append(
+                max(0.0, _LONG_PRESS_TIME - (current_time - press_time))
+            )
+
+        return min(deadlines)
+
+    def _next_event_timeout(self, current_time: float) -> float:
+        """Return the next timeout for the edge-driven wait loop."""
+        deadlines: list[float] = []
+
+        for transition_started_at in self._transition_times.values():
+            if transition_started_at is None:
+                continue
+            deadlines.append(
+                max(0.0, _DEBOUNCE_TIME - (current_time - transition_started_at))
+            )
+
+        for button in Button:
+            press_time = self._press_times[button]
+            if press_time is None or not self._button_states[button] or self._long_fired[button]:
+                continue
+            deadlines.append(
+                max(0.0, _LONG_PRESS_TIME - (current_time - press_time))
+            )
+
+        if deadlines:
+            return min(deadlines)
+        return _EDGE_IDLE_WAIT_TIMEOUT
+
+    def _poll_line_states(self, current_time: float) -> None:
+        """Update button state using a periodic GPIO read loop."""
+        for button in Button:
+            if self.simulate and button not in self._lines:
+                continue
+            current_state = self._read_button(button)
+            self._observe_raw_state(button, current_state, current_time)
+            self._advance_button_state(button, current_time)
+
+    def _event_wait_loop(self) -> None:
+        """Block on GPIO edge file descriptors so idle threads stay asleep."""
+        fd_to_button = {fd: button for button, fd in self._line_event_fds.items()}
+
+        while not self._stop_event.is_set():
+            current_time = time.monotonic()
+            timeout = self._next_event_timeout(current_time)
+
+            try:
+                ready, _, _ = select.select(list(fd_to_button), [], [], timeout)
+            except OSError as exc:
+                logger.warning("GPIO edge wait failed; falling back to polled reads: {}", exc)
+                self._polling_loop()
+                return
+
+            observed_at = time.monotonic()
+            for fd in ready:
+                button = fd_to_button.get(fd)
+                if button is None:
+                    continue
+                line = self._lines.get(button)
+                if line is None:
+                    continue
+                try:
+                    read_edge_events(line)
+                except Exception as exc:
+                    logger.debug(
+                        "Failed to drain GPIO edge events for button {}: {}",
+                        button.value,
+                        exc,
+                    )
+                    continue
+
+                self._observe_raw_state(button, self._read_button(button), observed_at)
+
+            for button in Button:
+                self._advance_button_state(button, observed_at)
+
+    def _polling_loop(self) -> None:
+        """Fallback polling path for runtimes without GPIO edge waits."""
+        while not self._stop_event.is_set():
+            current_time = time.monotonic()
+            self._poll_line_states(current_time)
+            self._stop_event.wait(self._next_poll_timeout(current_time))
+
+    def _poll_loop(self) -> None:
+        """Dispatch to the lowest-churn GPIO wait loop available on this runtime."""
+        if self._line_event_fds and len(self._line_event_fds) == len(self._lines):
+            self._event_wait_loop()
+            return
+
+        self._polling_loop()

--- a/src/yoyopod/ui/input/adapters/ptt_button.py
+++ b/src/yoyopod/ui/input/adapters/ptt_button.py
@@ -393,6 +393,16 @@ class PTTInputAdapter(InputHAL):
         else:
             self._handle_button_release(transition_started_at)
 
+    def _hold_deadline_pending(self) -> bool:
+        """Return True while a held button still has threshold-driven work pending."""
+        if not self.button_pressed or self.press_start_time is None:
+            return False
+        if self.raw_ptt_passthrough:
+            return not self.raw_hold_started
+        if not self.enable_navigation:
+            return False
+        return not self._hold_back_fired
+
     def _next_wait_timeout(self, current_time: float) -> float:
         """Return the next deadline for polling, debounce, hold, or single-tap resolution."""
         deadlines = [self.poll_rate]
@@ -402,10 +412,10 @@ class PTTInputAdapter(InputHAL):
                 max(0.0, self.debounce_time - (current_time - self._button_transition_time))
             )
 
-        if self.button_pressed and self.press_start_time is not None:
-            deadlines.append(
-                max(0.0, self.long_press_time - (current_time - self.press_start_time))
-            )
+        if self._hold_deadline_pending() and self.press_start_time is not None:
+            hold_remaining = self.long_press_time - (current_time - self.press_start_time)
+            if hold_remaining > 0.0:
+                deadlines.append(hold_remaining)
 
         if (
             self.enable_navigation

--- a/src/yoyopod/ui/input/adapters/ptt_button.py
+++ b/src/yoyopod/ui/input/adapters/ptt_button.py
@@ -421,6 +421,7 @@ class PTTInputAdapter(InputHAL):
             self.enable_navigation
             and self.double_tap_select_enabled
             and not self.button_pressed
+            and not self._raw_button_state
             and self.pending_single_tap_time is not None
         ):
             deadlines.append(

--- a/src/yoyopod/ui/input/adapters/ptt_button.py
+++ b/src/yoyopod/ui/input/adapters/ptt_button.py
@@ -28,7 +28,7 @@ class PTTInputAdapter(InputHAL):
     DEFAULT_DEBOUNCE_TIME = 0.05
     DEFAULT_LONG_PRESS_TIME = 0.8
     DEFAULT_DOUBLE_CLICK_TIME = 0.3
-    DEFAULT_POLL_RATE = 0.01
+    DEFAULT_POLL_RATE = 0.03
 
     def __init__(
         self,
@@ -60,6 +60,8 @@ class PTTInputAdapter(InputHAL):
         self.stop_event = Event()
 
         self.button_pressed = False
+        self._raw_button_state = False
+        self._button_transition_time: Optional[float] = None
         self.press_start_time: Optional[float] = None
         self.pending_single_tap_time: Optional[float] = None
         self.double_tap_candidate = False
@@ -346,6 +348,7 @@ class PTTInputAdapter(InputHAL):
             not self.enable_navigation
             or not self.double_tap_select_enabled
             or self.button_pressed
+            or self._raw_button_state
         ):
             return
 
@@ -364,35 +367,76 @@ class PTTInputAdapter(InputHAL):
             },
         )
 
+    def _observe_raw_state(self, current_state: bool, observed_at: float) -> None:
+        """Track raw button transitions and start a debounce window when needed."""
+        if current_state == self._raw_button_state:
+            return
+
+        self._raw_button_state = current_state
+        self._button_transition_time = observed_at
+
+    def _advance_debounced_state(self, current_time: float) -> None:
+        """Resolve a debounced physical state change into press or release callbacks."""
+        transition_started_at = self._button_transition_time
+        if transition_started_at is None:
+            return
+
+        if (current_time - transition_started_at) < self.debounce_time:
+            return
+
+        self._button_transition_time = None
+        if self._raw_button_state == self.button_pressed:
+            return
+
+        if self._raw_button_state:
+            self._handle_button_press(transition_started_at)
+        else:
+            self._handle_button_release(transition_started_at)
+
+    def _next_wait_timeout(self, current_time: float) -> float:
+        """Return the next deadline for polling, debounce, hold, or single-tap resolution."""
+        deadlines = [self.poll_rate]
+
+        if self._button_transition_time is not None:
+            deadlines.append(
+                max(0.0, self.debounce_time - (current_time - self._button_transition_time))
+            )
+
+        if self.button_pressed and self.press_start_time is not None:
+            deadlines.append(
+                max(0.0, self.long_press_time - (current_time - self.press_start_time))
+            )
+
+        if (
+            self.enable_navigation
+            and self.double_tap_select_enabled
+            and not self.button_pressed
+            and self.pending_single_tap_time is not None
+        ):
+            deadlines.append(
+                max(0.0, self.double_click_time - (current_time - self.pending_single_tap_time))
+            )
+
+        return min(deadlines)
+
     def _poll_button(self) -> None:
         """Poll the button and emit semantic actions."""
         logger.debug("PTT button polling started")
 
         while not self.stop_event.is_set():
-            current_time = time.time()
+            current_time = time.monotonic()
             self._emit_pending_navigation(current_time)
 
             current_state = self._get_button_state()
-            previous_state = self.button_pressed
+            self._observe_raw_state(current_state, current_time)
+            self._advance_debounced_state(current_time)
 
-            if current_state and not previous_state:
-                press_detected_at = current_time
-                time.sleep(self.debounce_time)
-                current_state = self._get_button_state()
-                if current_state:
-                    self._handle_button_press(press_detected_at)
-
-            elif (
-                current_state
-                and previous_state
+            if (
+                self.button_pressed
                 and self.press_start_time is not None
                 and (current_time - self.press_start_time) >= self.long_press_time
             ):
-                # existing raw_ptt_passthrough logic stays here
-                if (
-                    self.raw_ptt_passthrough
-                    and not self.raw_hold_started
-                ):
+                if self.raw_ptt_passthrough and not self.raw_hold_started:
                     self.raw_hold_started = True
                     self._fire_action(
                         InputAction.PTT_PRESS,
@@ -402,12 +446,8 @@ class PTTInputAdapter(InputHAL):
                             "duration": current_time - self.press_start_time,
                         },
                     )
-                # fire BACK at threshold for navigation mode
                 self._check_hold_threshold(current_time)
 
-            elif not current_state and previous_state:
-                self._handle_button_release(time.time())
-
-            time.sleep(self.poll_rate)
+            self.stop_event.wait(self._next_wait_timeout(current_time))
 
         logger.debug("PTT button polling stopped")

--- a/tests/test_four_button_adapter.py
+++ b/tests/test_four_button_adapter.py
@@ -1,0 +1,51 @@
+"""Focused tests for the four-button input adapter wait behavior."""
+
+from __future__ import annotations
+
+from yoyopod.ui.input import InputAction
+from yoyopod.ui.input.adapters.four_button import Button, FourButtonInputAdapter
+
+
+def test_idle_poll_loop_waits_on_stop_event_between_samples() -> None:
+    """The polling thread should park on the stop event between idle samples."""
+
+    adapter = FourButtonInputAdapter(simulate=True)
+    waits: list[float] = []
+
+    class FakeStopEvent:
+        def __init__(self) -> None:
+            self._set = False
+
+        def is_set(self) -> bool:
+            return self._set
+
+        def wait(self, timeout: float | None = None) -> bool:
+            waits.append(0.0 if timeout is None else timeout)
+            self._set = True
+            return True
+
+    adapter.stop_event = FakeStopEvent()
+
+    adapter._poll_buttons()
+
+    assert waits == [adapter.POLL_INTERVAL]
+
+
+def test_debounced_release_emits_button_action_without_inline_sleep() -> None:
+    """Stable press and release edges should still map to the configured action."""
+
+    adapter = FourButtonInputAdapter(simulate=True)
+    actions: list[tuple[InputAction, object | None]] = []
+    adapter.on_action(
+        InputAction.SELECT,
+        lambda data=None: actions.append((InputAction.SELECT, data)),
+    )
+
+    adapter._observe_raw_state(Button.A, True, 1.0)
+    adapter._advance_button_state(Button.A, 1.06)
+    adapter._observe_raw_state(Button.A, False, 1.20)
+    adapter._advance_button_state(Button.A, 1.26)
+
+    assert actions == [
+        (InputAction.SELECT, {"button": "A"}),
+    ]

--- a/tests/test_gpiod_buttons.py
+++ b/tests/test_gpiod_buttons.py
@@ -124,6 +124,57 @@ def test_edge_wait_loop_blocks_between_events(monkeypatch: pytest.MonkeyPatch) -
     assert timeouts == [gpiod_buttons._EDGE_IDLE_WAIT_TIMEOUT]
 
 
+def test_negative_event_fd_falls_back_to_polling_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from yoyopod.ui.input.adapters import gpiod_buttons
+
+    class FakeLine:
+        def event_get_fd(self) -> int:
+            return -1
+
+        def get_value(self) -> int:
+            return 1
+
+        def release(self) -> None:
+            return None
+
+    class FakeChip:
+        def close(self) -> None:
+            return None
+
+    line = FakeLine()
+    polling_calls: list[str] = []
+
+    def fake_select(_reads, _writes, _errors, _timeout):
+        raise AssertionError("invalid GPIO event fds should never reach select()")
+
+    monkeypatch.setattr(gpiod_buttons, "HAS_GPIOD", True)
+    monkeypatch.setattr(gpiod_buttons, "open_chip", lambda _name: FakeChip())
+    monkeypatch.setattr(
+        gpiod_buttons,
+        "request_input_events",
+        lambda _chip, _line_offset, _consumer: line,
+    )
+    monkeypatch.setattr(gpiod_buttons.select, "select", fake_select)
+
+    adapter = gpiod_buttons.GpiodButtonAdapter(
+        pin_config={"button_a": {"chip": "gpiochip0", "line": 10}},
+        simulate=False,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_polling_loop",
+        lambda: polling_calls.append("polled"),
+    )
+
+    assert adapter._line_event_fds == {}
+
+    adapter._poll_loop()
+
+    assert polling_calls == ["polled"]
+
+
 def test_edge_wait_loop_samples_level_when_event_drain_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_gpiod_buttons.py
+++ b/tests/test_gpiod_buttons.py
@@ -241,6 +241,30 @@ def test_edge_wait_loop_samples_level_when_event_drain_fails(
     assert received == [("select", {"button": "A"})]
 
 
+def test_read_edge_events_drains_legacy_event_queue(monkeypatch: pytest.MonkeyPatch) -> None:
+    from yoyopod.ui import gpiod_compat
+
+    first = object()
+    second = object()
+    pending_events = [first, second]
+    select_calls: list[tuple[list[int], float]] = []
+
+    class FakeLine:
+        fd = 101
+
+        def event_read(self) -> object:
+            return pending_events.pop(0)
+
+    def fake_select(reads, _writes, _errors, timeout):
+        select_calls.append((list(reads), timeout))
+        return ([101], [], []) if pending_events else ([], [], [])
+
+    monkeypatch.setattr(gpiod_compat.select, "select", fake_select)
+
+    assert gpiod_compat.read_edge_events(FakeLine()) == [first, second]
+    assert select_calls == [([101], 0.0), ([101], 0.0)]
+
+
 def test_event_wait_loop_seeds_initial_pressed_state(monkeypatch: pytest.MonkeyPatch) -> None:
     from yoyopod.ui.input.adapters import gpiod_buttons
     from yoyopod.ui.input.adapters.gpiod_buttons import Button

--- a/tests/test_gpiod_buttons.py
+++ b/tests/test_gpiod_buttons.py
@@ -122,3 +122,72 @@ def test_edge_wait_loop_blocks_between_events(monkeypatch: pytest.MonkeyPatch) -
     adapter._poll_loop()
 
     assert timeouts == [gpiod_buttons._EDGE_IDLE_WAIT_TIMEOUT]
+
+
+def test_edge_wait_loop_samples_level_when_event_drain_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from yoyopod.ui.input.adapters import gpiod_buttons
+    from yoyopod.ui.input.adapters.gpiod_buttons import Button
+
+    class FakeLine:
+        def __init__(self, fd: int, value: int) -> None:
+            self.fd = fd
+            self.value = value
+
+        def get_value(self) -> int:
+            return self.value
+
+        def release(self) -> None:
+            return None
+
+    class FakeChip:
+        def close(self) -> None:
+            return None
+
+    line = FakeLine(101, 1)
+    clock = iter((10.0, 10.0))
+
+    def fake_select(reads, _writes, _errors, timeout):
+        assert reads == [101]
+        assert timeout > 0.0
+        adapter._stop_event.set()
+        return ([101], [], [])
+
+    monkeypatch.setattr(gpiod_buttons, "HAS_GPIOD", True)
+    monkeypatch.setattr(gpiod_buttons, "open_chip", lambda _name: FakeChip())
+    monkeypatch.setattr(
+        gpiod_buttons,
+        "request_input_events",
+        lambda _chip, _line_offset, _consumer: line,
+    )
+    monkeypatch.setattr(gpiod_buttons, "get_event_fd", lambda requested_line: requested_line.fd)
+    monkeypatch.setattr(
+        gpiod_buttons,
+        "read_edge_events",
+        lambda _line: (_ for _ in ()).throw(RuntimeError("drain failed")),
+    )
+    monkeypatch.setattr(gpiod_buttons.select, "select", fake_select)
+    monkeypatch.setattr(gpiod_buttons.time, "monotonic", lambda: next(clock))
+
+    adapter = gpiod_buttons.GpiodButtonAdapter(
+        pin_config={"button_a": {"chip": "gpiochip0", "line": 10}},
+        simulate=False,
+    )
+    received: list[tuple[str, dict[str, str]]] = []
+    adapter.on_action(
+        InputAction.SELECT,
+        lambda data: received.append(("select", data)),
+    )
+    adapter._raw_button_states[Button.A] = True
+    adapter._button_states[Button.A] = True
+    adapter._press_times[Button.A] = 9.95
+
+    adapter._event_wait_loop()
+
+    transition_started_at = adapter._transition_times[Button.A]
+    assert transition_started_at == 10.0
+
+    adapter._advance_button_state(Button.A, transition_started_at + 0.06)
+
+    assert received == [("select", {"button": "A"})]

--- a/tests/test_gpiod_buttons.py
+++ b/tests/test_gpiod_buttons.py
@@ -145,12 +145,13 @@ def test_edge_wait_loop_samples_level_when_event_drain_fails(
         def close(self) -> None:
             return None
 
-    line = FakeLine(101, 1)
-    clock = iter((10.0, 10.0))
+    line = FakeLine(101, 0)
+    clock = iter((10.0, 10.0, 10.0))
 
     def fake_select(reads, _writes, _errors, timeout):
         assert reads == [101]
         assert timeout > 0.0
+        line.value = 1
         adapter._stop_event.set()
         return ([101], [], [])
 
@@ -179,15 +180,97 @@ def test_edge_wait_loop_samples_level_when_event_drain_fails(
         InputAction.SELECT,
         lambda data: received.append(("select", data)),
     )
-    adapter._raw_button_states[Button.A] = True
-    adapter._button_states[Button.A] = True
-    adapter._press_times[Button.A] = 9.95
-
     adapter._event_wait_loop()
 
     transition_started_at = adapter._transition_times[Button.A]
     assert transition_started_at == 10.0
 
     adapter._advance_button_state(Button.A, transition_started_at + 0.06)
+
+    assert received == [("select", {"button": "A"})]
+
+
+def test_event_wait_loop_seeds_initial_pressed_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    from yoyopod.ui.input.adapters import gpiod_buttons
+    from yoyopod.ui.input.adapters.gpiod_buttons import Button
+
+    class FakeLine:
+        def __init__(self, fd: int, value: int) -> None:
+            self.fd = fd
+            self.value = value
+
+        def get_value(self) -> int:
+            return self.value
+
+        def release(self) -> None:
+            return None
+
+    class FakeChip:
+        def close(self) -> None:
+            return None
+
+    line = FakeLine(101, 0)
+    clock = iter((10.0, 10.0, 10.0))
+
+    def fake_select(reads, _writes, _errors, timeout):
+        assert reads == [101]
+        assert timeout > 0.0
+        adapter._stop_event.set()
+        return ([], [], [])
+
+    monkeypatch.setattr(gpiod_buttons, "HAS_GPIOD", True)
+    monkeypatch.setattr(gpiod_buttons, "open_chip", lambda _name: FakeChip())
+    monkeypatch.setattr(
+        gpiod_buttons,
+        "request_input_events",
+        lambda _chip, _line_offset, _consumer: line,
+    )
+    monkeypatch.setattr(gpiod_buttons, "get_event_fd", lambda requested_line: requested_line.fd)
+    monkeypatch.setattr(gpiod_buttons, "read_edge_events", lambda _line: [])
+    monkeypatch.setattr(gpiod_buttons.select, "select", fake_select)
+    monkeypatch.setattr(gpiod_buttons.time, "monotonic", lambda: next(clock))
+
+    adapter = gpiod_buttons.GpiodButtonAdapter(
+        pin_config={"button_a": {"chip": "gpiochip0", "line": 10}},
+        simulate=False,
+    )
+
+    adapter._event_wait_loop()
+
+    assert adapter._raw_button_states[Button.A] is True
+    assert adapter._button_states[Button.A] is True
+    assert adapter._press_times[Button.A] == 10.0
+
+
+def test_apply_edge_events_preserves_queued_transitions(monkeypatch: pytest.MonkeyPatch) -> None:
+    from yoyopod.ui.input.adapters.gpiod_buttons import Button, GpiodButtonAdapter
+
+    class FakeEvent:
+        def __init__(self, event_type: str, timestamp_ns: int) -> None:
+            self.event_type = event_type
+            self.timestamp_ns = timestamp_ns
+
+    class FakeLine:
+        def get_value(self) -> int:
+            return 1
+
+    adapter = GpiodButtonAdapter(pin_config={}, simulate=True)
+    received: list[tuple[str, dict[str, str]]] = []
+    adapter.on_action(
+        InputAction.SELECT,
+        lambda data: received.append(("select", data)),
+    )
+
+    monkeypatch.setattr(
+        "yoyopod.ui.input.adapters.gpiod_buttons.read_edge_events",
+        lambda _line: [
+            FakeEvent("falling", 1_000_000_000),
+            FakeEvent("rising", 1_060_000_000),
+        ],
+    )
+
+    adapter._apply_edge_events(Button.A, FakeLine(), 1.0)
+    adapter._advance_button_state(Button.A, 1.05)
+    adapter._advance_button_state(Button.A, 1.11)
 
     assert received == [("select", {"button": "A"})]

--- a/tests/test_gpiod_buttons.py
+++ b/tests/test_gpiod_buttons.py
@@ -270,7 +270,57 @@ def test_apply_edge_events_preserves_queued_transitions(monkeypatch: pytest.Monk
     )
 
     adapter._apply_edge_events(Button.A, FakeLine(), 1.0)
-    adapter._advance_button_state(Button.A, 1.05)
-    adapter._advance_button_state(Button.A, 1.11)
+    adapter._advance_button_state(Button.A, 1.07)
+    adapter._advance_button_state(Button.A, 1.12)
 
     assert received == [("select", {"button": "A"})]
+
+
+def test_apply_edge_events_accepts_integer_edge_constants(monkeypatch: pytest.MonkeyPatch) -> None:
+    from yoyopod.ui.input.adapters.gpiod_buttons import Button, GpiodButtonAdapter
+
+    class FakeEvent:
+        def __init__(self, event_type: int, timestamp_ns: int) -> None:
+            self.event_type = event_type
+            self.timestamp_ns = timestamp_ns
+
+    class FakeLine:
+        def get_value(self) -> int:
+            raise AssertionError("edge decoding should not fall back to sampling")
+
+    adapter = GpiodButtonAdapter(pin_config={}, simulate=True)
+    received: list[tuple[str, dict[str, str]]] = []
+    adapter.on_action(InputAction.SELECT, lambda data: received.append(("select", data)))
+
+    monkeypatch.setattr(
+        "yoyopod.ui.input.adapters.gpiod_buttons.read_edge_events",
+        lambda _line: [
+            FakeEvent(2, 1_000_000_000),
+            FakeEvent(1, 1_060_000_000),
+        ],
+    )
+
+    adapter._apply_edge_events(Button.A, FakeLine(), 5.0)
+    adapter._advance_button_state(Button.A, 5.07)
+    adapter._advance_button_state(Button.A, 5.12)
+
+    assert received == [("select", {"button": "A"})]
+
+
+def test_edge_event_observed_at_projects_datetime_order_onto_monotonic_clock() -> None:
+    from datetime import datetime, timezone
+
+    from yoyopod.ui.input.adapters.gpiod_buttons import GpiodButtonAdapter
+
+    class FakeEvent:
+        def __init__(self, timestamp: datetime) -> None:
+            self.timestamp = timestamp
+
+    adapter = GpiodButtonAdapter(pin_config={}, simulate=True)
+    first = datetime(2026, 4, 18, 9, 0, 0, tzinfo=timezone.utc)
+    second = datetime(2026, 4, 18, 9, 0, 0, 60_000, tzinfo=timezone.utc)
+    base = adapter._edge_event_timestamp_seconds(FakeEvent(first))
+
+    assert base is not None
+    assert adapter._edge_event_observed_at(FakeEvent(first), 10.0, base) == 10.0
+    assert adapter._edge_event_observed_at(FakeEvent(second), 10.0, base) == pytest.approx(10.06)

--- a/tests/test_gpiod_buttons.py
+++ b/tests/test_gpiod_buttons.py
@@ -1,5 +1,7 @@
 """Unit tests for the gpiod-based 4-button input adapter."""
 
+from __future__ import annotations
+
 import pytest
 
 from yoyopod.ui.input.hal import InputAction
@@ -46,3 +48,77 @@ def test_adapter_start_stop_lifecycle():
     assert adapter.running is True
     adapter.stop()
     assert adapter.running is False
+
+
+def test_debounced_release_emits_action_without_busy_polling() -> None:
+    from yoyopod.ui.input.adapters.gpiod_buttons import Button, GpiodButtonAdapter
+
+    adapter = GpiodButtonAdapter(pin_config={}, simulate=True)
+    received: list[tuple[str, dict[str, str]]] = []
+    adapter.on_action(
+        InputAction.SELECT,
+        lambda data: received.append(("select", data)),
+    )
+
+    adapter._observe_raw_state(Button.A, True, 1.0)
+    adapter._advance_button_state(Button.A, 1.06)
+    adapter._observe_raw_state(Button.A, False, 1.20)
+    adapter._advance_button_state(Button.A, 1.26)
+
+    assert received == [("select", {"button": "A"})]
+
+
+def test_edge_wait_loop_blocks_between_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    from yoyopod.ui.input.adapters import gpiod_buttons
+
+    class FakeLine:
+        def __init__(self, fd: int) -> None:
+            self.fd = fd
+
+        def get_value(self) -> int:
+            return 1
+
+        def release(self) -> None:
+            return None
+
+    class FakeChip:
+        def close(self) -> None:
+            return None
+
+    line_by_offset = {
+        10: FakeLine(101),
+        11: FakeLine(102),
+        12: FakeLine(103),
+        13: FakeLine(104),
+    }
+    timeouts: list[float] = []
+
+    def fake_select(reads, _writes, _errors, timeout):
+        timeouts.append(timeout)
+        adapter._stop_event.set()
+        return ([], [], [])
+
+    monkeypatch.setattr(gpiod_buttons, "HAS_GPIOD", True)
+    monkeypatch.setattr(gpiod_buttons, "open_chip", lambda _name: FakeChip())
+    monkeypatch.setattr(
+        gpiod_buttons,
+        "request_input_events",
+        lambda _chip, line_offset, _consumer: line_by_offset[line_offset],
+    )
+    monkeypatch.setattr(gpiod_buttons, "get_event_fd", lambda line: line.fd)
+    monkeypatch.setattr(gpiod_buttons, "read_edge_events", lambda _line: [])
+    monkeypatch.setattr(gpiod_buttons.select, "select", fake_select)
+
+    adapter = gpiod_buttons.GpiodButtonAdapter(
+        pin_config={
+            "button_a": {"chip": "gpiochip0", "line": 10},
+            "button_b": {"chip": "gpiochip0", "line": 11},
+            "button_x": {"chip": "gpiochip0", "line": 12},
+            "button_y": {"chip": "gpiochip0", "line": 13},
+        },
+        simulate=False,
+    )
+
+    adapter._poll_loop()
+
+    assert timeouts == [gpiod_buttons._EDGE_IDLE_WAIT_TIMEOUT]

--- a/tests/test_ptt_adapter.py
+++ b/tests/test_ptt_adapter.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+import pytest
+
 from yoyopod.ui.input import InputAction
 from yoyopod.ui.input.adapters.ptt_button import PTTInputAdapter
 
@@ -170,3 +172,17 @@ def test_hold_back_fired_resets_on_next_press() -> None:
 
     back_count = sum(1 for a, _ in log if a == InputAction.BACK)
     assert back_count == 2
+
+
+def test_next_wait_timeout_skips_expired_tap_deadline_during_raw_press_debounce() -> None:
+    """A second raw press should wait on debounce, not spin on an expired tap deadline."""
+    adapter = FakePTTAdapter()
+    adapter.poll_rate = 1.0
+    adapter.pending_single_tap_time = 0.0
+    adapter._raw_button_state = True
+    adapter.button_pressed = False
+    adapter._button_transition_time = 0.31
+
+    timeout = adapter._next_wait_timeout(0.32)
+
+    assert timeout == pytest.approx(0.04)

--- a/tests/test_ptt_input_adapter.py
+++ b/tests/test_ptt_input_adapter.py
@@ -175,6 +175,29 @@ def test_idle_poll_loop_waits_on_stop_event_between_samples() -> None:
     assert waits == [adapter.poll_rate]
 
 
+def test_next_wait_timeout_falls_back_to_poll_rate_after_navigation_hold_fires() -> None:
+    """Held navigation presses should return to the idle cadence after BACK has fired."""
+
+    adapter = PTTInputAdapter(simulate=True, enable_navigation=True)
+    adapter.button_pressed = True
+    adapter.press_start_time = 0.0
+    adapter._hold_back_fired = True
+
+    assert adapter._next_wait_timeout(adapter.long_press_time + 0.1) == adapter.poll_rate
+
+
+def test_next_wait_timeout_falls_back_to_poll_rate_after_raw_hold_starts() -> None:
+    """Raw passthrough holds should not keep scheduling zero-time wakeups."""
+
+    adapter = PTTInputAdapter(simulate=True, enable_navigation=True)
+    adapter.set_raw_ptt_passthrough(True)
+    adapter.button_pressed = True
+    adapter.press_start_time = 0.0
+    adapter.raw_hold_started = True
+
+    assert adapter._next_wait_timeout(adapter.long_press_time + 0.1) == adapter.poll_rate
+
+
 def test_raw_ptt_passthrough_emits_hold_press_and_release_without_back() -> None:
     """Voice-note passthrough should surface raw hold events and suppress BACK."""
 

--- a/tests/test_ptt_input_adapter.py
+++ b/tests/test_ptt_input_adapter.py
@@ -127,22 +127,52 @@ def test_poll_loop_preserves_double_tap_window_across_debounce(monkeypatch) -> N
     def fake_time() -> float:
         return clock.current
 
-    def fake_sleep(duration: float) -> None:
-        clock.current = round(clock.current + duration, 4)
+    class FakeStopEvent:
+        def is_set(self) -> bool:
+            return clock.current >= 0.8
+
+        def wait(self, timeout: float | None = None) -> bool:
+            step = 0.0005 if timeout is None else max(timeout, 0.0005)
+            clock.current = round(clock.current + step, 4)
+            return False
 
     def fake_button_state() -> bool:
         current = clock.current
         return (0.0 <= current < 0.10) or (0.39 <= current < 0.49)
 
-    monkeypatch.setattr(ptt_button.time, "time", fake_time)
-    monkeypatch.setattr(ptt_button.time, "sleep", fake_sleep)
+    monkeypatch.setattr(ptt_button.time, "monotonic", fake_time)
     adapter._get_button_state = fake_button_state
     adapter.poll_rate = 0.01
-    adapter.stop_event = SimpleNamespace(is_set=lambda: clock.current >= 0.8)
+    adapter.stop_event = FakeStopEvent()
 
     adapter._poll_button()
 
     assert actions == [InputAction.SELECT]
+
+
+def test_idle_poll_loop_waits_on_stop_event_between_samples() -> None:
+    """The one-button adapter should sleep on the stop event while idle."""
+
+    adapter = PTTInputAdapter(simulate=True, enable_navigation=True)
+    waits: list[float] = []
+
+    class FakeStopEvent:
+        def __init__(self) -> None:
+            self._set = False
+
+        def is_set(self) -> bool:
+            return self._set
+
+        def wait(self, timeout: float | None = None) -> bool:
+            waits.append(0.0 if timeout is None else timeout)
+            self._set = True
+            return True
+
+    adapter.stop_event = FakeStopEvent()
+
+    adapter._poll_button()
+
+    assert waits == [adapter.poll_rate]
 
 
 def test_raw_ptt_passthrough_emits_hold_press_and_release_without_back() -> None:


### PR DESCRIPTION
## Summary
- replace the four-button and one-button adapters' inline debounce sleeps with deadline-based waits and a 30 ms idle poll cadence so idle button threads stop waking at 100 Hz under the GIL
- use both-edge gpiod requests when available, replay queued edges in order, seed startup-held GPIO state, preserve legacy integer and `datetime` event compatibility on the event-driven path, and drain queued legacy `event_read()` events in one batch before replay
- reject negative gpiod event-fd sentinels before they can reach `select.select()`, so broken gpiod runtimes stay on the polling fallback instead of killing the input thread
- skip expired Whisplay single-tap deadlines while a second raw press is still debouncing, so the one-button adapter does not reintroduce a zero-time wait loop under the GIL
- add focused regression coverage for queued-edge replay, startup-held inputs, integer edge decoding, `datetime` timestamp replay, negative event-fd fallback, expired-tap debounce handling, and legacy `event_read()` queue draining

## Validation
- `UV_CACHE_DIR=/tmp/yoyopod-issue-238/.uv-cache uv run pytest -q tests/test_gpiod_buttons.py tests/test_ptt_adapter.py tests/test_ptt_input_adapter.py tests/test_four_button_adapter.py`
- `UV_CACHE_DIR=/tmp/yoyopod-issue-238/.uv-cache uv run python scripts/quality.py gate`
- `UV_CACHE_DIR=/tmp/yoyopod-issue-238/.uv-cache uv run pytest -q` (rerun outside the sandbox because `tests/test_mpv_ipc.py` binds AF_UNIX sockets)

## Notes / limitations
- the DisplayHATMini and Whisplay adapters still poll because their current drivers expose read-state APIs, not edge interrupts; this fix lowers their idle cadence and removes inline debounce sleeps instead of pretending those backends are event-driven
- the gpiod adapter keeps a polling fallback for runtimes that cannot request edge events or expose a valid waitable event file descriptor
- if edge draining fails after readiness, the adapter samples the current GPIO level and advances from that observed state; this prevents stale button state but cannot reconstruct per-edge history on runtimes with broken event reads