### PR TITLE
[codex] Make music interruption/resume deterministic across call flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Supported display/input modes:
 - PiSugar Whisplay HAT: `240x280` portrait with a single PTT-style button
 - Simulation mode: browser display with keyboard and web-button input
 
+## Call And Music Contract
+
+- Incoming and outgoing call setup both pause local music once when playback is actively running.
+- Missed, rejected, failed, cancelled, and completed call teardown only auto-resume music when YoyoPod paused it for that call and `auto_resume_after_call` is enabled.
+- Calls that start while music is already paused or idle leave playback unchanged.
+- Playback FSM state only flips after the pause or resume command succeeds, so navigation after the call keeps the visible playback truth aligned with the backend.
+
 ## Quick Start
 
 Local-only contributor path:

--- a/src/yoyopod/coordinators/call.py
+++ b/src/yoyopod/coordinators/call.py
@@ -22,7 +22,7 @@ from yoyopod.events import (
     VoIPAvailabilityChangedEvent,
 )
 from yoyopod.communication import CallHistoryEntry, CallHistoryStore, CallState, RegistrationState
-from yoyopod.fsm import CallSessionState
+from yoyopod.fsm import CallSessionState, MusicState
 
 
 @dataclass(slots=True)
@@ -189,6 +189,7 @@ class CallCoordinator:
             CallState.OUTGOING_RINGING,
             CallState.OUTGOING_EARLY_MEDIA,
         ):
+            self._pause_music_for_call(phase="outgoing")
             self._ensure_outgoing_call_session()
             self.runtime.call_fsm.transition("dial")
             self.runtime.sync_app_state("call_outgoing")
@@ -210,7 +211,7 @@ class CallCoordinator:
             return
 
         if state == CallState.INCOMING:
-            self._pause_music_for_incoming_call()
+            self._pause_music_for_call(phase="incoming")
             self.runtime.call_fsm.transition("incoming")
             self.runtime.sync_app_state("call_incoming_state")
             self._present_incoming_call_if_ready()
@@ -271,11 +272,11 @@ class CallCoordinator:
             self.runtime.call_fsm.sync(CallSessionState.IDLE)
 
         if should_resume:
-            logger.info("Auto-resuming music after call")
-            if self.runtime.music_backend:
-                self.runtime.music_backend.play()
-            self.runtime.music_fsm.transition("play")
-            self.screen_coordinator.refresh_now_playing_screen()
+            if self._resume_music_after_call():
+                logger.info("Auto-resumed music after call")
+            else:
+                logger.warning("Music remains paused after failed auto-resume")
+                self.runtime.music_fsm.transition("pause")
         elif self.runtime.call_interruption_policy.music_interrupted_by_call:
             logger.info("Music stays paused (auto-resume disabled)")
             self.runtime.music_fsm.transition("pause")
@@ -350,25 +351,57 @@ class CallCoordinator:
         caller_info = self._current_caller_info()
         self._active_call_session = _CallSessionDraft(
             direction="outgoing",
-            display_name=str(caller_info.get("display_name") or caller_info.get("name") or "Unknown"),
+            display_name=str(
+                caller_info.get("display_name") or caller_info.get("name") or "Unknown"
+            ),
             sip_address=str(caller_info.get("address") or ""),
         )
 
-    def _pause_music_for_incoming_call(self) -> None:
-        """Pause active playback once when a call enters the incoming phase."""
+    def _pause_music_for_call(self, *, phase: str) -> None:
+        """Pause active playback once when a call enters an interruption phase."""
 
-        playback_state = (
-            self.runtime.music_backend.get_playback_state()
-            if self.runtime.music_backend and self.runtime.music_backend.is_connected
-            else "stopped"
-        )
-        if playback_state != "playing":
+        if self.runtime.call_interruption_policy.music_interrupted_by_call:
             return
 
