### PR TITLE
[codex] Retain LVGL scenes across screen transitions

### DIFF
--- a/src/yoyopod/ui/lvgl_binding/backend.py
+++ b/src/yoyopod/ui/lvgl_binding/backend.py
@@ -133,6 +133,7 @@ class LvglDisplayBackend:
         if self.initialized and self.binding is not None:
             self.binding.clear_screen()
             self.scene_generation += 1
+            self._retained_scene_claims.clear()
 
     def force_refresh(self) -> None:
         """Invalidate and redraw the active LVGL scene immediately."""
@@ -149,6 +150,7 @@ class LvglDisplayBackend:
         if not self.initialized or self.binding is None:
             return
         self.scene_generation += 1
+        self._retained_scene_claims.clear()
         self.binding.shutdown()
         self.binding = None
         self.initialized = False

--- a/src/yoyopod/ui/lvgl_binding/backend.py
+++ b/src/yoyopod/ui/lvgl_binding/backend.py
@@ -150,4 +150,5 @@ class LvglDisplayBackend:
             return
         self.scene_generation += 1
         self.binding.shutdown()
+        self.binding = None
         self.initialized = False

--- a/src/yoyopod/ui/lvgl_binding/backend.py
+++ b/src/yoyopod/ui/lvgl_binding/backend.py
@@ -36,6 +36,7 @@ class LvglDisplayBackend:
     binding: LvglBinding | None = None
     initialized: bool = field(init=False, default=False)
     scene_generation: int = field(init=False, default=0)
+    _retained_scene_claims: dict[str, int] = field(init=False, default_factory=dict)
     width: int = field(init=False, default=0)
     height: int = field(init=False, default=0)
 

--- a/src/yoyopod/ui/lvgl_binding/backend.py
+++ b/src/yoyopod/ui/lvgl_binding/backend.py
@@ -35,6 +35,7 @@ class LvglDisplayBackend:
     buffer_lines: int = 40
     binding: LvglBinding | None = None
     initialized: bool = field(init=False, default=False)
+    scene_generation: int = field(init=False, default=0)
     width: int = field(init=False, default=0)
     height: int = field(init=False, default=0)
 
@@ -130,6 +131,7 @@ class LvglDisplayBackend:
     def clear(self) -> None:
         if self.initialized and self.binding is not None:
             self.binding.clear_screen()
+            self.scene_generation += 1
 
     def force_refresh(self) -> None:
         """Invalidate and redraw the active LVGL scene immediately."""
@@ -145,5 +147,6 @@ class LvglDisplayBackend:
     def cleanup(self) -> None:
         if not self.initialized or self.binding is None:
             return
+        self.scene_generation += 1
         self.binding.shutdown()
         self.initialized = False

