### PR TITLE
[codex] stabilize device MQTT lifecycle

### DIFF
--- a/docs/CLOUD_PROVISIONING_AND_BACKEND.md
+++ b/docs/CLOUD_PROVISIONING_AND_BACKEND.md
@@ -255,6 +255,14 @@ Current command application in `CloudManager`:
   - causes the next loop tick to re-fetch config immediately
 - other command types are currently only logged as unhandled
 
+Current lifecycle guardrails:
+
+- `CloudManager.prepare_boot()` relies on provisioning reload to start MQTT once
+- replacing MQTT configuration stops the previous client before creating a new one
+- `DeviceMqttClient` uses one managed Paho network loop instead of separate reconnect threads
+
+This matters because duplicate MQTT clients using the same device id can force broker session takeovers and prevent battery telemetry from reaching the backend reliably.
+
 ## 10. Current Telemetry Definitely Wired In The Python Runtime
 
 The safest claim is what is definitely wired today.

--- a/docs/POWER_MODULE.md
+++ b/docs/POWER_MODULE.md
@@ -333,6 +333,13 @@ If power telemetry fails:
 - run `i2cdetect -y 1` on Raspberry Pi Zero 2W hardware
 - run `i2cdetect -y 7` on Radxa Cubie A7Z hardware
 
+If PiSugar is not visible on the expected I2C bus:
+- on Raspberry Pi Zero 2W plus PiSugar 3, the usual device addresses are `0x57` and `0x68`
+- if `0x57` disappears but other bus devices still respond, suspect physical contact between the PiSugar pogo pins and the underside of the Raspberry Pi GPIO header
+- clean the underside GPIO pads, reseat the PiSugar carefully, and re-run `i2cdetect`
+- if needed, add a small amount of solder to the underside GPIO pads to improve pogo-pin contact, then power-cycle and retest
+- once the PiSugar device reappears on I2C, restart `pisugar-server` and confirm `yoyoctl pi power battery` returns real battery values again
+
 Expected PiSugar 3 visibility usually includes:
 - `0x57`
 - `0x68`

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -62,7 +62,6 @@ class CloudManager:
         """Load secrets/cache and start MQTT before the runtime loop begins."""
 
         self._reload_provisioning(force=True, now=time.monotonic())
-        self._start_mqtt()
 
     def tick(self, now: float | None = None) -> None:
         """Advance auth/config sync on the coordinator loop."""

--- a/src/yoyopod/cloud/mqtt_client.py
+++ b/src/yoyopod/cloud/mqtt_client.py
@@ -63,7 +63,11 @@ class DeviceMqttClient:
             )
             return
 
-        client = mqtt.Client(client_id=f"yoyopod-{self._device_id}", clean_session=True, transport=self._transport)
+        client = mqtt.Client(
+            client_id=f"yoyopod-{self._device_id}",
+            clean_session=True,
+            transport=self._transport,
+        )
 
         if self._username:
             client.username_pw_set(self._username, self._password)
@@ -71,23 +75,47 @@ class DeviceMqttClient:
         if self._use_tls:
             client.tls_set()
 
+        # Keep reconnect behavior inside the single Paho network loop so
+        # replacement clients do not leave behind their own retry threads.
+        client.reconnect_delay_set(
+            min_delay=1,
+            max_delay=int(_RECONNECT_DELAY_SECONDS),
+        )
+
         client.on_connect = self._on_connect
         client.on_disconnect = self._on_disconnect
         client.on_message = self._on_message
 
-        self._client = client
-        self._stopped = False
+        with self._lock:
+            self._client = client
+            self._connected = False
+            self._stopped = False
 
-        # Connect in background thread so it doesn't block the boot sequence.
-        threading.Thread(target=self._connect_loop, daemon=True, name="mqtt-connect").start()
+        try:
+            client.connect_async(self._broker_host, self._port, keepalive=_KEEPALIVE_SECONDS)
+            client.loop_start()
+        except Exception as exc:
+            with self._lock:
+                self._client = None
+                self._connected = False
+                self._stopped = True
+            logger.warning("MQTT startup failed: {}", exc)
 
     def stop(self) -> None:
         """Disconnect and stop reconnect attempts."""
