### PR TITLE
[codex] Call-duration thread wakes every 1s just to tick a counter

### DIFF
--- a/src/yoyopod/communication/calling/manager.py
+++ b/src/yoyopod/communication/calling/manager.py
@@ -95,7 +95,6 @@ class VoIPManager:
         self.current_call_id: Optional[str] = None
         self.caller_address: Optional[str] = None
         self.caller_name: Optional[str] = None
-        self.call_duration: int = 0
         self.call_start_time: Optional[float] = None
         self.is_muted = False
         self._pending_terminal_action: str | None = None
@@ -129,8 +128,6 @@ class VoIPManager:
         self._iterate_stop_event = threading.Event()
         self._iterate_wakeup_event = threading.Event()
 
-        self.duration_thread: Optional[threading.Thread] = None
-        self.duration_stop_event = threading.Event()
         self._stopping = False
 
         self.backend.on_event(self._dispatch_backend_event)
@@ -865,18 +862,9 @@ class VoIPManager:
 
     def _start_call_timer(self) -> None:
         self.call_start_time = time.time()
-        self.call_duration = 0
-        self.duration_stop_event.clear()
-        self.duration_thread = threading.Thread(target=self._track_duration, daemon=True)
-        self.duration_thread.start()
 
     def _stop_call_timer(self) -> None:
-        self.duration_stop_event.set()
-        if self.duration_thread is not None:
-            self.duration_thread.join(timeout=1)
-            self.duration_thread = None
         self.call_start_time = None
-        self.call_duration = 0
 
     def _clear_call_session(self) -> None:
         self._stop_call_timer()
@@ -893,12 +881,6 @@ class VoIPManager:
         self.running = False
         self.registered = False
         self.registration_state = RegistrationState.NONE
-
-    def _track_duration(self) -> None:
-        while not self.duration_stop_event.is_set():
-            if self.call_start_time is not None:
-                self.call_duration = int(time.time() - self.call_start_time)
-            time.sleep(1)
 
     def _notify_availability_change(self, available: bool, reason: str) -> None:
         for callback in self.availability_callbacks:

--- a/tests/test_voip_backend.py
+++ b/tests/test_voip_backend.py
@@ -447,6 +447,8 @@ def test_voip_manager_derives_live_call_duration_without_worker_thread(
     manager.call_start_time = 940.0
     manager.call_state = CallState.CONNECTED
 
+    assert not hasattr(manager, "duration_thread")
+    assert not hasattr(VoIPManager, "_track_duration")
     assert manager.get_call_duration() == 60
 
 

--- a/tests/test_voip_backend.py
+++ b/tests/test_voip_backend.py
@@ -435,6 +435,21 @@ def test_voip_manager_starts_timer_on_streams_running_without_connected() -> Non
     assert started == [True]
 
 
+def test_voip_manager_derives_live_call_duration_without_worker_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Call duration should come from the current clock and stored start time."""
+
+    backend = MockVoIPBackend()
+    manager = VoIPManager(build_config(), backend=backend)
+    now = 1_000.9
+    monkeypatch.setattr(time, "time", lambda: now)
+    manager.call_start_time = 940.0
+    manager.call_state = CallState.CONNECTED
+
+    assert manager.get_call_duration() == 60
+
+
 def test_voip_manager_tracks_voice_note_send_and_delivery() -> None:
     """Voice-note record/send flow should update the active draft and summary state."""
 


### PR DESCRIPTION
Implements issue #244. Generated by wrapper-owned workflow watchdog.