-        logger.info("Auto-pausing music for incoming call")
-        self.runtime.call_interruption_policy.pause_for_call(self.runtime.music_fsm)
-        if self.runtime.music_backend:
-            self.runtime.music_backend.pause()
+        if self._current_music_playback_state() != "playing":
+            return
+
+        logger.info("Auto-pausing music for {} call", phase)
+        if (
+            self.runtime.music_backend
+            and self.runtime.music_backend.is_connected
+            and not self.runtime.music_backend.pause()
+        ):
+            logger.warning("Failed to auto-pause music for {} call", phase)
+            return
+
+        self.runtime.call_interruption_policy.mark_paused_for_call(self.runtime.music_fsm)
+
+    def _resume_music_after_call(self) -> bool:
+        """Resume interrupted music only when the backend confirms the command."""
+
+        if (
+            self.runtime.music_backend
+            and self.runtime.music_backend.is_connected
+            and not self.runtime.music_backend.play()
+        ):
+            return False
+
+        self.runtime.music_fsm.transition("play")
+        self.screen_coordinator.refresh_now_playing_screen()
+        return True
+
+    def _current_music_playback_state(self) -> str:
+        """Return the best available current playback state for interruption decisions."""
+
+        if self.runtime.music_backend and self.runtime.music_backend.is_connected:
+            return self.runtime.music_backend.get_playback_state()
+
+        return {
+            MusicState.IDLE: "stopped",
+            MusicState.PLAYING: "playing",
+            MusicState.PAUSED: "paused",
+        }[self.runtime.music_fsm.state]
 
     def _present_incoming_call_if_ready(self) -> None:
         """Show the incoming-call screen once state and caller metadata are both known."""

--- a/src/yoyopod/coordinators/call.py
+++ b/src/yoyopod/coordinators/call.py
@@ -22,7 +22,7 @@ from yoyopod.events import (
     VoIPAvailabilityChangedEvent,
 )
 from yoyopod.communication import CallHistoryEntry, CallHistoryStore, CallState, RegistrationState
-from yoyopod.fsm import CallSessionState, MusicState
+from yoyopod.fsm import CallSessionState
 
 
 @dataclass(slots=True)
@@ -363,15 +363,15 @@ class CallCoordinator:
         if self.runtime.call_interruption_policy.music_interrupted_by_call:
             return
 
-        if self._current_music_playback_state() != "playing":
+        if self.runtime.music_backend is None or not self.runtime.music_backend.is_connected:
+            logger.debug("Skipping auto-pause for {} call: music backend unavailable", phase)
+            return
+
+        if self.runtime.music_backend.get_playback_state() != "playing":
             return
 
         logger.info("Auto-pausing music for {} call", phase)
-        if (
-            self.runtime.music_backend
-            and self.runtime.music_backend.is_connected
-            and not self.runtime.music_backend.pause()
-        ):
+        if not self.runtime.music_backend.pause():
             logger.warning("Failed to auto-pause music for {} call", phase)
             return
 
@@ -380,28 +380,16 @@ class CallCoordinator:
     def _resume_music_after_call(self) -> bool:
         """Resume interrupted music only when the backend confirms the command."""
 
-        if (
-            self.runtime.music_backend
-            and self.runtime.music_backend.is_connected
-            and not self.runtime.music_backend.play()
-        ):
+        if self.runtime.music_backend is None or not self.runtime.music_backend.is_connected:
+            logger.warning("Cannot auto-resume music after call: music backend unavailable")
+            return False
+
+        if not self.runtime.music_backend.play():
             return False
 
         self.runtime.music_fsm.transition("play")
         self.screen_coordinator.refresh_now_playing_screen()
         return True
-
-    def _current_music_playback_state(self) -> str:
-        """Return the best available current playback state for interruption decisions."""
-
-        if self.runtime.music_backend and self.runtime.music_backend.is_connected:
-            return self.runtime.music_backend.get_playback_state()
-
-        return {
-            MusicState.IDLE: "stopped",
-            MusicState.PLAYING: "playing",
-            MusicState.PAUSED: "paused",
-        }[self.runtime.music_fsm.state]
 
     def _present_incoming_call_if_ready(self) -> None:
         """Show the incoming-call screen once state and caller metadata are both known."""

--- a/src/yoyopod/fsm.py
+++ b/src/yoyopod/fsm.py
@@ -152,6 +152,11 @@ class CallInterruptionPolicy:
 
     music_interrupted_by_call: bool = False
 
+    def mark_paused_for_call(self, music_fsm: MusicFSM) -> None:
+        """Record that a call successfully paused active playback."""
+        self.music_interrupted_by_call = True
+        music_fsm.transition("pause")
+
     def pause_for_call(self, music_fsm: MusicFSM) -> bool:
         """
         Mark and pause music if the call interrupted active playback.
@@ -161,7 +166,7 @@ class CallInterruptionPolicy:
         """
         self.music_interrupted_by_call = music_fsm.state == MusicState.PLAYING
         if self.music_interrupted_by_call:
-            music_fsm.transition("pause")
+            self.mark_paused_for_call(music_fsm)
         return self.music_interrupted_by_call
 
     def should_auto_resume(self, auto_resume: bool) -> bool:

--- a/src/yoyopod/fsm.py
+++ b/src/yoyopod/fsm.py
@@ -157,18 +157,6 @@ class CallInterruptionPolicy:
         self.music_interrupted_by_call = True
         music_fsm.transition("pause")
 