--- a/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
+++ b/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
@@ -3442,6 +3442,11 @@ int yoyopod_lvgl_init(void) {
 void yoyopod_lvgl_shutdown(void) {
     yoyopod_lvgl_clear_screen();
 
+    if(g_blank_screen != NULL) {
+        lv_obj_delete(g_blank_screen);
+        g_blank_screen = NULL;
+    }
+
     if(g_draw_buf != NULL) {
         lv_free(g_draw_buf);
         g_draw_buf = NULL;
@@ -3456,7 +3461,6 @@ void yoyopod_lvgl_shutdown(void) {
     g_indev = NULL;
     g_flush_cb = NULL;
     g_flush_user_data = NULL;
-    g_blank_screen = NULL;
     g_draw_buf_bytes = 0;
     g_key_head = 0;
     g_key_tail = 0;

--- a/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
+++ b/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
@@ -3456,6 +3456,7 @@ void yoyopod_lvgl_shutdown(void) {
     g_indev = NULL;
     g_flush_cb = NULL;
     g_flush_user_data = NULL;
+    g_blank_screen = NULL;
     g_draw_buf_bytes = 0;
     g_key_head = 0;
     g_key_tail = 0;

--- a/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
+++ b/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
@@ -3440,6 +3440,8 @@ int yoyopod_lvgl_init(void) {
 }
 
 void yoyopod_lvgl_shutdown(void) {
+    yoyopod_lvgl_clear_screen();
+
     if(g_draw_buf != NULL) {
         lv_free(g_draw_buf);
         g_draw_buf = NULL;

--- a/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
+++ b/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
@@ -226,6 +226,7 @@ static lv_indev_t * g_indev = NULL;
 static lv_group_t * g_group = NULL;
 static lv_color_t * g_draw_buf = NULL;
 static uint32_t g_draw_buf_bytes = 0;
+static lv_obj_t * g_blank_screen = NULL;
 static yoyopod_lvgl_flush_cb_t g_flush_cb = NULL;
 static void * g_flush_user_data = NULL;
 static char g_last_error[256] = "";
@@ -428,17 +429,60 @@ static void yoyopod_prepare_active_screen(void) {
     yoyopod_reset_scene_refs();
 }
 
+static int yoyopod_require_scene_screen(lv_obj_t * screen, const char * error_message) {
+    if(screen != NULL) {
+        return 0;
+    }
+
+    yoyopod_set_error(error_message);
+    return -1;
+}
+
+static lv_obj_t * yoyopod_ensure_blank_screen(void) {
+    if(g_blank_screen == NULL) {
+        g_blank_screen = lv_obj_create(NULL);
+        if(g_blank_screen == NULL) {
+            yoyopod_set_error("lv_obj_create(NULL) failed for blank scene");
+            return NULL;
+        }
+    }
+
+    lv_obj_set_style_bg_color(g_blank_screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
+    lv_obj_set_style_bg_opa(g_blank_screen, LV_OPA_COVER, 0);
+    return g_blank_screen;
+}
+
 static void yoyopod_release_scene_screen(lv_obj_t * screen) {
-    if(screen == NULL) {
+    if(screen == NULL || screen == g_blank_screen) {
         return;
     }
 
     if(lv_screen_active() == screen) {
-        lv_obj_clean(screen);
-        return;
+        lv_obj_t * blank_screen = yoyopod_ensure_blank_screen();
+        if(blank_screen == NULL) {
+            return;
+        }
+
+        yoyopod_clear_group();
+        if(blank_screen != lv_screen_active()) {
+            lv_screen_load(blank_screen);
+        }
     }
 
     lv_obj_delete(screen);
+}
+
+static int yoyopod_activate_scene_screen(lv_obj_t * screen, const char * error_message) {
+    if(yoyopod_require_scene_screen(screen, error_message) != 0) {
+        return -1;
+    }
+
+    if(screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(screen);
+    }
+
+    return 0;
 }
 
 static lv_obj_t * yoyopod_create_card(lv_obj_t * screen, const char * title, const char * subtitle, lv_color_t accent) {
@@ -1248,9 +1292,8 @@ int yoyopod_lvgl_hub_sync(
         yoyopod_hub_style_dot(g_hub_scene.dots[index], ink, selected);
     }
 
-    if(g_hub_scene.screen != lv_screen_active()) {
-        yoyopod_clear_group();
-        lv_screen_load(g_hub_scene.screen);
+    if(yoyopod_activate_scene_screen(g_hub_scene.screen, "hub scene screen is unavailable during sync") < 0) {
+        return -1;
     }
 
     return 0;
@@ -1413,9 +1456,8 @@ int yoyopod_lvgl_talk_sync(
 
     yoyopod_apply_footer_label(g_talk_scene.footer_label, footer, muted_dim);
 
-    if(g_talk_scene.screen != lv_screen_active()) {
-        yoyopod_clear_group();
-        lv_screen_load(g_talk_scene.screen);
+    if(yoyopod_activate_scene_screen(g_talk_scene.screen, "talk scene screen is unavailable during sync") < 0) {
+        return -1;
     }
 
     return 0;
@@ -1662,9 +1704,8 @@ int yoyopod_lvgl_talk_actions_sync(
 
     yoyopod_apply_footer_label(g_talk_actions_scene.footer_label, footer, muted_dim);
 
-    if(g_talk_actions_scene.screen != lv_screen_active()) {
-        yoyopod_clear_group();
-        lv_screen_load(g_talk_actions_scene.screen);
+    if(yoyopod_activate_scene_screen(g_talk_actions_scene.screen, "talk-actions scene screen is unavailable during sync") < 0) {
+        return -1;
     }
 
     return 0;
@@ -1919,9 +1960,8 @@ int yoyopod_lvgl_listen_sync(
 
     yoyopod_apply_footer_label(g_listen_scene.footer_label, footer, accent_dim);
 
-    if(g_listen_scene.screen != lv_screen_active()) {
-        yoyopod_clear_group();
-        lv_screen_load(g_listen_scene.screen);
+    if(yoyopod_activate_scene_screen(g_listen_scene.screen, "listen scene screen is unavailable during sync") < 0) {
+        return -1;
     }
 
     return 0;
@@ -2261,9 +2301,8 @@ int yoyopod_lvgl_playlist_sync(
 
     yoyopod_apply_footer_label(g_playlist_scene.footer_label, footer, muted_dim);
 
-    if(g_playlist_scene.screen != lv_screen_active()) {
-        yoyopod_clear_group();
-        lv_screen_load(g_playlist_scene.screen);
+    if(yoyopod_activate_scene_screen(g_playlist_scene.screen, "playlist scene screen is unavailable during sync") < 0) {
+        return -1;
     }
 
     return 0;
@@ -2488,9 +2527,8 @@ int yoyopod_lvgl_now_playing_sync(
 
     yoyopod_apply_footer_label(g_now_playing_scene.footer_label, footer, footer_text);
 
-    if(g_now_playing_scene.screen != lv_screen_active()) {
-        yoyopod_clear_group();
-        lv_screen_load(g_now_playing_scene.screen);
+    if(yoyopod_activate_scene_screen(g_now_playing_scene.screen, "now-playing scene screen is unavailable during sync") < 0) {
+        return -1;
     }
 
     return 0;
@@ -2633,9 +2671,8 @@ int yoyopod_lvgl_incoming_call_sync(
 
     yoyopod_apply_footer_label(g_incoming_call_scene.footer_label, footer, muted_dim);
 
-    if(g_incoming_call_scene.screen != lv_screen_active()) {
-        yoyopod_clear_group();
-        lv_screen_load(g_incoming_call_scene.screen);
+    if(yoyopod_activate_scene_screen(g_incoming_call_scene.screen, "incoming-call scene screen is unavailable during sync") < 0) {
+        return -1;
     }
 
     return 0;
@@ -2778,9 +2815,8 @@ int yoyopod_lvgl_outgoing_call_sync(
 
     yoyopod_apply_footer_label(g_outgoing_call_scene.footer_label, footer, muted_dim);
 
-    if(g_outgoing_call_scene.screen != lv_screen_active()) {
-        yoyopod_clear_group();
-        lv_screen_load(g_outgoing_call_scene.screen);
+    if(yoyopod_activate_scene_screen(g_outgoing_call_scene.screen, "outgoing-call scene screen is unavailable during sync") < 0) {
+        return -1;
     }
 
     return 0;
@@ -2951,9 +2987,8 @@ int yoyopod_lvgl_in_call_sync(
 
     yoyopod_apply_footer_label(g_in_call_scene.footer_label, footer, muted_dim);
 
-    if(g_in_call_scene.screen != lv_screen_active()) {
-        yoyopod_clear_group();
-        lv_screen_load(g_in_call_scene.screen);
+    if(yoyopod_activate_scene_screen(g_in_call_scene.screen, "in-call scene screen is unavailable during sync") < 0) {
+        return -1;
     }
 
     return 0;
@@ -3139,9 +3174,8 @@ int yoyopod_lvgl_ask_sync(
 
     yoyopod_apply_footer_label(g_ask_scene.footer_label, footer, muted_dim);
 
-    if(g_ask_scene.screen != lv_screen_active()) {
-        yoyopod_clear_group();
-        lv_screen_load(g_ask_scene.screen);
+    if(yoyopod_activate_scene_screen(g_ask_scene.screen, "ask scene screen is unavailable during sync") < 0) {
+        return -1;
     }
 
     return 0;
@@ -3329,9 +3363,8 @@ int yoyopod_lvgl_power_sync(
 
     yoyopod_apply_footer_label(g_power_scene.footer_label, footer, accent_dim);
 
-    if(g_power_scene.screen != lv_screen_active()) {
-        yoyopod_clear_group();
-        lv_screen_load(g_power_scene.screen);
+    if(yoyopod_activate_scene_screen(g_power_scene.screen, "power scene screen is unavailable during sync") < 0) {
+        return -1;
     }
 
     return 0;
@@ -3531,7 +3564,9 @@ void yoyopod_lvgl_clear_screen(void) {
     yoyopod_release_scene_screen(g_power_scene.screen);
 
     lv_obj_t * screen = lv_screen_active();
-    lv_obj_clean(screen);
+    if(screen != NULL) {
+        lv_obj_clean(screen);
+    }
     yoyopod_clear_group();
     yoyopod_reset_scene_refs();
 }

--- a/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
+++ b/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
@@ -340,6 +340,8 @@ static void yoyopod_reset_power_scene_refs(void) {
 
 static void yoyopod_reset_scene_refs(void) {
     yoyopod_reset_hub_scene_refs();
+    yoyopod_reset_talk_scene_refs();
+    yoyopod_reset_talk_actions_scene_refs();
     yoyopod_reset_listen_scene_refs();
     yoyopod_reset_playlist_scene_refs();
     yoyopod_reset_now_playing_scene_refs();
@@ -424,6 +426,19 @@ static void yoyopod_prepare_active_screen(void) {
     lv_obj_clean(screen);
     yoyopod_clear_group();
     yoyopod_reset_scene_refs();
+}
+
+static void yoyopod_release_scene_screen(lv_obj_t * screen) {
+    if(screen == NULL) {
+        return;
+    }
+
+    if(lv_screen_active() == screen) {
+        lv_obj_clean(screen);
+        return;
+    }
+
+    lv_obj_delete(screen);
 }
 
 static lv_obj_t * yoyopod_create_card(lv_obj_t * screen, const char * title, const char * subtitle, lv_color_t accent) {
@@ -1084,9 +1099,11 @@ int yoyopod_lvgl_hub_build(void) {
         return 0;
     }
 
-    yoyopod_prepare_active_screen();
-
-    g_hub_scene.screen = lv_screen_active();
+    g_hub_scene.screen = lv_obj_create(NULL);
+    if(g_hub_scene.screen == NULL) {
+        yoyopod_set_error("lv_obj_create(NULL) failed for hub scene");
+        return -1;
+    }
     lv_obj_set_style_bg_color(g_hub_scene.screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
     lv_obj_set_style_bg_opa(g_hub_scene.screen, LV_OPA_COVER, 0);
     yoyopod_status_bar_build(g_hub_scene.screen, &g_hub_scene.status_bar, 1);
@@ -1231,6 +1248,11 @@ int yoyopod_lvgl_hub_sync(
         yoyopod_hub_style_dot(g_hub_scene.dots[index], ink, selected);
     }
 
+    if(g_hub_scene.screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(g_hub_scene.screen);
+    }
+
     return 0;
 }
 
@@ -1239,9 +1261,7 @@ void yoyopod_lvgl_hub_destroy(void) {
         return;
     }
 
-    if(g_hub_scene.screen != NULL) {
-        lv_obj_clean(g_hub_scene.screen);
-    }
+    yoyopod_release_scene_screen(g_hub_scene.screen);
     yoyopod_clear_group();
     yoyopod_reset_hub_scene_refs();
 }
@@ -1256,9 +1276,11 @@ int yoyopod_lvgl_talk_build(void) {
         return 0;
     }
 
-    yoyopod_prepare_active_screen();
-
-    g_talk_scene.screen = lv_screen_active();
+    g_talk_scene.screen = lv_obj_create(NULL);
+    if(g_talk_scene.screen == NULL) {
+        yoyopod_set_error("lv_obj_create(NULL) failed for talk scene");
+        return -1;
+    }
     lv_obj_set_style_bg_color(g_talk_scene.screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
     lv_obj_set_style_bg_opa(g_talk_scene.screen, LV_OPA_COVER, 0);
     yoyopod_status_bar_build(g_talk_scene.screen, &g_talk_scene.status_bar, 1);
@@ -1390,6 +1412,12 @@ int yoyopod_lvgl_talk_sync(
     }
 
     yoyopod_apply_footer_label(g_talk_scene.footer_label, footer, muted_dim);
+
+    if(g_talk_scene.screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(g_talk_scene.screen);
+    }
+
     return 0;
 }
 
@@ -1398,9 +1426,7 @@ void yoyopod_lvgl_talk_destroy(void) {
         return;
     }
 
-    if(g_talk_scene.screen != NULL) {
-        lv_obj_clean(g_talk_scene.screen);
-    }
+    yoyopod_release_scene_screen(g_talk_scene.screen);
     yoyopod_clear_group();
     yoyopod_reset_talk_scene_refs();
 }
@@ -1415,9 +1441,11 @@ int yoyopod_lvgl_talk_actions_build(void) {
         return 0;
     }
 
-    yoyopod_prepare_active_screen();
-
-    g_talk_actions_scene.screen = lv_screen_active();
+    g_talk_actions_scene.screen = lv_obj_create(NULL);
+    if(g_talk_actions_scene.screen == NULL) {
+        yoyopod_set_error("lv_obj_create(NULL) failed for talk actions scene");
+        return -1;
+    }
     lv_obj_set_style_bg_color(g_talk_actions_scene.screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
     lv_obj_set_style_bg_opa(g_talk_actions_scene.screen, LV_OPA_COVER, 0);
     yoyopod_status_bar_build(g_talk_actions_scene.screen, &g_talk_actions_scene.status_bar, 1);
@@ -1633,6 +1661,12 @@ int yoyopod_lvgl_talk_actions_sync(
     }
 
     yoyopod_apply_footer_label(g_talk_actions_scene.footer_label, footer, muted_dim);
+
+    if(g_talk_actions_scene.screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(g_talk_actions_scene.screen);
+    }
+
     return 0;
 }
 
@@ -1641,9 +1675,7 @@ void yoyopod_lvgl_talk_actions_destroy(void) {
         return;
     }
 
-    if(g_talk_actions_scene.screen != NULL) {
-        lv_obj_clean(g_talk_actions_scene.screen);
-    }
+    yoyopod_release_scene_screen(g_talk_actions_scene.screen);
     yoyopod_clear_group();
     yoyopod_reset_talk_actions_scene_refs();
 }
@@ -1658,9 +1690,11 @@ int yoyopod_lvgl_listen_build(void) {
         return 0;
     }
 
-    yoyopod_prepare_active_screen();
-
-    g_listen_scene.screen = lv_screen_active();
+    g_listen_scene.screen = lv_obj_create(NULL);
+    if(g_listen_scene.screen == NULL) {
+        yoyopod_set_error("lv_obj_create(NULL) failed for listen scene");
+        return -1;
+    }
     lv_obj_set_style_bg_color(g_listen_scene.screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
     lv_obj_set_style_bg_opa(g_listen_scene.screen, LV_OPA_COVER, 0);
     yoyopod_status_bar_build(g_listen_scene.screen, &g_listen_scene.status_bar, 0);
@@ -1885,6 +1919,11 @@ int yoyopod_lvgl_listen_sync(
 
     yoyopod_apply_footer_label(g_listen_scene.footer_label, footer, accent_dim);
 
+    if(g_listen_scene.screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(g_listen_scene.screen);
+    }
+
     return 0;
 }
 
@@ -1893,9 +1932,7 @@ void yoyopod_lvgl_listen_destroy(void) {
         return;
     }
 
-    if(g_listen_scene.screen != NULL) {
-        lv_obj_clean(g_listen_scene.screen);
-    }
+    yoyopod_release_scene_screen(g_listen_scene.screen);
     yoyopod_clear_group();
     yoyopod_reset_listen_scene_refs();
 }
@@ -1910,9 +1947,11 @@ int yoyopod_lvgl_playlist_build(void) {
         return 0;
     }
 
-    yoyopod_prepare_active_screen();
-
-    g_playlist_scene.screen = lv_screen_active();
+    g_playlist_scene.screen = lv_obj_create(NULL);
+    if(g_playlist_scene.screen == NULL) {
+        yoyopod_set_error("lv_obj_create(NULL) failed for playlist scene");
+        return -1;
+    }
     lv_obj_set_style_bg_color(g_playlist_scene.screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
     lv_obj_set_style_bg_opa(g_playlist_scene.screen, LV_OPA_COVER, 0);
     yoyopod_status_bar_build(g_playlist_scene.screen, &g_playlist_scene.status_bar, 0);
@@ -2222,6 +2261,11 @@ int yoyopod_lvgl_playlist_sync(
 
     yoyopod_apply_footer_label(g_playlist_scene.footer_label, footer, muted_dim);
 
+    if(g_playlist_scene.screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(g_playlist_scene.screen);
+    }
+
     return 0;
 }
 
@@ -2230,9 +2274,7 @@ void yoyopod_lvgl_playlist_destroy(void) {
         return;
     }
 
-    if(g_playlist_scene.screen != NULL) {
-        lv_obj_clean(g_playlist_scene.screen);
-    }
+    yoyopod_release_scene_screen(g_playlist_scene.screen);
     yoyopod_clear_group();
     yoyopod_reset_playlist_scene_refs();
 }
@@ -2247,9 +2289,11 @@ int yoyopod_lvgl_now_playing_build(void) {
         return 0;
     }
 
-    yoyopod_prepare_active_screen();
-
-    g_now_playing_scene.screen = lv_screen_active();
+    g_now_playing_scene.screen = lv_obj_create(NULL);
+    if(g_now_playing_scene.screen == NULL) {
+        yoyopod_set_error("lv_obj_create(NULL) failed for now-playing scene");
+        return -1;
+    }
     lv_obj_set_style_bg_color(g_now_playing_scene.screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
     lv_obj_set_style_bg_opa(g_now_playing_scene.screen, LV_OPA_COVER, 0);
     yoyopod_status_bar_build(g_now_playing_scene.screen, &g_now_playing_scene.status_bar, 0);
@@ -2444,6 +2488,11 @@ int yoyopod_lvgl_now_playing_sync(
 
     yoyopod_apply_footer_label(g_now_playing_scene.footer_label, footer, footer_text);
 
+    if(g_now_playing_scene.screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(g_now_playing_scene.screen);
+    }
+
     return 0;
 }
 
@@ -2452,9 +2501,7 @@ void yoyopod_lvgl_now_playing_destroy(void) {
         return;
     }
 
-    if(g_now_playing_scene.screen != NULL) {
-        lv_obj_clean(g_now_playing_scene.screen);
-    }
+    yoyopod_release_scene_screen(g_now_playing_scene.screen);
     yoyopod_clear_group();
     yoyopod_reset_now_playing_scene_refs();
 }
@@ -2469,9 +2516,11 @@ int yoyopod_lvgl_incoming_call_build(void) {
         return 0;
     }
 
-    yoyopod_prepare_active_screen();
-
-    g_incoming_call_scene.screen = lv_screen_active();
+    g_incoming_call_scene.screen = lv_obj_create(NULL);
+    if(g_incoming_call_scene.screen == NULL) {
+        yoyopod_set_error("lv_obj_create(NULL) failed for incoming-call scene");
+        return -1;
+    }
     lv_obj_set_style_bg_color(g_incoming_call_scene.screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
     lv_obj_set_style_bg_opa(g_incoming_call_scene.screen, LV_OPA_COVER, 0);
     yoyopod_status_bar_build(g_incoming_call_scene.screen, &g_incoming_call_scene.status_bar, 1);
@@ -2584,6 +2633,11 @@ int yoyopod_lvgl_incoming_call_sync(
 
     yoyopod_apply_footer_label(g_incoming_call_scene.footer_label, footer, muted_dim);
 
+    if(g_incoming_call_scene.screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(g_incoming_call_scene.screen);
+    }
+
     return 0;
 }
 
@@ -2592,9 +2646,7 @@ void yoyopod_lvgl_incoming_call_destroy(void) {
         return;
     }
 
-    if(g_incoming_call_scene.screen != NULL) {
-        lv_obj_clean(g_incoming_call_scene.screen);
-    }
+    yoyopod_release_scene_screen(g_incoming_call_scene.screen);
     yoyopod_clear_group();
     yoyopod_reset_incoming_call_scene_refs();
 }
@@ -2609,9 +2661,11 @@ int yoyopod_lvgl_outgoing_call_build(void) {
         return 0;
     }
 
-    yoyopod_prepare_active_screen();
-
-    g_outgoing_call_scene.screen = lv_screen_active();
+    g_outgoing_call_scene.screen = lv_obj_create(NULL);
+    if(g_outgoing_call_scene.screen == NULL) {
+        yoyopod_set_error("lv_obj_create(NULL) failed for outgoing-call scene");
+        return -1;
+    }
     lv_obj_set_style_bg_color(g_outgoing_call_scene.screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
     lv_obj_set_style_bg_opa(g_outgoing_call_scene.screen, LV_OPA_COVER, 0);
     yoyopod_status_bar_build(g_outgoing_call_scene.screen, &g_outgoing_call_scene.status_bar, 1);
@@ -2724,6 +2778,11 @@ int yoyopod_lvgl_outgoing_call_sync(
 
     yoyopod_apply_footer_label(g_outgoing_call_scene.footer_label, footer, muted_dim);
 
+    if(g_outgoing_call_scene.screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(g_outgoing_call_scene.screen);
+    }
+
     return 0;
 }
 
@@ -2732,9 +2791,7 @@ void yoyopod_lvgl_outgoing_call_destroy(void) {
         return;
     }
 
-    if(g_outgoing_call_scene.screen != NULL) {
-        lv_obj_clean(g_outgoing_call_scene.screen);
-    }
+    yoyopod_release_scene_screen(g_outgoing_call_scene.screen);
     yoyopod_clear_group();
     yoyopod_reset_outgoing_call_scene_refs();
 }
@@ -2749,9 +2806,11 @@ int yoyopod_lvgl_in_call_build(void) {
         return 0;
     }
 
-    yoyopod_prepare_active_screen();
-
-    g_in_call_scene.screen = lv_screen_active();
+    g_in_call_scene.screen = lv_obj_create(NULL);
+    if(g_in_call_scene.screen == NULL) {
+        yoyopod_set_error("lv_obj_create(NULL) failed for in-call scene");
+        return -1;
+    }
     lv_obj_set_style_bg_color(g_in_call_scene.screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
     lv_obj_set_style_bg_opa(g_in_call_scene.screen, LV_OPA_COVER, 0);
     yoyopod_status_bar_build(g_in_call_scene.screen, &g_in_call_scene.status_bar, 1);
@@ -2892,6 +2951,11 @@ int yoyopod_lvgl_in_call_sync(
 
     yoyopod_apply_footer_label(g_in_call_scene.footer_label, footer, muted_dim);
 
+    if(g_in_call_scene.screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(g_in_call_scene.screen);
+    }
+
     return 0;
 }
 
@@ -2900,9 +2964,7 @@ void yoyopod_lvgl_in_call_destroy(void) {
         return;
     }
 
-    if(g_in_call_scene.screen != NULL) {
-        lv_obj_clean(g_in_call_scene.screen);
-    }
+    yoyopod_release_scene_screen(g_in_call_scene.screen);
     yoyopod_clear_group();
     yoyopod_reset_in_call_scene_refs();
 }
@@ -2917,9 +2979,11 @@ int yoyopod_lvgl_ask_build(void) {
         return 0;
     }
 
-    yoyopod_prepare_active_screen();
-
-    g_ask_scene.screen = lv_screen_active();
+    g_ask_scene.screen = lv_obj_create(NULL);
+    if(g_ask_scene.screen == NULL) {
+        yoyopod_set_error("lv_obj_create(NULL) failed for ask scene");
+        return -1;
+    }
     lv_obj_set_style_bg_color(g_ask_scene.screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
     lv_obj_set_style_bg_opa(g_ask_scene.screen, LV_OPA_COVER, 0);
     yoyopod_status_bar_build(g_ask_scene.screen, &g_ask_scene.status_bar, 1);
@@ -3074,6 +3138,12 @@ int yoyopod_lvgl_ask_sync(
     }
 
     yoyopod_apply_footer_label(g_ask_scene.footer_label, footer, muted_dim);
+
+    if(g_ask_scene.screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(g_ask_scene.screen);
+    }
+
     return 0;
 }
 
@@ -3082,9 +3152,7 @@ void yoyopod_lvgl_ask_destroy(void) {
         return;
     }
 
-    if(g_ask_scene.screen != NULL) {
-        lv_obj_clean(g_ask_scene.screen);
-    }
+    yoyopod_release_scene_screen(g_ask_scene.screen);
     yoyopod_clear_group();
     yoyopod_reset_ask_scene_refs();
 }
@@ -3099,9 +3167,11 @@ int yoyopod_lvgl_power_build(void) {
         return 0;
     }
 
-    yoyopod_prepare_active_screen();
-
-    g_power_scene.screen = lv_screen_active();
+    g_power_scene.screen = lv_obj_create(NULL);
+    if(g_power_scene.screen == NULL) {
+        yoyopod_set_error("lv_obj_create(NULL) failed for power scene");
+        return -1;
+    }
     lv_obj_set_style_bg_color(g_power_scene.screen, yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB), 0);
     lv_obj_set_style_bg_opa(g_power_scene.screen, LV_OPA_COVER, 0);
     yoyopod_status_bar_build(g_power_scene.screen, &g_power_scene.status_bar, 0);
@@ -3259,6 +3329,11 @@ int yoyopod_lvgl_power_sync(
 
     yoyopod_apply_footer_label(g_power_scene.footer_label, footer, accent_dim);
 
+    if(g_power_scene.screen != lv_screen_active()) {
+        yoyopod_clear_group();
+        lv_screen_load(g_power_scene.screen);
+    }
+
     return 0;
 }
 
@@ -3267,9 +3342,7 @@ void yoyopod_lvgl_power_destroy(void) {
         return;
     }
 
-    if(g_power_scene.screen != NULL) {
-        lv_obj_clean(g_power_scene.screen);
-    }
+    yoyopod_release_scene_screen(g_power_scene.screen);
     yoyopod_clear_group();
     yoyopod_reset_power_scene_refs();
 }
@@ -3444,6 +3517,18 @@ void yoyopod_lvgl_clear_screen(void) {
     if(!g_initialized || g_display == NULL) {
         return;
     }
+
+    yoyopod_release_scene_screen(g_hub_scene.screen);
+    yoyopod_release_scene_screen(g_talk_scene.screen);
+    yoyopod_release_scene_screen(g_talk_actions_scene.screen);
+    yoyopod_release_scene_screen(g_listen_scene.screen);
+    yoyopod_release_scene_screen(g_playlist_scene.screen);
+    yoyopod_release_scene_screen(g_now_playing_scene.screen);
+    yoyopod_release_scene_screen(g_incoming_call_scene.screen);
+    yoyopod_release_scene_screen(g_outgoing_call_scene.screen);
+    yoyopod_release_scene_screen(g_in_call_scene.screen);
+    yoyopod_release_scene_screen(g_ask_scene.screen);
+    yoyopod_release_scene_screen(g_power_scene.screen);
 
     lv_obj_t * screen = lv_screen_active();
     lv_obj_clean(screen);

--- a/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
+++ b/src/yoyopod/ui/lvgl_binding/native/lvgl_shim.c
@@ -1229,6 +1229,9 @@ int yoyopod_lvgl_hub_sync(
         yoyopod_set_error("hub scene must be built before sync");
         return -1;
     }
+    if(yoyopod_require_scene_screen(g_hub_scene.screen, "hub scene screen is unavailable during sync") != 0) {
+        return -1;
+    }
 
     const lv_color_t background = yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB);
     const lv_color_t footer_fill = yoyopod_color_u24(YOYOPOD_THEME_FOOTER_RGB);
@@ -1387,6 +1390,9 @@ int yoyopod_lvgl_talk_sync(
 ) {
     if(!g_talk_scene.built) {
         yoyopod_set_error("talk scene must be built before sync");
+        return -1;
+    }
+    if(yoyopod_require_scene_screen(g_talk_scene.screen, "talk scene screen is unavailable during sync") != 0) {
         return -1;
     }
 
@@ -1575,6 +1581,12 @@ int yoyopod_lvgl_talk_actions_sync(
 ) {
     if(!g_talk_actions_scene.built) {
         yoyopod_set_error("talk-actions scene must be built before sync");
+        return -1;
+    }
+    if(yoyopod_require_scene_screen(
+        g_talk_actions_scene.screen,
+        "talk-actions scene screen is unavailable during sync"
+    ) != 0) {
         return -1;
     }
 
@@ -1851,6 +1863,9 @@ int yoyopod_lvgl_listen_sync(
 ) {
     if(!g_listen_scene.built) {
         yoyopod_set_error("listen scene must be built before sync");
+        return -1;
+    }
+    if(yoyopod_require_scene_screen(g_listen_scene.screen, "listen scene screen is unavailable during sync") != 0) {
         return -1;
     }
 
@@ -2144,6 +2159,12 @@ int yoyopod_lvgl_playlist_sync(
         yoyopod_set_error("playlist scene must be built before sync");
         return -1;
     }
+    if(yoyopod_require_scene_screen(
+        g_playlist_scene.screen,
+        "playlist scene screen is unavailable during sync"
+    ) != 0) {
+        return -1;
+    }
 
     const lv_color_t background = yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB);
     const lv_color_t surface = yoyopod_color_u24(YOYOPOD_THEME_SURFACE_RGB);
@@ -2433,6 +2454,12 @@ int yoyopod_lvgl_now_playing_sync(
         yoyopod_set_error("now-playing scene must be built before sync");
         return -1;
     }
+    if(yoyopod_require_scene_screen(
+        g_now_playing_scene.screen,
+        "now-playing scene screen is unavailable during sync"
+    ) != 0) {
+        return -1;
+    }
 
     const lv_color_t background = yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB);
     const lv_color_t ink = yoyopod_color_u24(YOYOPOD_THEME_INK_RGB);
@@ -2626,6 +2653,12 @@ int yoyopod_lvgl_incoming_call_sync(
         yoyopod_set_error("incoming-call scene must be built before sync");
         return -1;
     }
+    if(yoyopod_require_scene_screen(
+        g_incoming_call_scene.screen,
+        "incoming-call scene screen is unavailable during sync"
+    ) != 0) {
+        return -1;
+    }
 
     (void)caller_address;
     const lv_color_t background = yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB);
@@ -2767,6 +2800,12 @@ int yoyopod_lvgl_outgoing_call_sync(
 ) {
     if(!g_outgoing_call_scene.built) {
         yoyopod_set_error("outgoing-call scene must be built before sync");
+        return -1;
+    }
+    if(yoyopod_require_scene_screen(
+        g_outgoing_call_scene.screen,
+        "outgoing-call scene screen is unavailable during sync"
+    ) != 0) {
         return -1;
     }
 
@@ -2929,6 +2968,9 @@ int yoyopod_lvgl_in_call_sync(
         yoyopod_set_error("in-call scene must be built before sync");
         return -1;
     }
+    if(yoyopod_require_scene_screen(g_in_call_scene.screen, "in-call scene screen is unavailable during sync") != 0) {
+        return -1;
+    }
 
     const lv_color_t background = yoyopod_color_u24(YOYOPOD_THEME_BACKGROUND_RGB);
     const lv_color_t ink = yoyopod_color_u24(YOYOPOD_THEME_INK_RGB);
@@ -3082,6 +3124,9 @@ int yoyopod_lvgl_ask_sync(
 ) {
     if(!g_ask_scene.built) {
         yoyopod_set_error("ask scene must be built before sync");
+        return -1;
+    }
+    if(yoyopod_require_scene_screen(g_ask_scene.screen, "ask scene screen is unavailable during sync") != 0) {
         return -1;
     }
 
@@ -3288,6 +3333,9 @@ int yoyopod_lvgl_power_sync(
 ) {
     if(!g_power_scene.built) {
         yoyopod_set_error("power scene must be built before sync");
+        return -1;
+    }
+    if(yoyopod_require_scene_screen(g_power_scene.screen, "power scene screen is unavailable during sync") != 0) {
         return -1;
     }
 

--- a/src/yoyopod/ui/screens/lvgl_lifecycle.py
+++ b/src/yoyopod/ui/screens/lvgl_lifecycle.py
@@ -66,7 +66,7 @@ def current_retained_view(
 def view_is_ready(view: RetainedLvglView) -> bool:
     """Return True when the backend can safely build or sync a native scene."""
 
-    return view.backend.binding is not None and bool(getattr(view.backend, "initialized", True))
+    return view.backend.binding is not None and bool(getattr(view.backend, "initialized", False))
 
 
 def should_build_retained_view(view: RetainedLvglView) -> bool:

--- a/src/yoyopod/ui/screens/lvgl_lifecycle.py
+++ b/src/yoyopod/ui/screens/lvgl_lifecycle.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Protocol, TypeVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 
@@ -18,10 +18,30 @@ class RetainedLvglView(Protocol):
         """Rebuild the native LVGL scene for this retained view."""
 
 
+RetainedLvglViewT = TypeVar("RetainedLvglViewT", bound=RetainedLvglView)
+
+
 def current_scene_generation(backend: LvglDisplayBackend) -> int:
     """Return the backend scene generation with a backwards-safe default."""
 
     return int(getattr(backend, "scene_generation", 0))
+
+
+def current_retained_view(
+    view: RetainedLvglViewT | None,
+    backend: LvglDisplayBackend | None,
+) -> RetainedLvglViewT | None:
+    """Return the cached retained view only when it still matches the backend."""
+
+    if view is None or backend is None:
+        return None
+    if getattr(view, "backend", None) is not backend:
+        return None
+    if view._build_generation != current_scene_generation(backend):
+        return None
+    if not view_is_ready(view):
+        return None
+    return view
 
 
 def view_is_ready(view: RetainedLvglView) -> bool:

--- a/src/yoyopod/ui/screens/lvgl_lifecycle.py
+++ b/src/yoyopod/ui/screens/lvgl_lifecycle.py
@@ -11,6 +11,7 @@ class RetainedLvglView(Protocol):
     """Structural type shared by retained Python LVGL views."""
 
     backend: LvglDisplayBackend
+    scene_key: str
     _built: bool
     _build_generation: int
 
@@ -27,6 +28,22 @@ def current_scene_generation(backend: LvglDisplayBackend) -> int:
     return int(getattr(backend, "scene_generation", 0))
 
 
+def _retained_scene_claims(backend: LvglDisplayBackend) -> dict[str, int]:
+    """Return the per-backend scene-ownership registry."""
+
+    claims = getattr(backend, "_retained_scene_claims", None)
+    if claims is None:
+        claims = {}
+        setattr(backend, "_retained_scene_claims", claims)
+    return claims
+
+
+def retained_scene_claimed_by(view: RetainedLvglView) -> bool:
+    """Return True when this view still owns its retained native scene type."""
+
+    return _retained_scene_claims(view.backend).get(view.scene_key) == id(view)
+
+
 def current_retained_view(
     view: RetainedLvglViewT | None,
     backend: LvglDisplayBackend | None,
@@ -38,6 +55,8 @@ def current_retained_view(
     if getattr(view, "backend", None) is not backend:
         return None
     if view._build_generation != current_scene_generation(backend):
+        return None
+    if not retained_scene_claimed_by(view):
         return None
     if not view_is_ready(view):
         return None
@@ -58,6 +77,7 @@ def should_build_retained_view(view: RetainedLvglView) -> bool:
     return (
         not view._built
         or view._build_generation != current_scene_generation(view.backend)
+        or not retained_scene_claimed_by(view)
     )
 
 
@@ -66,7 +86,10 @@ def ensure_retained_view_built(view: RetainedLvglView) -> bool:
 
     if not view_is_ready(view):
         return False
-    if view._build_generation != current_scene_generation(view.backend):
+    if (
+        view._build_generation != current_scene_generation(view.backend)
+        or not retained_scene_claimed_by(view)
+    ):
         view._built = False
     if not view._built:
         view.build()
@@ -78,6 +101,7 @@ def mark_retained_view_built(view: RetainedLvglView) -> None:
 
     view._built = True
     view._build_generation = current_scene_generation(view.backend)
+    _retained_scene_claims(view.backend)[view.scene_key] = id(view)
 
 
 def mark_retained_view_destroyed(view: RetainedLvglView) -> None:
@@ -85,3 +109,6 @@ def mark_retained_view_destroyed(view: RetainedLvglView) -> None:
 
     view._built = False
     view._build_generation = -1
+    claims = _retained_scene_claims(view.backend)
+    if claims.get(view.scene_key) == id(view):
+        claims.pop(view.scene_key, None)

--- a/src/yoyopod/ui/screens/lvgl_lifecycle.py
+++ b/src/yoyopod/ui/screens/lvgl_lifecycle.py
@@ -1,0 +1,67 @@
+"""Helpers for retained LVGL views that must survive backend resets."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+
+
+class RetainedLvglView(Protocol):
+    """Structural type shared by retained Python LVGL views."""
+
+    backend: LvglDisplayBackend
+    _built: bool
+    _build_generation: int
+
+    def build(self) -> None:
+        """Rebuild the native LVGL scene for this retained view."""
+
+
+def current_scene_generation(backend: LvglDisplayBackend) -> int:
+    """Return the backend scene generation with a backwards-safe default."""
+
+    return int(getattr(backend, "scene_generation", 0))
+
+
+def view_is_ready(view: RetainedLvglView) -> bool:
+    """Return True when the backend can safely build or sync a native scene."""
+
+    return view.backend.binding is not None and bool(getattr(view.backend, "initialized", True))
+
+
+def should_build_retained_view(view: RetainedLvglView) -> bool:
+    """Return True when the retained Python view must rebuild its native scene."""
+
+    if not view_is_ready(view):
+        return False
+    return (
+        not view._built
+        or view._build_generation != current_scene_generation(view.backend)
+    )
+
+
+def ensure_retained_view_built(view: RetainedLvglView) -> bool:
+    """Rebuild the retained native scene when the backend cleared it underneath us."""
+
+    if not view_is_ready(view):
+        return False
+    if view._build_generation != current_scene_generation(view.backend):
+        view._built = False
+    if not view._built:
+        view.build()
+    return view._built and view_is_ready(view)
+
+
+def mark_retained_view_built(view: RetainedLvglView) -> None:
+    """Record that the retained view matches the current backend scene generation."""
+
+    view._built = True
+    view._build_generation = current_scene_generation(view.backend)
+
+
+def mark_retained_view_destroyed(view: RetainedLvglView) -> None:
+    """Record that the retained view no longer has a live native scene."""
+
+    view._built = False
+    view._build_generation = -1

--- a/src/yoyopod/ui/screens/lvgl_lifecycle.py
+++ b/src/yoyopod/ui/screens/lvgl_lifecycle.py
@@ -97,7 +97,7 @@ def ensure_retained_view_built(view: RetainedLvglView) -> bool:
 
 
 def mark_retained_view_built(view: RetainedLvglView) -> None:
-    """Record that the retained view matches the current backend scene generation."""
+    """Record that this view is the current owner of its pooled retained scene."""
 
     view._built = True
     view._build_generation = current_scene_generation(view.backend)

--- a/src/yoyopod/ui/screens/lvgl_scene_keys.py
+++ b/src/yoyopod/ui/screens/lvgl_scene_keys.py
@@ -1,0 +1,12 @@
+"""Canonical retained-scene keys for pooled LVGL view families.
+
+These keys describe native scene pools, not independent per-controller caches.
+When multiple controllers intentionally share one scene family, only the latest
+retained Python view that built that scene remains reusable.
+"""
+
+LIST_SCENE_KEY = "playlist"
+"""Shared list-scene pool for playlists, recents, contacts, and call history."""
+
+TALK_ACTIONS_SCENE_KEY = "talk_actions"
+"""Shared action-scene pool for Talk contact actions and voice-note states."""

--- a/src/yoyopod/ui/screens/music/lvgl/now_playing_view.py
+++ b/src/yoyopod/ui/screens/music/lvgl/now_playing_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglNowPlayingView:
     """Own the LVGL object lifecycle for NowPlayingScreen."""
 
+    scene_key: ClassVar[str] = "now_playing"
     screen: "NowPlayingScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/music/lvgl/now_playing_view.py
+++ b/src/yoyopod/ui/screens/music/lvgl/now_playing_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import LISTEN
 
@@ -21,19 +27,20 @@ class LvglNowPlayingView:
     screen: "NowPlayingScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
         """Create the native now-playing scene once."""
 
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.now_playing_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
         """Push the current playback controller state into the native scene."""
 
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         state = self.screen.current_state()
@@ -67,7 +74,7 @@ class LvglNowPlayingView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.now_playing_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/music/lvgl/playlist_view.py
+++ b/src/yoyopod/ui/screens/music/lvgl/playlist_view.py
@@ -12,6 +12,7 @@ from yoyopod.ui.screens.lvgl_lifecycle import (
     mark_retained_view_destroyed,
     should_build_retained_view,
 )
+from yoyopod.ui.screens.lvgl_scene_keys import LIST_SCENE_KEY
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import LISTEN
 
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 class LvglPlaylistView:
     """Own the LVGL object lifecycle for PlaylistScreen."""
 
-    scene_key: ClassVar[str] = "playlist"
+    scene_key: ClassVar[str] = LIST_SCENE_KEY
     screen: "PlaylistScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/music/lvgl/playlist_view.py
+++ b/src/yoyopod/ui/screens/music/lvgl/playlist_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import LISTEN
 
@@ -21,19 +27,20 @@ class LvglPlaylistView:
     screen: "PlaylistScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
         """Create the native playlist scene once."""
 
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.playlist_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
         """Push the current playlist controller state into the native scene."""
 
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         title_text = self.screen.get_title_text() if hasattr(self.screen, "get_title_text") else "Playlists"
@@ -82,7 +89,7 @@ class LvglPlaylistView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.playlist_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     def _empty_state_copy(self) -> tuple[str, str]:
         if hasattr(self.screen, "get_empty_state_copy"):

--- a/src/yoyopod/ui/screens/music/lvgl/playlist_view.py
+++ b/src/yoyopod/ui/screens/music/lvgl/playlist_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglPlaylistView:
     """Own the LVGL object lifecycle for PlaylistScreen."""
 
+    scene_key: ClassVar[str] = "playlist"
     screen: "PlaylistScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/music/now_playing.py
+++ b/src/yoyopod/ui/screens/music/now_playing.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.music.lvgl import LvglNowPlayingView
 from yoyopod.ui.screens.theme import (
     BACKGROUND,
@@ -189,17 +190,20 @@ class NowPlayingScreen(Screen):
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
             return None
 
         ui_backend = (
             self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
         )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
             return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
+        if self._lvgl_view is not None:
+            return self._lvgl_view
 
         self._lvgl_view = LvglNowPlayingView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/music/now_playing.py
+++ b/src/yoyopod/ui/screens/music/now_playing.py
@@ -184,10 +184,7 @@ class NowPlayingScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving now playing."""
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL now-playing view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/music/playlist.py
+++ b/src/yoyopod/ui/screens/music/playlist.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from yoyopod.audio.local_service import LocalMusicService
 from yoyopod.ui.display import Display
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.music.lvgl import LvglPlaylistView
 from yoyopod.ui.screens.theme import (
@@ -55,15 +56,18 @@ class PlaylistScreen(Screen):
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
             return None
 
         ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
             return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
+        if self._lvgl_view is not None:
+            return self._lvgl_view
 
         self._lvgl_view = LvglPlaylistView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/music/playlist.py
+++ b/src/yoyopod/ui/screens/music/playlist.py
@@ -50,10 +50,7 @@ class PlaylistScreen(Screen):
         self.fetch_playlists()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving playlists."""
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL playlist view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/music/recent.py
+++ b/src/yoyopod/ui/screens/music/recent.py
@@ -9,6 +9,7 @@ from loguru import logger
 from yoyopod.audio import LocalMusicService, RecentTrackEntry
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.music.lvgl import LvglPlaylistView
 from yoyopod.ui.screens.theme import (
     draw_empty_state,
@@ -54,15 +55,20 @@ class RecentTracksScreen(Screen):
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
+            return None
+
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
+            return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
         if self._lvgl_view is not None:
             return self._lvgl_view
-
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            return None
-
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            return None
 
         self._lvgl_view = LvglPlaylistView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/music/recent.py
+++ b/src/yoyopod/ui/screens/music/recent.py
@@ -49,10 +49,7 @@ class RecentTracksScreen(Screen):
         self.refresh_tracks()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving recents."""
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL recent-tracks view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/navigation/ask.py
+++ b/src/yoyopod/ui/screens/navigation/ask.py
@@ -102,9 +102,6 @@ class AskScreen(AskScreenVoiceMixin, AskScreenRenderingMixin, Screen):
         self.voice_runtime.cancel()
         self._cancel_auto_return()
         self._quick_command = False
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
         super().exit()
 
     def set_screen_manager(self, manager) -> None:

--- a/src/yoyopod/ui/screens/navigation/ask_rendering.py
+++ b/src/yoyopod/ui/screens/navigation/ask_rendering.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.navigation.lvgl import LvglAskView
 from yoyopod.ui.screens.theme import (
     ASK,
@@ -42,10 +43,8 @@ class AskScreenRenderingMixin:
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
 
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
             return None
 
         ui_backend = (
@@ -54,7 +53,12 @@ class AskScreenRenderingMixin:
             else None
         )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
             return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
+        if self._lvgl_view is not None:
+            return self._lvgl_view
 
         self._lvgl_view = LvglAskView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/navigation/hub.py
+++ b/src/yoyopod/ui/screens/navigation/hub.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 from yoyopod.ui.display import Display
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.navigation.lvgl import LvglHubView
 from yoyopod.ui.screens.theme import (
@@ -72,17 +73,20 @@ class HubScreen(Screen):
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
             return None
 
         ui_backend = (
             self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
         )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
             return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
+        if self._lvgl_view is not None:
+            return self._lvgl_view
 
         self._lvgl_view = LvglHubView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/navigation/hub.py
+++ b/src/yoyopod/ui/screens/navigation/hub.py
@@ -67,10 +67,7 @@ class HubScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving the hub."""
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL Hub view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/navigation/listen.py
+++ b/src/yoyopod/ui/screens/navigation/listen.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional
 from yoyopod.audio.local_service import LocalLibraryItem, LocalMusicService
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.navigation.lvgl import LvglListenView
 from yoyopod.ui.screens.theme import (
     draw_list_item,
@@ -47,15 +48,20 @@ class ListenScreen(Screen):
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
+            return None
+
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
+            return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
         if self._lvgl_view is not None:
             return self._lvgl_view
-
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            return None
-
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            return None
 
         self._lvgl_view = LvglListenView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/navigation/listen.py
+++ b/src/yoyopod/ui/screens/navigation/listen.py
@@ -42,10 +42,7 @@ class ListenScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving Listen."""
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL Listen view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/navigation/lvgl/ask_view.py
+++ b/src/yoyopod/ui/screens/navigation/lvgl/ask_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglAskView:
     """Own the LVGL object lifecycle for AskScreen."""
 
+    scene_key: ClassVar[str] = "ask"
     screen: "AskScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/navigation/lvgl/ask_view.py
+++ b/src/yoyopod/ui/screens/navigation/lvgl/ask_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import ASK
 
@@ -21,15 +27,16 @@ class LvglAskView:
     screen: "AskScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.ask_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         context = self.screen.context
@@ -51,7 +58,7 @@ class LvglAskView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.ask_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/navigation/lvgl/hub_view.py
+++ b/src/yoyopod/ui/screens/navigation/lvgl/hub_view.py
@@ -7,6 +7,12 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import theme_for
 
@@ -22,19 +28,20 @@ class LvglHubView:
     screen: "HubScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
         """Create the native LVGL Hub scene once."""
 
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.hub_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
         """Push the current Hub controller state into the native scene."""
 
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         cards = self.screen._cards()
@@ -64,7 +71,7 @@ class LvglHubView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.hub_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/navigation/lvgl/hub_view.py
+++ b/src/yoyopod/ui/screens/navigation/lvgl/hub_view.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 class LvglHubView:
     """Own the LVGL object lifecycle for the root Hub screen."""
 
+    scene_key: ClassVar[str] = "hub"
     screen: "HubScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/navigation/lvgl/listen_view.py
+++ b/src/yoyopod/ui/screens/navigation/lvgl/listen_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglListenView:
     """Own the LVGL object lifecycle for ListenScreen."""
 
+    scene_key: ClassVar[str] = "listen"
     screen: "ListenScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/navigation/lvgl/listen_view.py
+++ b/src/yoyopod/ui/screens/navigation/lvgl/listen_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import LISTEN
 
@@ -21,19 +27,20 @@ class LvglListenView:
     screen: "ListenScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
         """Create the native Listen scene once."""
 
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.listen_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
         """Push the current Listen controller state into the native scene."""
 
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         items = [item.title for item in self.screen.items[:4]]
@@ -70,7 +77,7 @@ class LvglListenView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.listen_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/system/lvgl/power_view.py
+++ b/src/yoyopod/ui/screens/system/lvgl/power_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import SETUP
 
@@ -21,15 +27,16 @@ class LvglPowerView:
     screen: "PowerScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.power_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         state = self.screen._get_state()
@@ -106,7 +113,7 @@ class LvglPowerView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.power_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/system/lvgl/power_view.py
+++ b/src/yoyopod/ui/screens/system/lvgl/power_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglPowerView:
     """Own the LVGL object lifecycle for PowerScreen."""
 
+    scene_key: ClassVar[str] = "power"
     screen: "PowerScreen"
     backend: LvglDisplayBackend
     _built: bool = False
@@ -39,65 +40,18 @@ class LvglPowerView:
         if not ensure_retained_view_built(self):
             return
 
-        state = self.screen._get_state()
-        pages = self.screen._build_pages_for_display(state=state)
-        if not pages:
-            return
-
-        self.screen.page_index %= len(pages)
-        active_page = pages[self.screen.page_index]
+        payload = self.screen.lvgl_payload()
         context = self.screen.context
         sync_network_status(self.backend.binding, context)
 
-        picker_mode = not self.screen.is_one_button_mode() and not getattr(
-            self.screen,
-            "in_detail",
-            False,
-        )
-        if picker_mode:
-            items = []
-            for index, page in self.screen._visible_picker_pages(pages, max_items=5):
-                prefix = "> " if index == self.screen.page_index else ""
-                items.append(f"{prefix}{page.title}")
-
-            self.backend.binding.power_sync(
-                title_text="Setup",
-                page_text=None,
-                icon_key=self.screen._page_icon_key(active_page.title),
-                footer=self.screen._instruction_text(active_page),
-                items=items,
-                current_page_index=self.screen.page_index,
-                total_pages=len(pages),
-                voip_state=self._voip_state(context),
-                battery_percent=self._battery_percent(context),
-                charging=(
-                    bool(getattr(context, "battery_charging", False))
-                    if context is not None
-                    else False
-                ),
-                power_available=(
-                    bool(getattr(context, "power_available", True)) if context is not None else True
-                ),
-                accent=SETUP.accent,
-            )
-            return
-
-        visible_rows, visible_selected_index = self.screen._visible_rows_for_page(active_page)
-        items = []
-        for index, (label, value) in enumerate(visible_rows):
-            row_text = f"{label}: {value}"
-            if visible_selected_index is not None and index == visible_selected_index:
-                row_text = f"> {row_text}"
-            items.append(row_text)
-
         self.backend.binding.power_sync(
-            title_text=active_page.title,
-            page_text=None,
-            icon_key=self.screen._page_icon_key(active_page.title),
-            footer=self.screen._instruction_text(active_page),
-            items=items,
-            current_page_index=self.screen.page_index,
-            total_pages=len(pages),
+            title_text=payload.title_text,
+            page_text=payload.page_text,
+            icon_key=payload.icon_key,
+            footer=payload.footer,
+            items=list(payload.items),
+            current_page_index=payload.current_page_index,
+            total_pages=payload.total_pages,
             voip_state=self._voip_state(context),
             battery_percent=self._battery_percent(context),
             charging=(

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -12,6 +12,7 @@ from loguru import logger
 from yoyopod.device import format_device_label
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.system.lvgl import LvglPowerView
 from yoyopod.ui.screens.theme import (
     INK,
@@ -266,17 +267,20 @@ class PowerScreen(Screen):
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
             return None
 
         ui_backend = (
             self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
         )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
             return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
+        if self._lvgl_view is not None:
+            return self._lvgl_view
 
         self._lvgl_view = LvglPowerView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -261,10 +261,7 @@ class PowerScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving Setup."""
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL Setup view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -69,6 +69,19 @@ class PowerScreenActions:
     unmute: Callable[[], bool] | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class PowerScreenLvglPayload:
+    """Pure LVGL payload derived from the current Setup controller state."""
+
+    title_text: str
+    page_text: str | None
+    icon_key: str
+    footer: str
+    items: tuple[str, ...]
+    current_page_index: int
+    total_pages: int
+
+
 def _build_network_rows_from_manager(network_manager: object | None) -> list[tuple[str, str]]:
     """Build the cellular network status rows from a backend-facing manager."""
 
@@ -289,18 +302,19 @@ class PowerScreen(Screen):
     def render(self) -> None:
         """Render the active Setup page."""
         lvgl_view = self._ensure_lvgl_view()
+        pages = self._build_pages_for_display()
+        if not pages:
+            return
+        active_page_index = self._page_index_for(pages)
+        active_page = pages[active_page_index]
         if lvgl_view is not None:
             lvgl_view.sync()
             return
 
-        state = self._get_state()
-        pages = self._build_pages_for_display(state=state)
-        self.page_index %= len(pages)
-        active_page = pages[self.page_index]
         picker_mode = not self.is_one_button_mode() and not self.in_detail
         render_backdrop(self.display, "setup")
         render_status_bar(self.display, self.context, show_time=False)
-        page_text = f"{self.page_index + 1}/{len(pages)}"
+        page_text = f"{active_page_index + 1}/{len(pages)}"
 
         halo_size = 44
         halo_left = (self.display.WIDTH - halo_size) // 2
@@ -410,7 +424,11 @@ class PowerScreen(Screen):
             max_visible = max(1, min(len(pages), available // item_height))
 
             for offset, (index, page) in enumerate(
-                self._visible_picker_pages(pages, max_items=max_visible)
+                self._visible_picker_pages(
+                    pages,
+                    max_items=max_visible,
+                    current_page_index=active_page_index,
+                )
             ):
                 title = page.title
                 subtitle = self._page_subtitle(page.title)
@@ -442,7 +460,7 @@ class PowerScreen(Screen):
                     font_size=11,
                 )
 
-        self._render_page_dots(total_pages=len(pages))
+        self._render_page_dots(total_pages=len(pages), current_page_index=active_page_index)
 
         help_text = self._instruction_text(active_page)
         render_footer(self.display, help_text, mode="setup")
@@ -481,11 +499,27 @@ class PowerScreen(Screen):
             return "Commands and audio"
         return ""
 
+    def _page_index_for(self, pages: list[PowerPage]) -> int:
+        """Return the active page index without mutating controller state."""
+
+        if not pages:
+            return 0
+        return self.page_index % len(pages)
+
+    @staticmethod
+    def _selected_row_for_page(page: PowerPage, selected_row: int) -> int:
+        """Clamp one page's selected row without writing it back."""
+
+        if not page.rows:
+            return 0
+        return selected_row % len(page.rows)
+
     def _visible_picker_pages(
         self,
         pages: list[PowerPage],
         *,
         max_items: int,
+        current_page_index: int | None = None,
     ) -> list[tuple[int, PowerPage]]:
         """Return the visible page-picker window around the current page."""
 
@@ -493,7 +527,13 @@ class PowerScreen(Screen):
             return []
 
         max_items = max(1, min(max_items, len(pages)))
-        start_index = max(0, min(self.page_index - (max_items // 2), len(pages) - max_items))
+        active_page_index = (
+            self._page_index_for(pages) if current_page_index is None else current_page_index
+        )
+        start_index = max(
+            0,
+            min(active_page_index - (max_items // 2), len(pages) - max_items),
+        )
         return [(start_index + offset, pages[start_index + offset]) for offset in range(max_items)]
 
     def _visible_rows_for_page(
@@ -508,18 +548,17 @@ class PowerScreen(Screen):
             max_rows = self._row_capacity_for_page(page)
 
         if not page.rows:
-            self.selected_row = 0
             return [], None
 
-        self.selected_row %= len(page.rows)
+        selected_row = self._selected_row_for_page(page, self.selected_row)
         if not page.interactive or len(page.rows) <= max_rows:
-            return page.rows[:max_rows], (self.selected_row if page.interactive else None)
+            return page.rows[:max_rows], (selected_row if page.interactive else None)
 
-        start = max(0, self.selected_row - (max_rows - 1))
+        start = max(0, selected_row - (max_rows - 1))
         end = min(len(page.rows), start + max_rows)
         start = max(0, end - max_rows)
         visible_rows = page.rows[start:end]
-        return visible_rows, self.selected_row - start
+        return visible_rows, selected_row - start
 
     def _row_capacity_for_page(self, page: PowerPage) -> int:
         """Return how many rows the current display/layout can safely show."""
@@ -528,17 +567,18 @@ class PowerScreen(Screen):
             return 5
         return 4
 
-    def _render_page_dots(self, *, total_pages: int) -> None:
+    def _render_page_dots(self, *, total_pages: int, current_page_index: int | None = None) -> None:
         """Render the compact Setup page-position dots."""
 
         if total_pages <= 1:
             return
 
+        active_page_index = 0 if current_page_index is None else current_page_index
         dots_width = max(0, (total_pages - 1) * 10)
         dots_x = (self.display.WIDTH - dots_width) // 2
         dots_y = self.display.HEIGHT - 42
         for index in range(total_pages):
-            color = SETUP.accent if index == self.page_index else MUTED
+            color = SETUP.accent if index == active_page_index else MUTED
             self.display.circle(dots_x + (index * 10), dots_y, 2, fill=color)
 
     def build_pages(
@@ -596,14 +636,63 @@ class PowerScreen(Screen):
         if not pages:
             return pages
 
-        self.page_index %= len(pages)
-        active_page = pages[self.page_index]
+        active_page = pages[self._page_index_for(pages)]
         if active_page.title != "GPS":
             return pages
 
         if self._maybe_refresh_gps_page():
             pages = self.build_pages(state=self._get_state())
         return pages
+
+    def lvgl_payload(self) -> PowerScreenLvglPayload:
+        """Return the current Setup LVGL payload without mutating controller state."""
+
+        pages = self.build_pages(state=self._get_state())
+        if not pages:
+            return PowerScreenLvglPayload(
+                title_text="Setup",
+                page_text=None,
+                icon_key="care",
+                footer="",
+                items=(),
+                current_page_index=0,
+                total_pages=0,
+            )
+
+        active_page_index = self._page_index_for(pages)
+        active_page = pages[active_page_index]
+        picker_mode = not self.is_one_button_mode() and not self.in_detail
+
+        if picker_mode:
+            items = tuple(
+                f"{'> ' if index == active_page_index else ''}{page.title}"
+                for index, page in self._visible_picker_pages(
+                    pages,
+                    max_items=5,
+                    current_page_index=active_page_index,
+                )
+            )
+            title_text = "Setup"
+        else:
+            visible_rows, visible_selected_index = self._visible_rows_for_page(active_page)
+            formatted_rows: list[str] = []
+            for index, (label, value) in enumerate(visible_rows):
+                row_text = f"{label}: {value}"
+                if visible_selected_index is not None and index == visible_selected_index:
+                    row_text = f"> {row_text}"
+                formatted_rows.append(row_text)
+            items = tuple(formatted_rows)
+            title_text = active_page.title
+
+        return PowerScreenLvglPayload(
+            title_text=title_text,
+            page_text=None,
+            icon_key=self._page_icon_key(active_page.title),
+            footer=self._instruction_text(active_page),
+            items=items,
+            current_page_index=active_page_index,
+            total_pages=len(pages),
+        )
 
     def _build_voice_rows(self, *, summary_mode: bool = False) -> list[tuple[str, str]]:
         """Build the voice-related settings page."""

--- a/src/yoyopod/ui/screens/view.py
+++ b/src/yoyopod/ui/screens/view.py
@@ -6,7 +6,12 @@ from typing import Protocol
 
 
 class ScreenView(Protocol):
-    """Lifecycle shared by backend-specific screen view implementations."""
+    """Lifecycle shared by backend-specific screen view implementations.
+
+    destroy() is backend-managed teardown for permanently released retained views;
+    the current runtime relies on backend clear/reset/cleanup rather than calling it
+    during normal screen transitions.
+    """
 
     def build(self) -> None:
         """Create widget/object state once for a retained backend view."""
@@ -15,4 +20,4 @@ class ScreenView(Protocol):
         """Update and present an already-built view from controller state."""
 
     def destroy(self) -> None:
-        """Tear down widgets only when the retained view is permanently released."""
+        """Backend-managed teardown hook, mainly exercised by lifecycle tests."""

--- a/src/yoyopod/ui/screens/view.py
+++ b/src/yoyopod/ui/screens/view.py
@@ -9,10 +9,10 @@ class ScreenView(Protocol):
     """Lifecycle shared by backend-specific screen view implementations."""
 
     def build(self) -> None:
-        """Create widget/object state once when a screen becomes active."""
+        """Create widget/object state once for a retained backend view."""
 
     def sync(self) -> None:
-        """Update an already-built view from the current controller state."""
+        """Update and present an already-built view from controller state."""
 
     def destroy(self) -> None:
-        """Tear down widgets, callbacks, and timers when leaving the screen."""
+        """Tear down widgets only when the retained view is permanently released."""

--- a/src/yoyopod/ui/screens/voip/call_history.py
+++ b/src/yoyopod/ui/screens/voip/call_history.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.theme import (
     draw_empty_state,
     draw_list_item,
@@ -56,15 +57,20 @@ class CallHistoryScreen(Screen):
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
+            return None
+
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
+            return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
         if self._lvgl_view is not None:
             return self._lvgl_view
-
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            return None
-
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            return None
 
         self._lvgl_view = LvglCallHistoryView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/voip/call_history.py
+++ b/src/yoyopod/ui/screens/voip/call_history.py
@@ -52,10 +52,7 @@ class CallHistoryScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving recents."""
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL call-history view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/voip/contact_list.py
+++ b/src/yoyopod/ui/screens/voip/contact_list.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.theme import (
     draw_empty_state,
     draw_list_item,
@@ -76,15 +77,20 @@ class ContactListScreen(Screen):
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
+            return None
+
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
+            return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
         if self._lvgl_view is not None:
             return self._lvgl_view
-
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            return None
-
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            return None
 
         self._lvgl_view = LvglContactListView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/voip/contact_list.py
+++ b/src/yoyopod/ui/screens/voip/contact_list.py
@@ -71,10 +71,7 @@ class ContactListScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving contacts."""
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL contacts view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/voip/in_call.py
+++ b/src/yoyopod/ui/screens/voip/in_call.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.theme import (
     ERROR,
     INK,
@@ -52,15 +53,20 @@ class InCallScreen(Screen):
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
 
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
+            return None
+
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
+            return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
         if self._lvgl_view is not None:
             return self._lvgl_view
-
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            return None
-
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            return None
 
         self._lvgl_view = LvglInCallView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/voip/in_call.py
+++ b/src/yoyopod/ui/screens/voip/in_call.py
@@ -46,11 +46,7 @@ class InCallScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving the live call."""
-
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL in-call view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/voip/incoming_call.py
+++ b/src/yoyopod/ui/screens/voip/incoming_call.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.voip.lvgl import LvglIncomingCallView
 from yoyopod.ui.screens.theme import (
     INK,
@@ -45,6 +46,7 @@ class IncomingCallScreen(Screen):
     def enter(self) -> None:
         """Create the LVGL view when the screen becomes active."""
         super().enter()
+        self.ring_animation_frame = 0
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
@@ -53,15 +55,20 @@ class IncomingCallScreen(Screen):
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
+            return None
+
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
+            return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
         if self._lvgl_view is not None:
             return self._lvgl_view
-
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            return None
-
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            return None
 
         self._lvgl_view = LvglIncomingCallView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/voip/incoming_call.py
+++ b/src/yoyopod/ui/screens/voip/incoming_call.py
@@ -48,10 +48,7 @@ class IncomingCallScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving incoming call."""
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL incoming-call view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/voip/lvgl/call_history_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/call_history_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglCallHistoryView:
     """Own the LVGL object lifecycle for CallHistoryScreen."""
 
+    scene_key: ClassVar[str] = "playlist"
     screen: "CallHistoryScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/lvgl/call_history_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/call_history_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -21,15 +27,16 @@ class LvglCallHistoryView:
     screen: "CallHistoryScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.playlist_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         visible_items, visible_badges, selected_visible_index = self.screen.get_visible_window()
@@ -61,7 +68,7 @@ class LvglCallHistoryView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.playlist_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:
@@ -74,4 +81,3 @@ class LvglCallHistoryView:
         if context is None or not getattr(context, "voip_configured", False):
             return 0
         return 1 if getattr(context, "voip_ready", False) else 2
-

--- a/src/yoyopod/ui/screens/voip/lvgl/call_history_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/call_history_view.py
@@ -12,6 +12,7 @@ from yoyopod.ui.screens.lvgl_lifecycle import (
     mark_retained_view_destroyed,
     should_build_retained_view,
 )
+from yoyopod.ui.screens.lvgl_scene_keys import LIST_SCENE_KEY
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 class LvglCallHistoryView:
     """Own the LVGL object lifecycle for CallHistoryScreen."""
 
-    scene_key: ClassVar[str] = "playlist"
+    scene_key: ClassVar[str] = LIST_SCENE_KEY
     screen: "CallHistoryScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/lvgl/call_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/call_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -21,15 +27,16 @@ class LvglCallView:
     screen: "CallScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.talk_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         model = self.screen.current_card_model()
@@ -53,7 +60,7 @@ class LvglCallView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.talk_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/voip/lvgl/call_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/call_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglCallView:
     """Own the LVGL object lifecycle for the people-first Talk screen."""
 
+    scene_key: ClassVar[str] = "talk"
     screen: "CallScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/lvgl/contact_list_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/contact_list_view.py
@@ -12,6 +12,7 @@ from yoyopod.ui.screens.lvgl_lifecycle import (
     mark_retained_view_destroyed,
     should_build_retained_view,
 )
+from yoyopod.ui.screens.lvgl_scene_keys import LIST_SCENE_KEY
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 class LvglContactListView:
     """Own the LVGL object lifecycle for ContactListScreen."""
 
-    scene_key: ClassVar[str] = "playlist"
+    scene_key: ClassVar[str] = LIST_SCENE_KEY
     screen: "ContactListScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/lvgl/contact_list_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/contact_list_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -21,15 +27,16 @@ class LvglContactListView:
     screen: "ContactListScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.playlist_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         visible_items, visible_badges, selected_visible_index = self.screen.get_visible_window()
@@ -61,7 +68,7 @@ class LvglContactListView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.playlist_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/voip/lvgl/contact_list_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/contact_list_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglContactListView:
     """Own the LVGL object lifecycle for ContactListScreen."""
 
+    scene_key: ClassVar[str] = "playlist"
     screen: "ContactListScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/lvgl/in_call_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/in_call_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -21,15 +27,16 @@ class LvglInCallView:
     screen: "InCallScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.in_call_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         caller_name = "Unknown"
@@ -66,7 +73,7 @@ class LvglInCallView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.in_call_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/voip/lvgl/in_call_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/in_call_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglInCallView:
     """Own the LVGL object lifecycle for InCallScreen."""
 
+    scene_key: ClassVar[str] = "in_call"
     screen: "InCallScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/lvgl/incoming_call_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/incoming_call_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglIncomingCallView:
     """Own the LVGL object lifecycle for IncomingCallScreen."""
 
+    scene_key: ClassVar[str] = "incoming_call"
     screen: "IncomingCallScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/lvgl/incoming_call_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/incoming_call_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -21,19 +27,20 @@ class LvglIncomingCallView:
     screen: "IncomingCallScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
         """Create the native incoming-call scene once."""
 
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.incoming_call_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
         """Push the current caller state into the native scene."""
 
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         footer = "Tap = Answer | Hold = Decline" if self.screen.is_one_button_mode() else "A answer | B reject"
@@ -57,7 +64,7 @@ class LvglIncomingCallView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.incoming_call_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/voip/lvgl/outgoing_call_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/outgoing_call_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -21,15 +27,16 @@ class LvglOutgoingCallView:
     screen: "OutgoingCallScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.outgoing_call_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         callee_name = self.screen.callee_name or "Unknown"
@@ -58,7 +65,7 @@ class LvglOutgoingCallView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.outgoing_call_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/voip/lvgl/outgoing_call_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/outgoing_call_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglOutgoingCallView:
     """Own the LVGL object lifecycle for OutgoingCallScreen."""
 
+    scene_key: ClassVar[str] = "outgoing_call"
     screen: "OutgoingCallScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/lvgl/talk_contact_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/talk_contact_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -21,15 +27,16 @@ class LvglTalkContactView:
     screen: "TalkContactScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.talk_actions_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         visible_items, _visible_subtitles, selected_visible_index = self.screen.get_visible_actions()
@@ -59,7 +66,7 @@ class LvglTalkContactView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.talk_actions_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/voip/lvgl/talk_contact_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/talk_contact_view.py
@@ -12,6 +12,7 @@ from yoyopod.ui.screens.lvgl_lifecycle import (
     mark_retained_view_destroyed,
     should_build_retained_view,
 )
+from yoyopod.ui.screens.lvgl_scene_keys import TALK_ACTIONS_SCENE_KEY
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 class LvglTalkContactView:
     """Own the LVGL object lifecycle for TalkContactScreen."""
 
-    scene_key: ClassVar[str] = "talk_actions"
+    scene_key: ClassVar[str] = TALK_ACTIONS_SCENE_KEY
     screen: "TalkContactScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/lvgl/talk_contact_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/talk_contact_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglTalkContactView:
     """Own the LVGL object lifecycle for TalkContactScreen."""
 
+    scene_key: ClassVar[str] = "talk_actions"
     screen: "TalkContactScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/lvgl/voice_note_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/voice_note_view.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
 from yoyopod.ui.screens.lvgl_lifecycle import (
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 class LvglVoiceNoteView:
     """Own the LVGL object lifecycle for VoiceNoteScreen."""
 
+    scene_key: ClassVar[str] = "talk_actions"
     screen: "VoiceNoteScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/lvgl/voice_note_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/voice_note_view.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from yoyopod.ui.lvgl_binding import LvglDisplayBackend
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    ensure_retained_view_built,
+    mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
+)
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -21,15 +27,16 @@ class LvglVoiceNoteView:
     screen: "VoiceNoteScreen"
     backend: LvglDisplayBackend
     _built: bool = False
+    _build_generation: int = -1
 
     def build(self) -> None:
-        if self._built or self.backend.binding is None:
+        if not should_build_retained_view(self):
             return
         self.backend.binding.talk_actions_build()
-        self._built = True
+        mark_retained_view_built(self)
 
     def sync(self) -> None:
-        if not self._built or self.backend.binding is None:
+        if not ensure_retained_view_built(self):
             return
 
         context = self.screen.context
@@ -82,7 +89,7 @@ class LvglVoiceNoteView:
         if not self._built or self.backend.binding is None:
             return
         self.backend.binding.talk_actions_destroy()
-        self._built = False
+        mark_retained_view_destroyed(self)
 
     @staticmethod
     def _battery_percent(context: "AppContext | None") -> int:

--- a/src/yoyopod/ui/screens/voip/lvgl/voice_note_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/voice_note_view.py
@@ -12,6 +12,7 @@ from yoyopod.ui.screens.lvgl_lifecycle import (
     mark_retained_view_destroyed,
     should_build_retained_view,
 )
+from yoyopod.ui.screens.lvgl_scene_keys import TALK_ACTIONS_SCENE_KEY
 from yoyopod.ui.screens.lvgl_status import sync_network_status
 from yoyopod.ui.screens.theme import TALK
 
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 class LvglVoiceNoteView:
     """Own the LVGL object lifecycle for VoiceNoteScreen."""
 
-    scene_key: ClassVar[str] = "talk_actions"
+    scene_key: ClassVar[str] = TALK_ACTIONS_SCENE_KEY
     screen: "VoiceNoteScreen"
     backend: LvglDisplayBackend
     _built: bool = False

--- a/src/yoyopod/ui/screens/voip/outgoing_call.py
+++ b/src/yoyopod/ui/screens/voip/outgoing_call.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.voip.lvgl import LvglOutgoingCallView
 from yoyopod.ui.screens.theme import (
     INK,
@@ -45,6 +46,7 @@ class OutgoingCallScreen(Screen):
     def enter(self) -> None:
         """Create the LVGL view when the screen becomes active."""
         super().enter()
+        self.ring_animation_frame = 0
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
@@ -53,15 +55,20 @@ class OutgoingCallScreen(Screen):
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
+            return None
+
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
+            return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
         if self._lvgl_view is not None:
             return self._lvgl_view
-
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            return None
-
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            return None
 
         self._lvgl_view = LvglOutgoingCallView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/voip/outgoing_call.py
+++ b/src/yoyopod/ui/screens/voip/outgoing_call.py
@@ -48,10 +48,7 @@ class OutgoingCallScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving outgoing call."""
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL outgoing-call view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/voip/quick_call.py
+++ b/src/yoyopod/ui/screens/voip/quick_call.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.theme import (
     INK,
     draw_empty_state,
@@ -82,17 +83,20 @@ class CallScreen(Screen):
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
 
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
             return None
 
         ui_backend = (
             self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
         )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
             return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
+        if self._lvgl_view is not None:
+            return self._lvgl_view
 
         self._lvgl_view = LvglCallView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/voip/quick_call.py
+++ b/src/yoyopod/ui/screens/voip/quick_call.py
@@ -76,11 +76,7 @@ class CallScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving Talk."""
-
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL Talk view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/voip/talk_contact.py
+++ b/src/yoyopod/ui/screens/voip/talk_contact.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.theme import (
     INK,
     TALK,
@@ -63,17 +64,20 @@ class TalkContactScreen(Screen):
     def _ensure_lvgl_view(self) -> "ScreenView | None":
         """Create an LVGL view when the Whisplay renderer is active."""
 
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
             return None
 
         ui_backend = (
             self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
         )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
             return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
+        if self._lvgl_view is not None:
+            return self._lvgl_view
 
         self._lvgl_view = LvglTalkContactView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/voip/talk_contact.py
+++ b/src/yoyopod/ui/screens/voip/talk_contact.py
@@ -57,11 +57,7 @@ class TalkContactScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving the action screen."""
-
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL action view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/src/yoyopod/ui/screens/voip/voice_note.py
+++ b/src/yoyopod/ui/screens/voip/voice_note.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.theme import (
     ERROR,
     INK,
@@ -201,17 +202,20 @@ class VoiceNoteScreen(Screen):
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
         if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
             return None
 
         ui_backend = (
             self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
         )
         if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
             return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
+        if self._lvgl_view is not None:
+            return self._lvgl_view
 
         self._lvgl_view = LvglVoiceNoteView(self, ui_backend)
         self._lvgl_view.build()

--- a/src/yoyopod/ui/screens/voip/voice_note.py
+++ b/src/yoyopod/ui/screens/voip/voice_note.py
@@ -197,11 +197,7 @@ class VoiceNoteScreen(Screen):
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
-        """Tear down any active LVGL view when leaving voice notes."""
-
-        if self._lvgl_view is not None:
-            self._lvgl_view.destroy()
-            self._lvgl_view = None
+        """Leave the retained LVGL voice-note view alive across transitions."""
         super().exit()
 
     def _ensure_lvgl_view(self) -> "ScreenView | None":

--- a/tests/test_hub_lvgl_view.py
+++ b/tests/test_hub_lvgl_view.py
@@ -33,6 +33,9 @@ class FakeLvglBackend:
         self.initialized = True
         self.scene_generation = 0
 
+    def reset(self) -> None:
+        self.scene_generation += 1
+
 
 class FakeLvglDisplay:
     """Tiny Display double for LVGL Hub delegation tests."""
@@ -103,11 +106,13 @@ def test_hub_screen_rebuilds_retained_lvgl_view_after_backend_reset() -> None:
     screen.render()
 
     assert binding.hub_build_calls == 1
+    first_view = screen._lvgl_view
 
-    display.get_ui_backend().scene_generation += 1
+    display.get_ui_backend().reset()
     screen.enter()
     screen.render()
 
+    assert screen._lvgl_view is not first_view
     assert binding.hub_build_calls == 2
     assert len(binding.hub_sync_payloads) == 2
 

--- a/tests/test_hub_lvgl_view.py
+++ b/tests/test_hub_lvgl_view.py
@@ -45,8 +45,8 @@ class FakeLvglDisplay:
         return self._ui_backend
 
 
-def test_hub_screen_builds_syncs_and_destroys_lvgl_view() -> None:
-    """HubScreen should delegate its lifecycle to an LVGL view when available."""
+def test_hub_screen_reuses_retained_lvgl_view_across_exit_and_reentry() -> None:
+    """HubScreen should retain its LVGL view across transitions."""
 
     binding = FakeLvglBinding()
     display = FakeLvglDisplay(binding)
@@ -82,7 +82,13 @@ def test_hub_screen_builds_syncs_and_destroys_lvgl_view() -> None:
     assert second_payload["selected_index"] == 1
 
     screen.exit()
-    assert binding.hub_destroy_calls == 1
+    assert binding.hub_destroy_calls == 0
+
+    screen.enter()
+    screen.render()
+
+    assert binding.hub_build_calls == 1
+    assert len(binding.hub_sync_payloads) == 3
 
 
 def test_hub_screen_falls_back_cleanly_when_lvgl_backend_is_unavailable() -> None:

--- a/tests/test_hub_lvgl_view.py
+++ b/tests/test_hub_lvgl_view.py
@@ -31,6 +31,7 @@ class FakeLvglBackend:
     def __init__(self, binding: FakeLvglBinding) -> None:
         self.binding = binding
         self.initialized = True
+        self.scene_generation = 0
 
 
 class FakeLvglDisplay:
@@ -89,6 +90,26 @@ def test_hub_screen_reuses_retained_lvgl_view_across_exit_and_reentry() -> None:
 
     assert binding.hub_build_calls == 1
     assert len(binding.hub_sync_payloads) == 3
+
+
+def test_hub_screen_rebuilds_retained_lvgl_view_after_backend_reset() -> None:
+    """HubScreen should rebuild a retained view after the backend clears native scenes."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    screen = HubScreen(display, AppContext(interaction_profile=InteractionProfile.ONE_BUTTON))
+
+    screen.enter()
+    screen.render()
+
+    assert binding.hub_build_calls == 1
+
+    display.get_ui_backend().scene_generation += 1
+    screen.enter()
+    screen.render()
+
+    assert binding.hub_build_calls == 2
+    assert len(binding.hub_sync_payloads) == 2
 
 
 def test_hub_screen_falls_back_cleanly_when_lvgl_backend_is_unavailable() -> None:

--- a/tests/test_incoming_call_lvgl_view.py
+++ b/tests/test_incoming_call_lvgl_view.py
@@ -45,8 +45,8 @@ class FakeLvglDisplay:
         return self._ui_backend
 
 
-def test_incoming_call_screen_builds_syncs_and_destroys_lvgl_view() -> None:
-    """IncomingCallScreen should delegate lifecycle and caller state to LVGL."""
+def test_incoming_call_screen_reuses_retained_lvgl_view_across_exit_and_reentry() -> None:
+    """IncomingCallScreen should retain its LVGL view across transitions."""
 
     binding = FakeLvglBinding()
     display = FakeLvglDisplay(binding)
@@ -78,7 +78,13 @@ def test_incoming_call_screen_builds_syncs_and_destroys_lvgl_view() -> None:
     assert payload["footer"] == "Tap = Answer | Hold = Decline"
 
     screen.exit()
-    assert binding.incoming_call_destroy_calls == 1
+    assert binding.incoming_call_destroy_calls == 0
+
+    screen.enter()
+    screen.render()
+
+    assert binding.incoming_call_build_calls == 1
+    assert len(binding.incoming_call_sync_payloads) == 2
 
 
 def test_incoming_call_screen_uses_safe_unknown_defaults_through_lvgl() -> None:

--- a/tests/test_listen_lvgl_view.py
+++ b/tests/test_listen_lvgl_view.py
@@ -46,8 +46,8 @@ class FakeLvglDisplay:
         return self._ui_backend
 
 
-def test_listen_screen_builds_syncs_and_destroys_lvgl_view() -> None:
-    """ListenScreen should delegate its lifecycle to an LVGL view when available."""
+def test_listen_screen_reuses_retained_lvgl_view_across_exit_and_reentry() -> None:
+    """ListenScreen should retain its LVGL view across transitions."""
 
     binding = FakeLvglBinding()
     display = FakeLvglDisplay(binding)
@@ -87,4 +87,10 @@ def test_listen_screen_builds_syncs_and_destroys_lvgl_view() -> None:
     assert second_payload["selected_index"] == 1
 
     screen.exit()
-    assert binding.listen_destroy_calls == 1
+    assert binding.listen_destroy_calls == 0
+
+    screen.enter()
+    screen.render()
+
+    assert binding.listen_build_calls == 1
+    assert len(binding.listen_sync_payloads) == 3

--- a/tests/test_lvgl_foundation.py
+++ b/tests/test_lvgl_foundation.py
@@ -183,6 +183,7 @@ def test_lvgl_backend_cleanup_shuts_down_the_native_binding() -> None:
     backend.cleanup()
 
     assert binding.shutdown_calls == 1
+    assert backend.binding is None
     assert backend.initialized is False
     assert backend.scene_generation == 1
 

--- a/tests/test_lvgl_foundation.py
+++ b/tests/test_lvgl_foundation.py
@@ -159,6 +159,20 @@ def test_lvgl_backend_reset_clears_the_active_scene() -> None:
     assert backend.scene_generation == 1
 
 
+def test_lvgl_backend_reset_clears_retained_scene_claims() -> None:
+    """Reset should drop stale retained-scene ownership alongside native scene teardown."""
+
+    binding = FakeBinding()
+    target = FakeFlushTarget()
+    backend = LvglDisplayBackend(target, binding=binding)
+    backend.initialize()
+    backend._retained_scene_claims["playlist"] = 123
+
+    backend.reset()
+
+    assert backend._retained_scene_claims == {}
+
+
 def test_lvgl_backend_force_refresh_delegates_to_native_binding() -> None:
     """Force-refresh should invalidate the active LVGL scene once initialized."""
 
@@ -186,6 +200,20 @@ def test_lvgl_backend_cleanup_shuts_down_the_native_binding() -> None:
     assert backend.binding is None
     assert backend.initialized is False
     assert backend.scene_generation == 1
+
+
+def test_lvgl_backend_cleanup_clears_retained_scene_claims() -> None:
+    """Cleanup should discard retained-scene ownership before the binding is dropped."""
+
+    binding = FakeBinding()
+    target = FakeFlushTarget()
+    backend = LvglDisplayBackend(target, binding=binding)
+    backend.initialize()
+    backend._retained_scene_claims["playlist"] = 123
+
+    backend.cleanup()
+
+    assert backend._retained_scene_claims == {}
 
 
 def test_lvgl_input_bridge_ignores_queued_actions_until_backend_is_ready() -> None:

--- a/tests/test_lvgl_foundation.py
+++ b/tests/test_lvgl_foundation.py
@@ -156,6 +156,7 @@ def test_lvgl_backend_reset_clears_the_active_scene() -> None:
     backend.reset()
 
     assert binding.clear_calls == 1
+    assert backend.scene_generation == 1
 
 
 def test_lvgl_backend_force_refresh_delegates_to_native_binding() -> None:
@@ -183,6 +184,7 @@ def test_lvgl_backend_cleanup_shuts_down_the_native_binding() -> None:
 
     assert binding.shutdown_calls == 1
     assert backend.initialized is False
+    assert backend.scene_generation == 1
 
 
 def test_lvgl_input_bridge_ignores_queued_actions_until_backend_is_ready() -> None:

--- a/tests/test_lvgl_lifecycle.py
+++ b/tests/test_lvgl_lifecycle.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import ClassVar
 
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view, mark_retained_view_built
+from yoyopod.ui.screens.lvgl_lifecycle import (
+    current_retained_view,
+    mark_retained_view_built,
+    view_is_ready,
+)
 
 
 class FakeBackend:
@@ -30,6 +34,14 @@ class SharedSceneView:
         mark_retained_view_built(self)
 
 
+class MissingInitializedBackend:
+    """Backend stub that intentionally omits the initialized flag."""
+
+    def __init__(self) -> None:
+        self.binding = object()
+        self.scene_generation = 0
+
+
 def test_current_retained_view_rejects_stale_shared_scene_owner() -> None:
     """Only the latest wrapper for one native scene key should stay reusable."""
 
@@ -44,3 +56,15 @@ def test_current_retained_view_rejects_stale_shared_scene_owner() -> None:
 
     assert current_retained_view(first, backend) is None
     assert current_retained_view(second, backend) is second
+
+
+def test_view_is_ready_requires_explicit_backend_initialization() -> None:
+    """Retained-scene helpers should fail closed on incomplete backend doubles."""
+
+    backend = MissingInitializedBackend()
+    view = SharedSceneView(backend)  # type: ignore[arg-type]
+
+    mark_retained_view_built(view)
+
+    assert view_is_ready(view) is False
+    assert current_retained_view(view, backend) is None

--- a/tests/test_lvgl_lifecycle.py
+++ b/tests/test_lvgl_lifecycle.py
@@ -8,6 +8,8 @@ from typing import ClassVar
 from yoyopod.ui.screens.lvgl_lifecycle import (
     current_retained_view,
     mark_retained_view_built,
+    mark_retained_view_destroyed,
+    should_build_retained_view,
     view_is_ready,
 )
 
@@ -32,6 +34,9 @@ class SharedSceneView:
 
     def build(self) -> None:
         mark_retained_view_built(self)
+
+    def destroy(self) -> None:
+        mark_retained_view_destroyed(self)
 
 
 class MissingInitializedBackend:
@@ -68,3 +73,22 @@ def test_view_is_ready_requires_explicit_backend_initialization() -> None:
 
     assert view_is_ready(view) is False
     assert current_retained_view(view, backend) is None
+
+
+def test_destroyed_retained_view_releases_scene_claim_and_requires_rebuild() -> None:
+    """Explicit cleanup should drop retained-scene ownership until the next build."""
+
+    backend = FakeBackend()
+    view = SharedSceneView(backend)
+
+    mark_retained_view_built(view)
+    assert current_retained_view(view, backend) is view
+
+    view.destroy()
+
+    assert current_retained_view(view, backend) is None
+    assert should_build_retained_view(view) is True
+
+    view.build()
+
+    assert current_retained_view(view, backend) is view

--- a/tests/test_lvgl_lifecycle.py
+++ b/tests/test_lvgl_lifecycle.py
@@ -1,0 +1,46 @@
+"""Unit tests for retained LVGL Python-view lifecycle helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view, mark_retained_view_built
+
+
+class FakeBackend:
+    """Minimal backend stub for retained-scene ownership tests."""
+
+    def __init__(self) -> None:
+        self.binding = object()
+        self.initialized = True
+        self.scene_generation = 0
+
+
+@dataclass(slots=True)
+class SharedSceneView:
+    """Small retained-view double that shares one native scene key."""
+
+    scene_key: ClassVar[str] = "shared"
+    backend: FakeBackend
+    _built: bool = False
+    _build_generation: int = -1
+
+    def build(self) -> None:
+        mark_retained_view_built(self)
+
+
+def test_current_retained_view_rejects_stale_shared_scene_owner() -> None:
+    """Only the latest wrapper for one native scene key should stay reusable."""
+
+    backend = FakeBackend()
+    first = SharedSceneView(backend)
+    second = SharedSceneView(backend)
+
+    mark_retained_view_built(first)
+    assert current_retained_view(first, backend) is first
+
+    mark_retained_view_built(second)
+
+    assert current_retained_view(first, backend) is None
+    assert current_retained_view(second, backend) is second

--- a/tests/test_lvgl_shim_lifecycle_contract.py
+++ b/tests/test_lvgl_shim_lifecycle_contract.py
@@ -67,6 +67,7 @@ def test_shutdown_clears_retained_scenes_before_freeing_draw_buffers() -> None:
 
     assert "yoyopod_lvgl_clear_screen();" in body
     assert body.index("yoyopod_lvgl_clear_screen();") < body.index("lv_free(g_draw_buf);")
+    assert "g_blank_screen = NULL;" in body
 
 
 def test_retained_scene_syncs_guard_missing_roots_before_activation() -> None:

--- a/tests/test_lvgl_shim_lifecycle_contract.py
+++ b/tests/test_lvgl_shim_lifecycle_contract.py
@@ -67,6 +67,8 @@ def test_shutdown_clears_retained_scenes_before_freeing_draw_buffers() -> None:
 
     assert "yoyopod_lvgl_clear_screen();" in body
     assert body.index("yoyopod_lvgl_clear_screen();") < body.index("lv_free(g_draw_buf);")
+    assert "lv_obj_delete(g_blank_screen);" in body
+    assert body.index("lv_obj_delete(g_blank_screen);") < body.index("g_blank_screen = NULL;")
     assert "g_blank_screen = NULL;" in body
 
 

--- a/tests/test_lvgl_shim_lifecycle_contract.py
+++ b/tests/test_lvgl_shim_lifecycle_contract.py
@@ -1,0 +1,97 @@
+"""Source-contract tests for the retained LVGL scene lifecycle seam."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SHIM_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "yoyopod"
+    / "ui"
+    / "lvgl_binding"
+    / "native"
+    / "lvgl_shim.c"
+)
+
+
+def _read_shim_source() -> str:
+    return SHIM_PATH.read_text(encoding="utf-8")
+
+
+def _function_body(signature: str) -> str:
+    source = _read_shim_source()
+    start = source.index(signature)
+    body_start = source.index("{", start)
+    depth = 1
+    cursor = body_start + 1
+
+    while depth > 0 and cursor < len(source):
+        if source[cursor] == "{":
+            depth += 1
+        elif source[cursor] == "}":
+            depth -= 1
+        cursor += 1
+
+    return source[body_start + 1 : cursor - 1]
+
+
+def test_release_scene_screen_replaces_active_root_before_delete() -> None:
+    """Active retained scenes should load the reusable blank root before deletion."""
+
+    body = _function_body("static void yoyopod_release_scene_screen")
+
+    assert "yoyopod_ensure_blank_screen()" in body
+    assert "lv_screen_active() == screen" in body
+    assert "lv_screen_load(blank_screen);" in body
+    assert "lv_obj_delete(screen);" in body
+    assert "lv_obj_clean(screen);" not in body
+
+
+def test_clear_screen_reuses_the_blank_screen_instead_of_allocating_placeholders() -> None:
+    """Full-screen clears should rely on the shared blank root instead of per-reset screens."""
+
+    source = _read_shim_source()
+    body = _function_body("void yoyopod_lvgl_clear_screen")
+
+    assert "static lv_obj_t * g_blank_screen = NULL;" in source
+    assert "placeholder_screen" not in body
+    assert "lv_obj_create(NULL)" not in body
+
+
+def test_retained_scene_syncs_guard_missing_roots_before_activation() -> None:
+    """Each retained sync path should reject a missing scene root before load-time activation."""
+
+    sync_functions = {
+        "int yoyopod_lvgl_hub_sync": "g_hub_scene.screen",
+        "int yoyopod_lvgl_talk_sync": "g_talk_scene.screen",
+        "int yoyopod_lvgl_talk_actions_sync": "g_talk_actions_scene.screen",
+        "int yoyopod_lvgl_listen_sync": "g_listen_scene.screen",
+        "int yoyopod_lvgl_playlist_sync": "g_playlist_scene.screen",
+        "int yoyopod_lvgl_now_playing_sync": "g_now_playing_scene.screen",
+        "int yoyopod_lvgl_incoming_call_sync": "g_incoming_call_scene.screen",
+        "int yoyopod_lvgl_outgoing_call_sync": "g_outgoing_call_scene.screen",
+        "int yoyopod_lvgl_in_call_sync": "g_in_call_scene.screen",
+        "int yoyopod_lvgl_ask_sync": "g_ask_scene.screen",
+        "int yoyopod_lvgl_power_sync": "g_power_scene.screen",
+    }
+
+    for signature, scene_ref in sync_functions.items():
+        body = _function_body(signature)
+        guard_match = re.search(
+            rf"yoyopod_require_scene_screen\(\s*{re.escape(scene_ref)}\s*,",
+            body,
+            re.MULTILINE,
+        )
+        activate_match = re.search(
+            rf"yoyopod_activate_scene_screen\(\s*{re.escape(scene_ref)}\s*,",
+            body,
+            re.MULTILINE,
+        )
+
+        assert guard_match is not None, f"missing root guard in {signature}"
+        assert activate_match is not None, f"missing activation helper in {signature}"
+        assert (
+            guard_match.start() < activate_match.start()
+        ), f"root guard should run before activation in {signature}"

--- a/tests/test_lvgl_shim_lifecycle_contract.py
+++ b/tests/test_lvgl_shim_lifecycle_contract.py
@@ -60,6 +60,15 @@ def test_clear_screen_reuses_the_blank_screen_instead_of_allocating_placeholders
     assert "lv_obj_create(NULL)" not in body
 
 
+def test_shutdown_clears_retained_scenes_before_freeing_draw_buffers() -> None:
+    """Shutdown should release retained scenes before buffer storage is freed."""
+
+    body = _function_body("void yoyopod_lvgl_shutdown")
+
+    assert "yoyopod_lvgl_clear_screen();" in body
+    assert body.index("yoyopod_lvgl_clear_screen();") < body.index("lv_free(g_draw_buf);")
+
+
 def test_retained_scene_syncs_guard_missing_roots_before_activation() -> None:
     """Each retained sync path should reject a missing scene root before load-time activation."""
 

--- a/tests/test_now_playing_lvgl_view.py
+++ b/tests/test_now_playing_lvgl_view.py
@@ -50,8 +50,8 @@ class FakeLvglDisplay:
         return self._ui_backend
 
 
-def test_now_playing_screen_builds_syncs_and_destroys_lvgl_view() -> None:
-    """NowPlayingScreen should delegate lifecycle and playback state to LVGL."""
+def test_now_playing_screen_reuses_retained_lvgl_view_across_exit_and_reentry() -> None:
+    """NowPlayingScreen should retain its LVGL view across transitions."""
 
     binding = FakeLvglBinding()
     display = FakeLvglDisplay(binding)
@@ -95,7 +95,13 @@ def test_now_playing_screen_builds_syncs_and_destroys_lvgl_view() -> None:
     assert payload["power_available"] is True
 
     screen.exit()
-    assert binding.now_playing_destroy_calls == 1
+    assert binding.now_playing_destroy_calls == 0
+
+    screen.enter()
+    screen.render()
+
+    assert binding.now_playing_build_calls == 1
+    assert len(binding.now_playing_sync_payloads) == 2
 
 
 def test_now_playing_screen_syncs_offline_state_through_lvgl() -> None:

--- a/tests/test_playlist_lvgl_view.py
+++ b/tests/test_playlist_lvgl_view.py
@@ -147,6 +147,41 @@ def test_playlist_screen_rebuilds_retained_lvgl_view_after_backend_reset(tmp_pat
     assert binding.playlist_build_calls == 2
 
 
+def test_playlist_view_sync_rebuilds_same_retained_instance_after_backend_reset(
+    tmp_path: Path,
+) -> None:
+    """A built retained playlist view should self-rebuild on sync after backend reset."""
+
+    music_dir = tmp_path / "Music"
+    music_dir.mkdir()
+    _write_playlist(music_dir / "Alpha.m3u", 12)
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    backend = MockMusicBackend()
+    backend.start()
+    screen = PlaylistScreen(
+        display,
+        AppContext(interaction_profile=InteractionProfile.ONE_BUTTON),
+        music_service=LocalMusicService(backend, music_dir=music_dir),
+    )
+
+    screen.enter()
+
+    retained_view = screen._lvgl_view
+    assert retained_view is not None
+    assert binding.playlist_build_calls == 1
+    sync_count_before_reset = len(binding.playlist_sync_payloads)
+
+    display.get_ui_backend().reset()
+    retained_view.sync()
+
+    assert screen._lvgl_view is retained_view
+    assert binding.playlist_build_calls == 2
+    assert len(binding.playlist_sync_payloads) == sync_count_before_reset + 1
+    assert binding.playlist_sync_payloads[-1]["items"] == ["Alpha"]
+
+
 def test_playlist_screen_syncs_error_state_through_lvgl(tmp_path: Path) -> None:
     """PlaylistScreen should send the music-offline empty state through LVGL."""
 

--- a/tests/test_playlist_lvgl_view.py
+++ b/tests/test_playlist_lvgl_view.py
@@ -36,6 +36,9 @@ class FakeLvglBackend:
         self.initialized = True
         self.scene_generation = 0
 
+    def reset(self) -> None:
+        self.scene_generation += 1
+
 
 class FakeLvglDisplay:
     """Tiny Display double for LVGL playlist delegation tests."""
@@ -135,10 +138,12 @@ def test_playlist_screen_rebuilds_retained_lvgl_view_after_backend_reset(tmp_pat
     screen.enter()
 
     assert binding.playlist_build_calls == 1
+    first_view = screen._lvgl_view
 
-    display.get_ui_backend().scene_generation += 1
+    display.get_ui_backend().reset()
     screen.enter()
 
+    assert screen._lvgl_view is not first_view
     assert binding.playlist_build_calls == 2
 
 

--- a/tests/test_playlist_lvgl_view.py
+++ b/tests/test_playlist_lvgl_view.py
@@ -34,6 +34,7 @@ class FakeLvglBackend:
     def __init__(self, binding: FakeLvglBinding) -> None:
         self.binding = binding
         self.initialized = True
+        self.scene_generation = 0
 
 
 class FakeLvglDisplay:
@@ -112,6 +113,33 @@ def test_playlist_screen_reuses_retained_lvgl_view_across_exit_and_reentry(tmp_p
 
     assert binding.playlist_build_calls == 1
     assert len(binding.playlist_sync_payloads) >= 4
+
+
+def test_playlist_screen_rebuilds_retained_lvgl_view_after_backend_reset(tmp_path: Path) -> None:
+    """PlaylistScreen should rebuild after a backend clear releases the native scene."""
+
+    music_dir = tmp_path / "Music"
+    music_dir.mkdir()
+    _write_playlist(music_dir / "Alpha.m3u", 12)
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    backend = MockMusicBackend()
+    backend.start()
+    screen = PlaylistScreen(
+        display,
+        AppContext(interaction_profile=InteractionProfile.ONE_BUTTON),
+        music_service=LocalMusicService(backend, music_dir=music_dir),
+    )
+
+    screen.enter()
+
+    assert binding.playlist_build_calls == 1
+
+    display.get_ui_backend().scene_generation += 1
+    screen.enter()
+
+    assert binding.playlist_build_calls == 2
 
 
 def test_playlist_screen_syncs_error_state_through_lvgl(tmp_path: Path) -> None:

--- a/tests/test_playlist_lvgl_view.py
+++ b/tests/test_playlist_lvgl_view.py
@@ -56,8 +56,8 @@ def _write_playlist(path: Path, track_count: int) -> None:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def test_playlist_screen_builds_syncs_and_destroys_lvgl_view(tmp_path: Path) -> None:
-    """PlaylistScreen should delegate lifecycle and visible-window state to LVGL."""
+def test_playlist_screen_reuses_retained_lvgl_view_across_exit_and_reentry(tmp_path: Path) -> None:
+    """PlaylistScreen should retain its LVGL view across transitions."""
 
     music_dir = tmp_path / "Music"
     music_dir.mkdir()
@@ -106,7 +106,12 @@ def test_playlist_screen_builds_syncs_and_destroys_lvgl_view(tmp_path: Path) -> 
     assert scrolled_payload["selected_visible_index"] == 2
 
     screen.exit()
-    assert binding.playlist_destroy_calls == 1
+    assert binding.playlist_destroy_calls == 0
+
+    screen.enter()
+
+    assert binding.playlist_build_calls == 1
+    assert len(binding.playlist_sync_payloads) >= 4
 
 
 def test_playlist_screen_syncs_error_state_through_lvgl(tmp_path: Path) -> None:

--- a/tests/test_remaining_lvgl_views.py
+++ b/tests/test_remaining_lvgl_views.py
@@ -8,11 +8,17 @@ from yoyopod.app_context import AppContext
 from yoyopod.ui.input import InteractionProfile
 from yoyopod.ui.screens import (
     CallScreen,
+    CallHistoryScreen,
     ContactListScreen,
+    IncomingCallScreen,
     InCallScreen,
+    ListenScreen,
+    NowPlayingScreen,
     OutgoingCallScreen,
     PowerScreen,
+    RecentTracksScreen,
     TalkContactScreen,
+    VoiceNoteScreen,
 )
 
 
@@ -42,9 +48,15 @@ class FakeLvglBinding:
         self.in_call_build_calls = 0
         self.in_call_destroy_calls = 0
         self.in_call_sync_payloads: list[dict] = []
+        self.listen_build_calls = 0
+        self.listen_destroy_calls = 0
+        self.listen_sync_payloads: list[dict] = []
         self.ask_build_calls = 0
         self.ask_destroy_calls = 0
         self.ask_sync_payloads: list[dict] = []
+        self.now_playing_build_calls = 0
+        self.now_playing_destroy_calls = 0
+        self.now_playing_sync_payloads: list[dict] = []
         self.power_build_calls = 0
         self.power_destroy_calls = 0
         self.power_sync_payloads: list[dict] = []
@@ -112,6 +124,15 @@ class FakeLvglBinding:
     def in_call_destroy(self) -> None:
         self.in_call_destroy_calls += 1
 
+    def listen_build(self) -> None:
+        self.listen_build_calls += 1
+
+    def listen_sync(self, **payload) -> None:
+        self.listen_sync_payloads.append(payload)
+
+    def listen_destroy(self) -> None:
+        self.listen_destroy_calls += 1
+
     def ask_build(self) -> None:
         self.ask_build_calls += 1
 
@@ -120,6 +141,15 @@ class FakeLvglBinding:
 
     def ask_destroy(self) -> None:
         self.ask_destroy_calls += 1
+
+    def now_playing_build(self) -> None:
+        self.now_playing_build_calls += 1
+
+    def now_playing_sync(self, **payload) -> None:
+        self.now_playing_sync_payloads.append(payload)
+
+    def now_playing_destroy(self) -> None:
+        self.now_playing_destroy_calls += 1
 
     def power_build(self) -> None:
         self.power_build_calls += 1
@@ -141,6 +171,9 @@ class FakeLvglBackend:
         self.binding = binding
         self.initialized = True
         self.scene_generation = 0
+
+    def reset(self) -> None:
+        self.scene_generation += 1
 
 
 class FakeLvglDisplay:
@@ -226,6 +259,22 @@ def make_one_button_context() -> AppContext:
     context.battery_percent = 64
     context.battery_charging = False
     context.power_available = True
+    return context
+
+
+def make_talk_contact_context() -> AppContext:
+    """Create a TalkContact-ready context with one selected person."""
+
+    context = make_one_button_context()
+    context.set_talk_contact(name="Mama", sip_address="sip:mama@example.com")
+    return context
+
+
+def make_voice_note_context() -> AppContext:
+    """Create a VoiceNote-ready context with one selected recipient."""
+
+    context = make_one_button_context()
+    context.set_voice_note_recipient(name="Hagar", sip_address="sip:hagar@example.com")
     return context
 
 
@@ -318,12 +367,138 @@ def test_call_screen_rebuilds_retained_lvgl_view_after_backend_reset() -> None:
 
     assert binding.talk_build_calls == 1
 
-    display.get_ui_backend().scene_generation += 1
+    display.get_ui_backend().reset()
     screen.enter()
     screen.render()
 
     assert binding.talk_build_calls == 2
     assert len(binding.talk_sync_payloads) == 2
+
+
+def test_remaining_retained_lvgl_screens_rebuild_after_exit_and_backend_reset() -> None:
+    """Remaining retained LVGL controllers should rebuild after exit/reset/re-entry."""
+
+    from yoyopod.audio import LocalMusicService
+    from yoyopod.ui.screens.navigation.ask import AskScreen
+
+    cases = [
+        (
+            lambda display: ListenScreen(
+                display,
+                make_one_button_context(),
+                music_service=LocalMusicService(None),
+            ),
+            "listen_build_calls",
+        ),
+        (
+            lambda display: AskScreen(
+                display=display,
+                context=make_one_button_context(),
+            ),
+            "ask_build_calls",
+        ),
+        (
+            lambda display: RecentTracksScreen(
+                display,
+                make_one_button_context(),
+                music_service=LocalMusicService(None),
+            ),
+            "playlist_build_calls",
+        ),
+        (
+            lambda display: NowPlayingScreen(
+                display,
+                make_one_button_context(),
+            ),
+            "now_playing_build_calls",
+        ),
+        (
+            lambda display: IncomingCallScreen(
+                display,
+                make_one_button_context(),
+                caller_address="sip:parent@example.com",
+                caller_name="Parent",
+            ),
+            "incoming_call_build_calls",
+        ),
+        (
+            lambda display: OutgoingCallScreen(
+                display,
+                make_one_button_context(),
+                callee_address="sip:parent@example.com",
+                callee_name="Parent",
+            ),
+            "outgoing_call_build_calls",
+        ),
+        (
+            lambda display: InCallScreen(
+                display,
+                make_one_button_context(),
+                voip_manager=FakeVoipManager(caller_info={"display_name": "Parent"}),
+            ),
+            "in_call_build_calls",
+        ),
+        (
+            lambda display: CallHistoryScreen(
+                display,
+                make_one_button_context(),
+                voip_manager=FakeVoipManager(),
+            ),
+            "playlist_build_calls",
+        ),
+        (
+            lambda display: ContactListScreen(
+                display,
+                make_one_button_context(),
+                voip_manager=FakeVoipManager(),
+                people_directory=FakeConfigManager(
+                    [FakeContact("Amy", "sip:amy@example.com", True, notes="Mama")]
+                ),
+            ),
+            "playlist_build_calls",
+        ),
+        (
+            lambda display: TalkContactScreen(
+                display,
+                make_talk_contact_context(),
+                voip_manager=FakeVoipManager(),
+            ),
+            "talk_actions_build_calls",
+        ),
+        (
+            lambda display: VoiceNoteScreen(
+                display,
+                make_voice_note_context(),
+            ),
+            "talk_actions_build_calls",
+        ),
+        (
+            lambda display: PowerScreen(
+                display,
+                AppContext(),
+            ),
+            "power_build_calls",
+        ),
+    ]
+
+    for build_screen, build_attr in cases:
+        binding = FakeLvglBinding()
+        display = FakeLvglDisplay(binding)
+        screen = build_screen(display)
+
+        screen.enter()
+        screen.render()
+
+        assert getattr(binding, build_attr) == 1
+        first_view = screen._lvgl_view
+
+        screen.exit()
+        display.get_ui_backend().reset()
+        screen.enter()
+        screen.render()
+
+        assert screen._lvgl_view is not first_view
+        assert getattr(binding, build_attr) == 2
 
 
 def test_hub_view_syncs_network_status_bar_state_through_lvgl() -> None:

--- a/tests/test_remaining_lvgl_views.py
+++ b/tests/test_remaining_lvgl_views.py
@@ -898,3 +898,29 @@ def test_power_screen_reports_full_network_page_count_through_lvgl() -> None:
     ]
 
     screen.exit()
+
+
+def test_power_screen_lvgl_render_keeps_controller_indices_stable() -> None:
+    """LVGL sync should derive the active Setup page without rewriting controller indices."""
+
+    from yoyopod.ui.screens.system.power import build_power_screen_state_provider
+
+    binding = FakeLvglBinding()
+    screen = PowerScreen(
+        FakeLvglDisplay(binding),
+        AppContext(),
+        state_provider=build_power_screen_state_provider(status_provider=lambda: {}),
+    )
+
+    screen.enter()
+    screen.page_index = 7
+    screen.in_detail = True
+    screen.selected_row = 7
+    screen.render()
+
+    payload = binding.power_sync_payloads[-1]
+    assert payload["title_text"] == "Voice"
+    assert payload["current_page_index"] == 3
+    assert payload["items"][0].startswith("> Voice Cmds:")
+    assert screen.page_index == 7
+    assert screen.selected_row == 7

--- a/tests/test_remaining_lvgl_views.py
+++ b/tests/test_remaining_lvgl_views.py
@@ -140,6 +140,7 @@ class FakeLvglBackend:
     def __init__(self, binding: FakeLvglBinding) -> None:
         self.binding = binding
         self.initialized = True
+        self.scene_generation = 0
 
 
 class FakeLvglDisplay:
@@ -293,6 +294,36 @@ def test_call_screen_can_reenter_lvgl_view_without_rebuilding() -> None:
 
     assert binding.talk_build_calls == 1
     assert binding.talk_destroy_calls == 0
+
+
+def test_call_screen_rebuilds_retained_lvgl_view_after_backend_reset() -> None:
+    """Talk should rebuild its retained LVGL scene after a backend reset clears it."""
+
+    display = FakeLvglDisplay(FakeLvglBinding())
+    binding = display.get_ui_backend().binding
+    screen = CallScreen(
+        display,
+        make_one_button_context(),
+        voip_manager=FakeVoipManager(),
+        people_directory=FakeConfigManager(
+            [
+                FakeContact("Hagar", "sip:hagar@example.com", True),
+                FakeContact("Mama", "sip:mama@example.com", True),
+            ]
+        ),
+    )
+
+    screen.enter()
+    screen.render()
+
+    assert binding.talk_build_calls == 1
+
+    display.get_ui_backend().scene_generation += 1
+    screen.enter()
+    screen.render()
+
+    assert binding.talk_build_calls == 2
+    assert len(binding.talk_sync_payloads) == 2
 
 
 def test_hub_view_syncs_network_status_bar_state_through_lvgl() -> None:

--- a/tests/test_remaining_lvgl_views.py
+++ b/tests/test_remaining_lvgl_views.py
@@ -591,6 +591,43 @@ def test_contact_list_screen_syncs_sorted_contacts_through_lvgl() -> None:
     assert binding.playlist_destroy_calls == 0
 
 
+def test_list_family_screens_replace_stale_owner_after_shared_scene_reclaim() -> None:
+    """Shared list-scene screens should replace stale wrappers on re-entry."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+
+    contacts = ContactListScreen(
+        display,
+        make_one_button_context(),
+        voip_manager=FakeVoipManager(),
+        people_directory=FakeConfigManager(
+            [FakeContact("Amy", "sip:amy@example.com", True, notes="Mama")]
+        ),
+    )
+    recents = CallHistoryScreen(
+        display,
+        make_one_button_context(),
+        voip_manager=FakeVoipManager(),
+    )
+
+    contacts.enter()
+    contacts.render()
+    first_contacts_view = contacts._lvgl_view
+    assert first_contacts_view is not None
+    assert binding.playlist_build_calls == 1
+
+    recents.enter()
+    recents.render()
+    assert binding.playlist_build_calls == 2
+
+    contacts.enter()
+    contacts.render()
+
+    assert contacts._lvgl_view is not first_contacts_view
+    assert binding.playlist_build_calls == 3
+
+
 def test_outgoing_call_screen_syncs_current_callee_through_lvgl() -> None:
     """OutgoingCallScreen should send callee and footer state through LVGL."""
 
@@ -704,6 +741,39 @@ def test_voice_note_screen_uses_talk_actions_scene_for_voice_note_states() -> No
 
     screen.exit()
     assert binding.talk_actions_destroy_calls == 0
+
+
+def test_talk_action_screens_replace_stale_owner_after_shared_scene_reclaim() -> None:
+    """Shared Talk action screens should replace stale wrappers on re-entry."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+
+    contact_actions = TalkContactScreen(
+        display,
+        make_talk_contact_context(),
+        voip_manager=FakeVoipManager(),
+    )
+    voice_note = VoiceNoteScreen(
+        display,
+        make_voice_note_context(),
+    )
+
+    contact_actions.enter()
+    contact_actions.render()
+    first_contact_view = contact_actions._lvgl_view
+    assert first_contact_view is not None
+    assert binding.talk_actions_build_calls == 1
+
+    voice_note.enter()
+    voice_note.render()
+    assert binding.talk_actions_build_calls == 2
+
+    contact_actions.enter()
+    contact_actions.render()
+
+    assert contact_actions._lvgl_view is not first_contact_view
+    assert binding.talk_actions_build_calls == 3
 
 
 def test_power_screen_cycles_four_lvgl_pages() -> None:

--- a/tests/test_remaining_lvgl_views.py
+++ b/tests/test_remaining_lvgl_views.py
@@ -228,8 +228,8 @@ def make_one_button_context() -> AppContext:
     return context
 
 
-def test_call_screen_builds_syncs_and_destroys_lvgl_view() -> None:
-    """CallScreen should delegate the Talk contact deck through LVGL."""
+def test_call_screen_reuses_retained_lvgl_view_across_exit_and_reentry() -> None:
+    """CallScreen should retain the Talk scene across transitions."""
 
     binding = FakeLvglBinding()
     screen = CallScreen(
@@ -263,10 +263,10 @@ def test_call_screen_builds_syncs_and_destroys_lvgl_view() -> None:
     assert payload["selected_index"] == 1
 
     screen.exit()
-    assert binding.talk_destroy_calls == 1
+    assert binding.talk_destroy_calls == 0
 
 
-def test_call_screen_can_reenter_lvgl_view_without_lifecycle_errors() -> None:
+def test_call_screen_can_reenter_lvgl_view_without_rebuilding() -> None:
     """Talk should survive repeated enter/render/exit cycles on the LVGL path."""
 
     binding = FakeLvglBinding()
@@ -291,8 +291,8 @@ def test_call_screen_can_reenter_lvgl_view_without_lifecycle_errors() -> None:
         assert payload["title_text"] == expected_title
         screen.exit()
 
-    assert binding.talk_build_calls == 2
-    assert binding.talk_destroy_calls == 2
+    assert binding.talk_build_calls == 1
+    assert binding.talk_destroy_calls == 0
 
 
 def test_hub_view_syncs_network_status_bar_state_through_lvgl() -> None:
@@ -348,7 +348,7 @@ def test_talk_contact_screen_syncs_actions_through_lvgl() -> None:
     assert payload["footer"] == "Tap Next | 2x Select | Hold Back"
 
     screen.exit()
-    assert binding.talk_actions_destroy_calls == 1
+    assert binding.talk_actions_destroy_calls == 0
 
 
 def test_contact_list_screen_syncs_sorted_contacts_through_lvgl() -> None:
@@ -382,7 +382,7 @@ def test_contact_list_screen_syncs_sorted_contacts_through_lvgl() -> None:
     assert payload["footer"] == "Tap Next | 2x Open | Hold Back"
 
     screen.exit()
-    assert binding.playlist_destroy_calls == 1
+    assert binding.playlist_destroy_calls == 0
 
 
 def test_outgoing_call_screen_syncs_current_callee_through_lvgl() -> None:
@@ -410,7 +410,7 @@ def test_outgoing_call_screen_syncs_current_callee_through_lvgl() -> None:
     assert payload["footer"] == "Hold = Cancel"
 
     screen.exit()
-    assert binding.outgoing_call_destroy_calls == 1
+    assert binding.outgoing_call_destroy_calls == 0
 
 
 def test_in_call_screen_syncs_duration_and_mute_state_through_lvgl() -> None:
@@ -439,11 +439,11 @@ def test_in_call_screen_syncs_duration_and_mute_state_through_lvgl() -> None:
     assert payload["footer"] == "Tap = Unmute | Hold = End"
 
     screen.exit()
-    assert binding.in_call_destroy_calls == 1
+    assert binding.in_call_destroy_calls == 0
 
 
-def test_ask_screen_builds_syncs_and_destroys_lvgl_view() -> None:
-    """AskScreen should delegate its voice-command shell through LVGL."""
+def test_ask_screen_keeps_its_retained_lvgl_view_on_exit() -> None:
+    """AskScreen should keep its retained voice-command scene on exit."""
 
     from yoyopod.ui.screens.navigation.ask import AskScreen as _AskScreen
 
@@ -463,7 +463,7 @@ def test_ask_screen_builds_syncs_and_destroys_lvgl_view() -> None:
     assert payload["icon_key"] == "ask"
 
     screen.exit()
-    assert binding.ask_destroy_calls == 1
+    assert binding.ask_destroy_calls == 0
 
 
 def test_voice_note_screen_uses_talk_actions_scene_for_voice_note_states() -> None:
@@ -497,7 +497,7 @@ def test_voice_note_screen_uses_talk_actions_scene_for_voice_note_states() -> No
     assert payload["icon_keys"] == ["voice_note"]
 
     screen.exit()
-    assert binding.talk_actions_destroy_calls == 1
+    assert binding.talk_actions_destroy_calls == 0
 
 
 def test_power_screen_cycles_four_lvgl_pages() -> None:
@@ -597,7 +597,7 @@ def test_power_screen_cycles_four_lvgl_pages() -> None:
     assert any("Speaker:" in item for item in payload["items"])
 
     screen.exit()
-    assert binding.power_destroy_calls == 1
+    assert binding.power_destroy_calls == 0
 
 
 def test_power_screen_one_button_voice_page_wraps_immediately() -> None:


### PR DESCRIPTION
## Summary
- retain LVGL-backed screens by allocating dedicated native scene roots instead of rebuilding `lv_screen_active()` on every transition
- keep Python LVGL screen views alive across `exit()` and reload the retained native scene during `sync()` instead of destroy+rebuild churn
- guard retained-scene sync paths against missing native roots and clear retained scenes during native shutdown before draw buffers are freed
- invalidate stale retained views after backend clears by tracking `scene_generation`, and make shared native scene reuse explicit by recording per-scene ownership so only the latest Python wrapper for a pooled native scene stays reusable
- clear retained-scene ownership claims whenever backend reset/cleanup drops native scenes so stale wrappers cannot keep ownership metadata across renderer handoffs
- document the intentionally shared retained-scene pools via canonical `lvgl_scene_keys` constants and add cross-screen regressions proving stale owners are replaced when another controller reclaims a shared `playlist` or `talk_actions` scene
- route `LvglPowerView.sync()` through a pure Setup payload so LVGL sync no longer rewrites controller navigation state during render
- add regression coverage for the repaired shutdown, shared-scene ownership, backend-clear ownership reset, and Setup LVGL sync seams

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_remaining_lvgl_views.py tests/test_lvgl_lifecycle.py tests/test_lvgl_foundation.py tests/test_playlist_lvgl_view.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/quality.py gate`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
  - the sandboxed run failed only because `tests/test_mpv_ipc.py` binds local `AF_UNIX` sockets
  - reran the same full suite outside the sandbox and passed with `608 passed in 23.69s`

## Notes
- native scenes are still pooled per scene type such as `playlist` and `talk_actions`, but ownership is now explicit both in the Python lifecycle seam and in the canonical shared-scene key definitions; revisiting an older wrapper after another controller claimed the same scene type forces that wrapper to rebuild instead of assuming it still owns the retained scene
- backend reset/cleanup now also clears the per-backend retained-scene claim registry so stale ownership metadata cannot survive once native scenes are torn down
- `.codex` artifacts and the unrelated preserved `data/test_messages/messages.json` change were not included