### PR TITLE
[codex] Add cloud contact sync for Pi runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Current product surface:
 - `Ask` - staged shell for future safe AI interactions
 - `Setup` - power, care, and device status
 
+Approved contacts are now backend-synced policy data:
+
+- the Pi stores mutable people data in `data/people/contacts.yaml`
+- backend config sync can merge household-approved contacts into that file
+- contacts may carry both `sip_address` and `phone_number`
+- calling is currently SIP-first; GSM numbers are stored for later enablement
+- a claimed device may bootstrap prestored local contacts to the backend once
+  when the backend household contact list is still empty
+
 Supported display/input modes:
 - Pimoroni Display HAT Mini: `320x240` landscape with four buttons
 - PiSugar Whisplay HAT: `240x280` portrait with a single PTT-style button

--- a/config/cloud/backend.yaml
+++ b/config/cloud/backend.yaml
@@ -3,6 +3,7 @@ backend:
   auth_path: "/v1/auth/device"
   refresh_path: "/v1/auth/device/refresh"
   config_path_template: "/v1/devices/{device_id}/config"
+  contacts_bootstrap_path_template: "/v1/devices/{device_id}/contacts/bootstrap"
   timeout_seconds: 3.0
   config_poll_interval_seconds: 300
   claim_retry_seconds: 60

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -126,6 +126,15 @@ env vars. Mutable contacts live in `data/people/contacts.yaml`, optionally
 bootstrapped from `config/people/contacts.seed.yaml`. Mutable media history
 lives in `data/media/recent_tracks.json`.
 
+Current approved-contacts behavior:
+
+- contacts may include both `sip_address` and `phone_number`
+- the runtime prefers SIP for calling while GSM remains disabled
+- backend config sync can replace the cloud-managed subset while preserving
+  local-only contacts
+- a claimed device may upload prestored local contacts once when backend
+  authority is still empty for that household
+
 ## Running
 
 Production app:
@@ -217,6 +226,10 @@ yoyoctl remote logs --lines 200
 That remote flow mirrors the same baseline contract. You still need feature-specific
 follow-through for assets like Vosk models and for unusual board/modem bringup.
 Add `--with-voice` and/or `--with-network` to the setup commands when the target depends on those paths.
+
+If a GitHub fetch or push fails with a short-lived connectivity error, retry it
+several times before treating it as a real failure. This environment has seen
+brief `github.com` reachability blips.
 
 The detailed deploy and validation flows live in:
 

--- a/docs/PI_DEV_WORKFLOW.md
+++ b/docs/PI_DEV_WORKFLOW.md
@@ -82,6 +82,10 @@ $env:YOYOPOD_PI_HOST="rpi-zero"
 $env:YOYOPOD_PI_PROJECT_DIR="~/YoyoPod_Core"
 ```
 
+If your actual deployed board uses a different stable checkout path, set that in
+your local override instead of assuming the repo default. For example, the live
+`piz` board in this environment uses `~/yoyo-py`.
+
 ## Default Validate-On-Board Flow
 
 Use this when validating a feature branch or PR on target hardware.
@@ -103,6 +107,8 @@ Use this when validating a feature branch or PR on target hardware.
    ```bash
    git push -u origin <branch>
    ```
+   If `github.com` is briefly unreachable, do not treat one short network error
+   as a definitive failure. Retry the push a few times before escalating.
 4. Run the repo-owned hardware validation flow:
    ```bash
    yoyoctl remote validate --branch <branch> --sha <commit>

--- a/src/yoyopod/cloud/client.py
+++ b/src/yoyopod/cloud/client.py
@@ -36,12 +36,14 @@ class CloudDeviceClient:
         auth_path: str,
         refresh_path: str,
         config_path_template: str,
+        contacts_bootstrap_path_template: str,
         timeout_seconds: float = 3.0,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.auth_path = auth_path
         self.refresh_path = refresh_path
         self.config_path_template = config_path_template
+        self.contacts_bootstrap_path_template = contacts_bootstrap_path_template
         self.timeout_seconds = max(0.1, float(timeout_seconds))
 
     def authenticate(self, *, device_id: str, device_secret: str) -> CloudAccessToken:
@@ -71,6 +73,26 @@ class CloudDeviceClient:
         )
         if not isinstance(payload, dict):
             raise CloudClientError("Malformed cloud config payload", payload={"payload": payload})
+        return payload
+
+    def bootstrap_contacts(
+        self,
+        *,
+        access_token: str,
+        device_id: str,
+        entries: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        payload = self._request_json(
+            "POST",
+            self._url(self.contacts_bootstrap_path_template.format(device_id=device_id)),
+            headers=self._auth_headers(access_token),
+            json={"entries": entries},
+        )
+        if not isinstance(payload, dict):
+            raise CloudClientError(
+                "Malformed cloud contact bootstrap payload",
+                payload={"payload": payload},
+            )
         return payload
 
     def _request_json(

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -43,6 +43,7 @@ class CloudManager:
             auth_path=backend.auth_path,
             refresh_path=backend.refresh_path,
             config_path_template=backend.config_path_template,
+            contacts_bootstrap_path_template=backend.contacts_bootstrap_path_template,
             timeout_seconds=backend.timeout_seconds,
         )
         self.status = CloudStatusSnapshot()
@@ -57,6 +58,7 @@ class CloudManager:
         self._provisioning_generation = 0
         self._mqtt: DeviceMqttClient | None = None
         self._next_battery_report_at = 0.0
+        self._contacts_bootstrap_attempted = False
 
     def prepare_boot(self) -> None:
         """Load secrets/cache and start MQTT before the runtime loop begins."""
@@ -174,6 +176,7 @@ class CloudManager:
                 auth_path=backend.auth_path,
                 refresh_path=backend.refresh_path,
                 config_path_template=backend.config_path_template,
+                contacts_bootstrap_path_template=backend.contacts_bootstrap_path_template,
                 timeout_seconds=backend.timeout_seconds,
             )
 
