### PR TITLE
[codex] Remove render-time power/GPS refresh work from the Setup screen

### DIFF
--- a/src/yoyopod/coordinators/screen.py
+++ b/src/yoyopod/coordinators/screen.py
@@ -60,8 +60,7 @@ class ScreenCoordinator:
             and self.runtime.power_screen is not None
             and self.runtime.screen_manager.current_screen == self.runtime.power_screen
         ):
-            self.runtime.power_screen.refresh_for_visible_tick()
-            self.runtime.power_screen.render()
+            self.refresh_current_screen()
 
     def refresh_current_screen(self) -> None:
         """Refresh whichever screen is currently visible."""

--- a/src/yoyopod/coordinators/screen.py
+++ b/src/yoyopod/coordinators/screen.py
@@ -60,6 +60,13 @@ class ScreenCoordinator:
             and self.runtime.power_screen is not None
             and self.runtime.screen_manager.current_screen == self.runtime.power_screen
         ):
+            refresh_for_visible_tick = getattr(
+                self.runtime.power_screen,
+                "refresh_for_visible_tick",
+                None,
+            )
+            if callable(refresh_for_visible_tick):
+                refresh_for_visible_tick()
             self.runtime.power_screen.render()
 
     def refresh_current_screen(self) -> None:

--- a/src/yoyopod/coordinators/screen.py
+++ b/src/yoyopod/coordinators/screen.py
@@ -60,13 +60,7 @@ class ScreenCoordinator:
             and self.runtime.power_screen is not None
             and self.runtime.screen_manager.current_screen == self.runtime.power_screen
         ):
-            refresh_for_visible_tick = getattr(
-                self.runtime.power_screen,
-                "refresh_for_visible_tick",
-                None,
-            )
-            if callable(refresh_for_visible_tick):
-                refresh_for_visible_tick()
+            self.runtime.power_screen.refresh_for_visible_tick()
             self.runtime.power_screen.render()
 
     def refresh_current_screen(self) -> None:

--- a/src/yoyopod/coordinators/screen.py
+++ b/src/yoyopod/coordinators/screen.py
@@ -72,7 +72,7 @@ class ScreenCoordinator:
         if current_screen is None:
             return
 
-        current_screen.render()
+        self.runtime.screen_manager.refresh_current_screen()
         logger.debug("  -> Current screen refreshed")
 
     def refresh_now_playing_screen(self) -> None:

--- a/src/yoyopod/runtime/screen_power.py
+++ b/src/yoyopod/runtime/screen_power.py
@@ -119,9 +119,7 @@ class ScreenPowerService:
             self.app.display.set_backlight(self.app._active_brightness)
 
         if render_current and self.app.screen_manager is not None:
-            current_screen = self.app.screen_manager.get_current_screen()
-            if current_screen is not None:
-                current_screen.render()
+            self.app.screen_manager.refresh_current_screen()
 
         if self.app._lvgl_backend is not None and self.app._lvgl_backend.initialized:
             self.app._lvgl_backend.force_refresh()
@@ -255,9 +253,7 @@ class ScreenPowerService:
         if now >= self.app._power_alert.expires_at:
             self.app._power_alert = None
             if self.app.screen_manager is not None:
