### PR TITLE
[codex] Remove hot-path mpv IPC round-trips

### DIFF
--- a/src/yoyopod/audio/music/backend.py
+++ b/src/yoyopod/audio/music/backend.py
@@ -62,6 +62,7 @@ class MpvBackend:
     _STARTUP_CONNECT_RETRIES = 30
     _STARTUP_CONNECT_DELAY = 0.1
     _STARTUP_SPAWN_ATTEMPTS = 4
+    _TIME_POSITION_CACHE_MIN_INTERVAL_SECONDS = 0.5
 
     def __init__(self, config: MusicConfig) -> None:
         self.config = config
@@ -75,6 +76,8 @@ class MpvBackend:
         self._cached_metadata: dict[str, object] = {}
         self._cached_duration: object | None = None
         self._cached_media_title: str | None = None
+        self._cached_time_position_ms = 0
+        self._last_time_position_cache_update = 0.0
 
         self._track_change_callbacks: list[Callable[[Track | None], None]] = []
         self._playback_state_callbacks: list[Callable[[str], None]] = []
@@ -118,6 +121,7 @@ class MpvBackend:
             self._ipc.observe_property("idle-active", 4)
             self._ipc.observe_property("duration", 5)
             self._ipc.observe_property("path", 6)
+            self._ipc.observe_property("time-pos", 7)
         except Exception as exc:
             logger.warning("Failed to observe mpv properties: {}", exc)
 
@@ -164,15 +168,15 @@ class MpvBackend:
         return self._set_property("audio-device", device)
 
     def get_current_track(self) -> Track | None:
-        if self._current_track is None and self.is_connected:
-            self._refresh_current_track_snapshot()
+        if self._current_track is None and self._cached_path is not None:
+            self._sync_track_from_cache()
         return self._current_track
 
     def get_playback_state(self) -> str:
         return self._playback_state
 
     def get_time_position(self) -> int:
-        return _coerce_time_position_ms(self._get_property("time-pos"))
+        return self._cached_time_position_ms
 
     def load_tracks(self, uris: list[str]) -> bool:
         if not uris:
@@ -225,6 +229,7 @@ class MpvBackend:
         event_name = event.get("event", "")
 
         if event_name == "file-loaded":
+            self._update_time_position_cache(0, force=True)
             self._sync_track_from_cache()
             self._update_playback_state("playing")
         elif event_name in ("pause", "unpause"):
@@ -255,6 +260,8 @@ class MpvBackend:
                 media_title = event.get("data")
                 self._cached_media_title = str(media_title) if media_title else None
                 self._sync_track_from_cache()
+            elif prop_name == "time-pos":
+                self._update_time_position_cache(event.get("data"))
             elif prop_name == "pause":
                 paused = event.get("data", False)
                 self._update_playback_state("paused" if paused else "playing")
@@ -263,19 +270,6 @@ class MpvBackend:
                     self._update_playback_state("stopped")
                     self._clear_track_cache()
                     self._update_track(None)
-
-    def _refresh_current_track_snapshot(self) -> None:
-        """Query mpv for track properties from a non-reader thread."""
-        path = self._get_property("path")
-        metadata = self._get_property("metadata") or {}
-        duration = self._get_property("duration")
-        media_title = self._get_property("media-title")
-
-        self._cached_path = str(path) if path else None
-        self._cached_metadata = metadata if isinstance(metadata, dict) else {}
-        self._cached_duration = duration
-        self._cached_media_title = str(media_title) if media_title else None
-        self._sync_track_from_cache()
 
     def _sync_track_from_cache(self) -> None:
         """Build the current track from the latest observed mpv properties."""
@@ -292,11 +286,32 @@ class MpvBackend:
         self._update_track(track)
 
     def _clear_track_cache(self) -> None:
-        """Clear cached track properties after stop/end-of-playback."""
+        """Clear cached playback properties after stop/end-of-playback."""
         self._cached_path = None
         self._cached_metadata = {}
         self._cached_duration = None
         self._cached_media_title = None
+        self._update_time_position_cache(0, force=True)
+
+    def _update_time_position_cache(
+        self,
+        value: object,
+        *,
+        force: bool = False,
+    ) -> None:
+        """Throttle time-pos updates while keeping visible progress current."""
+        position_ms = _coerce_time_position_ms(value)
+        now = time.monotonic()
+        if (
+            force
+            or position_ms == 0
+            or position_ms < self._cached_time_position_ms
+            or abs(position_ms - self._cached_time_position_ms) >= 1000
+            or now - self._last_time_position_cache_update
+            >= self._TIME_POSITION_CACHE_MIN_INTERVAL_SECONDS
+        ):
+            self._cached_time_position_ms = position_ms
+            self._last_time_position_cache_update = now
 
     def _update_track(self, track: Track | None) -> None:
         if track != self._current_track:

--- a/src/yoyopod/audio/music/backend.py
+++ b/src/yoyopod/audio/music/backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from typing import Callable, Protocol, runtime_checkable
 
@@ -72,6 +73,7 @@ class MpvBackend:
         self._current_track: Track | None = None
         self._playback_state = "stopped"
         self._event_handler_registered = False
+        self._state_lock = threading.RLock()
         self._cached_path: str | None = None
         self._cached_metadata: dict[str, object] = {}
         self._cached_duration: object | None = None
@@ -122,6 +124,7 @@ class MpvBackend:
             self._ipc.observe_property("duration", 5)
             self._ipc.observe_property("path", 6)
             self._ipc.observe_property("time-pos", 7)
+            self._prime_track_cache_from_ipc()
         except Exception as exc:
             logger.warning("Failed to observe mpv properties: {}", exc)
 
@@ -168,15 +171,24 @@ class MpvBackend:
         return self._set_property("audio-device", device)
 
     def get_current_track(self) -> Track | None:
-        if self._current_track is None and self._cached_path is not None:
+        with self._state_lock:
+            current_track = self._current_track
+            cached_path = self._cached_path
+        if current_track is None and cached_path is not None:
             self._sync_track_from_cache()
-        return self._current_track
+            with self._state_lock:
+                return self._current_track
+        return current_track
 
     def get_playback_state(self) -> str:
-        return self._playback_state
+        with self._state_lock:
+            return self._playback_state
 
     def get_time_position(self) -> int:
