### PR TITLE
[codex] Fix lazy formatting in hot-path logging

### DIFF
--- a/src/yoyopod/event_bus.py
+++ b/src/yoyopod/event_bus.py
@@ -32,7 +32,7 @@ class EventBus:
     def subscribe(self, event_type: type[Any], handler: EventHandler) -> None:
         """Register a handler for a specific event type."""
         self._subscribers[event_type].append(handler)
-        logger.debug(f"Subscribed handler for {event_type.__name__}")
+        logger.trace("Subscribed handler for {}", event_type.__name__)
 
     def publish(self, event: Any) -> None:
         """Publish an event, queueing it if called off the main thread."""
@@ -41,7 +41,7 @@ class EventBus:
             return
 
         self._queue.put(event)
-        logger.debug(f"Queued event: {event.__class__.__name__}")
+        logger.trace("Queued event: {}", event.__class__.__name__)
 
     def drain(self, limit: int | None = None) -> int:
         """

--- a/src/yoyopod/fsm.py
+++ b/src/yoyopod/fsm.py
@@ -61,7 +61,12 @@ class MusicFSM:
 
         self.previous_state = self.state
         self.state = target
-        logger.debug(f"MusicFSM: {self.previous_state.value} -> {self.state.value} ({trigger})")
+        logger.debug(
+            "MusicFSM: {} -> {} ({})",
+            self.previous_state.value,
+            self.state.value,
+            trigger,
+        )
         return True
 
     def sync(self, state: MusicState) -> None:
@@ -71,7 +76,7 @@ class MusicFSM:
 
         self.previous_state = self.state
         self.state = state
-        logger.debug(f"MusicFSM synced to {self.state.value}")
+        logger.debug("MusicFSM synced to {}", self.state.value)
 
 
 class CallFSM:
@@ -118,7 +123,12 @@ class CallFSM:
 
         self.previous_state = self.state
         self.state = target
-        logger.debug(f"CallFSM: {self.previous_state.value} -> {self.state.value} ({trigger})")
+        logger.debug(
+            "CallFSM: {} -> {} ({})",
+            self.previous_state.value,
+            self.state.value,
+            trigger,
+        )
         return True
 
     def sync(self, state: CallSessionState) -> None:
@@ -128,7 +138,7 @@ class CallFSM:
 
         self.previous_state = self.state
         self.state = state
-        logger.debug(f"CallFSM synced to {self.state.value}")
+        logger.debug("CallFSM synced to {}", self.state.value)
 
     @property
     def is_active(self) -> bool:

--- a/src/yoyopod/ui/input/manager.py
+++ b/src/yoyopod/ui/input/manager.py
@@ -103,7 +103,7 @@ class InputManager:
             manager.on_action(InputAction.SELECT, handle_select)
         """
         self.callbacks[action].append(callback)