@@ -187,6 +190,7 @@ class CloudManager:
         self._next_refresh_at = 0.0
         self._next_config_poll_at = 0.0
         self._network_retry_index = 0
+        self._contacts_bootstrap_attempted = False
         if self._mqtt is not None:
             self._mqtt.stop()
             self._mqtt = None
@@ -516,6 +520,7 @@ class CloudManager:
         self._sync_context_state()
         from yoyopod import __version__
         self.publish_heartbeat(firmware_version=__version__)
+        self._maybe_bootstrap_local_contacts(payload=payload, completed_at=completed_at)
 
     def _start_worker(self, *, name: str, work: Callable[[], None]) -> None:
         threading.Thread(target=work, daemon=True, name=name).start()
@@ -636,6 +641,156 @@ class CloudManager:
             return
 
         self.app.people_directory.merge_cloud_contacts(entries)
+
+    def _local_contacts_bootstrap_entries(self) -> list[dict[str, Any]]:
+        """Build one bootstrap payload from non-cloud local contacts."""
+
+        if self.app.people_directory is None:
+            return []
+
+        local_contacts = self.app.people_directory.get_local_contacts()
+        if not local_contacts:
+            return []
+
+        quick_dial_by_address = {
+            str(address): int(slot)
+            for slot, address in self.app.people_directory.speed_dial.items()
+            if str(address).strip()
+        }
+
+        entries: list[dict[str, Any]] = []
+        for contact in local_contacts:
+            entries.append(
+                {
+                    "name": contact.name,
+                    "phoneNumber": contact.phone_number.strip() or None,
+                    "sipAddress": contact.sip_address.strip() or None,
+                    "relationship": contact.notes.strip() or None,
+                    "isPrimary": bool(contact.favorite),
+                    "canCall": bool(contact.can_call),
+                    "canReceive": bool(contact.can_receive),
+                    "quickDial": quick_dial_by_address.get(contact.sip_address.strip()),
+                }
+            )
+        return entries
+
+    def _payload_has_backend_contacts(self, payload: dict[str, Any]) -> bool:
+        contacts_payload = payload.get("contacts", {})
+        if not isinstance(contacts_payload, dict):
+            return False
+        entries = contacts_payload.get("entries", [])
+        return isinstance(entries, list) and len(entries) > 0
+
+    def _maybe_bootstrap_local_contacts(self, *, payload: dict[str, Any], completed_at: float) -> None:
+        """Upload local seeded contacts once when the backend still has none."""
+
+        if self._contacts_bootstrap_attempted:
+            return
+        if self._payload_has_backend_contacts(payload):
+            return
+        if self._access_token is None:
+            return
+
+        entries = self._local_contacts_bootstrap_entries()
+        if not entries:
+            self._contacts_bootstrap_attempted = True
+            return
+
+        self._contacts_bootstrap_attempted = True
+        self._request_in_flight = True
+        access_token = self._access_token.access_token
+        device_id = self.config_manager.get_cloud_device_id().strip()
+        generation = self._provisioning_generation
+        self._start_worker(
+            name="cloud-contacts-bootstrap",
+            work=lambda: self._run_bootstrap_contacts(
+                access_token=access_token,
+                device_id=device_id,
+                generation=generation,
+                entries=entries,
+            ),
+        )
+
+    def _run_bootstrap_contacts(
+        self,
+        *,
+        access_token: str,
+        device_id: str,
+        generation: int,
+        entries: list[dict[str, Any]],
+    ) -> None:
+        try:
+            payload = self.client.bootstrap_contacts(
+                access_token=access_token,
+                device_id=device_id,
+                entries=entries,
+            )
+        except CloudClientError as exc:
+            self.app._queue_main_thread_callback(
+                lambda exc=exc, generation=generation, access_token=access_token, device_id=device_id, completed_at=time.monotonic(): self._complete_bootstrap_contacts(
+                    access_token=access_token,
+                    device_id=device_id,
+                    generation=generation,
+                    completed_at=completed_at,
+                    error=exc,
+                )
+            )
+            return
+        except Exception as exc:
+            error = CloudClientError(str(exc))
+            self.app._queue_main_thread_callback(
+                lambda error=error, generation=generation, access_token=access_token, device_id=device_id, completed_at=time.monotonic(): self._complete_bootstrap_contacts(
+                    access_token=access_token,
+                    device_id=device_id,
+                    generation=generation,
+                    completed_at=completed_at,
+                    error=error,
+                )
+            )
+            return
+
+        self.app._queue_main_thread_callback(
+            lambda payload=payload, generation=generation, access_token=access_token, device_id=device_id, completed_at=time.monotonic(): self._complete_bootstrap_contacts(
+                access_token=access_token,
+                device_id=device_id,
+                generation=generation,
+                completed_at=completed_at,
+                payload=payload,
+            )
+        )
+
+    def _complete_bootstrap_contacts(
+        self,
+        *,
+        access_token: str,
+        device_id: str,
+        generation: int,
+        completed_at: float,
+        payload: dict[str, Any] | None = None,
+        error: CloudClientError | None = None,
+    ) -> None:
+        self._request_in_flight = False
+        if not self._matches_current_request(
+            access_token=access_token,
+            generation=generation,
+            device_id=device_id,
+        ):
+            return
+
+        if error is not None:
+            logger.warning("Cloud contact bootstrap failed for {}: {}", device_id, error)
+            return
+
+        imported_count = int((payload or {}).get("importedCount") or 0)
+        skipped_count = int((payload or {}).get("skippedCount") or 0)
+        logger.info(
+            "Cloud contact bootstrap completed for {} (imported={}, skipped={})",
+            device_id,
+            imported_count,
+            skipped_count,
+        )
+        if imported_count > 0:
+            self._next_config_poll_at = completed_at
 
     def _load_cached_config(self) -> None:
         cache_path = self._cache_path()

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -488,7 +488,11 @@ class CloudManager:
 
         assert payload is not None
         config_version = int(payload.get("config_version") or 0)