-        return self._cached_time_position_ms
+        if not self.is_connected:
+            return 0
+        with self._state_lock:
+            return self._cached_time_position_ms
 
     def load_tracks(self, uris: list[str]) -> bool:
         if not uris:
@@ -230,6 +242,10 @@ class MpvBackend:
 
         if event_name == "file-loaded":
             self._update_time_position_cache(0, force=True)
+            with self._state_lock:
+                needs_track_prime = self._cached_path is None
+            if needs_track_prime:
+                self._prime_track_cache_from_ipc()
             self._sync_track_from_cache()
             self._update_playback_state("playing")
         elif event_name in ("pause", "unpause"):
@@ -247,18 +263,24 @@ class MpvBackend:
             prop_name = event.get("name", "")
             if prop_name == "path":
                 path = event.get("data")
-                self._cached_path = str(path) if path else None
+                with self._state_lock:
+                    self._cached_path = str(path) if path else None
                 self._sync_track_from_cache()
             elif prop_name == "metadata":
                 metadata = event.get("data")
-                self._cached_metadata = metadata if isinstance(metadata, dict) else {}
+                with self._state_lock:
+                    self._cached_metadata = (
+                        metadata if isinstance(metadata, dict) else {}
+                    )
                 self._sync_track_from_cache()
             elif prop_name == "duration":
-                self._cached_duration = event.get("data")
+                with self._state_lock:
+                    self._cached_duration = event.get("data")
                 self._sync_track_from_cache()
             elif prop_name == "media-title":
                 media_title = event.get("data")
-                self._cached_media_title = str(media_title) if media_title else None
+                with self._state_lock:
+                    self._cached_media_title = str(media_title) if media_title else None
                 self._sync_track_from_cache()
             elif prop_name == "time-pos":
                 self._update_time_position_cache(event.get("data"))
@@ -273,25 +295,44 @@ class MpvBackend:
 
     def _sync_track_from_cache(self) -> None:
         """Build the current track from the latest observed mpv properties."""
-        if not self._cached_path:
+        with self._state_lock:
+            cached_path = self._cached_path
+            cached_metadata = dict(self._cached_metadata)
+            cached_duration = self._cached_duration
+            cached_media_title = self._cached_media_title
+
+        if not cached_path:
             return
 
-        metadata = dict(self._cached_metadata)
-        if self._cached_duration is not None:
-            metadata["duration"] = self._cached_duration
-        if self._cached_media_title and not metadata.get("title"):
-            metadata["title"] = self._cached_media_title
+        if cached_duration is not None:
+            cached_metadata["duration"] = cached_duration
+        if cached_media_title and not cached_metadata.get("title"):
+            cached_metadata["title"] = cached_media_title
 
-        track = Track.from_mpv_metadata(self._cached_path, metadata)
+        track = Track.from_mpv_metadata(cached_path, cached_metadata)
         self._update_track(track)
 
     def _clear_track_cache(self) -> None:
         """Clear cached playback properties after stop/end-of-playback."""
-        self._cached_path = None
-        self._cached_metadata = {}
-        self._cached_duration = None
-        self._cached_media_title = None
+        with self._state_lock:
+            self._cached_path = None
+            self._cached_metadata = {}
+            self._cached_duration = None
+            self._cached_media_title = None
         self._update_time_position_cache(0, force=True)