-                current_screen = self.app.screen_manager.get_current_screen()
-                if current_screen is not None:
-                    current_screen.render()
+                self.app.screen_manager.refresh_current_screen()
             return False
 
         self.render_power_overlay(

--- a/src/yoyopod/ui/screens/manager.py
+++ b/src/yoyopod/ui/screens/manager.py
@@ -97,7 +97,7 @@ class ScreenManager:
         self.current_screen = self.screens[screen_name]
         self.current_screen.enter()
         self._connect_buttons()
-        self.current_screen.render()
+        self.refresh_current_screen()
         self._notify_screen_changed()
 
         logger.info(f"Pushed screen: {screen_name} (stack depth: {len(self.screen_stack)})")
@@ -129,7 +129,7 @@ class ScreenManager:
         self.current_screen = self.screen_stack.pop()
         self.current_screen.enter()
         self._connect_buttons()
-        self.current_screen.render()
+        self.refresh_current_screen()
         self._notify_screen_changed()
 
         logger.info(f"Popped screen (stack depth: {len(self.screen_stack)})")
@@ -162,7 +162,7 @@ class ScreenManager:
         self.current_screen = self.screens[screen_name]
         self.current_screen.enter()
         self._connect_buttons()
-        self.current_screen.render()
+        self.refresh_current_screen()
         self._notify_screen_changed()
 
         logger.info(f"Replaced screen with: {screen_name}")

--- a/src/yoyopod/ui/screens/manager.py
+++ b/src/yoyopod/ui/screens/manager.py
@@ -39,7 +39,7 @@ class ScreenManager:
     def __init__(
         self,
         display: Display,
-        input_manager: Optional['InputManager'] = None,
+        input_manager: Optional["InputManager"] = None,
         router: Optional[ScreenRouter] = None,
         on_screen_changed: Optional[Callable[[Optional[str]], None]] = None,
         action_scheduler: Optional[Callable[[Callable[[], None]], None]] = None,
@@ -186,6 +186,11 @@ class ScreenManager:
         """Re-render the current screen."""
         if self.current_screen:
             started_at = time.monotonic()
+            refresh_for_visible_tick = getattr(
+                self.current_screen, "refresh_for_visible_tick", None
+            )
+            if callable(refresh_for_visible_tick):
+                refresh_for_visible_tick()
             self.current_screen.render()
             self._warn_if_slow(
                 "refresh_current_screen",
@@ -274,11 +279,13 @@ class ScreenManager:
 
         def wrap_with_refresh(action: "InputAction"):
             """Wrap action handler to automatically refresh display after execution."""
+
             def wrapper(data=None):
                 if self.action_scheduler is not None:
                     self.action_scheduler(lambda: dispatch_action(action, data))
                     return
                 dispatch_action(action, data)
+
             return wrapper
 
         for action in InputAction:

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -790,6 +790,8 @@ class PowerScreen(Screen):
         if not force and self._prepared_state is not None and not gps_refreshed:
             return self._prepared_state
 
+        # GPS refresh mutates shared modem state, so a successful query should be followed by a
+        # fresh provider read even when we would otherwise keep reusing cached prepared state.
         try:
             self._prepared_state = self._state_provider()
         except Exception:
@@ -897,6 +899,9 @@ class PowerScreen(Screen):
     def _refresh_after_page_change(self) -> None:
         """Refresh prepared state after explicit user navigation between pages."""
 
+        # Page navigation is still an explicit controller action, so we can refresh prepared state
+        # here without reintroducing render-time work. Keep providers cached/in-memory if this
+        # hook ever starts to feel expensive.
         self.refresh_prepared_state(
             force=True,
             allow_gps_refresh=self._current_page_title() == "GPS",

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -273,6 +273,8 @@ class PowerScreen(Screen):
         self._lvgl_view: "ScreenView | None" = None
         self._last_gps_query_at = 0.0
         self._gps_refresh_interval_seconds = 2.0
+        self._visible_tick_refresh_grace_seconds = 0.5
+        self._last_prepared_refresh_at = 0.0
         self._prepared_state: PowerScreenState | None = None
         self._cached_pages: list[PowerPage] | None = None
         self._cached_pages_signature: tuple[object, ...] | None = None
@@ -791,7 +793,8 @@ class PowerScreen(Screen):
         if allow_gps_refresh:
             self._refresh_gps_if_due()
         try:
-            self._prepared_state = self._state_provider()
+            self._prepared_state = self._normalize_prepared_state(self._state_provider())
+            self._last_prepared_refresh_at = time.monotonic()
         except Exception:
             self._prepared_state = PowerScreenState()
         return self._prepared_state
@@ -799,6 +802,12 @@ class PowerScreen(Screen):
     def refresh_for_visible_tick(self) -> None:
         """Refresh prepared state before a coordinator-driven visible-screen render."""
 
+        if (
+            self._prepared_state is not None
+            and (time.monotonic() - self._last_prepared_refresh_at)
+            < self._visible_tick_refresh_grace_seconds
+        ):
+            return
         # Determine GPS eligibility from the page the user is already viewing before this refresh
         # starts. Page navigation performs its own explicit refresh, so the pre-refresh page title
         # still represents the active page when the periodic visible-tick arrives.
@@ -806,16 +815,10 @@ class PowerScreen(Screen):
             allow_gps_refresh=self._current_page_title() == "GPS",
         )
 
-    def _prepared_pages(
-        self,
-        *,
-        state: PowerScreenState | None = None,
-    ) -> list[PowerPage]:
+    def _prepared_pages(self) -> list[PowerPage]:
         """Return cached page models until prepared state or voice inputs change."""
 
-        if state is not None:
-            resolved_state = state
-        elif self._prepared_state is None:
+        if self._prepared_state is None:
             resolved_state = PowerScreenState()
         else:
             resolved_state = self._prepared_state
@@ -832,6 +835,20 @@ class PowerScreen(Screen):
         self._cached_pages = self.build_pages(state=resolved_state)
         self._cached_pages_signature = cache_signature
         return self._cached_pages
+
+    @staticmethod
+    def _normalize_prepared_state(state: PowerScreenState) -> PowerScreenState:
+        """Freeze provider output into a self-owned prepared-state snapshot."""
+
+        return PowerScreenState(
+            snapshot=state.snapshot,
+            status=dict(state.status),
+            network_enabled=state.network_enabled,
+            network_rows=tuple(state.network_rows),
+            gps_rows=tuple(state.gps_rows),
+            playback_devices=tuple(state.playback_devices),
+            capture_devices=tuple(state.capture_devices),
+        )
 
     def _voice_page_signature(self) -> tuple[object, ...] | None:
         """Return the voice-facing inputs that affect Setup page content."""

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -262,6 +262,11 @@ class PowerScreen(Screen):
         self._lvgl_view: "ScreenView | None" = None
         self._last_gps_query_at = 0.0
         self._gps_refresh_interval_seconds = 2.0
+        self._prepared_state: PowerScreenState | None = None
+        self._cached_pages: list[PowerPage] | None = None
+        self._cached_pages_state: PowerScreenState | None = None
+        self._cached_pages_voice_signature: tuple[object, ...] | None = None
+        self._cached_pages_one_button_mode: bool | None = None
 
     def enter(self) -> None:
         """Create the LVGL view when the screen becomes active."""
@@ -272,6 +277,7 @@ class PowerScreen(Screen):
         self.in_detail = False
         if self._actions.refresh_voice_devices is not None:
             self._actions.refresh_voice_devices()
+        self.refresh_prepared_state(force=True, reason="enter")
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
@@ -302,7 +308,7 @@ class PowerScreen(Screen):
     def render(self) -> None:
         """Render the active Setup page."""
         lvgl_view = self._ensure_lvgl_view()
-        pages = self._build_pages_for_display()
+        pages = self._prepared_pages()
         if not pages:
             return
         active_page_index = self._page_index_for(pages)
@@ -625,29 +631,21 @@ class PowerScreen(Screen):
         status: dict[str, object] | None = None,
         state: PowerScreenState | None = None,
     ) -> list[PowerPage]:
-        """Build pages and opportunistically refresh GPS when the GPS page is active."""
+        """Return prepared pages for the current display state."""
 
         resolved_state = state or self._get_state()
-        pages = self.build_pages(
-            snapshot=snapshot,
-            status=status,
-            state=resolved_state,
-        )
-        if not pages:
-            return pages
-
-        active_page = pages[self._page_index_for(pages)]
-        if active_page.title != "GPS":
-            return pages
-
-        if self._maybe_refresh_gps_page():
-            pages = self.build_pages(state=self._get_state())
-        return pages
+        if snapshot is not None or status is not None:
+            return self.build_pages(
+                snapshot=snapshot,
+                status=status,
+                state=resolved_state,
+            )
+        return self._prepared_pages(state=resolved_state)
 
     def lvgl_payload(self) -> PowerScreenLvglPayload:
         """Return the current Setup LVGL payload without mutating controller state."""
 
-        pages = self.build_pages(state=self._get_state())
+        pages = self._prepared_pages()
         if not pages:
             return PowerScreenLvglPayload(
                 title_text="Setup",
@@ -762,8 +760,8 @@ class PowerScreen(Screen):
             )
         )
 
-    def _maybe_refresh_gps_page(self) -> bool:
-        """Query GPS when the user is actively viewing the GPS page."""
+    def _refresh_gps_if_due(self) -> bool:
+        """Query GPS through an explicit refresh hook when the GPS page is active."""
 
         now = time.monotonic()
         if now - self._last_gps_query_at < self._gps_refresh_interval_seconds:
@@ -781,12 +779,105 @@ class PowerScreen(Screen):
         return bool(coord)
 
     def _get_state(self) -> PowerScreenState:
-        """Return the prepared state for the current render."""
+        """Return cached prepared state, hydrating it only when missing."""
+
+        if self._prepared_state is None:
+            return self.refresh_prepared_state(force=True, reason="lazy_load")
+        return self._prepared_state
+
+    def refresh_prepared_state(
+        self,
+        *,
+        force: bool = False,
+        allow_gps_refresh: bool = False,
+        reason: str = "explicit",
+    ) -> PowerScreenState:
+        """Refresh and cache prepared Setup state outside render-time code paths."""
+
+        gps_refreshed = allow_gps_refresh and self._refresh_gps_if_due()
+        if not force and self._prepared_state is not None and not gps_refreshed:
+            return self._prepared_state
 
         try:
-            return self._state_provider()
+            self._prepared_state = self._state_provider()
         except Exception:
-            return PowerScreenState()
+            self._prepared_state = PowerScreenState()
+        return self._prepared_state
+
+    def refresh_for_visible_tick(self) -> None:
+        """Refresh prepared state before a coordinator-driven visible-screen render."""
+
+        self.refresh_prepared_state(
+            force=True,
+            allow_gps_refresh=self._current_page_title() == "GPS",
+            reason="visible_tick",
+        )
+
+    def _prepared_pages(
+        self,
+        *,
+        state: PowerScreenState | None = None,
+    ) -> list[PowerPage]:
+        """Return cached page models until prepared state or voice inputs change."""
+
+        resolved_state = state or self._get_state()
+        voice_signature = self._voice_page_signature()
+        one_button_mode = self.is_one_button_mode()
+        if (
+            self._cached_pages is not None
+            and self._cached_pages_state == resolved_state
+            and self._cached_pages_voice_signature == voice_signature
+            and self._cached_pages_one_button_mode == one_button_mode
+        ):
+            return self._cached_pages
+
+        self._cached_pages = self.build_pages(state=resolved_state)
+        self._cached_pages_state = resolved_state
+        self._cached_pages_voice_signature = voice_signature
+        self._cached_pages_one_button_mode = one_button_mode
+        return self._cached_pages
+
+    def _invalidate_page_cache(self) -> None:
+        """Drop cached page models after local UI state mutations."""
+
+        self._cached_pages = None
+        self._cached_pages_state = None
+        self._cached_pages_voice_signature = None
+        self._cached_pages_one_button_mode = None
+
+    def _voice_page_signature(self) -> tuple[object, ...] | None:
+        """Return the voice-facing inputs that affect Setup page content."""
+
+        if self.context is None:
+            return None
+
+        voice = self.context.voice
+        return (
+            voice.commands_enabled,
+            voice.ai_requests_enabled,
+            voice.screen_read_enabled,
+            voice.speaker_device_id,
+            voice.capture_device_id,
+            voice.mic_muted,
+            voice.output_volume,
+        )
+
+    def _current_page_title(self) -> str | None:
+        """Return the currently selected Setup page title from prepared pages."""
+
+        pages = self._prepared_pages()
+        if not pages:
+            return None
+        return pages[self._page_index_for(pages)].title
+
+    def _refresh_after_page_change(self, *, reason: str) -> None:
+        """Refresh prepared state after explicit user navigation between pages."""
+
+        self.refresh_prepared_state(
+            force=True,
+            allow_gps_refresh=self._current_page_title() == "GPS",
+            reason=reason,
+        )
 
     def _get_snapshot(self) -> Optional["PowerSnapshot"]:
         """Return the latest power snapshot."""
@@ -977,7 +1068,7 @@ class PowerScreen(Screen):
     def _active_pages(self) -> list[PowerPage]:
         """Return the current page list for navigation helpers."""
 
-        return self.build_pages(state=self._get_state())
+        return self._prepared_pages()
 
     def _active_page(self) -> PowerPage:
         """Return the current active page."""
@@ -1021,16 +1112,19 @@ class PowerScreen(Screen):
         row_index = self.selected_row
         if row_index == 0:
             self.context.configure_voice(commands_enabled=not self.context.voice.commands_enabled)
+            self._invalidate_page_cache()
             return
         if row_index == 1:
             self.context.configure_voice(
                 ai_requests_enabled=not self.context.voice.ai_requests_enabled
             )
+            self._invalidate_page_cache()
             return
         if row_index == 2:
             self.context.configure_voice(
                 screen_read_enabled=not self.context.voice.screen_read_enabled
             )
+            self._invalidate_page_cache()
             return
         if row_index == 3:
             self._cycle_speaker_device(direction)
@@ -1049,6 +1143,7 @@ class PowerScreen(Screen):
         else:
             volume = self.context.voice.output_volume + (5 * direction)
             self.context.set_volume(max(0, min(100, volume)))
+            self._invalidate_page_cache()
             return
         self._sync_context_output_volume(current)
 
@@ -1086,6 +1181,7 @@ class PowerScreen(Screen):
             direction,
         )
         self.context.configure_voice(speaker_device_id=next_device)