-    def pause_for_call(self, music_fsm: MusicFSM) -> bool:
-        """
-        Mark and pause music if the call interrupted active playback.
-
-        Returns:
-            True if music was actively playing and is now paused for the call.
-        """
-        self.music_interrupted_by_call = music_fsm.state == MusicState.PLAYING
-        if self.music_interrupted_by_call:
-            self.mark_paused_for_call(music_fsm)
-        return self.music_interrupted_by_call
-
     def should_auto_resume(self, auto_resume: bool) -> bool:
         """Return True if interrupted playback should resume after call end."""
         return self.music_interrupted_by_call and auto_resume

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -168,13 +168,19 @@ class FakeMusicBackend(MockMusicBackend):
         self._playback_state = playback_state
         self.pause_calls = 0
         self.play_calls = 0
+        self.pause_result = True
+        self.play_result = True
 
     def pause(self) -> bool:
         self.pause_calls += 1
+        if not self.pause_result:
+            return False
         return super().pause()
 
     def play(self) -> bool:
         self.play_calls += 1
+        if not self.play_result:
+            return False
         return super().play()
 
 
@@ -647,6 +653,21 @@ def test_incoming_call_pauses_playing_music_once() -> None:
     assert len(harness.screen_manager.screen_stack) == 2
 
 
+def test_incoming_call_keeps_music_playing_when_pause_command_fails() -> None:
+    """Incoming-call setup should preserve playback truth when the pause command fails."""
+    harness = OrchestrationHarness.build(playback_state="playing")
+    harness.music_backend.pause_result = False
+    harness.sync_runtime(music_state=MusicState.PLAYING, trigger="playback_playing")
+
+    harness.publish(CallStateChangedEvent(state=CallState.INCOMING))
+
+    assert harness.drain_events() == 1
+    assert harness.music_backend.pause_calls == 1
+    assert harness.music_fsm.state == MusicState.PLAYING
+    assert not harness.call_interruption_policy.music_interrupted_by_call
+    assert harness.call_fsm.state == CallSessionState.INCOMING
+
+
 def test_incoming_call_metadata_waits_for_incoming_state_before_mutating_runtime() -> None:
     """Caller metadata alone should not move the runtime into an active incoming phase."""
     harness = OrchestrationHarness.build(playback_state="playing")
@@ -708,6 +729,27 @@ def test_call_end_keeps_music_paused_when_auto_resume_disabled() -> None:
     assert harness.screen_manager.current_screen is harness.screens.menu
 
 