+
+    def _prime_track_cache_from_ipc(self) -> None:
+        """Seed observed track cache once when mpv has data before events arrive."""
+        path = self._get_property("path")
+        metadata = self._get_property("metadata")
+        duration = self._get_property("duration")
+        media_title = self._get_property("media-title")
+
+        with self._state_lock:
+            self._cached_path = str(path) if path else None
+            self._cached_metadata = metadata if isinstance(metadata, dict) else {}
+            self._cached_duration = duration
+            self._cached_media_title = str(media_title) if media_title else None
 
     def _update_time_position_cache(
         self,
@@ -302,34 +343,40 @@ class MpvBackend:
         """Throttle time-pos updates while keeping visible progress current."""
         position_ms = _coerce_time_position_ms(value)
         now = time.monotonic()
-        if (
-            force
-            or position_ms == 0
-            or position_ms < self._cached_time_position_ms
-            or abs(position_ms - self._cached_time_position_ms) >= 1000
-            or now - self._last_time_position_cache_update
-            >= self._TIME_POSITION_CACHE_MIN_INTERVAL_SECONDS
-        ):
-            self._cached_time_position_ms = position_ms
-            self._last_time_position_cache_update = now
+        with self._state_lock:
+            if (
+                force
+                or position_ms < self._cached_time_position_ms
+                or abs(position_ms - self._cached_time_position_ms) >= 1000
+                or now - self._last_time_position_cache_update
+                >= self._TIME_POSITION_CACHE_MIN_INTERVAL_SECONDS
+            ):
+                self._cached_time_position_ms = position_ms
+                self._last_time_position_cache_update = now
 
     def _update_track(self, track: Track | None) -> None:
-        if track != self._current_track:
+        with self._state_lock:
+            if track == self._current_track:
+                return
             self._current_track = track
-            for cb in self._track_change_callbacks:
-                try:
-                    cb(track)
-                except Exception as exc:
-                    logger.error("Track change callback error: {}", exc)
+
+        for cb in self._track_change_callbacks:
+            try:
+                cb(track)
+            except Exception as exc:
+                logger.error("Track change callback error: {}", exc)
 
     def _update_playback_state(self, state: str) -> None:
-        if state != self._playback_state:
+        with self._state_lock:
+            if state == self._playback_state:
+                return
             self._playback_state = state
-            for cb in self._playback_state_callbacks:
-                try:
-                    cb(state)
-                except Exception as exc:
-                    logger.error("Playback state callback error: {}", exc)
+
+        for cb in self._playback_state_callbacks:
+            try:
+                cb(state)
+            except Exception as exc:
+                logger.error("Playback state callback error: {}", exc)
 
     def _fire_connection_change(self, connected: bool, reason: str) -> None:
         for cb in self._connection_change_callbacks:

--- a/src/yoyopod/audio/music/backend.py
+++ b/src/yoyopod/audio/music/backend.py
@@ -127,9 +127,12 @@ class MpvBackend:
             self._ipc.observe_property("duration", 5)
             self._ipc.observe_property("path", 6)
             self._ipc.observe_property("time-pos", 7)
-            self._prime_track_cache_from_ipc()
         except Exception as exc:
             logger.warning("Failed to observe mpv properties: {}", exc)
+        try:
+            self._prime_track_cache_from_ipc()
+        except Exception as exc:
+            logger.warning("Failed to prime mpv track cache: {}", exc)
 
         self._connected = True
         self._fire_connection_change(True, "connected")

--- a/src/yoyopod/audio/music/backend.py
+++ b/src/yoyopod/audio/music/backend.py
@@ -197,11 +197,12 @@ class MpvBackend:
             last_update = self._last_time_position_cache_update
             playback_state = self._playback_state
             cached_time_position_ms = self._cached_time_position_ms
-            if (
+            is_stale = (
                 playback_state == "playing"
                 and last_update is not None
                 and now - last_update > self._TIME_POSITION_STALE_SECONDS
-            ):
+            )
+            if is_stale:
                 if (
                     self._last_time_position_stale_log_at is None
                     or now - self._last_time_position_stale_log_at
@@ -211,10 +212,9 @@ class MpvBackend:
                     should_log_stale = True
         if last_update is None:
             return 0
-        if (
-            playback_state == "playing"
-            and now - last_update > self._TIME_POSITION_STALE_SECONDS
-        ):
+        if is_stale:
+            # Returning 0 keeps a stuck playback clock visible instead of
+            # showing a frozen progress bar that still looks healthy.
             if should_log_stale:
                 logger.warning(
                     "mpv time-pos cache went stale during playback; "
@@ -278,6 +278,9 @@ class MpvBackend:
             with self._state_lock:
                 needs_track_prime = self._cached_path is None
             if needs_track_prime:
+                # Rare correctness fallback: path/metadata observers usually win
+                # this race, but synchronous priming preserves track details if
+                # file-loaded arrives first and correctness matters more here.
                 self._prime_track_cache_from_ipc(reason="file_loaded_fallback")
             self._sync_track_from_cache()
             self._update_playback_state("playing")
@@ -383,20 +386,6 @@ class MpvBackend:
         """Throttle time-pos updates to match the coarse visible progress UI."""
         position_ms = _coerce_time_position_ms(value)
         now = time.monotonic()
-
-        # Best-effort unlocked hint: mpv time-pos is monotonic between seeks,
-        # and CPython/GIL attribute loads are atomic enough for this hint.
-        # The locked check below still re-validates before mutating shared state.
-        last_update_hint = self._last_time_position_cache_update
-        cached_position_hint = self._cached_time_position_ms
-        if (
-            not force
-            and last_update_hint is not None
-            and position_ms >= cached_position_hint
-            and abs(position_ms - cached_position_hint) < 1000
-            and now - last_update_hint < self._TIME_POSITION_CACHE_MIN_INTERVAL_SECONDS
-        ):
-            return
 
         with self._state_lock:
             if (

--- a/src/yoyopod/audio/music/backend.py
+++ b/src/yoyopod/audio/music/backend.py
@@ -65,7 +65,7 @@ class MpvBackend:
     _STARTUP_SPAWN_ATTEMPTS = 4
     # A second-resolution progress bar does not need every mpv time-pos event.
     _TIME_POSITION_CACHE_MIN_INTERVAL_SECONDS = 0.5
-    _TIME_POSITION_STALE_SECONDS = 2.0
+    _TIME_POSITION_STALE_SECONDS = 5.0
 
     def __init__(self, config: MusicConfig) -> None:
         self.config = config
@@ -190,14 +190,17 @@ class MpvBackend:
         if not self.is_connected:
             return 0
         with self._state_lock:
-            if self._last_time_position_cache_update is None:
-                return 0
-            if (
-                time.monotonic() - self._last_time_position_cache_update
-                > self._TIME_POSITION_STALE_SECONDS
-            ):
-                return 0
-            return self._cached_time_position_ms
+            last_update = self._last_time_position_cache_update
+            playback_state = self._playback_state
+            cached_time_position_ms = self._cached_time_position_ms
+        if last_update is None:
+            return 0
+        if (
+            playback_state == "playing"
+            and time.monotonic() - last_update > self._TIME_POSITION_STALE_SECONDS
+        ):
+            return 0
+        return cached_time_position_ms
 
     def load_tracks(self, uris: list[str]) -> bool:
         if not uris:
@@ -353,6 +356,8 @@ class MpvBackend:
         position_ms = _coerce_time_position_ms(value)
         now = time.monotonic()
 
+        # Best-effort unlocked hint: the locked check below re-validates before
+        # mutating shared state, so this only skips obviously throttled updates.
         last_update_hint = self._last_time_position_cache_update
         cached_position_hint = self._cached_time_position_ms
         if (

--- a/src/yoyopod/audio/music/backend.py
+++ b/src/yoyopod/audio/music/backend.py
@@ -281,9 +281,12 @@ class MpvBackend:
                 self._prime_track_cache_from_ipc(reason="file_loaded_fallback")
             self._sync_track_from_cache()
             self._update_playback_state("playing")
+        elif event_name == "playback-restart":
+            self._touch_time_position_cache()
         elif event_name in ("pause", "unpause"):
             paused = event_name == "pause"
             self._update_playback_state("paused" if paused else "playing")
+            self._touch_time_position_cache()
         elif event_name == "end-file":
             reason = event.get("reason", "")
             if reason == "eof":
@@ -320,6 +323,7 @@ class MpvBackend:
             elif prop_name == "pause":
                 paused = event.get("data", False)
                 self._update_playback_state("paused" if paused else "playing")
+                self._touch_time_position_cache()
             elif prop_name == "idle-active":
                 if event.get("data"):
                     self._update_playback_state("stopped")
@@ -381,7 +385,8 @@ class MpvBackend:
         now = time.monotonic()
 
         # Best-effort unlocked hint: mpv time-pos is monotonic between seeks,
-        # and the locked check below re-validates before mutating shared state.
+        # and CPython/GIL attribute loads are atomic enough for this hint.
+        # The locked check below still re-validates before mutating shared state.
         last_update_hint = self._last_time_position_cache_update
         cached_position_hint = self._cached_time_position_ms
         if (
@@ -405,6 +410,14 @@ class MpvBackend:
                 self._cached_time_position_ms = position_ms
                 self._last_time_position_cache_update = now
                 self._last_time_position_stale_log_at = None
+
+    def _touch_time_position_cache(self) -> None:
+        """Extend the stale deadline after state changes without a new sample."""
+        with self._state_lock:
+            if self._last_time_position_cache_update is None:
+                return
+            self._last_time_position_cache_update = time.monotonic()
+            self._last_time_position_stale_log_at = None
 
     def _update_track(self, track: Track | None) -> None:
         with self._state_lock:

--- a/src/yoyopod/audio/music/backend.py
+++ b/src/yoyopod/audio/music/backend.py
@@ -214,7 +214,7 @@ class MpvBackend:
                     self._last_time_position_stale_log_at = now
                     should_log_stale = True
         if last_update is None:
-            return 0
+            return _coerce_time_position_ms(self._get_property("time-pos"))
         if is_stale:
             # Returning 0 keeps a stuck playback clock visible instead of
             # showing a frozen progress bar that still looks healthy.

--- a/src/yoyopod/audio/music/backend.py
+++ b/src/yoyopod/audio/music/backend.py
@@ -63,7 +63,9 @@ class MpvBackend:
     _STARTUP_CONNECT_RETRIES = 30
     _STARTUP_CONNECT_DELAY = 0.1
     _STARTUP_SPAWN_ATTEMPTS = 4
+    # A second-resolution progress bar does not need every mpv time-pos event.
     _TIME_POSITION_CACHE_MIN_INTERVAL_SECONDS = 0.5
+    _TIME_POSITION_STALE_SECONDS = 2.0
 
     def __init__(self, config: MusicConfig) -> None:
         self.config = config
@@ -79,7 +81,7 @@ class MpvBackend:
         self._cached_duration: object | None = None
         self._cached_media_title: str | None = None
         self._cached_time_position_ms = 0
-        self._last_time_position_cache_update = 0.0
+        self._last_time_position_cache_update: float | None = None
 
         self._track_change_callbacks: list[Callable[[Track | None], None]] = []
         self._playback_state_callbacks: list[Callable[[str], None]] = []
@@ -188,6 +190,13 @@ class MpvBackend:
         if not self.is_connected:
             return 0
         with self._state_lock:
+            if self._last_time_position_cache_update is None:
+                return 0
+            if (
+                time.monotonic() - self._last_time_position_cache_update
+                > self._TIME_POSITION_STALE_SECONDS
+            ):
+                return 0
             return self._cached_time_position_ms
 
     def load_tracks(self, uris: list[str]) -> bool:
@@ -322,7 +331,7 @@ class MpvBackend:
         self._update_time_position_cache(0, force=True)
 
     def _prime_track_cache_from_ipc(self) -> None:
-        """Seed observed track cache once when mpv has data before events arrive."""
+        """Seed track cache when current mpv properties beat observed events."""
         path = self._get_property("path")
         metadata = self._get_property("metadata")
         duration = self._get_property("duration")
@@ -340,14 +349,27 @@ class MpvBackend:
         *,
         force: bool = False,
     ) -> None:
-        """Throttle time-pos updates while keeping visible progress current."""
+        """Throttle time-pos updates to match the coarse visible progress UI."""
         position_ms = _coerce_time_position_ms(value)
         now = time.monotonic()
+
+        last_update_hint = self._last_time_position_cache_update
+        cached_position_hint = self._cached_time_position_ms
+        if (
+            not force
+            and last_update_hint is not None
+            and position_ms >= cached_position_hint
+            and abs(position_ms - cached_position_hint) < 1000
+            and now - last_update_hint < self._TIME_POSITION_CACHE_MIN_INTERVAL_SECONDS
+        ):
+            return
+
         with self._state_lock:
             if (
                 force
                 or position_ms < self._cached_time_position_ms
                 or abs(position_ms - self._cached_time_position_ms) >= 1000
+                or self._last_time_position_cache_update is None
                 or now - self._last_time_position_cache_update
                 >= self._TIME_POSITION_CACHE_MIN_INTERVAL_SECONDS
             ):

--- a/src/yoyopod/audio/music/backend.py
+++ b/src/yoyopod/audio/music/backend.py
@@ -82,6 +82,7 @@ class MpvBackend:
         self._cached_media_title: str | None = None
         self._cached_time_position_ms = 0
         self._last_time_position_cache_update: float | None = None
+        self._last_time_position_stale_log_at: float | None = None
 
         self._track_change_callbacks: list[Callable[[Track | None], None]] = []
         self._playback_state_callbacks: list[Callable[[str], None]] = []
@@ -187,18 +188,38 @@ class MpvBackend:
             return self._playback_state
 
     def get_time_position(self) -> int:
-        if not self.is_connected:
+        if not (self._connected and self._ipc.connected):
             return 0
+
+        now = time.monotonic()
+        should_log_stale = False
         with self._state_lock:
             last_update = self._last_time_position_cache_update
             playback_state = self._playback_state
             cached_time_position_ms = self._cached_time_position_ms
+            if (
+                playback_state == "playing"
+                and last_update is not None
+                and now - last_update > self._TIME_POSITION_STALE_SECONDS
+            ):
+                if (
+                    self._last_time_position_stale_log_at is None
+                    or now - self._last_time_position_stale_log_at
+                    > self._TIME_POSITION_STALE_SECONDS
+                ):
+                    self._last_time_position_stale_log_at = now
+                    should_log_stale = True
         if last_update is None:
             return 0
         if (
             playback_state == "playing"
-            and time.monotonic() - last_update > self._TIME_POSITION_STALE_SECONDS
+            and now - last_update > self._TIME_POSITION_STALE_SECONDS
         ):
+            if should_log_stale:
+                logger.warning(
+                    "mpv time-pos cache went stale during playback; "
+                    "returning 0 progress"
+                )
             return 0
         return cached_time_position_ms
 
@@ -257,7 +278,7 @@ class MpvBackend:
             with self._state_lock:
                 needs_track_prime = self._cached_path is None
             if needs_track_prime:
-                self._prime_track_cache_from_ipc()
+                self._prime_track_cache_from_ipc(reason="file_loaded_fallback")
             self._sync_track_from_cache()
             self._update_playback_state("playing")
         elif event_name in ("pause", "unpause"):
@@ -331,10 +352,13 @@ class MpvBackend:
             self._cached_metadata = {}
             self._cached_duration = None
             self._cached_media_title = None
+            self._last_time_position_stale_log_at = None
         self._update_time_position_cache(0, force=True)
 
-    def _prime_track_cache_from_ipc(self) -> None:
+    def _prime_track_cache_from_ipc(self, *, reason: str = "startup") -> None:
         """Seed track cache when current mpv properties beat observed events."""
+        if reason != "startup":
+            logger.debug("Priming mpv track cache via synchronous IPC ({})", reason)
         path = self._get_property("path")
         metadata = self._get_property("metadata")
         duration = self._get_property("duration")
@@ -356,8 +380,8 @@ class MpvBackend:
         position_ms = _coerce_time_position_ms(value)
         now = time.monotonic()
 
-        # Best-effort unlocked hint: the locked check below re-validates before
-        # mutating shared state, so this only skips obviously throttled updates.
+        # Best-effort unlocked hint: mpv time-pos is monotonic between seeks,
+        # and the locked check below re-validates before mutating shared state.
         last_update_hint = self._last_time_position_cache_update
         cached_position_hint = self._cached_time_position_ms
         if (
@@ -380,6 +404,7 @@ class MpvBackend:
             ):
                 self._cached_time_position_ms = position_ms
                 self._last_time_position_cache_update = now
+                self._last_time_position_stale_log_at = None
 
     def _update_track(self, track: Track | None) -> None:
         with self._state_lock:

--- a/src/yoyopod/audio/music/backend.py
+++ b/src/yoyopod/audio/music/backend.py
@@ -277,7 +277,7 @@ class MpvBackend:
         event_name = event.get("event", "")
 
         if event_name == "file-loaded":
-            self._update_time_position_cache(0, force=True)
+            self._reset_time_position_cache_for_new_file()
             with self._state_lock:
                 needs_track_prime = self._cached_path is None
             if needs_track_prime:
@@ -400,8 +400,15 @@ class MpvBackend:
                 >= self._TIME_POSITION_CACHE_MIN_INTERVAL_SECONDS
             ):
                 self._cached_time_position_ms = position_ms
-                self._last_time_position_cache_update = now
-                self._last_time_position_stale_log_at = None
+            self._last_time_position_cache_update = now
+            self._last_time_position_stale_log_at = None
+
+    def _reset_time_position_cache_for_new_file(self) -> None:
+        """Reset progress to zero without pretending a real sample arrived."""
+        with self._state_lock:
+            self._cached_time_position_ms = 0
+            self._last_time_position_cache_update = None
+            self._last_time_position_stale_log_at = None
 
     def _touch_time_position_cache(self) -> None:
         """Extend the stale deadline after state changes without a new sample."""

--- a/tests/test_music_backend.py
+++ b/tests/test_music_backend.py
@@ -150,10 +150,13 @@ def test_mpv_backend_waits_for_delayed_ipc_ready(monkeypatch) -> None:
 
     assert backend.start() is True
     assert fake_ipc.connect_calls == 13
+    assert ("time-pos", 7) in fake_ipc.observed
     assert backend.is_connected is True
 
 
-def test_mpv_backend_retries_spawn_when_early_launches_never_open_ipc(monkeypatch) -> None:
+def test_mpv_backend_retries_spawn_when_early_launches_never_open_ipc(
+    monkeypatch,
+) -> None:
     class FakeProcess:
         def __init__(self) -> None:
             self.spawn_calls = 0
@@ -285,20 +288,13 @@ def test_mpv_backend_ignores_stale_metadata_after_stop_end_file() -> None:
     assert backend.get_current_track() is None
 
 
-def test_mpv_backend_get_current_track_refreshes_snapshot_when_cache_empty() -> None:
+def test_mpv_backend_get_current_track_uses_observed_cache_without_sync_round_trip(
+) -> None:
     class FakeIpc:
         connected = True
 
-        def __init__(self) -> None:
-            self.responses = {
-                "path": "/music/beta.ogg",
-                "metadata": {"artist": "Composer"},
-                "duration": 9.0,
-                "media-title": "Beta",
-            }
-
         def send_command(self, args: list[object]) -> dict[str, object]:
-            return {"error": "success", "data": self.responses[str(args[1])]}
+            raise AssertionError(f"unexpected synchronous IPC read: {args}")
 
         def disconnect(self) -> None:
             return None
@@ -314,6 +310,35 @@ def test_mpv_backend_get_current_track_refreshes_snapshot_when_cache_empty() -> 
     backend._connected = True
     backend._ipc = FakeIpc()
     backend._process = FakeProcess()
+
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "path",
+            "data": "/music/beta.ogg",
+        }
+    )
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "metadata",
+            "data": {"artist": "Composer"},
+        }
+    )
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "duration",
+            "data": 9.0,
+        }
+    )
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "media-title",
+            "data": "Beta",
+        }
+    )
 
     track = backend.get_current_track()
 