+        self._invalidate_page_cache()
         if self._actions.persist_speaker_device is not None:
             self._actions.persist_speaker_device(next_device)
 
@@ -1098,18 +1194,27 @@ class PowerScreen(Screen):
             direction,
         )
         self.context.configure_voice(capture_device_id=next_device)
+        self._invalidate_page_cache()
         if self._actions.persist_capture_device is not None:
             self._actions.persist_capture_device(next_device)
 
     def _next_page(self) -> None:
         """Advance to the next page with wraparound."""
-        self.page_index = (self.page_index + 1) % len(self._active_pages())
+        pages = self._active_pages()
+        if not pages:
+            return
+        self.page_index = (self.page_index + 1) % len(pages)
         self.selected_row = 0
+        self._refresh_after_page_change(reason="next_page")
 
     def _previous_page(self) -> None:
         """Return to the previous page with wraparound."""
-        self.page_index = (self.page_index - 1) % len(self._active_pages())
+        pages = self._active_pages()
+        if not pages:
+            return
+        self.page_index = (self.page_index - 1) % len(pages)
         self.selected_row = 0
+        self._refresh_after_page_change(reason="previous_page")
 
     def on_advance(self, data=None) -> None:
         """Single-button tap cycles pages."""
@@ -1214,6 +1319,7 @@ class PowerScreen(Screen):
 
         if self.context is not None:
             self.context.set_mic_muted(muted)
+        self._invalidate_page_cache()
         action = self._actions.mute if muted else self._actions.unmute
         if action is not None:
             action()
@@ -1224,3 +1330,4 @@ class PowerScreen(Screen):
         if volume is None or self.context is None:
             return
         self.context.cache_output_volume(volume)
+        self._invalidate_page_cache()

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Callable, Optional
 
@@ -47,7 +47,7 @@ class PowerScreenState:
     """Prepared power/setup state consumed by the Setup screen."""
 
     snapshot: "PowerSnapshot | None" = None
-    status: tuple[tuple[str, object], ...] = ()
+    status: dict[str, object] = field(default_factory=dict)
     network_enabled: bool = False
     network_rows: tuple[tuple[str, str], ...] = ()
     gps_rows: tuple[tuple[str, str], ...] = ()
@@ -91,25 +91,6 @@ _VOICE_PAGE_SIGNATURE_FIELDS = (
     "mic_muted",
     "output_volume",
 )
-_VOICE_STATE_FIELD_NAMES = (
-    "commands_enabled",
-    "ai_requests_enabled",
-    "screen_read_enabled",
-    "stt_enabled",
-    "tts_enabled",
-    "mic_muted",
-    "speaker_device_id",
-    "capture_device_id",
-    "stt_available",
-    "tts_available",
-    "last_transcript",
-    "last_spoken_text",
-    "last_mode",
-    "output_volume",
-    "interaction",
-)
-
-
 def _build_network_rows_from_manager(network_manager: object | None) -> list[tuple[str, str]]:
     """Build the cellular network status rows from a backend-facing manager."""
 