+def test_call_end_keeps_music_paused_when_resume_command_fails() -> None:
+    """Call teardown should not claim playback resumed when the backend rejects resume."""
+    harness = OrchestrationHarness.build(playback_state="paused", auto_resume=True)
+    harness.music_backend.play_result = False
+    harness.sync_runtime(
+        music_state=MusicState.PAUSED,
+        call_state=CallSessionState.ACTIVE,
+        music_interrupted_by_call=True,
+    )
+    harness.push_screens("incoming_call", "in_call")
+
+    harness.publish(CallEndedEvent())
+
+    assert harness.drain_events() == 1
+    assert harness.music_backend.play_calls == 1
+    assert harness.music_fsm.state == MusicState.PAUSED
+    assert harness.call_fsm.state == CallSessionState.IDLE
+    assert not harness.call_interruption_policy.music_interrupted_by_call
+    assert harness.screen_manager.current_screen is harness.screens.menu
+
+
 @pytest.mark.parametrize(
     ("music_state", "playback_state"),
     [
@@ -730,6 +772,30 @@ def test_outgoing_call_does_not_change_idle_or_paused_music(
     assert app.call_fsm.state == CallSessionState.OUTGOING
     assert app.music_fsm.state == music_state
     assert screen_manager.current_screen is app.outgoing_call_screen
+
+
+def test_outgoing_call_pauses_playing_music_and_resumes_on_terminal_end() -> None:
+    """Outgoing-call setup should follow the same pause/resume contract as incoming calls."""
+    harness = OrchestrationHarness.build(playback_state="playing", auto_resume=True)
+    harness.sync_runtime(music_state=MusicState.PLAYING, trigger="playback_playing")
+
+    harness.publish(CallStateChangedEvent(state=CallState.OUTGOING))
+
+    assert harness.drain_events() == 1
+    assert harness.music_backend.pause_calls == 1
+    assert harness.music_fsm.state == MusicState.PAUSED
+    assert harness.call_fsm.state == CallSessionState.OUTGOING
+    assert harness.call_interruption_policy.music_interrupted_by_call
+    assert harness.screen_manager.current_screen is harness.screens.outgoing_call
+
+    harness.publish(CallStateChangedEvent(state=CallState.END))
+
+    assert harness.drain_events() == 1
+    assert harness.music_backend.play_calls == 1
+    assert harness.music_fsm.state == MusicState.PLAYING
+    assert harness.call_fsm.state == CallSessionState.IDLE
+    assert not harness.call_interruption_policy.music_interrupted_by_call
+    assert harness.screen_manager.current_screen is harness.screens.menu
 
 
 def test_terminal_error_state_ends_incoming_call_without_waiting_for_released() -> None:

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -668,6 +668,21 @@ def test_incoming_call_keeps_music_playing_when_pause_command_fails() -> None:
     assert harness.call_fsm.state == CallSessionState.INCOMING
 
 
+def test_incoming_call_does_not_mark_interrupted_when_music_backend_is_unavailable() -> None:
+    """Call setup should not claim a successful pause without a connected music backend."""
+    harness = OrchestrationHarness.build(playback_state="playing")
+    harness.music_backend.stop()
+    harness.sync_runtime(music_state=MusicState.PLAYING, trigger="playback_playing")
+
+    harness.publish(CallStateChangedEvent(state=CallState.INCOMING))
+
+    assert harness.drain_events() == 1
+    assert harness.music_backend.pause_calls == 0
+    assert harness.music_fsm.state == MusicState.PLAYING
+    assert not harness.call_interruption_policy.music_interrupted_by_call
+    assert harness.call_fsm.state == CallSessionState.INCOMING
+
+
 def test_incoming_call_metadata_waits_for_incoming_state_before_mutating_runtime() -> None:
     """Caller metadata alone should not move the runtime into an active incoming phase."""
     harness = OrchestrationHarness.build(playback_state="playing")
@@ -744,6 +759,27 @@ def test_call_end_keeps_music_paused_when_resume_command_fails() -> None:
 
     assert harness.drain_events() == 1
     assert harness.music_backend.play_calls == 1
+    assert harness.music_fsm.state == MusicState.PAUSED
+    assert harness.call_fsm.state == CallSessionState.IDLE
+    assert not harness.call_interruption_policy.music_interrupted_by_call
+    assert harness.screen_manager.current_screen is harness.screens.menu
+
+
+def test_call_end_keeps_music_paused_when_music_backend_is_unavailable() -> None:
+    """Call teardown should not claim playback resumed without a connected backend."""
+    harness = OrchestrationHarness.build(playback_state="paused", auto_resume=True)
+    harness.music_backend.stop()
+    harness.sync_runtime(
+        music_state=MusicState.PAUSED,
+        call_state=CallSessionState.ACTIVE,
+        music_interrupted_by_call=True,
+    )
+    harness.push_screens("incoming_call", "in_call")
+
+    harness.publish(CallEndedEvent())
+
+    assert harness.drain_events() == 1
+    assert harness.music_backend.play_calls == 0
     assert harness.music_fsm.state == MusicState.PAUSED
     assert harness.call_fsm.state == CallSessionState.IDLE
     assert not harness.call_interruption_policy.music_interrupted_by_call

--- a/tests/test_fsm_runtime.py
+++ b/tests/test_fsm_runtime.py
@@ -71,12 +71,13 @@ def test_call_interruption_policy_pauses_and_resumes_music() -> None:
     music_fsm = MusicFSM()
     policy = CallInterruptionPolicy()
 
-    assert not policy.pause_for_call(music_fsm)
+    assert not policy.music_interrupted_by_call
     assert not policy.should_auto_resume(auto_resume=True)
 
     assert music_fsm.transition("play")
-    assert policy.pause_for_call(music_fsm)
+    policy.mark_paused_for_call(music_fsm)
     assert music_fsm.state == MusicState.PAUSED
+    assert policy.music_interrupted_by_call
     assert policy.should_auto_resume(auto_resume=True)
     assert not policy.should_auto_resume(auto_resume=False)
 
@@ -128,7 +129,7 @@ def test_runtime_state_is_derived_from_split_fsms() -> None:
     assert state_change.entered(AppRuntimeState.PLAYING_WITH_VOIP)
     assert runtime.current_app_state == AppRuntimeState.PLAYING_WITH_VOIP
 
-    runtime.call_interruption_policy.pause_for_call(runtime.music_fsm)
+    runtime.call_interruption_policy.mark_paused_for_call(runtime.music_fsm)
     state_change = runtime.sync_app_state("auto_pause_for_call")
     assert state_change.entered(AppRuntimeState.PAUSED_BY_CALL)
     assert runtime.current_app_state == AppRuntimeState.PAUSED_BY_CALL


### PR DESCRIPTION
Implements issue #180. Generated by wrapper-owned workflow watchdog.