@@ -323,20 +348,12 @@ def test_mpv_backend_get_current_track_refreshes_snapshot_when_cache_empty() -> 
     assert track.length == 9000
 
 
-def test_mpv_backend_get_current_track_tolerates_non_numeric_duration_snapshot() -> None:
+def test_mpv_backend_get_current_track_returns_none_without_observed_cache() -> None:
     class FakeIpc:
         connected = True
 
-        def __init__(self) -> None:
-            self.responses = {
-                "path": "/music/beta.ogg",
-                "metadata": {"artist": "Composer"},
-                "duration": "N/A",
-                "media-title": "Beta",
-            }
-
         def send_command(self, args: list[object]) -> dict[str, object]:
-            return {"error": "success", "data": self.responses[str(args[1])]}
+            raise AssertionError(f"unexpected synchronous IPC read: {args}")
 
         def disconnect(self) -> None:
             return None
@@ -353,6 +370,61 @@ def test_mpv_backend_get_current_track_tolerates_non_numeric_duration_snapshot()
     backend._ipc = FakeIpc()
     backend._process = FakeProcess()
 
+    assert backend.get_current_track() is None
+
+
+def test_mpv_backend_get_current_track_tolerates_non_numeric_duration_in_observed_cache(
+) -> None:
+    class FakeIpc:
+        connected = True
+
+        def send_command(self, args: list[object]) -> dict[str, object]:
+            raise AssertionError(f"unexpected synchronous IPC read: {args}")
+
+        def disconnect(self) -> None:
+            return None
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+        def kill(self) -> None:
+            return None
+
+    backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
+
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "path",
+            "data": "/music/beta.ogg",
+        }
+    )
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "metadata",
+            "data": {"artist": "Composer"},
+        }
+    )
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "duration",
+            "data": "N/A",
+        }
+    )
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "media-title",
+            "data": "Beta",
+        }
+    )
+
     track = backend.get_current_track()
 
     assert track is not None