@@ -213,7 +194,7 @@ def build_power_screen_state_provider(
 
         return PowerScreenState(
             snapshot=snapshot,
-            status=tuple(sorted(status.items())),
+            status=status,
             network_enabled=bool(
                 network_manager is not None and getattr(network_manager.config, "enabled", False)
             ),
@@ -292,7 +273,7 @@ class PowerScreen(Screen):
         self._gps_refresh_interval_seconds = 2.0
         self._prepared_state: PowerScreenState | None = None
         self._cached_pages: list[PowerPage] | None = None
-        self._cached_pages_state: PowerScreenState | None = None
+        self._cached_pages_signature: tuple[object, ...] | None = None
         self._cached_pages_voice_signature: tuple[object, ...] | None = None
         self._cached_pages_one_button_mode: bool | None = None
 
@@ -789,10 +770,10 @@ class PowerScreen(Screen):
         return bool(coord)
 
     def _get_state(self) -> PowerScreenState:
-        """Return cached prepared state without hydrating from render-adjacent paths."""
+        """Return cached prepared state, hydrating it for explicit non-render callers."""
 
         if self._prepared_state is None:
-            return PowerScreenState()
+            return self.refresh_prepared_state(force=True)
         return self._prepared_state
 
     def refresh_prepared_state(
@@ -828,19 +809,24 @@ class PowerScreen(Screen):
     ) -> list[PowerPage]:
         """Return cached page models until prepared state or voice inputs change."""
 
-        resolved_state = state or self._get_state()
+        resolved_state = state or self._prepared_state or PowerScreenState()
         voice_signature = self._voice_page_signature()
         one_button_mode = self.is_one_button_mode()
+        cache_signature = self._page_cache_signature(
+            state=resolved_state,
+            voice_signature=voice_signature,
+            one_button_mode=one_button_mode,
+        )
         if (
             self._cached_pages is not None
-            and self._cached_pages_state == resolved_state
+            and self._cached_pages_signature == cache_signature
             and self._cached_pages_voice_signature == voice_signature
             and self._cached_pages_one_button_mode == one_button_mode
         ):
             return self._cached_pages
 
         self._cached_pages = self.build_pages(state=resolved_state)
-        self._cached_pages_state = resolved_state
+        self._cached_pages_signature = cache_signature
         self._cached_pages_voice_signature = voice_signature
         self._cached_pages_one_button_mode = one_button_mode
         return self._cached_pages
@@ -849,7 +835,7 @@ class PowerScreen(Screen):
         """Drop cached page models after local UI state mutations."""
 
         self._cached_pages = None
-        self._cached_pages_state = None
+        self._cached_pages_signature = None
         self._cached_pages_voice_signature = None
         self._cached_pages_one_button_mode = None
 
@@ -860,11 +846,28 @@ class PowerScreen(Screen):
             return None
 
         voice = self.context.voice
-        voice_field_names = tuple(field_info.name for field_info in fields(type(voice)))
-        assert voice_field_names == _VOICE_STATE_FIELD_NAMES, (
-            "VoiceState field list changed; revisit PowerScreen voice cache signature."
-        )
         return tuple(getattr(voice, field_name) for field_name in _VOICE_PAGE_SIGNATURE_FIELDS)
+
+    @staticmethod
+    def _page_cache_signature(
+        *,
+        state: PowerScreenState,
+        voice_signature: tuple[object, ...] | None,
+        one_button_mode: bool,
+    ) -> tuple[object, ...]:
+        """Return the stable inputs used to reuse prepared page models."""
+
+        return (
+            state.snapshot,
+            tuple(sorted(state.status.items())),
+            state.network_enabled,
+            state.network_rows,
+            state.gps_rows,
+            state.playback_devices,
+            state.capture_devices,
+            voice_signature,
+            one_button_mode,
+        )
 
     def _current_page_title(self) -> str | None:
         """Return the currently selected Setup page title from prepared pages."""

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -286,7 +286,7 @@ class PowerScreen(Screen):
         self.in_detail = False
         if self._actions.refresh_voice_devices is not None:
             self._actions.refresh_voice_devices()
-        self.refresh_prepared_state(force=True)
+        self.refresh_prepared_state()
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
@@ -773,26 +773,23 @@ class PowerScreen(Screen):
         """Return cached prepared state, hydrating it for explicit non-render callers."""
 
         if self._prepared_state is None:
-            return self.refresh_prepared_state(force=True)
+            return self.refresh_prepared_state()
         return self._prepared_state
 
     def refresh_prepared_state(
         self,
         *,
-        force: bool = False,
         allow_gps_refresh: bool = False,
     ) -> PowerScreenState:
         """Refresh and cache prepared Setup state outside render-time code paths."""
 
-        gps_refreshed = allow_gps_refresh and self._refresh_gps_if_due()
-        if not force and self._prepared_state is not None and not gps_refreshed:
-            return self._prepared_state
-
-        # Forced visible-tick refreshes intentionally rerun the provider; page caching only skips
-        # the later build_pages work. If provider inputs ever become expensive, memoize them below
-        # this screen layer rather than trying to recover that cost from render-time caching.
-        # GPS refresh mutates shared modem state, so a successful query should be followed by a
-        # fresh provider read even when we would otherwise keep reusing cached prepared state.
+        # Explicit refresh hooks intentionally rerun the provider; page caching only skips the
+        # later build_pages work. If provider inputs ever become expensive, memoize them below this
+        # screen layer rather than trying to recover that cost from render-time caching.
+        # GPS refresh mutates shared modem state, so a successful query should be followed by the
+        # same fresh provider read as any other explicit hydration path.
+        if allow_gps_refresh:
+            self._refresh_gps_if_due()
         try:
             self._prepared_state = self._state_provider()
         except Exception:
@@ -806,7 +803,6 @@ class PowerScreen(Screen):
         # starts. Page navigation performs its own explicit refresh, so the pre-refresh page title
         # still represents the active page when the periodic visible-tick arrives.
         self.refresh_prepared_state(
-            force=True,
             allow_gps_refresh=self._current_page_title() == "GPS",
         )
 
@@ -880,7 +876,7 @@ class PowerScreen(Screen):
 
         return (
             PowerScreen._snapshot_page_signature(state.snapshot),
-            tuple(sorted(state.status.items())),
+            tuple(sorted(state.status.items(), key=lambda item: item[0])),
             state.network_enabled,
             state.network_rows,
             state.gps_rows,
@@ -905,7 +901,6 @@ class PowerScreen(Screen):
         # here without reintroducing render-time work. Keep providers cached/in-memory if this
         # hook ever starts to feel expensive.
         self.refresh_prepared_state(
-            force=True,
             allow_gps_refresh=self._current_page_title() == "GPS",
         )
 

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -277,7 +277,7 @@ class PowerScreen(Screen):
         self.in_detail = False
         if self._actions.refresh_voice_devices is not None:
             self._actions.refresh_voice_devices()
-        self.refresh_prepared_state(force=True, reason="enter")
+        self.refresh_prepared_state(force=True)
         self._ensure_lvgl_view()
 
     def exit(self) -> None:
@@ -624,24 +624,6 @@ class PowerScreen(Screen):
         )
         return pages
 
-    def _build_pages_for_display(
-        self,
-        *,
-        snapshot: Optional["PowerSnapshot"] = None,
-        status: dict[str, object] | None = None,
-        state: PowerScreenState | None = None,
-    ) -> list[PowerPage]:
-        """Return prepared pages for the current display state."""
-
-        resolved_state = state or self._get_state()
-        if snapshot is not None or status is not None:
-            return self.build_pages(
-                snapshot=snapshot,
-                status=status,
-                state=resolved_state,
-            )
-        return self._prepared_pages(state=resolved_state)
-
     def lvgl_payload(self) -> PowerScreenLvglPayload:
         """Return the current Setup LVGL payload without mutating controller state."""
 
@@ -779,10 +761,10 @@ class PowerScreen(Screen):
         return bool(coord)
 
     def _get_state(self) -> PowerScreenState:
-        """Return cached prepared state, hydrating it only when missing."""
+        """Return cached prepared state without hydrating from render-adjacent paths."""
 
         if self._prepared_state is None:
-            return self.refresh_prepared_state(force=True, reason="lazy_load")
+            return PowerScreenState()
         return self._prepared_state
 
     def refresh_prepared_state(
@@ -790,7 +772,6 @@ class PowerScreen(Screen):
         *,
         force: bool = False,
         allow_gps_refresh: bool = False,
-        reason: str = "explicit",
     ) -> PowerScreenState:
         """Refresh and cache prepared Setup state outside render-time code paths."""
 
@@ -810,7 +791,6 @@ class PowerScreen(Screen):
         self.refresh_prepared_state(
             force=True,
             allow_gps_refresh=self._current_page_title() == "GPS",
-            reason="visible_tick",
         )
 
     def _prepared_pages(
@@ -870,13 +850,12 @@ class PowerScreen(Screen):
             return None
         return pages[self._page_index_for(pages)].title
 
-    def _refresh_after_page_change(self, *, reason: str) -> None:
+    def _refresh_after_page_change(self) -> None:
         """Refresh prepared state after explicit user navigation between pages."""
 
         self.refresh_prepared_state(
             force=True,
             allow_gps_refresh=self._current_page_title() == "GPS",
-            reason=reason,
         )
 
     def _get_snapshot(self) -> Optional["PowerSnapshot"]:
@@ -1205,7 +1184,7 @@ class PowerScreen(Screen):
             return
         self.page_index = (self.page_index + 1) % len(pages)
         self.selected_row = 0
-        self._refresh_after_page_change(reason="next_page")
+        self._refresh_after_page_change()
 
     def _previous_page(self) -> None:
         """Return to the previous page with wraparound."""
@@ -1214,7 +1193,7 @@ class PowerScreen(Screen):
             return
         self.page_index = (self.page_index - 1) % len(pages)
         self.selected_row = 0
-        self._refresh_after_page_change(reason="previous_page")
+        self._refresh_after_page_change()
 
     def on_advance(self, data=None) -> None:
         """Single-button tap cycles pages."""

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -833,14 +833,6 @@ class PowerScreen(Screen):
         self._cached_pages_one_button_mode = one_button_mode
         return self._cached_pages
 
-    def _invalidate_page_cache(self) -> None:
-        """Drop cached page models after local UI state mutations."""
-
-        self._cached_pages = None
-        self._cached_pages_signature = None
-        self._cached_pages_voice_signature = None
-        self._cached_pages_one_button_mode = None
-
     def _voice_page_signature(self) -> tuple[object, ...] | None:
         """Return the voice-facing inputs that affect Setup page content."""
 
@@ -849,6 +841,29 @@ class PowerScreen(Screen):
 
         voice = self.context.voice
         return tuple(getattr(voice, field_name) for field_name in _VOICE_PAGE_SIGNATURE_FIELDS)
+
+    @staticmethod
+    def _snapshot_page_signature(snapshot: "PowerSnapshot | None") -> tuple[object, ...] | None:
+        """Return only the snapshot fields that affect prepared Setup page content."""
+
+        if snapshot is None:
+            return None
+
+        return (
+            snapshot.available,
+            snapshot.error,
+            snapshot.source,
+            snapshot.device.model,
+            snapshot.battery.level_percent,
+            snapshot.battery.charging,
+            snapshot.battery.power_plugged,
+            snapshot.battery.voltage_volts,
+            snapshot.battery.temperature_celsius,
+            snapshot.rtc.time,
+            snapshot.rtc.alarm_enabled,
+            snapshot.rtc.alarm_time,
+            snapshot.shutdown.safe_shutdown_level_percent,
+        )
 
     @staticmethod
     def _page_cache_signature(
@@ -860,7 +875,7 @@ class PowerScreen(Screen):
         """Return the stable inputs used to reuse prepared page models."""
 
         return (
-            state.snapshot,
+            PowerScreen._snapshot_page_signature(state.snapshot),
             tuple(sorted(state.status.items())),
             state.network_enabled,
             state.network_rows,
@@ -1120,19 +1135,16 @@ class PowerScreen(Screen):
         row_index = self.selected_row
         if row_index == 0:
             self.context.configure_voice(commands_enabled=not self.context.voice.commands_enabled)
-            self._invalidate_page_cache()
             return
         if row_index == 1:
             self.context.configure_voice(
                 ai_requests_enabled=not self.context.voice.ai_requests_enabled
             )
-            self._invalidate_page_cache()
             return
         if row_index == 2:
             self.context.configure_voice(
                 screen_read_enabled=not self.context.voice.screen_read_enabled
             )
-            self._invalidate_page_cache()
             return
         if row_index == 3:
             self._cycle_speaker_device(direction)
@@ -1151,7 +1163,6 @@ class PowerScreen(Screen):
         else:
             volume = self.context.voice.output_volume + (5 * direction)
             self.context.set_volume(max(0, min(100, volume)))
-            self._invalidate_page_cache()
             return
         self._sync_context_output_volume(current)
 
@@ -1189,7 +1200,6 @@ class PowerScreen(Screen):
             direction,
         )
         self.context.configure_voice(speaker_device_id=next_device)
-        self._invalidate_page_cache()
         if self._actions.persist_speaker_device is not None:
             self._actions.persist_speaker_device(next_device)
 
@@ -1202,7 +1212,6 @@ class PowerScreen(Screen):
             direction,
         )
         self.context.configure_voice(capture_device_id=next_device)
-        self._invalidate_page_cache()
         if self._actions.persist_capture_device is not None:
             self._actions.persist_capture_device(next_device)
 
@@ -1327,7 +1336,6 @@ class PowerScreen(Screen):
 
         if self.context is not None:
             self.context.set_mic_muted(muted)
-        self._invalidate_page_cache()
         action = self._actions.mute if muted else self._actions.unmute
         if action is not None:
             action()
@@ -1338,4 +1346,3 @@ class PowerScreen(Screen):
         if volume is None or self.context is None:
             return
         self.context.cache_output_volume(volume)
-        self._invalidate_page_cache()

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -790,6 +790,9 @@ class PowerScreen(Screen):
         if not force and self._prepared_state is not None and not gps_refreshed:
             return self._prepared_state
 
+        # Forced visible-tick refreshes intentionally rerun the provider; page caching only skips
+        # the later build_pages work. If provider inputs ever become expensive, memoize them below
+        # this screen layer rather than trying to recover that cost from render-time caching.
         # GPS refresh mutates shared modem state, so a successful query should be followed by a
         # fresh provider read even when we would otherwise keep reusing cached prepared state.
         try:
@@ -801,6 +804,9 @@ class PowerScreen(Screen):
     def refresh_for_visible_tick(self) -> None:
         """Refresh prepared state before a coordinator-driven visible-screen render."""
 
+        # Determine GPS eligibility from the page the user is already viewing before this refresh
+        # starts. Page navigation performs its own explicit refresh, so the pre-refresh page title
+        # still represents the active page when the periodic visible-tick arrives.
         self.refresh_prepared_state(
             force=True,
             allow_gps_refresh=self._current_page_title() == "GPS",
@@ -813,7 +819,12 @@ class PowerScreen(Screen):
     ) -> list[PowerPage]:
         """Return cached page models until prepared state or voice inputs change."""
 
-        resolved_state = state or self._prepared_state or PowerScreenState()
+        if state is not None:
+            resolved_state = state
+        elif self._prepared_state is None:
+            resolved_state = PowerScreenState()
+        else:
+            resolved_state = self._prepared_state
         voice_signature = self._voice_page_signature()
         one_button_mode = self.is_one_button_mode()
         cache_signature = self._page_cache_signature(

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -276,8 +276,6 @@ class PowerScreen(Screen):
         self._prepared_state: PowerScreenState | None = None
         self._cached_pages: list[PowerPage] | None = None
         self._cached_pages_signature: tuple[object, ...] | None = None
-        self._cached_pages_voice_signature: tuple[object, ...] | None = None
-        self._cached_pages_one_button_mode: bool | None = None
 
     def enter(self) -> None:
         """Create the LVGL view when the screen becomes active."""
@@ -832,18 +830,11 @@ class PowerScreen(Screen):
             voice_signature=voice_signature,
             one_button_mode=one_button_mode,
         )
-        if (
-            self._cached_pages is not None
-            and self._cached_pages_signature == cache_signature
-            and self._cached_pages_voice_signature == voice_signature
-            and self._cached_pages_one_button_mode == one_button_mode
-        ):
+        if self._cached_pages is not None and self._cached_pages_signature == cache_signature:
             return self._cached_pages
 
         self._cached_pages = self.build_pages(state=resolved_state)
         self._cached_pages_signature = cache_signature
-        self._cached_pages_voice_signature = voice_signature
-        self._cached_pages_one_button_mode = one_button_mode
         return self._cached_pages
 
     def _voice_page_signature(self) -> tuple[object, ...] | None:

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, fields
 from datetime import datetime
 from typing import TYPE_CHECKING, Callable, Optional
 
@@ -47,7 +47,7 @@ class PowerScreenState:
     """Prepared power/setup state consumed by the Setup screen."""
 
     snapshot: "PowerSnapshot | None" = None
-    status: dict[str, object] = field(default_factory=dict)
+    status: tuple[tuple[str, object], ...] = ()
     network_enabled: bool = False
     network_rows: tuple[tuple[str, str], ...] = ()
     gps_rows: tuple[tuple[str, str], ...] = ()
@@ -80,6 +80,34 @@ class PowerScreenLvglPayload:
     items: tuple[str, ...]
     current_page_index: int
     total_pages: int
+
+
+_VOICE_PAGE_SIGNATURE_FIELDS = (
+    "commands_enabled",
+    "ai_requests_enabled",
+    "screen_read_enabled",
+    "speaker_device_id",
+    "capture_device_id",
+    "mic_muted",
+    "output_volume",
+)
+_VOICE_STATE_FIELD_NAMES = (
+    "commands_enabled",
+    "ai_requests_enabled",
+    "screen_read_enabled",
+    "stt_enabled",
+    "tts_enabled",
+    "mic_muted",
+    "speaker_device_id",
+    "capture_device_id",
+    "stt_available",
+    "tts_available",
+    "last_transcript",
+    "last_spoken_text",
+    "last_mode",
+    "output_volume",
+    "interaction",
+)
 
 
 def _build_network_rows_from_manager(network_manager: object | None) -> list[tuple[str, str]]:
@@ -185,7 +213,7 @@ def build_power_screen_state_provider(
 
         return PowerScreenState(
             snapshot=snapshot,
-            status=status,
+            status=tuple(sorted(status.items())),
             network_enabled=bool(
                 network_manager is not None and getattr(network_manager.config, "enabled", False)
             ),
@@ -597,7 +625,7 @@ class PowerScreen(Screen):
         """Build compact setup pages for rendering and tests."""
         resolved_state = state or self._get_state()
         resolved_snapshot = snapshot if snapshot is not None else resolved_state.snapshot
-        resolved_status = status if status is not None else resolved_state.status
+        resolved_status = status if status is not None else dict(resolved_state.status)
         battery_rows = self._build_battery_rows(snapshot=resolved_snapshot)
         runtime_rows = self._build_runtime_rows(
             snapshot=resolved_snapshot,
@@ -832,15 +860,11 @@ class PowerScreen(Screen):
             return None
 
         voice = self.context.voice
-        return (
-            voice.commands_enabled,
-            voice.ai_requests_enabled,
-            voice.screen_read_enabled,
-            voice.speaker_device_id,
-            voice.capture_device_id,
-            voice.mic_muted,
-            voice.output_volume,
+        voice_field_names = tuple(field_info.name for field_info in fields(type(voice)))
+        assert voice_field_names == _VOICE_STATE_FIELD_NAMES, (
+            "VoiceState field list changed; revisit PowerScreen voice cache signature."
         )
+        return tuple(getattr(voice, field_name) for field_name in _VOICE_PAGE_SIGNATURE_FIELDS)
 
     def _current_page_title(self) -> str | None:
         """Return the currently selected Setup page title from prepared pages."""

--- a/src/yoyopod/ui/screens/system/power.py
+++ b/src/yoyopod/ui/screens/system/power.py
@@ -91,6 +91,8 @@ _VOICE_PAGE_SIGNATURE_FIELDS = (
     "mic_muted",
     "output_volume",
 )
+
+
 def _build_network_rows_from_manager(network_manager: object | None) -> list[tuple[str, str]]:
     """Build the cellular network status rows from a backend-facing manager."""
 

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -64,10 +64,14 @@ class FakeScreen:
 
     def __init__(self) -> None:
         self.render_calls = 0
+        self.refresh_for_visible_tick_calls = 0
         self.route_name: str | None = None
 
     def render(self) -> None:
         self.render_calls += 1
+
+    def refresh_for_visible_tick(self) -> None:
+        self.refresh_for_visible_tick_calls += 1
 
 
 class FakeIncomingCallScreen(FakeScreen):
@@ -1077,10 +1081,12 @@ def test_periodic_power_refresh_only_renders_visible_power_screen() -> None:
 
     app._update_power_screen_if_needed()
     assert app.power_screen.render_calls == 0
+    assert app.power_screen.refresh_for_visible_tick_calls == 0
 
     screen_manager.push_screen("power")
     app._update_power_screen_if_needed()
     assert app.power_screen.render_calls == 1
+    assert app.power_screen.refresh_for_visible_tick_calls == 1
 
 
 def test_power_poll_honors_interval_and_tracks_unavailable_backend() -> None:
@@ -1634,6 +1640,7 @@ def test_runtime_loop_service_refreshes_visible_power_screen() -> None:
 
     assert updated_at == 1.0
     assert app.power_screen.render_calls > render_calls_before
+    assert app.power_screen.refresh_for_visible_tick_calls > 0
 
 
 def test_runtime_loop_relaxes_idle_cadence_and_exposes_snapshot() -> None:

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -39,6 +39,7 @@ from yoyopod.fsm import (
 )
 from yoyopod.power import BatteryState, PowerSnapshot
 from yoyopod.runtime.loop import RuntimeLoopService
+from yoyopod.runtime.models import PowerAlert
 from yoyopod.ui.input import InputManager, InteractionProfile
 
 
@@ -1242,6 +1243,35 @@ def test_user_activity_event_wakes_screen_and_refreshes_current_screen() -> None
     assert app.menu_screen.render_calls == render_calls_before + 1
 
 
+def test_user_activity_event_wakes_screen_and_refreshes_visible_power_screen_hook() -> None:
+    """Wake renders should route visible Setup screens through the shared refresh hook."""
+
+    app, _, screen_manager = _build_app_with_power(
+        FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+    app.display = FakeDisplay()
+    app.app_settings = SimpleNamespace(
+        ui=SimpleNamespace(screen_timeout_seconds=300),
+        display=SimpleNamespace(brightness=75, backlight_timeout_seconds=30),
+    )
+
+    app._screen_timeout_seconds = app._resolve_screen_timeout_seconds()
+    app._active_brightness = app._resolve_active_brightness()
+    app._configure_screen_power(initial_now=0.0)
+    screen_manager.push_screen("power")
+    app._sleep_screen(31.0)
+
+    render_calls_before = app.power_screen.render_calls
+    refresh_calls_before = app.power_screen.refresh_for_visible_tick_calls
+
+    _publish_from_worker(app, UserActivityEvent(action_name="select"))
+
+    assert app.event_bus.drain() == 1
+    assert app.context.screen_awake is True
+    assert app.power_screen.render_calls == render_calls_before + 1
+    assert app.power_screen.refresh_for_visible_tick_calls == refresh_calls_before + 1
+
+
 def test_status_exposes_input_and_responsiveness_markers() -> None:
     """Diagnostics status should distinguish raw input liveness from handled input."""
 
@@ -1444,6 +1474,31 @@ def test_power_restore_cancels_pending_shutdown() -> None:
     assert app._pending_shutdown is None
     assert app._power_alert is not None
     assert app._power_alert.title == "Power Restored"
+
+
+def test_expired_power_alert_refreshes_visible_power_screen_through_shared_hook() -> None:
+    """Overlay dismissal should reuse the shared refresh path for the Setup screen."""
+
+    app, _, screen_manager = _build_app_with_power(
+        FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+    screen_manager.push_screen("power")
+    app._power_alert = PowerAlert(
+        title="Low Battery",
+        subtitle="15% remaining",
+        color=(255, 255, 0),
+        expires_at=0.0,
+    )
+
+    render_calls_before = app.power_screen.render_calls
+    refresh_calls_before = app.power_screen.refresh_for_visible_tick_calls
+
+    handled = app.screen_power_service.update_power_overlays(now=1.0)
+
+    assert handled is False
+    assert app._power_alert is None
+    assert app.power_screen.render_calls == render_calls_before + 1
+    assert app.power_screen.refresh_for_visible_tick_calls == refresh_calls_before + 1
 
 
 def test_pending_shutdown_runs_hooks_and_requests_system_poweroff(tmp_path) -> None:

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -46,9 +46,12 @@ class RenderableScreen(Protocol):
     """Small screen surface used by orchestration test doubles."""
 
     render_calls: int
+    refresh_for_visible_tick_calls: int
     route_name: str | None
 
     def render(self) -> None: ...
+
+    def refresh_for_visible_tick(self) -> None: ...
 
 
 class IncomingCallScreenLike(RenderableScreen, Protocol):
@@ -143,6 +146,12 @@ class FakeScreenManager:
 
     def get_current_screen(self) -> RenderableScreen | None:
         return self.current_screen
+
+    def refresh_current_screen(self) -> None:
+        if self.current_screen is None:
+            return
+        self.current_screen.refresh_for_visible_tick()
+        self.current_screen.render()
 
     def _notify_screen_changed(self, route_name: str | None) -> None:
         if self.on_screen_changed is not None:
@@ -1085,6 +1094,19 @@ def test_periodic_power_refresh_only_renders_visible_power_screen() -> None:
 
     screen_manager.push_screen("power")
     app._update_power_screen_if_needed()
+    assert app.power_screen.render_calls == 1
+    assert app.power_screen.refresh_for_visible_tick_calls == 1
+
+
+def test_power_poll_refreshes_visible_power_screen_through_shared_refresh_hook() -> None:
+    """Power snapshot refreshes should reuse the generic visible-screen refresh hook."""
+    app, _, screen_manager = _build_app_with_power(
+        FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+    screen_manager.push_screen("power")
+
+    app._poll_power_status(now=0.0, force=True)
+
     assert app.power_screen.render_calls == 1
     assert app.power_screen.refresh_for_visible_tick_calls == 1
 

--- a/tests/test_network_ui.py
+++ b/tests/test_network_ui.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from yoyopod.app_context import AppContext
 from yoyopod.network.models import GpsCoordinate, ModemPhase, ModemState, SignalInfo
+from yoyopod.ui.input import InteractionProfile
 from yoyopod.ui.screens.system.power import (
     PowerScreen,
     build_power_screen_actions,
@@ -121,25 +123,53 @@ def test_gps_page_no_fix():
     assert ("Lat", "--") in rows
 
 
-def test_active_gps_page_refreshes_coordinates_before_render():
-    """The GPS Setup page should trigger a GPS query when it becomes active."""
+def test_gps_page_render_does_not_query_coordinates():
+    """GPS render helpers should consume cached state instead of querying coordinates."""
 
     nm = FakeNetworkManager()
     nm._state.gps = GpsCoordinate(lat=48.8738, lng=2.3522, altitude=349.6, speed=0.0)
     screen = PowerScreen(
         FakeDisplay(),
+        AppContext(interaction_profile=InteractionProfile.ONE_BUTTON),
         state_provider=build_power_screen_state_provider(network_manager=nm),
         actions=build_power_screen_actions(network_manager=nm),
     )
+    screen.enter()
     screen.page_index = 2
 
-    pages = screen._build_pages_for_display()
+    payload = screen.lvgl_payload()
+
+    assert nm.query_gps_calls == 0
+    assert payload.title_text == "GPS"
+    assert payload.items == (
+        "Fix: Yes",
+        "Lat: 48.873800",
+        "Lng: 2.352200",
+        "Alt: 349.6m",
+        "Speed: 0.0km/h",
+    )
+
+
+def test_active_gps_page_refreshes_coordinates_via_explicit_state_hook():
+    """The GPS Setup page should only query coordinates through an explicit refresh hook."""
+
+    nm = FakeNetworkManager()
+    nm._state.gps = GpsCoordinate(lat=48.8738, lng=2.3522, altitude=349.6, speed=0.0)
+    screen = PowerScreen(
+        FakeDisplay(),
+        AppContext(interaction_profile=InteractionProfile.ONE_BUTTON),
+        state_provider=build_power_screen_state_provider(network_manager=nm),
+        actions=build_power_screen_actions(network_manager=nm),
+    )
+    screen.enter()
+    screen.page_index = 2
+
+    screen.refresh_prepared_state(force=True, allow_gps_refresh=True, reason="test")
+    payload = screen.lvgl_payload()
 
     assert nm.query_gps_calls == 1
-    gps_page = pages[2]
-    assert gps_page.title == "GPS"
-    assert ("Fix", "Yes") in gps_page.rows
-    assert any("48.8738" in value for _, value in gps_page.rows)
+    assert payload.title_text == "GPS"
+    assert "Lat: 48.873800" in payload.items
 
 
 def test_build_pages_includes_network_when_enabled():

--- a/tests/test_network_ui.py
+++ b/tests/test_network_ui.py
@@ -169,7 +169,7 @@ def test_active_gps_page_refreshes_coordinates_via_explicit_state_hook():
     screen.enter()
     screen.page_index = 2
 
-    screen.refresh_prepared_state(force=True, allow_gps_refresh=True)
+    screen.refresh_prepared_state(allow_gps_refresh=True)
     payload = screen.lvgl_payload()
 
     assert nm.query_gps_calls == 1

--- a/tests/test_network_ui.py
+++ b/tests/test_network_ui.py
@@ -72,6 +72,7 @@ def test_network_page_online():
         FakeDisplay(),
         state_provider=build_power_screen_state_provider(network_manager=nm),
     )
+    screen.enter()
     rows = screen._build_network_rows()
     assert ("Status", "Online") in rows
     assert ("Carrier", "Telekom.de") in rows
@@ -86,6 +87,7 @@ def test_network_page_disabled():
         FakeDisplay(),
         state_provider=build_power_screen_state_provider(network_manager=nm),
     )
+    screen.enter()
     rows = screen._build_network_rows()
     assert rows == [("Status", "Disabled")]
 
@@ -93,6 +95,7 @@ def test_network_page_disabled():
 def test_network_page_no_manager():
     """Network page should show Disabled when no network manager."""
     screen = PowerScreen(FakeDisplay())
+    screen.enter()
     rows = screen._build_network_rows()
     assert rows == [("Status", "Disabled")]
 
@@ -105,6 +108,7 @@ def test_gps_page_with_fix():
         FakeDisplay(),
         state_provider=build_power_screen_state_provider(network_manager=nm),
     )
+    screen.enter()
     rows = screen._build_gps_rows()
     assert ("Fix", "Yes") in rows
     assert any("48.8738" in v for _, v in rows)
@@ -118,6 +122,7 @@ def test_gps_page_no_fix():
         FakeDisplay(),
         state_provider=build_power_screen_state_provider(network_manager=nm),
     )
+    screen.enter()
     rows = screen._build_gps_rows()
     assert ("Fix", "Searching") in rows
     assert ("Lat", "--") in rows
@@ -164,7 +169,7 @@ def test_active_gps_page_refreshes_coordinates_via_explicit_state_hook():
     screen.enter()
     screen.page_index = 2
 
-    screen.refresh_prepared_state(force=True, allow_gps_refresh=True, reason="test")
+    screen.refresh_prepared_state(force=True, allow_gps_refresh=True)
     payload = screen.lvgl_payload()
 
     assert nm.query_gps_calls == 1
@@ -179,6 +184,7 @@ def test_build_pages_includes_network_when_enabled():
         FakeDisplay(),
         state_provider=build_power_screen_state_provider(network_manager=nm),
     )
+    screen.enter()
     pages = screen.build_pages()
     titles = [p.title for p in pages]
     assert "Network" in titles
@@ -190,6 +196,7 @@ def test_build_pages_includes_network_when_enabled():
 def test_build_pages_excludes_network_when_disabled():
     """build_pages should omit Network and GPS pages when network is disabled."""
     screen = PowerScreen(FakeDisplay())
+    screen.enter()
     pages = screen.build_pages()
     titles = [p.title for p in pages]
     assert "Network" not in titles

--- a/tests/test_power_screen.py
+++ b/tests/test_power_screen.py
@@ -10,6 +10,7 @@ from yoyopod.ui.display import Display
 from yoyopod.ui.input import InteractionProfile
 from yoyopod.ui.screens.system.power import (
     PowerScreen,
+    PowerScreenState,
     build_power_screen_actions,
     build_power_screen_state_provider,
 )
@@ -286,5 +287,49 @@ def test_power_screen_uses_injected_voice_device_hooks() -> None:
             ("speaker", "plughw:CARD=wm8960soundcard,DEV=0"),
             ("capture", "plughw:CARD=USB,DEV=0"),
         ]
+    finally:
+        display.cleanup()
+
+
+def test_power_screen_reuses_prepared_pages_until_explicit_refresh() -> None:
+    """Setup should reuse cached prepared pages until an explicit refresh updates state."""
+
+    class TogglingStateProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self) -> PowerScreenState:
+            self.calls += 1
+            network_enabled = self.calls > 1
+            return PowerScreenState(
+                network_enabled=network_enabled,
+                network_rows=(("Status", "Online"),),
+                gps_rows=(
+                    ("Fix", "Yes"),
+                    ("Lat", "48.873800"),
+                    ("Lng", "2.352200"),
+                    ("Alt", "349.6m"),
+                    ("Speed", "0.0km/h"),
+                ),
+            )
+
+    display = Display(simulate=True)
+    try:
+        provider = TogglingStateProvider()
+        screen = PowerScreen(display, AppContext(), state_provider=provider)
+
+        screen.enter()
+        first_payload = screen.lvgl_payload()
+        second_payload = screen.lvgl_payload()
+
+        assert provider.calls == 1
+        assert first_payload.total_pages == 4
+        assert second_payload.total_pages == 4
+
+        screen.refresh_prepared_state(force=True, reason="test")
+        refreshed_payload = screen.lvgl_payload()
+
+        assert provider.calls == 2
+        assert refreshed_payload.total_pages == 6
     finally:
         display.cleanup()

--- a/tests/test_power_screen.py
+++ b/tests/test_power_screen.py
@@ -340,6 +340,52 @@ def test_power_screen_reuses_prepared_pages_until_explicit_refresh() -> None:
         display.cleanup()
 
 
+def test_power_screen_visible_tick_skips_immediate_post_enter_refresh() -> None:
+    """Entering Setup should not immediately double-fetch on the next visible tick."""
+
+    class CountingStateProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self) -> PowerScreenState:
+            self.calls += 1
+            return PowerScreenState()
+
+    display = Display(simulate=True)
+    try:
+        provider = CountingStateProvider()
+        screen = PowerScreen(display, AppContext(), state_provider=provider)
+        screen._visible_tick_refresh_grace_seconds = 60.0
+
+        screen.enter()
+        screen.refresh_for_visible_tick()
+
+        assert provider.calls == 1
+    finally:
+        display.cleanup()
+
+
+def test_power_screen_copies_provider_status_on_refresh() -> None:
+    """Prepared state should not retain provider-owned mutable status mappings."""
+
+    shared_status = {"screen_awake": True}
+
+    def provider() -> PowerScreenState:
+        return PowerScreenState(status=shared_status)
+
+    display = Display(simulate=True)
+    try:
+        screen = PowerScreen(display, AppContext(), state_provider=provider)
+
+        refreshed_state = screen.refresh_prepared_state()
+        shared_status["screen_awake"] = False
+
+        assert refreshed_state.status["screen_awake"] is True
+        assert screen._get_status()["screen_awake"] is True
+    finally:
+        display.cleanup()
+
+
 def test_power_screen_snapshot_cache_ignores_hidden_snapshot_fields() -> None:
     """Prepared pages should survive snapshot-only churn that does not affect Setup rows."""
 

--- a/tests/test_power_screen.py
+++ b/tests/test_power_screen.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from dataclasses import fields
 from datetime import datetime
 
 from yoyopod.app_context import AppContext
 from yoyopod.power import BatteryState, PowerDeviceInfo, PowerSnapshot, RTCState, ShutdownState
+from yoyopod.runtime_state import VoiceState
 from yoyopod.ui.display import Display
 from yoyopod.ui.input import InteractionProfile
 from yoyopod.ui.screens.system.power import (
@@ -337,8 +339,30 @@ def test_power_screen_reuses_prepared_pages_until_explicit_refresh() -> None:
         display.cleanup()
 
 
-def test_power_screen_lazy_state_path_returns_default_without_provider_call() -> None:
-    """Cache misses should not hydrate prepared state from render-adjacent getters."""
+def test_power_screen_voice_state_schema_changes_require_signature_review() -> None:
+    """VoiceState schema drift should be caught in tests, not via runtime assertions."""
+
+    assert tuple(field_info.name for field_info in fields(VoiceState)) == (
+        "commands_enabled",
+        "ai_requests_enabled",
+        "screen_read_enabled",
+        "stt_enabled",
+        "tts_enabled",
+        "mic_muted",
+        "speaker_device_id",
+        "capture_device_id",
+        "stt_available",
+        "tts_available",
+        "last_transcript",
+        "last_spoken_text",
+        "last_mode",
+        "output_volume",
+        "interaction",
+    )
+
+
+def test_power_screen_render_path_uses_default_state_without_provider_call() -> None:
+    """Render-adjacent page preparation should not hydrate the provider on cache miss."""
 
     class CountingStateProvider:
         def __init__(self) -> None:
@@ -353,9 +377,9 @@ def test_power_screen_lazy_state_path_returns_default_without_provider_call() ->
         provider = CountingStateProvider()
         screen = PowerScreen(display, AppContext(), state_provider=provider)
 
-        state = screen._get_state()
+        payload = screen.lvgl_payload()
 
-        assert state == PowerScreenState()
+        assert payload.total_pages == 4
         assert provider.calls == 0
     finally:
         display.cleanup()

--- a/tests/test_power_screen.py
+++ b/tests/test_power_screen.py
@@ -331,7 +331,7 @@ def test_power_screen_reuses_prepared_pages_until_explicit_refresh() -> None:
         assert first_payload.total_pages == 4
         assert second_payload.total_pages == 4
 
-        screen.refresh_prepared_state(force=True)
+        screen.refresh_prepared_state()
         refreshed_payload = screen.lvgl_payload()
 
         assert provider.calls == 2
@@ -390,7 +390,7 @@ def test_power_screen_snapshot_cache_ignores_hidden_snapshot_fields() -> None:
         screen.enter()
         first_pages = screen._prepared_pages()
 
-        screen.refresh_prepared_state(force=True)
+        screen.refresh_prepared_state()
         second_pages = screen._prepared_pages()
 
         assert provider.calls == 2

--- a/tests/test_power_screen.py
+++ b/tests/test_power_screen.py
@@ -11,6 +11,7 @@ from yoyopod.runtime_state import VoiceState
 from yoyopod.ui.display import Display
 from yoyopod.ui.input import InteractionProfile
 from yoyopod.ui.screens.system.power import (
+    _VOICE_PAGE_SIGNATURE_FIELDS,
     PowerScreen,
     PowerScreenState,
     build_power_screen_actions,
@@ -339,25 +340,79 @@ def test_power_screen_reuses_prepared_pages_until_explicit_refresh() -> None:
         display.cleanup()
 
 
-def test_power_screen_voice_state_schema_changes_require_signature_review() -> None:
-    """VoiceState schema drift should be caught in tests, not via runtime assertions."""
+def test_power_screen_snapshot_cache_ignores_hidden_snapshot_fields() -> None:
+    """Prepared pages should survive snapshot-only churn that does not affect Setup rows."""
 
-    assert tuple(field_info.name for field_info in fields(VoiceState)) == (
+    class HiddenFieldChurnProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self) -> PowerScreenState:
+            self.calls += 1
+            return PowerScreenState(
+                snapshot=PowerSnapshot(
+                    available=True,
+                    checked_at=datetime(2026, 4, 5, 12, 0, self.calls),
+                    source="battery",
+                    error=None,
+                    device=PowerDeviceInfo(
+                        model="PiSugar 3",
+                        firmware_version=f"v{self.calls}",
+                    ),
+                    battery=BatteryState(
+                        level_percent=55.2,
+                        voltage_volts=3.62,
+                        charging=True,
+                        power_plugged=True,
+                        allow_charging=bool(self.calls % 2),
+                        output_enabled=bool((self.calls + 1) % 2),
+                        temperature_celsius=29.5,
+                    ),
+                    rtc=RTCState(
+                        time=datetime(2026, 4, 5, 13, 30, 0),
+                        alarm_enabled=True,
+                        alarm_time=datetime(2026, 4, 6, 7, 30, 0),
+                        alarm_repeat_mask=self.calls,
+                        adjust_ppm=self.calls,
+                    ),
+                    shutdown=ShutdownState(
+                        safe_shutdown_level_percent=10.0,
+                        safe_shutdown_delay_seconds=15 + self.calls,
+                    ),
+                )
+            )
+
+    display = Display(simulate=True)
+    try:
+        provider = HiddenFieldChurnProvider()
+        screen = PowerScreen(display, AppContext(), state_provider=provider)
+
+        screen.enter()
+        first_pages = screen._prepared_pages()
+
+        screen.refresh_prepared_state(force=True)
+        second_pages = screen._prepared_pages()
+
+        assert provider.calls == 2
+        assert second_pages is first_pages
+    finally:
+        display.cleanup()
+
+
+def test_power_screen_voice_signature_fields_stay_in_sync_with_voice_state() -> None:
+    """Only the voice-signature subset should require review when the schema changes."""
+
+    assert _VOICE_PAGE_SIGNATURE_FIELDS == (
         "commands_enabled",
         "ai_requests_enabled",
         "screen_read_enabled",
-        "stt_enabled",
-        "tts_enabled",
-        "mic_muted",
         "speaker_device_id",
         "capture_device_id",
-        "stt_available",
-        "tts_available",
-        "last_transcript",
-        "last_spoken_text",
-        "last_mode",
+        "mic_muted",
         "output_volume",
-        "interaction",
+    )
+    assert set(_VOICE_PAGE_SIGNATURE_FIELDS).issubset(
+        {field_info.name for field_info in fields(VoiceState)}
     )
 
 

--- a/tests/test_power_screen.py
+++ b/tests/test_power_screen.py
@@ -76,6 +76,7 @@ def test_power_screen_builds_battery_and_runtime_pages() -> None:
                 status_provider=lambda: status,
             ),
         )
+        screen.enter()
 
         pages = screen.build_pages(
             snapshot=screen._get_snapshot(),
@@ -115,6 +116,7 @@ def test_power_screen_formats_unavailable_snapshot() -> None:
                 status_provider=lambda: {},
             ),
         )
+        screen.enter()
 
         pages = screen.build_pages(snapshot=snapshot, status={})
 
@@ -326,10 +328,34 @@ def test_power_screen_reuses_prepared_pages_until_explicit_refresh() -> None:
         assert first_payload.total_pages == 4
         assert second_payload.total_pages == 4
 
-        screen.refresh_prepared_state(force=True, reason="test")
+        screen.refresh_prepared_state(force=True)
         refreshed_payload = screen.lvgl_payload()
 
         assert provider.calls == 2
         assert refreshed_payload.total_pages == 6
+    finally:
+        display.cleanup()
+
+
+def test_power_screen_lazy_state_path_returns_default_without_provider_call() -> None:
+    """Cache misses should not hydrate prepared state from render-adjacent getters."""
+
+    class CountingStateProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self) -> PowerScreenState:
+            self.calls += 1
+            return PowerScreenState(network_enabled=True)
+
+    display = Display(simulate=True)
+    try:
+        provider = CountingStateProvider()
+        screen = PowerScreen(display, AppContext(), state_provider=provider)
+
+        state = screen._get_state()
+
+        assert state == PowerScreenState()
+        assert provider.calls == 0
     finally:
         display.cleanup()

--- a/tests/test_screen_routing.py
+++ b/tests/test_screen_routing.py
@@ -41,6 +41,23 @@ class RoutableStubScreen(Screen):
         self.request_route("back")
 
 
+class HookAwareStubScreen(Screen):
+    """Minimal screen double that exposes refresh-hook counters."""
+
+    def __init__(self, display: Display, context: AppContext | None = None) -> None:
+        super().__init__(display, context, "HookAwareStub")
+        self.render_calls = 0
+        self.refresh_for_visible_tick_calls = 0
+
+    def render(self) -> None:
+        """Count renders performed by the screen manager."""
+        self.render_calls += 1
+
+    def refresh_for_visible_tick(self) -> None:
+        """Count visible-tick refreshes before render."""
+        self.refresh_for_visible_tick_calls += 1
+
+
 @pytest.fixture
 def display() -> Display:
     """Create a simulation display and clean it up after the test."""
@@ -172,6 +189,35 @@ def test_screen_manager_routes_power_status_through_stack(display: Display) -> N
     input_manager.simulate_action(InputAction.SELECT)
 
     assert screen_manager.current_screen is power
+
+
+def test_screen_manager_routes_visible_screen_renders_through_refresh_hook(
+    display: Display,
+) -> None:
+    """Push/pop/replace should invoke the visible-screen refresh hook before render."""
+
+    context = AppContext()
+    input_manager = InputManager()
+    screen_manager = ScreenManager(display, input_manager)
+
+    menu = RoutableStubScreen(display, context)
+    power = HookAwareStubScreen(display, context)
+    other = RoutableStubScreen(display, context)
+
+    screen_manager.register_screen("menu", menu)
+    screen_manager.register_screen("power", power)
+    screen_manager.register_screen("other", other)
+
+    screen_manager.replace_screen("power")
+
+    assert power.render_calls == 1
+    assert power.refresh_for_visible_tick_calls == 1
+
+    screen_manager.push_screen("other")
+    screen_manager.pop_screen()
+
+    assert power.render_calls == 2
+    assert power.refresh_for_visible_tick_calls == 2
 
 
 def test_screen_manager_routes_whisplay_hub_cards_through_stack(display: Display) -> None:
@@ -574,7 +620,9 @@ def test_ask_screen_fallback_settings_keep_configured_voice_defaults() -> None:
     """Missing providers should still inherit configured backend/model voice settings."""
 
     context = AppContext()
-    context.configure_voice(commands_enabled=True, ai_requests_enabled=True, screen_read_enabled=True)
+    context.configure_voice(
+        commands_enabled=True, ai_requests_enabled=True, screen_read_enabled=True
+    )
     context.set_mic_muted(True)
     context.set_volume(77)
     screen = AskScreen(
@@ -721,7 +769,9 @@ def test_ask_screen_quick_command_errors_schedule_auto_return() -> None:
     """Quick-command failures should still auto-return after showing the reply."""
 
     context = AppContext()
-    context.configure_voice(commands_enabled=False, ai_requests_enabled=True, screen_read_enabled=True)
+    context.configure_voice(
+        commands_enabled=False, ai_requests_enabled=True, screen_read_enabled=True
+    )
     ask = AskScreen(display=object(), context=context)
 
     ask.set_quick_command(True)
@@ -765,7 +815,8 @@ def test_ask_screen_applies_route_requests_immediately_off_input_path() -> None:
         action_scheduler=None,
         apply_navigation_request=lambda request, source_screen=None: applied_requests.append(
             (request, source_screen)
-        ) or True,
+        )
+        or True,
         get_current_screen=lambda: ask,
         refresh_current_screen=lambda: None,
     )
@@ -794,7 +845,8 @@ def test_ask_screen_auto_pop_applies_back_route_immediately() -> None:
         action_scheduler=None,
         apply_navigation_request=lambda request, source_screen=None: applied_requests.append(
             (request, source_screen)
-        ) or True,
+        )
+        or True,
     )
     ask.set_screen_manager(manager)
     ask.set_route_name("ask")


### PR DESCRIPTION
Implements issue #178. Generated by wrapper-owned workflow watchdog.