-        self._stopped = True
-        client = self._client
+        with self._lock:
+            self._stopped = True
+            self._connected = False
+            client = self._client
+            self._client = None
+
         if client is not None:
             try:
                 client.disconnect()
+            except Exception:
+                pass
+            try:
+                client.loop_stop()
             except Exception:
                 pass
 
@@ -137,37 +165,11 @@ class DeviceMqttClient:
             logger.warning("MQTT publish error for {}: {}", event_type, exc)
             return False
 
-    def _connect_loop(self) -> None:
-        """Attempt to connect (and reconnect) to the broker."""
-        while not self._stopped:
-            try:
-                client = self._client
-                if client is None:
-                    break
-
-                client.connect(self._broker_host, self._port, keepalive=_KEEPALIVE_SECONDS)
-                client.loop_forever()
-
-            except OSError as exc:
-                logger.warning(
-                    "MQTT connection failed: {} — retrying in {}s",
-                    exc,
-                    _RECONNECT_DELAY_SECONDS,
-                )
-                if not self._stopped:
-                    time.sleep(_RECONNECT_DELAY_SECONDS)
-            except Exception as exc:
-                logger.warning(
-                    "MQTT unexpected error: {} — retrying in {}s",
-                    exc,
-                    _RECONNECT_DELAY_SECONDS,
-                )
-                if not self._stopped:
-                    time.sleep(_RECONNECT_DELAY_SECONDS)
-
     def _on_connect(self, client: Any, userdata: Any, flags: Any, rc: int) -> None:
         if rc == 0:
             with self._lock:
+                if self._client is not client or self._stopped:
+                    return
                 self._connected = True
             client.subscribe(f"yoyopod/{self._device_id}/cmd", qos=1)
             logger.info(
@@ -178,6 +180,8 @@ class DeviceMqttClient:
 
     def _on_disconnect(self, client: Any, userdata: Any, rc: int) -> None:
         with self._lock:
+            if self._client is not None and self._client is not client:
+                return
             self._connected = False
         if rc != 0 and not self._stopped:
             logger.warning("MQTT disconnected unexpectedly: rc={}", rc)


### PR DESCRIPTION
## What changed
- removed the extra boot-time MQTT start in `CloudManager.prepare_boot()` so a provisioned device does not create two MQTT clients immediately on launch
- replaced the ad hoc MQTT reconnect thread pattern with a single managed Paho network loop and deterministic shutdown in `DeviceMqttClient`
- documented the deployed MQTT lifecycle guardrails in the cloud backend doc
- documented the PiSugar pogo-pin / GPIO contact failure mode that can make the battery HAT disappear from I2C

## Why it changed
The device was repeatedly losing its MQTT session because multiple clients using the same device id were being created from the same process. That session takeover prevented battery telemetry from reaching the backend reliably.

During validation, a second device-side issue also surfaced: PiSugar had dropped off the I2C bus due to physical contact loss, which made battery values unavailable locally even after MQTT was fixed. The docs update captures that recovery path because it directly affected this flow.

## Impact
- device MQTT transport is now singleton-style and should not self-compete on boot or replacement
- battery telemetry can reach the backend reliably once local PiSugar values are available
- PiSugar troubleshooting now includes the real-world hardware contact check that restored I2C visibility on the Raspberry Pi Zero 2W target

## Validation
- `./.venv/bin/python -m py_compile src/yoyopod/cloud/manager.py src/yoyopod/cloud/mqtt_client.py`
- restarted `yoyopod@raouf.service` on `piz` and confirmed MQTT reconnect churn stopped after the lifecycle fix
- verified PiSugar reappeared on `i2c-1` at `0x57` after hardware reseat/contact repair
- verified live Pi power snapshot returned real values again (`battery ~= 93.9`, `charging = false`)
- verified the running app reported battery locally and the backend saw the device online again