-        unapplied_keys = self.config_manager.apply_cloud_overrides(payload)
+        self._apply_cloud_contacts(payload)
+        runtime_payload = {
+            key: value for key, value in payload.items() if key != "contacts"
+        }
+        unapplied_keys = self.config_manager.apply_cloud_overrides(runtime_payload)
         self._apply_runtime_side_effects(payload)
         self.status.backend_reachable = True
         self.status.cloud_state = "ready"
@@ -616,6 +620,23 @@ class CloudManager:
 
         self._sync_context_state()
 
+    def _apply_cloud_contacts(self, payload: dict[str, Any]) -> None:
+        """Merge cloud-managed contacts into the mutable people directory."""
+
+        contacts_payload = payload.get("contacts", {})
+        if not isinstance(contacts_payload, dict):
+            return
+
+        entries = contacts_payload.get("entries", [])
+        if not isinstance(entries, list):
+            return
+
+        if self.app.people_directory is None:
+            logger.warning("Skipping cloud contacts sync because no people directory is loaded")
+            return
+
+        self.app.people_directory.merge_cloud_contacts(entries)
+
     def _load_cached_config(self) -> None:
         cache_path = self._cache_path()
         if not cache_path.exists():
@@ -646,7 +667,11 @@ class CloudManager:
             logger.warning("Ignoring malformed cloud config cache payload {}", cache_path)
             return
 
-        unapplied_keys = self.config_manager.apply_cloud_overrides(raw_payload)
+        self._apply_cloud_contacts(raw_payload)
+        runtime_payload = {
+            key: value for key, value in raw_payload.items() if key != "contacts"
+        }
+        unapplied_keys = self.config_manager.apply_cloud_overrides(runtime_payload)
         self._apply_runtime_side_effects(raw_payload)
         self.status.config_source = "cache"
         self.status.config_version = int(payload.get("config_version") or 0)

--- a/src/yoyopod/config/models.py
+++ b/src/yoyopod/config/models.py
@@ -602,6 +602,7 @@ class CloudBackendConfig:
     auth_path: str = "/v1/auth/device"
     refresh_path: str = "/v1/auth/device/refresh"
     config_path_template: str = "/v1/devices/{device_id}/config"