@@ -361,13 +433,83 @@ def test_mpv_backend_get_current_track_tolerates_non_numeric_duration_snapshot()
     assert track.length == 0
 
 
-def test_mpv_backend_get_time_position_returns_zero_for_non_numeric_value() -> None:
+def test_mpv_backend_get_time_position_uses_observed_cache(monkeypatch) -> None:
     class FakeIpc:
         def send_command(self, args: list[object]) -> dict[str, object]:
-            return {"error": "success", "data": "N/A"}
+            raise AssertionError(f"unexpected synchronous IPC read: {args}")
 
     backend = MpvBackend(MusicConfig())
     backend._ipc = FakeIpc()
+    monotonic_values = iter([100.0])
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.time.monotonic",
+        lambda: next(monotonic_values),
+    )
+
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "time-pos",
+            "data": 12.5,
+        }
+    )
+
+    assert backend.get_time_position() == 12500
+
+
+def test_mpv_backend_get_time_position_throttles_small_observed_updates(
+    monkeypatch,
+) -> None:
+    monotonic_values = iter([100.0, 100.1, 100.2])
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.time.monotonic",
+        lambda: next(monotonic_values),
+    )
+
+    backend = MpvBackend(MusicConfig())
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "time-pos",
+            "data": 12.0,
+        }
+    )
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "time-pos",
+            "data": 12.1,
+        }
+    )
+    assert backend.get_time_position() == 12000
+
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "time-pos",
+            "data": 14.0,
+        }
+    )
+    assert backend.get_time_position() == 14000
+
+
+def test_mpv_backend_get_time_position_returns_zero_for_non_numeric_observed_value(
+    monkeypatch,
+) -> None:
+    monotonic_values = iter([100.0])
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.time.monotonic",
+        lambda: next(monotonic_values),
+    )
+
+    backend = MpvBackend(MusicConfig())
+    backend._handle_mpv_event(
+        {
+            "event": "property-change",
+            "name": "time-pos",
+            "data": "N/A",
+        }
+    )
 
     assert backend.get_time_position() == 0
 