-        logger.debug(f"Registered callback for action: {action.value}")
+        logger.debug("Registered callback for action: {}", action.value)
 
     def on_activity(
         self,
@@ -156,7 +156,7 @@ class InputManager:
             try:
                 adapter.start()
                 adapter_name = adapter.__class__.__name__
-                logger.debug(f"Started adapter: {adapter_name}")
+                logger.debug("Started adapter: {}", adapter_name)
             except Exception as e:
                 adapter_name = adapter.__class__.__name__
                 logger.error(f"Failed to start adapter {adapter_name}: {e}")
@@ -179,7 +179,7 @@ class InputManager:
             try:
                 adapter.stop()
                 adapter_name = adapter.__class__.__name__
-                logger.debug(f"Stopped adapter: {adapter_name}")
+                logger.debug("Stopped adapter: {}", adapter_name)
             except Exception as e:
                 adapter_name = adapter.__class__.__name__
                 logger.error(f"Failed to stop adapter {adapter_name}: {e}")
@@ -217,7 +217,7 @@ class InputManager:
 
         callbacks = self.callbacks.get(action, [])
         if callbacks:
-            logger.debug(f"Action fired: {action.value} (data: {data})")
+            logger.trace("Action fired: {} (data: {})", action.value, data)
             for callback in callbacks:
                 try:
                     callback(data)
@@ -225,7 +225,7 @@ class InputManager:
                     logger.error(f"Error in action callback for {action.value}: {e}")
         else:
             # No callbacks registered - this is normal during screen transitions
-            logger.trace(f"Action {action.value} fired but no callbacks registered")
+            logger.trace("Action {} fired but no callbacks registered", action.value)
 
     def simulate_action(
         self,

--- a/src/yoyopod/ui/screens/manager.py
+++ b/src/yoyopod/ui/screens/manager.py
@@ -73,7 +73,7 @@ class ScreenManager:
         self.screens[name] = screen
         screen.set_screen_manager(self)
         screen.set_route_name(name)
-        logger.debug(f"Registered screen: {name}")
+        logger.debug("Registered screen: {}", name)
 
     def push_screen(self, screen_name: str) -> None:
         """
@@ -284,7 +284,7 @@ class ScreenManager:
         for action in InputAction:
             self.input_manager.on_action(action, wrap_with_refresh(action))
 
-        logger.debug(f"Connected input actions for {self.current_screen.name}")
+        logger.debug("Connected input actions for {}", self.current_screen.name)
 
     def _disconnect_inputs(self) -> None:
         """Disconnect input action handlers for the current screen."""
@@ -299,7 +299,7 @@ class ScreenManager:
         # Clear all action callbacks
         self.input_manager.clear_callbacks()
 
-        logger.debug(f"Disconnected input actions for {self.current_screen.name}")
+        logger.debug("Disconnected input actions for {}", self.current_screen.name)
 
     def _configure_screen_input_modes(self) -> None:
         """Adjust adapter-specific modes based on the active screen."""

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 import pytest
 
+import yoyopod.event_bus as event_bus_module
 from yoyopod.event_bus import EventBus
 
 
@@ -46,6 +47,36 @@ def test_background_publish_is_queued_until_drain() -> None:
     assert bus.drain() == 1
     assert bus.pending_count() == 0
     assert seen_thread_ids == [bus.main_thread_id]
+
+
+def test_event_bus_hot_path_logs_trace_with_deferred_formatting(monkeypatch) -> None:
+    """EventBus hot-path logs should use TRACE with deferred formatting args."""
+    trace_calls: list[tuple[str, tuple[object, ...]]] = []
+    debug_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    monkeypatch.setattr(
+        event_bus_module.logger,
+        "trace",
+        lambda message, *args: trace_calls.append((message, args)),
+    )
+    monkeypatch.setattr(
+        event_bus_module.logger,
+        "debug",
+        lambda message, *args: debug_calls.append((message, args)),
+    )
+
+    bus = EventBus()
+    bus.subscribe(DemoEvent, lambda event: None)
+
+    worker = threading.Thread(target=lambda: bus.publish(DemoEvent(value="queued")))
+    worker.start()
+    worker.join()
+
+    assert trace_calls == [
+        ("Subscribed handler for {}", ("DemoEvent",)),
+        ("Queued event: {}", ("DemoEvent",)),
+    ]
+    assert debug_calls == []
 
 
 def test_strict_event_bus_reraises_handler_errors() -> None:

--- a/tests/test_fsm_runtime.py
+++ b/tests/test_fsm_runtime.py
@@ -1,5 +1,8 @@
 """Tests for the split FSM orchestration layer and derived runtime state."""
 
+from __future__ import annotations
+
+import yoyopod.fsm as fsm_module
 from yoyopod.coordinators.runtime import AppRuntimeState, CoordinatorRuntime
 from yoyopod.fsm import (
     CallFSM,
@@ -79,6 +82,33 @@ def test_call_interruption_policy_pauses_and_resumes_music() -> None:
 
     policy.clear()
     assert not policy.music_interrupted_by_call
+
+
+def test_fsm_debug_logs_defer_formatting(monkeypatch) -> None:
+    """FSM debug logging should pass format args to Loguru instead of eager f-strings."""
+
+    debug_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    monkeypatch.setattr(
+        fsm_module.logger,
+        "debug",
+        lambda message, *args: debug_calls.append((message, args)),
+    )
+
+    music_fsm = MusicFSM()
+    assert music_fsm.transition("play")
+    music_fsm.sync(MusicState.PAUSED)
+
+    call_fsm = CallFSM()
+    assert call_fsm.transition("dial")
+    call_fsm.sync(CallSessionState.ACTIVE)
+
+    assert debug_calls == [
+        ("MusicFSM: {} -> {} ({})", ("idle", "playing", "play")),
+        ("MusicFSM synced to {}", ("paused",)),
+        ("CallFSM: {} -> {} ({})", ("idle", "outgoing", "dial")),
+        ("CallFSM synced to {}", ("active",)),
+    ]
 
 
 def test_runtime_state_is_derived_from_split_fsms() -> None:

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import yoyopod.ui.input.manager as input_manager_module
 from yoyopod.ui.input import InputAction, InputManager
 
 
@@ -65,3 +66,34 @@ def test_input_manager_forwards_raw_adapter_activity() -> None:
     assert events == [
         (None, {"pressed": True}),
     ]
+
+
+def test_input_manager_action_logs_trace_with_deferred_formatting(monkeypatch) -> None:
+    """Action dispatch logging should stay at TRACE and pass format args lazily."""
+    manager = InputManager()
+    seen_data: list[object | None] = []
+    trace_calls: list[tuple[str, tuple[object, ...]]] = []
+    debug_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    manager.on_action(InputAction.SELECT, lambda data: seen_data.append(data))
+
+    monkeypatch.setattr(
+        input_manager_module.logger,
+        "trace",
+        lambda message, *args: trace_calls.append((message, args)),
+    )
+    monkeypatch.setattr(
+        input_manager_module.logger,
+        "debug",
+        lambda message, *args: debug_calls.append((message, args)),
+    )
+
+    manager._fire_action(InputAction.SELECT, {"source": "test"})
+    manager._fire_action(InputAction.BACK)
+
+    assert seen_data == [{"source": "test"}]
+    assert trace_calls == [
+        ("Action fired: {} (data: {})", ("select", {"source": "test"})),
+        ("Action {} fired but no callbacks registered", ("back",)),
+    ]
+    assert debug_calls == []


### PR DESCRIPTION
## Summary
- replace issue #240 hot-path logger f-strings with Loguru brace-style formatting in the targeted FSM, event bus, input manager, and screen manager paths
- keep the scope narrow to the intended logging fix only
- add focused regression tests that assert deferred formatting args are passed through lazily

## Validation
- ============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/radxa/WS/YoyoPod_Core
configfile: pyproject.toml
collected 13 items

tests/test_fsm_runtime.py ......                                         [ 46%]
tests/test_event_bus.py ....                                             [ 76%]
tests/test_input_manager.py ...                                          [100%]

============================== 13 passed in 0.64s ==============================
- 

## Notes
- This PR cleanly replaces #257, which was branched from a stale base and carried unrelated changes.
- After this PR is up, #257 should be closed as superseded.

Closes #240