+    contacts_bootstrap_path_template: str = "/v1/devices/{device_id}/contacts/bootstrap"
     timeout_seconds: float = config_value(default=3.0, env="YOYOPOD_CLOUD_TIMEOUT_SECONDS")
     config_poll_interval_seconds: int = config_value(
         default=300,

--- a/src/yoyopod/people/__init__.py
+++ b/src/yoyopod/people/__init__.py
@@ -1,9 +1,11 @@
 """Mutable people-data seams for the YoyoPod runtime."""
 
 from yoyopod.people.directory import PeopleDirectory
+from yoyopod.people.cloud_sync import build_cloud_contact
 from yoyopod.people.models import Contact, contacts_from_mapping, contacts_to_mapping
 
 __all__ = [
+    "build_cloud_contact",
     "Contact",
     "PeopleDirectory",
     "contacts_from_mapping",

--- a/src/yoyopod/people/cloud_sync.py
+++ b/src/yoyopod/people/cloud_sync.py
@@ -1,0 +1,29 @@
+"""Cloud-contact synchronization helpers for the mutable people directory."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from yoyopod.people.models import Contact
+
+
+def build_cloud_contact(entry: dict[str, Any]) -> Contact | None:
+    """Build one cloud-managed contact from backend config payload."""
+
+    contact_id = str(entry.get("id") or "").strip()
+    name = str(entry.get("name") or "").strip()
+    if not contact_id or not name:
+        return None
+
+    relationship = str(entry.get("relationship") or "").strip()
+    return Contact(
+        name=name,
+        sip_address=str(entry.get("sip_address") or "").strip(),
+        phone_number=str(entry.get("phone_number") or "").strip(),
+        favorite=bool(entry.get("is_primary", False)),
+        notes=relationship,
+        contact_id=contact_id,
+        sync_origin="cloud",
+        can_call=bool(entry.get("can_call", True)),
+        can_receive=bool(entry.get("can_receive", True)),
+    )

--- a/src/yoyopod/people/directory.py
+++ b/src/yoyopod/people/directory.py
@@ -174,6 +174,16 @@ class PeopleDirectory:
         self.speed_dial[number] = sip_address
         self.save()
 
+    @staticmethod
+    def _contact_identity(contact: Contact) -> tuple[str, str, str]:
+        """Return a normalized identity tuple for dedupe decisions."""
+
+        return (
+            contact.name.strip().lower(),
+            contact.sip_address.strip().lower(),
+            contact.phone_number.strip(),
+        )
+
     def merge_cloud_contacts(self, entries: list[dict[str, object]]) -> bool:
         """Replace the cloud-managed contact subset while preserving local contacts."""
 
@@ -182,11 +192,8 @@ class PeopleDirectory:
             for contact in self.contacts
             if contact.sync_origin == "cloud" and contact.sip_address.strip()
         }
-        local_contacts = [
-            contact for contact in self.contacts if contact.sync_origin != "cloud"
-        ]
-
         merged_cloud_contacts: list[Contact] = []
+        merged_cloud_identities: set[tuple[str, str, str]] = set()
         updated_speed_dial = {
             int(slot): address
             for slot, address in self.speed_dial.items()
@@ -200,12 +207,20 @@ class PeopleDirectory:
             if contact is None:
                 continue
             merged_cloud_contacts.append(contact)
+            merged_cloud_identities.add(self._contact_identity(contact))
 
             quick_dial = entry.get("quick_dial")
             if isinstance(quick_dial, int) and 1 <= quick_dial <= 9:
                 route, address = contact.preferred_call_target(gsm_enabled=False)
                 if route == "sip" and address:
                     updated_speed_dial[quick_dial] = address
+
+        local_contacts = [
+            contact
+            for contact in self.contacts
+            if contact.sync_origin != "cloud"
+            and self._contact_identity(contact) not in merged_cloud_identities
+        ]
 
         self.contacts = local_contacts + merged_cloud_contacts
         self.speed_dial = dict(sorted(updated_speed_dial.items()))

--- a/src/yoyopod/people/directory.py
+++ b/src/yoyopod/people/directory.py
@@ -99,6 +99,11 @@ class PeopleDirectory:
             contact for contact in self.contacts if contact.is_callable(gsm_enabled=gsm_enabled)
         ]
 
+    def get_local_contacts(self) -> list[Contact]:
+        """Return contacts that are not managed by cloud sync."""
+
+        return [contact for contact in self.contacts if contact.sync_origin != "cloud"]
+
     def get_contact_by_name(self, name: str) -> Contact | None:
         """Return one contact matched by source name."""
 

--- a/src/yoyopod/people/directory.py
+++ b/src/yoyopod/people/directory.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from loguru import logger
 
 from yoyopod.config.storage import atomic_write_yaml, load_yaml_mapping
+from yoyopod.people.cloud_sync import build_cloud_contact
 from yoyopod.people.models import Contact, contacts_from_mapping, contacts_to_mapping
 
 
@@ -91,6 +92,13 @@ class PeopleDirectory:
             return [contact for contact in self.contacts if contact.favorite]
         return list(self.contacts)
 
+    def get_callable_contacts(self, *, gsm_enabled: bool = False) -> list[Contact]:
+        """Return contacts that can be called on the currently enabled transports."""
+
+        return [
+            contact for contact in self.contacts if contact.is_callable(gsm_enabled=gsm_enabled)
+        ]
+
     def get_contact_by_name(self, name: str) -> Contact | None:
         """Return one contact matched by source name."""
 
@@ -160,6 +168,49 @@ class PeopleDirectory:
 
         self.speed_dial[number] = sip_address
         self.save()
+
+    def merge_cloud_contacts(self, entries: list[dict[str, object]]) -> bool:
+        """Replace the cloud-managed contact subset while preserving local contacts."""
+
+        existing_cloud_addresses = {
+            contact.sip_address.strip()
+            for contact in self.contacts
+            if contact.sync_origin == "cloud" and contact.sip_address.strip()
+        }
+        local_contacts = [
+            contact for contact in self.contacts if contact.sync_origin != "cloud"
+        ]
+
+        merged_cloud_contacts: list[Contact] = []
+        updated_speed_dial = {
+            int(slot): address
+            for slot, address in self.speed_dial.items()
+            if address not in existing_cloud_addresses
+        }
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            contact = build_cloud_contact(entry)
+            if contact is None:
+                continue
+            merged_cloud_contacts.append(contact)
+
+            quick_dial = entry.get("quick_dial")
+            if isinstance(quick_dial, int) and 1 <= quick_dial <= 9:
+                route, address = contact.preferred_call_target(gsm_enabled=False)
+                if route == "sip" and address:
+                    updated_speed_dial[quick_dial] = address
+
+        self.contacts = local_contacts + merged_cloud_contacts
+        self.speed_dial = dict(sorted(updated_speed_dial.items()))
+        logger.info(
+            "Merged {} cloud contacts into {} (preserved {} local contacts)",
+            len(merged_cloud_contacts),
+            self.contacts_file,
+            len(local_contacts),
+        )
+        return self.save()
 
     def reload(self) -> bool:
         """Reload mutable people data from disk."""

--- a/src/yoyopod/people/models.py
+++ b/src/yoyopod/people/models.py
@@ -82,20 +82,27 @@ def contacts_to_mapping(
 ) -> dict[str, Any]:
     """Serialize contacts and speed dial into a YAML-friendly mapping."""
 
+    serialized_contacts: list[dict[str, Any]] = []
+    for contact in contacts:
+        entry = {
+            "name": contact.name,
+            "sip_address": contact.sip_address,
+            "favorite": contact.favorite,
+            "notes": contact.notes,
+        }
+        if contact.phone_number:
+            entry["phone_number"] = contact.phone_number
+        if contact.contact_id:
+            entry["contact_id"] = contact.contact_id
+        if contact.sync_origin != "local":
+            entry["sync_origin"] = contact.sync_origin
+        if not contact.can_call:
+            entry["can_call"] = contact.can_call
+        if not contact.can_receive:
+            entry["can_receive"] = contact.can_receive
+        serialized_contacts.append(entry)
+
     return {
-        "contacts": [
-            {
-                "name": contact.name,
-                "sip_address": contact.sip_address,
-                "phone_number": contact.phone_number,
-                "favorite": contact.favorite,
-                "notes": contact.notes,
-                "contact_id": contact.contact_id,
-                "sync_origin": contact.sync_origin,
-                "can_call": contact.can_call,
-                "can_receive": contact.can_receive,
-            }
-            for contact in contacts
-        ],
+        "contacts": serialized_contacts,
         "speed_dial": speed_dial,
     }

--- a/src/yoyopod/people/models.py
+++ b/src/yoyopod/people/models.py
@@ -11,9 +11,14 @@ class Contact:
     """One mutable address-book entry used by the Talk flow."""
 
     name: str
-    sip_address: str
+    sip_address: str = ""
+    phone_number: str = ""
     favorite: bool = False
     notes: str = ""
+    contact_id: str = ""
+    sync_origin: str = "local"
+    can_call: bool = True
+    can_receive: bool = True
 
     @property
     def display_name(self) -> str:
@@ -23,7 +28,26 @@ class Contact:
         return label or self.name
 
     def __str__(self) -> str:
-        return f"{self.name} ({self.sip_address})"
+        return f"{self.name} ({self.sip_address or self.phone_number or 'no-address'})"
+
+    def preferred_call_target(
+        self,
+        *,
+        gsm_enabled: bool = False,
+    ) -> tuple[str | None, str]:
+        """Return the active call route and address for this contact."""
+
+        if self.sip_address.strip():
+            return "sip", self.sip_address.strip()
+        if gsm_enabled and self.phone_number.strip():
+            return "gsm", self.phone_number.strip()
+        return None, ""
+
+    def is_callable(self, *, gsm_enabled: bool = False) -> bool:
+        """Return whether this contact can be called on the active device."""
+
+        route, _ = self.preferred_call_target(gsm_enabled=gsm_enabled)
+        return bool(route)
 
 
 def contacts_from_mapping(data: dict[str, Any]) -> tuple[list[Contact], dict[int, str]]:
@@ -33,12 +57,23 @@ def contacts_from_mapping(data: dict[str, Any]) -> tuple[list[Contact], dict[int
         Contact(
             name=contact_data.get("name", ""),
             sip_address=contact_data.get("sip_address", ""),
+            phone_number=contact_data.get("phone_number", ""),
             favorite=contact_data.get("favorite", False),
             notes=contact_data.get("notes", ""),
+            contact_id=contact_data.get("contact_id", ""),
+            sync_origin=contact_data.get("sync_origin", "local"),
+            can_call=contact_data.get("can_call", True),
+            can_receive=contact_data.get("can_receive", True),
         )
         for contact_data in data.get("contacts", [])
     ]
-    return contacts, data.get("speed_dial", {})
+    raw_speed_dial = data.get("speed_dial", {})
+    speed_dial = {
+        int(slot): str(address)
+        for slot, address in raw_speed_dial.items()
+        if str(slot).isdigit() and str(address).strip()
+    }
+    return contacts, speed_dial
 
 
 def contacts_to_mapping(
@@ -52,8 +87,13 @@ def contacts_to_mapping(
             {
                 "name": contact.name,
                 "sip_address": contact.sip_address,
+                "phone_number": contact.phone_number,
                 "favorite": contact.favorite,
                 "notes": contact.notes,
+                "contact_id": contact.contact_id,
+                "sync_origin": contact.sync_origin,
+                "can_call": contact.can_call,
+                "can_receive": contact.can_receive,
             }
             for contact in contacts
         ],

--- a/src/yoyopod/runtime/voice.py
+++ b/src/yoyopod/runtime/voice.py
@@ -272,9 +272,16 @@ class VoiceCommandExecutor:
         if contact is None:
             return VoiceCommandOutcome("No Match", f"I could not find {spoken_name}.")
 
+        route, address = contact.preferred_call_target(gsm_enabled=False)
+        if route != "sip" or not address:
+            return VoiceCommandOutcome(
+                "Not Ready",
+                f"{contact.display_name} is saved, but this device can only place SIP calls right now.",
+            )
+
         display_name = contact.display_name
         if self._context is not None:
-            self._context.set_talk_contact(name=display_name, sip_address=contact.sip_address)
+            self._context.set_talk_contact(name=display_name, sip_address=address)
 
         if self._voip_manager is None:
             return VoiceCommandOutcome(
@@ -282,7 +289,7 @@ class VoiceCommandExecutor:
                 f"I found {display_name}, but calling is not ready.",
             )
 
-        if self._voip_manager.make_call(contact.sip_address, contact_name=display_name):
+        if self._voip_manager.make_call(address, contact_name=display_name):
             return VoiceCommandOutcome(
                 "Calling",
                 f"Calling {display_name}.",

--- a/src/yoyopod/ui/screens/voip/contact_list.py
+++ b/src/yoyopod/ui/screens/voip/contact_list.py
@@ -99,7 +99,7 @@ class ContactListScreen(Screen):
     def load_contacts(self) -> None:
         """Load contacts from the people directory."""
         if self.people_directory:
-            contacts = self.people_directory.get_contacts()
+            contacts = self.people_directory.get_callable_contacts(gsm_enabled=False)
             favorites = [contact for contact in contacts if contact.favorite]
             others = [contact for contact in contacts if not contact.favorite]
             self.contacts = favorites + others

--- a/src/yoyopod/ui/screens/voip/quick_call.py
+++ b/src/yoyopod/ui/screens/voip/quick_call.py
@@ -108,7 +108,7 @@ class CallScreen(Screen):
         if self.people_directory is None:
             return []
 
-        contacts = list(self.people_directory.get_contacts())
+        contacts = list(self.people_directory.get_callable_contacts(gsm_enabled=False))
         favorites = [contact for contact in contacts if contact.favorite]
         others = [contact for contact in contacts if not contact.favorite]
         return (favorites + others)[: self._MAX_CONTACTS]

--- a/tests/test_call_screen.py
+++ b/tests/test_call_screen.py
@@ -30,6 +30,11 @@ class FakePeopleDirectory:
     def get_contacts(self) -> list[Contact]:
         return list(self._contacts)
 
+    def get_callable_contacts(self, *, gsm_enabled: bool = False) -> list[Contact]:
+        return [
+            contact for contact in self._contacts if contact.is_callable(gsm_enabled=gsm_enabled)
+        ]
+
 
 class FakeVoIPManager:
     """Minimal VoIP manager double for Talk actions."""

--- a/tests/test_cloud_contact_bootstrap.py
+++ b/tests/test_cloud_contact_bootstrap.py
@@ -1,0 +1,129 @@
+"""Focused tests for one-time local-contact bootstrap into backend authority."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from yoyopod.cloud.manager import CloudManager
+from yoyopod.cloud.models import CloudAccessToken
+from yoyopod.people import Contact
+
+
+class _FakePeopleDirectory:
+    def __init__(self) -> None:
+        self.contacts = [
+            Contact(
+                name="Hagar",
+                sip_address="sip:hagarmo@sip.linphone.org",
+                favorite=True,
+                notes="Mama",
+            )
+        ]
+        self.speed_dial = {1: "sip:hagarmo@sip.linphone.org"}
+
+    def get_local_contacts(self) -> list[Contact]:
+        return list(self.contacts)
+
+
+class _FakeConfigManager:
+    def __init__(self) -> None:
+        self.cloud_secrets_error = ""
+        self._backend = SimpleNamespace(
+            api_base_url="https://yoyopod.moraouf.net",
+            auth_path="/v1/auth/device",
+            refresh_path="/v1/auth/device/refresh",
+            config_path_template="/v1/devices/{device_id}/config",
+            contacts_bootstrap_path_template="/v1/devices/{device_id}/contacts/bootstrap",
+            timeout_seconds=3.0,
+            config_poll_interval_seconds=300,
+            claim_retry_seconds=60,
+            battery_report_interval_seconds=60,
+        )
+
+    def get_cloud_settings(self):
+        return SimpleNamespace(backend=self._backend)
+
+    def get_cloud_device_id(self) -> str:
+        return "YYP-DEV-0001"
+
+    def get_cloud_device_secret(self) -> str:
+        return "secret"
+
+    def load_cloud_config(self) -> None:
+        return None
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def bootstrap_contacts(self, *, access_token: str, device_id: str, entries: list[dict[str, object]]):
+        self.calls.append(
+            {
+                "access_token": access_token,
+                "device_id": device_id,
+                "entries": entries,
+            }
+        )
+        return {"success": True, "importedCount": 1, "skippedCount": 0}
+
+
+class _FakeApp:
+    def __init__(self) -> None:
+        self.people_directory = _FakePeopleDirectory()
+
+    def _queue_main_thread_callback(self, callback):
+        callback()
+
+
+def test_local_contacts_bootstrap_payload_uses_seeded_contact_fields() -> None:
+    app = _FakeApp()
+    manager = CloudManager(
+        app=app,
+        config_manager=_FakeConfigManager(),
+        client=_FakeClient(),
+    )
+    manager._access_token = CloudAccessToken(
+        access_token="token-123",
+        issued_at_epoch=1.0,
+        expires_at_epoch=3601.0,
+        lifetime_seconds=3600.0,
+    )
+
+    entries = manager._local_contacts_bootstrap_entries()
+
+    assert entries == [
+        {
+            "name": "Hagar",
+            "phoneNumber": None,
+            "sipAddress": "sip:hagarmo@sip.linphone.org",
+            "relationship": "Mama",
+            "isPrimary": True,
+            "canCall": True,
+            "canReceive": True,
+            "quickDial": 1,
+        }
+    ]
+
+
+def test_bootstrap_runs_once_when_backend_contacts_are_empty() -> None:
+    app = _FakeApp()
+    client = _FakeClient()
+    manager = CloudManager(
+        app=app,
+        config_manager=_FakeConfigManager(),
+        client=client,
+    )
+    manager._access_token = CloudAccessToken(
+        access_token="token-123",
+        issued_at_epoch=1.0,
+        expires_at_epoch=3601.0,
+        lifetime_seconds=3600.0,
+    )
+    manager._start_worker = lambda *, name, work: work()  # type: ignore[method-assign]
+
+    manager._maybe_bootstrap_local_contacts(payload={"contacts": {"entries": []}}, completed_at=10.0)
+    manager._maybe_bootstrap_local_contacts(payload={"contacts": {"entries": []}}, completed_at=11.0)
+
+    assert len(client.calls) == 1
+    assert client.calls[0]["device_id"] == "YYP-DEV-0001"

--- a/tests/test_people_cloud_sync.py
+++ b/tests/test_people_cloud_sync.py
@@ -1,0 +1,114 @@
+"""Focused tests for cloud-managed contact sync and call routing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from yoyopod.people import Contact, PeopleDirectory
+
+
+def test_cloud_contact_sync_preserves_local_contacts_and_updates_speed_dial(
+    tmp_path: Path,
+) -> None:
+    contacts_file = tmp_path / "data" / "people" / "contacts.yaml"
+    contacts_file.parent.mkdir(parents=True, exist_ok=True)
+    contacts_file.write_text(
+        yaml.safe_dump(
+            {
+                "contacts": [
+                    {
+                        "name": "Local Grandma",
+                        "sip_address": "sip:grandma@example.com",
+                        "favorite": True,
+                        "notes": "Grandma",
+                    },
+                    {
+                        "name": "Old Dashboard Mom",
+                        "sip_address": "sip:old-mom@example.com",
+                        "phone_number": "+1 555-0101",
+                        "favorite": True,
+                        "notes": "Parent",
+                        "contact_id": "contact-mom",
+                        "sync_origin": "cloud",
+                    },
+                ],
+                "speed_dial": {
+                    1: "sip:old-mom@example.com",
+                    9: "sip:grandma@example.com",
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    directory = PeopleDirectory(contacts_file)
+
+    saved = directory.merge_cloud_contacts(
+        [
+            {
+                "id": "contact-mom",
+                "name": "Mom",
+                "sip_address": "sip:mom@example.com",
+                "phone_number": "+1 555-0101",
+                "relationship": "parent",
+                "is_primary": True,
+                "can_call": True,
+                "can_receive": True,
+                "quick_dial": 1,
+            },
+            {
+                "id": "contact-dad",
+                "name": "Dad",
+                "sip_address": "",
+                "phone_number": "+1 555-0102",
+                "relationship": "parent",
+                "is_primary": False,
+                "can_call": True,
+                "can_receive": True,
+                "quick_dial": 2,
+            },
+        ]
+    )
+
+    assert saved is True
+    assert [contact.name for contact in directory.contacts] == [
+        "Local Grandma",
+        "Mom",
+        "Dad",
+    ]
+    assert directory.speed_dial == {
+        1: "sip:mom@example.com",
+        9: "sip:grandma@example.com",
+    }
+
+    persisted = yaml.safe_load(contacts_file.read_text(encoding="utf-8"))
+    assert [contact["name"] for contact in persisted["contacts"]] == [
+        "Local Grandma",
+        "Mom",
+        "Dad",
+    ]
+
+
+def test_contact_prefers_sip_call_path_while_gsm_is_disabled() -> None:
+    contact = Contact(
+        name="Mom",
+        sip_address="sip:mom@example.com",
+        phone_number="+1 555-0101",
+    )
+    phone_only = Contact(
+        name="Dad",
+        phone_number="+1 555-0102",
+    )
+
+    assert contact.preferred_call_target(gsm_enabled=False) == (
+        "sip",
+        "sip:mom@example.com",
+    )
+    assert phone_only.preferred_call_target(gsm_enabled=False) == (None, "")
+    assert phone_only.preferred_call_target(gsm_enabled=True) == (
+        "gsm",
+        "+1 555-0102",
+    )

--- a/tests/test_people_cloud_sync.py
+++ b/tests/test_people_cloud_sync.py
@@ -112,3 +112,48 @@ def test_contact_prefers_sip_call_path_while_gsm_is_disabled() -> None:
         "gsm",
         "+1 555-0102",
     )
+
+
+def test_cloud_contact_sync_dedupes_matching_seed_contact(tmp_path: Path) -> None:
+    contacts_file = tmp_path / "data" / "people" / "contacts.yaml"
+    contacts_file.parent.mkdir(parents=True, exist_ok=True)
+    contacts_file.write_text(
+        yaml.safe_dump(
+            {
+                "contacts": [
+                    {
+                        "name": "Hagar",
+                        "sip_address": "sip:hagarmo@sip.linphone.org",
+                        "favorite": True,
+                        "notes": "Mama",
+                    }
+                ],
+                "speed_dial": {
+                    1: "sip:hagarmo@sip.linphone.org",
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    directory = PeopleDirectory(contacts_file)
+    directory.merge_cloud_contacts(
+        [
+            {
+                "id": "contact-hagar",
+                "name": "Hagar",
+                "sip_address": "sip:hagarmo@sip.linphone.org",
+                "phone_number": None,
+                "relationship": "Mama",
+                "is_primary": True,
+                "can_call": True,
+                "can_receive": True,
+                "quick_dial": 1,
+            }
+        ]
+    )
+
+    assert len(directory.contacts) == 1
+    assert directory.contacts[0].sync_origin == "cloud"
+    assert directory.contacts[0].contact_id == "contact-hagar"

--- a/tests/test_remaining_lvgl_views.py
+++ b/tests/test_remaining_lvgl_views.py
@@ -208,6 +208,19 @@ class FakeContact:
     def display_name(self) -> str:
         return self.notes or self.name
 
+    def preferred_call_target(
+        self,
+        *,
+        gsm_enabled: bool = False,
+    ) -> tuple[str | None, str]:
+        if self.sip_address.strip():
+            return "sip", self.sip_address.strip()
+        return None, ""
+
+    def is_callable(self, *, gsm_enabled: bool = False) -> bool:
+        route, _ = self.preferred_call_target(gsm_enabled=gsm_enabled)
+        return bool(route)
+
 
 class FakeConfigManager:
     """Minimal config manager returning a stable contact list."""
@@ -217,6 +230,11 @@ class FakeConfigManager:
 
     def get_contacts(self) -> list[FakeContact]:
         return list(self._contacts)
+
+    def get_callable_contacts(self, *, gsm_enabled: bool = False) -> list[FakeContact]:
+        return [
+            contact for contact in self._contacts if contact.is_callable(gsm_enabled=gsm_enabled)
+        ]
 
 
 class FakeVoipManager:

--- a/tests/test_runtime_voice.py
+++ b/tests/test_runtime_voice.py
@@ -24,6 +24,15 @@ class _FakeContact:
         self.sip_address = sip_address
         self.notes = notes
 
+    def preferred_call_target(
+        self,
+        *,
+        gsm_enabled: bool = False,
+    ) -> tuple[str | None, str]:
+        if self.sip_address.strip():
+            return "sip", self.sip_address.strip()
+        return None, ""
+
 
 class _FakeConfigManager:
     def __init__(self, contacts: list[_FakeContact]) -> None:
@@ -52,6 +61,13 @@ class _FakeConfigManager:
 
     def get_contacts(self) -> list[_FakeContact]:
         return list(self._contacts)
+
+    def get_callable_contacts(self, *, gsm_enabled: bool = False) -> list[_FakeContact]:
+        return [
+            contact for contact in self._contacts if contact.preferred_call_target(
+                gsm_enabled=gsm_enabled
+            )[0]
+        ]
 
     def get_capture_device_id(self) -> str | None:
         return None

--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -280,6 +280,15 @@ class _FakeContact:
     def display_name(self) -> str:
         return self.notes or self.name
 
+    def preferred_call_target(
+        self,
+        *,
+        gsm_enabled: bool = False,
+    ) -> tuple[str | None, str]:
+        if self.sip_address.strip():
+            return "sip", self.sip_address.strip()
+        return None, ""
+
 
 class _FakeConfigManager:
     def __init__(self, contacts: list[_FakeContact]) -> None:
@@ -287,6 +296,13 @@ class _FakeConfigManager:
 
     def get_contacts(self) -> list[_FakeContact]:
         return self._contacts
+
+    def get_callable_contacts(self, *, gsm_enabled: bool = False) -> list[_FakeContact]:
+        return [
+            contact for contact in self._contacts if contact.preferred_call_target(
+                gsm_enabled=gsm_enabled
+            )[0]
+        ]
 
     def get_capture_device_id(self) -> str | None:
         return None

--- a/tests/test_whisplay_one_button.py
+++ b/tests/test_whisplay_one_button.py
@@ -98,6 +98,19 @@ class FakeContact:
     def display_name(self) -> str:
         return self.notes or self.name
 
+    def preferred_call_target(
+        self,
+        *,
+        gsm_enabled: bool = False,
+    ) -> tuple[str | None, str]:
+        if self.sip_address.strip():
+            return "sip", self.sip_address.strip()
+        return None, ""
+
+    def is_callable(self, *, gsm_enabled: bool = False) -> bool:
+        route, _ = self.preferred_call_target(gsm_enabled=gsm_enabled)
+        return bool(route)
+
 
 class FakePeopleDirectory:
     """Minimal people-directory returning test contacts."""
@@ -107,6 +120,11 @@ class FakePeopleDirectory:
 
     def get_contacts(self) -> list[FakeContact]:
         return list(self._contacts)
+
+    def get_callable_contacts(self, *, gsm_enabled: bool = False) -> list[FakeContact]:
+        return [
+            contact for contact in self._contacts if contact.is_callable(gsm_enabled=gsm_enabled)
+        ]
 
 
 class FakeVoIPManager:


### PR DESCRIPTION
## What changed
- extend the mutable people model to carry both `sip_address` and `phone_number`
- add cloud-contact sync helpers that merge backend-managed contacts into `data/people/contacts.yaml`
- preserve local/manual contacts and local speed-dial entries while replacing only the cloud-managed subset
- add a one-time bootstrap upload path so a device with seeded local contacts can import them into backend authority when the backend contact list is empty
- dedupe matching seeded local contacts once the same contact is present as a backend-managed cloud contact
- keep Talk and voice flows SIP-first while GSM is still disabled
- add focused tests for merge behavior, bootstrap upload payloads, dedupe behavior, and SIP-vs-GSM route selection

## Why
The device runtime needs to consume approved contacts from the backend without wiping existing local configuration, while also providing a professional migration path for prestored seed contacts. After bootstrap, backend remains authoritative and the Pi returns to downstream sync only.

## Impact
- cloud-managed contacts reach the Pi runtime and persist in the mutable contact store
- prestored seed contacts can be promoted into backend authority on first sync when needed
- matching local seed contacts are deduped once their backend-managed counterpart exists
- phone-only contacts are stored for later GSM support but do not appear as callable while GSM is disabled

## Validation
- `uv run pytest tests/test_people_cloud_sync.py tests/test_cloud_contact_bootstrap.py tests/test_config_helpers.py`