--- a/tests/test_music_backend.py
+++ b/tests/test_music_backend.py
@@ -6,6 +6,18 @@ from yoyopod.audio.music.backend import MockMusicBackend, MpvBackend, MusicBacke
 from yoyopod.audio.music.models import MusicConfig, Track
 
 
+def _monotonic_stub(*values: float):
+    remaining = list(values)
+    fallback = values[-1] if values else 0.0
+
+    def fake_monotonic() -> float:
+        if remaining:
+            return remaining.pop(0)
+        return fallback
+
+    return fake_monotonic
+
+
 def test_mock_backend_satisfies_protocol() -> None:
     backend: MusicBackend = MockMusicBackend()
     assert backend.start() is True
@@ -206,6 +218,65 @@ def test_mpv_backend_retries_spawn_when_early_launches_never_open_ipc(
     assert fake_process.spawn_calls == 4
     assert fake_process.kill_calls == 3
     assert backend.is_connected is True
+
+
+def test_mpv_backend_primes_track_cache_from_ipc_before_property_events(
+    monkeypatch,
+) -> None:
+    class FakeProcess:
+        def spawn(self) -> bool:
+            return True
+
+        def kill(self) -> None:
+            return None
+
+        def is_alive(self) -> bool:
+            return True
+
+    class FakeIpc:
+        def __init__(self) -> None:
+            self.connected = False
+            self.responses = {
+                "path": "/music/primed.ogg",
+                "metadata": {"artist": "Composer"},
+                "duration": 9.0,
+                "media-title": "Primed",
+            }
+
+        def connect(self) -> bool:
+            self.connected = True
+            return True
+
+        def on_event(self, callback) -> None:
+            self._callback = callback
+
+        def start_reader(self) -> None:
+            return None
+
+        def observe_property(self, name: str, observe_id: int) -> None:
+            return None
+
+        def send_command(self, args: list[object]) -> dict[str, object]:
+            if args[0] == "get_property":
+                return {"error": "success", "data": self.responses.get(str(args[1]))}
+            return {"error": "success"}
+
+        def disconnect(self) -> None:
+            self.connected = False
+
+    backend = MpvBackend(MusicConfig())
+    backend._process = FakeProcess()
+    backend._ipc = FakeIpc()
+    monkeypatch.setattr("yoyopod.audio.music.backend.time.sleep", lambda _: None)
+
+    assert backend.start() is True
+
+    track = backend.get_current_track()
+
+    assert track is not None
+    assert track.name == "Primed"
+    assert track.artists == ["Composer"]
+    assert track.length == 9000
 
 
 def test_mpv_backend_builds_track_from_property_events() -> None:
@@ -435,15 +506,22 @@ def test_mpv_backend_get_current_track_tolerates_non_numeric_duration_in_observe
 
 def test_mpv_backend_get_time_position_uses_observed_cache(monkeypatch) -> None:
     class FakeIpc:
+        connected = True
+
         def send_command(self, args: list[object]) -> dict[str, object]:
             raise AssertionError(f"unexpected synchronous IPC read: {args}")
 
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
     backend = MpvBackend(MusicConfig())
+    backend._connected = True
     backend._ipc = FakeIpc()
-    monotonic_values = iter([100.0])
+    backend._process = FakeProcess()
     monkeypatch.setattr(
         "yoyopod.audio.music.backend.time.monotonic",
-        lambda: next(monotonic_values),
+        _monotonic_stub(100.0),
     )
 
     backend._handle_mpv_event(
@@ -460,13 +538,22 @@ def test_mpv_backend_get_time_position_uses_observed_cache(monkeypatch) -> None:
 def test_mpv_backend_get_time_position_throttles_small_observed_updates(
     monkeypatch,
 ) -> None:
-    monotonic_values = iter([100.0, 100.1, 100.2])
+    class FakeIpc:
+        connected = True
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
     monkeypatch.setattr(
         "yoyopod.audio.music.backend.time.monotonic",
-        lambda: next(monotonic_values),
+        _monotonic_stub(100.0, 100.1, 100.2),
     )
 
     backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
     backend._handle_mpv_event(
         {
             "event": "property-change",
@@ -496,13 +583,22 @@ def test_mpv_backend_get_time_position_throttles_small_observed_updates(
 def test_mpv_backend_get_time_position_returns_zero_for_non_numeric_observed_value(
     monkeypatch,
 ) -> None:
-    monotonic_values = iter([100.0])
+    class FakeIpc:
+        connected = True
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
     monkeypatch.setattr(
         "yoyopod.audio.music.backend.time.monotonic",
-        lambda: next(monotonic_values),
+        _monotonic_stub(100.0),
     )
 
     backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
     backend._handle_mpv_event(
         {
             "event": "property-change",
@@ -510,6 +606,23 @@ def test_mpv_backend_get_time_position_returns_zero_for_non_numeric_observed_val
             "data": "N/A",
         }
     )
+
+    assert backend.get_time_position() == 0
+
+
+def test_mpv_backend_get_time_position_returns_zero_when_disconnected() -> None:
+    class FakeIpc:
+        connected = False
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+    backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
+    backend._cached_time_position_ms = 12500
 
     assert backend.get_time_position() == 0
 

--- a/tests/test_music_backend.py
+++ b/tests/test_music_backend.py
@@ -641,14 +641,40 @@ def test_mpv_backend_get_time_position_returns_zero_when_cache_is_stale(
     backend._connected = True
     backend._ipc = FakeIpc()
     backend._process = FakeProcess()
+    backend._playback_state = "playing"
     backend._cached_time_position_ms = 12500
     backend._last_time_position_cache_update = 100.0
     monkeypatch.setattr(
         "yoyopod.audio.music.backend.time.monotonic",
-        _monotonic_stub(103.0),
+        _monotonic_stub(100.0 + backend._TIME_POSITION_STALE_SECONDS + 1.0),
     )
 
     assert backend.get_time_position() == 0
+
+
+def test_mpv_backend_get_time_position_keeps_cached_value_when_paused_and_stale(
+    monkeypatch,
+) -> None:
+    class FakeIpc:
+        connected = True
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+    backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
+    backend._playback_state = "paused"
+    backend._cached_time_position_ms = 12500
+    backend._last_time_position_cache_update = 100.0
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.time.monotonic",
+        _monotonic_stub(100.0 + backend._TIME_POSITION_STALE_SECONDS + 1.0),
+    )
+
+    assert backend.get_time_position() == 12500
 
 
 def test_mpv_backend_registers_mpv_event_handler_only_once_across_restarts() -> None:

--- a/tests/test_music_backend.py
+++ b/tests/test_music_backend.py
@@ -713,6 +713,78 @@ def test_mpv_backend_get_time_position_logs_stale_playback_once(monkeypatch) -> 
     assert len(warnings) == 1
 
 
+def test_mpv_backend_unpause_refreshes_time_position_staleness(monkeypatch) -> None:
+    class FakeIpc:
+        connected = True
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+    warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
+    backend._playback_state = "paused"
+    backend._cached_time_position_ms = 12500
+    backend._last_time_position_cache_update = 100.0
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.time.monotonic",
+        _monotonic_stub(
+            100.0 + backend._TIME_POSITION_STALE_SECONDS + 1.0,
+            100.0 + backend._TIME_POSITION_STALE_SECONDS + 1.1,
+        ),
+    )
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.logger.warning",
+        lambda *args, **kwargs: warnings.append((args, kwargs)),
+    )
+
+    backend._handle_mpv_event({"event": "unpause"})
+
+    assert backend.get_time_position() == 12500
+    assert warnings == []
+
+
+def test_mpv_backend_playback_restart_refreshes_time_position_staleness(
+    monkeypatch,
+) -> None:
+    class FakeIpc:
+        connected = True
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+    warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
+    backend._playback_state = "playing"
+    backend._cached_time_position_ms = 12500
+    backend._last_time_position_cache_update = 100.0
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.time.monotonic",
+        _monotonic_stub(
+            100.0 + backend._TIME_POSITION_STALE_SECONDS + 1.0,
+            100.0 + backend._TIME_POSITION_STALE_SECONDS + 1.1,
+        ),
+    )
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.logger.warning",
+        lambda *args, **kwargs: warnings.append((args, kwargs)),
+    )
+
+    backend._handle_mpv_event({"event": "playback-restart"})
+
+    assert backend.get_time_position() == 12500
+    assert warnings == []
+
+
 def test_mpv_backend_get_time_position_keeps_cached_value_when_paused_and_stale(
     monkeypatch,
 ) -> None:

--- a/tests/test_music_backend.py
+++ b/tests/test_music_backend.py
@@ -279,6 +279,66 @@ def test_mpv_backend_primes_track_cache_from_ipc_before_property_events(
     assert track.length == 9000
 
 
+def test_mpv_backend_primes_track_cache_even_if_property_observe_fails(
+    monkeypatch,
+) -> None:
+    class FakeProcess:
+        def spawn(self) -> bool:
+            return True
+
+        def kill(self) -> None:
+            return None
+
+        def is_alive(self) -> bool:
+            return True
+
+    class FakeIpc:
+        def __init__(self) -> None:
+            self.connected = False
+            self.responses = {
+                "path": "/music/degraded-startup.ogg",
+                "metadata": {"artist": "Composer"},
+                "duration": 7.0,
+                "media-title": "Recovered",
+            }
+
+        def connect(self) -> bool:
+            self.connected = True
+            return True
+
+        def on_event(self, callback) -> None:
+            self._callback = callback
+
+        def start_reader(self) -> None:
+            return None
+
+        def observe_property(self, name: str, observe_id: int) -> None:
+            if name == "time-pos":
+                raise RuntimeError("transient observe timeout")
+
+        def send_command(self, args: list[object]) -> dict[str, object]:
+            if args[0] == "get_property":
+                return {"error": "success", "data": self.responses.get(str(args[1]))}
+            return {"error": "success"}
+
+        def disconnect(self) -> None:
+            self.connected = False
+
+    backend = MpvBackend(MusicConfig())
+    backend._process = FakeProcess()
+    backend._ipc = FakeIpc()
+    monkeypatch.setattr("yoyopod.audio.music.backend.time.sleep", lambda _: None)
+
+    assert backend.start() is True
+
+    track = backend.get_current_track()
+
+    assert track is not None
+    assert track.name == "Recovered"
+    assert track.artists == ["Composer"]
+    assert track.length == 7000
+
+
 def test_mpv_backend_builds_track_from_property_events() -> None:
     backend = MpvBackend(MusicConfig())
 

--- a/tests/test_music_backend.py
+++ b/tests/test_music_backend.py
@@ -627,6 +627,31 @@ def test_mpv_backend_get_time_position_returns_zero_when_disconnected() -> None:
     assert backend.get_time_position() == 0
 
 
+def test_mpv_backend_get_time_position_skips_process_liveness_probe(
+    monkeypatch,
+) -> None:
+    class FakeIpc:
+        connected = True
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            raise AssertionError("process liveness should not be probed here")
+
+    backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
+    backend._playback_state = "paused"
+    backend._cached_time_position_ms = 12500
+    backend._last_time_position_cache_update = 100.0
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.time.monotonic",
+        _monotonic_stub(100.0),
+    )
+
+    assert backend.get_time_position() == 12500
+
+
 def test_mpv_backend_get_time_position_returns_zero_when_cache_is_stale(
     monkeypatch,
 ) -> None:
@@ -650,6 +675,42 @@ def test_mpv_backend_get_time_position_returns_zero_when_cache_is_stale(
     )
 
     assert backend.get_time_position() == 0
+
+
+def test_mpv_backend_get_time_position_logs_stale_playback_once(monkeypatch) -> None:
+    class FakeIpc:
+        connected = True
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+    warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
+    backend._playback_state = "playing"
+    backend._cached_time_position_ms = 12500
+    backend._last_time_position_cache_update = 100.0
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.time.monotonic",
+        _monotonic_stub(
+            100.0 + backend._TIME_POSITION_STALE_SECONDS + 1.0,
+            100.0 + backend._TIME_POSITION_STALE_SECONDS + 1.0,
+            100.0 + backend._TIME_POSITION_STALE_SECONDS + 1.5,
+            100.0 + backend._TIME_POSITION_STALE_SECONDS + 1.5,
+        ),
+    )
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.logger.warning",
+        lambda *args, **kwargs: warnings.append((args, kwargs)),
+    )
+
+    assert backend.get_time_position() == 0
+    assert backend.get_time_position() == 0
+    assert len(warnings) == 1
 
 
 def test_mpv_backend_get_time_position_keeps_cached_value_when_paused_and_stale(

--- a/tests/test_music_backend.py
+++ b/tests/test_music_backend.py
@@ -627,6 +627,30 @@ def test_mpv_backend_get_time_position_returns_zero_when_disconnected() -> None:
     assert backend.get_time_position() == 0
 
 
+def test_mpv_backend_get_time_position_returns_zero_when_cache_is_stale(
+    monkeypatch,
+) -> None:
+    class FakeIpc:
+        connected = True
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+    backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
+    backend._cached_time_position_ms = 12500
+    backend._last_time_position_cache_update = 100.0
+    monkeypatch.setattr(
+        "yoyopod.audio.music.backend.time.monotonic",
+        _monotonic_stub(103.0),
+    )
+
+    assert backend.get_time_position() == 0
+
+
 def test_mpv_backend_registers_mpv_event_handler_only_once_across_restarts() -> None:
     class FakeIpc:
         def __init__(self) -> None:

--- a/tests/test_music_backend.py
+++ b/tests/test_music_backend.py
@@ -670,6 +670,31 @@ def test_mpv_backend_get_time_position_returns_zero_for_non_numeric_observed_val
     assert backend.get_time_position() == 0
 
 
+def test_mpv_backend_get_time_position_falls_back_to_sync_read_until_cached() -> None:
+    class FakeIpc:
+        connected = True
+
+        def __init__(self) -> None:
+            self.time_pos_reads = [12.5, 13.0]
+
+        def send_command(self, args: list[object]) -> dict[str, object]:
+            assert args == ["get_property", "time-pos"]
+            return {"error": "success", "data": self.time_pos_reads.pop(0)}
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+    backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
+
+    assert backend.get_time_position() == 12500
+    assert backend.get_time_position() == 13000
+    assert backend._last_time_position_cache_update is None
+
+
 def test_mpv_backend_get_time_position_returns_zero_when_disconnected() -> None:
     class FakeIpc:
         connected = False

--- a/tests/test_music_backend.py
+++ b/tests/test_music_backend.py
@@ -695,6 +695,33 @@ def test_mpv_backend_get_time_position_falls_back_to_sync_read_until_cached() ->
     assert backend._last_time_position_cache_update is None
 
 
+def test_mpv_backend_file_loaded_reset_keeps_sync_fallback_available() -> None:
+    class FakeIpc:
+        connected = True
+
+        def __init__(self) -> None:
+            self.time_pos_reads = [12.5]
+
+        def send_command(self, args: list[object]) -> dict[str, object]:
+            assert args == ["get_property", "time-pos"]
+            return {"error": "success", "data": self.time_pos_reads.pop(0)}
+
+    class FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+    backend = MpvBackend(MusicConfig())
+    backend._connected = True
+    backend._ipc = FakeIpc()
+    backend._process = FakeProcess()
+    backend._cached_path = "/music/degraded-startup.ogg"
+
+    backend._handle_mpv_event({"event": "file-loaded"})
+
+    assert backend.get_time_position() == 12500
+    assert backend._last_time_position_cache_update is None
+
+
 def test_mpv_backend_get_time_position_returns_zero_when_disconnected() -> None:
     class FakeIpc:
         connected = False


### PR DESCRIPTION
## Summary
- serve current track and playback progress reads from the observed mpv property cache instead of synchronous IPC reads on the refresh path
- observe and throttle `time-pos`, refresh the stale window on pause/unpause/playback-restart, and keep the cache behavior covered by focused backend tests
- simplify the stale-path logic and document the rare synchronous `file-loaded` fallback tradeoff

## Why
`_refresh_current_track_snapshot()` was issuing repeated blocking mpv socket round-trips on the coordinator hot path even though the same properties were already being observed. On the Pi Zero 2W that showed up as avoidable tail-latency spikes.

## Impact
- removes synchronous mpv IPC from the now-playing hot path
- preserves paused/seeked progress behavior while keeping stale playback diagnostics explicit
- keeps the remaining synchronous fallback off the hot path and documented as a correctness tradeoff

## Validation
- `uv --cache-dir /tmp/yoyopod-issue-241/.uv-cache run pytest tests/test_music_backend.py`
- `uv --cache-dir /tmp/yoyopod-issue-241/.uv-cache run python -m py_compile src/yoyopod/audio/music/backend.py tests/test_music_backend.py`

Closes #241