### PR TITLE
[codex] PiSugar poll can stall coordinator under shared lock

### DIFF
--- a/src/yoyopod/power/runtime.py
+++ b/src/yoyopod/power/runtime.py
@@ -37,7 +37,10 @@ class PowerRuntimeService:
         self.app._next_power_poll_at = poll_now + interval
 
         if force:
-            self._publish_snapshot(snapshot=self.app.power_manager.get_snapshot())
+            if self.app._power_refresh_in_flight:
+                self._publish_cached_snapshot_if_ready()
+                return
+
             self._start_power_refresh_worker()
             return
 
@@ -87,10 +90,30 @@ class PowerRuntimeService:
         self.app._power_refresh_in_flight = False
         self._publish_snapshot(snapshot=snapshot)
 
+    def _publish_cached_snapshot_if_ready(self) -> None:
+        """Publish cached power state only when a prior refresh already established runtime state."""
+
+        if self.app.power_manager is None:
+            return
+
+        self.app.boot_service.ensure_coordinators()
+        assert self.app.coordinator_runtime is not None
+        if self.app.coordinator_runtime.power_snapshot is None:
+            return
+
+        self._publish_snapshot(snapshot=self.app.power_manager.get_snapshot())
+
     def _publish_snapshot(self, *, snapshot: "PowerSnapshot") -> None:
         """Publish one power snapshot onto the coordinator thread."""
 
         self.app.boot_service.ensure_coordinators()
+        assert self.app.coordinator_runtime is not None
+        if (
+            self.app.coordinator_runtime.power_snapshot == snapshot
+            and self.app._power_available == snapshot.available
+        ):
+            return
+
         assert self.app.power_coordinator is not None
         self.app.power_coordinator.publish_snapshot(snapshot)
 

--- a/src/yoyopod/power/runtime.py
+++ b/src/yoyopod/power/runtime.py
@@ -22,6 +22,7 @@ class PowerRuntimeService:
     def __init__(self, app: "YoyoPodApp") -> None:
         self.app = app
         self._power_io_lock = threading.Lock()
+        self._watchdog_io_lock = threading.Lock()
 
     def poll_status(self, now: float | None = None, force: bool = False) -> None:
         """Refresh PiSugar power telemetry without stalling the coordinator loop."""
@@ -36,9 +37,14 @@ class PowerRuntimeService:
         self.app._next_power_poll_at = poll_now + interval
 
         if force:
-            snapshot = self._refresh_snapshot()
-            self._complete_refresh(snapshot=snapshot)
+            self._publish_snapshot(snapshot=self.app.power_manager.get_snapshot())
+            self._start_power_refresh_worker()
             return
+
+        self._start_power_refresh_worker()
+
+    def _start_power_refresh_worker(self) -> None:
+        """Schedule one background refresh when no worker is already running."""
 
         if self.app._power_refresh_in_flight:
             return
@@ -79,6 +85,11 @@ class PowerRuntimeService:
         """Publish one completed power refresh back onto the coordinator thread."""
 
         self.app._power_refresh_in_flight = False
+        self._publish_snapshot(snapshot=snapshot)
+
+    def _publish_snapshot(self, *, snapshot: "PowerSnapshot") -> None:
+        """Publish one power snapshot onto the coordinator thread."""
+
         self.app.boot_service.ensure_coordinators()
         assert self.app.power_coordinator is not None
         self.app.power_coordinator.publish_snapshot(snapshot)
@@ -108,7 +119,7 @@ class PowerRuntimeService:
                 timeout_seconds,
             )
 
-        with self._power_io_lock:
+        with self._watchdog_io_lock:
             enabled = self.app.power_manager.enable_watchdog()
         if not enabled:
             logger.warning("Power watchdog could not be enabled")
@@ -156,7 +167,7 @@ class PowerRuntimeService:
                 float(power_manager.config.watchdog_feed_interval_seconds),
             )
             started_at = time.monotonic()
-            with self._power_io_lock:
+            with self._watchdog_io_lock:
                 success = power_manager.feed_watchdog()
             duration_seconds = max(0.0, time.monotonic() - started_at)
             if duration_seconds >= self._SLOW_WATCHDOG_FEED_WARNING_SECONDS:
@@ -201,7 +212,7 @@ class PowerRuntimeService:
 
         disabled = False
         if self.app.power_manager is not None:
-            with self._power_io_lock:
+            with self._watchdog_io_lock:
                 disabled = self.app.power_manager.disable_watchdog()
         if disabled:
             logger.info("Power watchdog disabled for intentional stop")

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -402,6 +402,13 @@ def _complete_power_refresh(app: YoyoPodApp) -> None:
     assert app.get_status()["power_refresh_in_flight"] is False
 
 
+def _force_power_refresh(app: YoyoPodApp, *, now: float) -> None:
+    """Run one forced power refresh and drain its async completion."""
+
+    app._poll_power_status(now=now, force=True)
+    _complete_power_refresh(app)
+
+
 def _navigate_from_worker(screen_manager: FakeScreenManager, screen_name: str) -> None:
     worker = threading.Thread(target=lambda: screen_manager.push_screen(screen_name))
     worker.start()
@@ -1180,9 +1187,8 @@ def test_power_poll_updates_context_runtime_and_visible_screen() -> None:
         ]
     )
 
-    app._poll_power_status(now=0.0, force=True)
+    _force_power_refresh(app, now=0.0)
 
-    _wait_for(lambda: app.power_manager.refresh_calls == 1)
     assert app.power_manager.refresh_calls == 1
     assert app.context.battery_percent == 55
     assert app.context.battery_charging is True
@@ -1217,7 +1223,7 @@ def test_power_poll_refreshes_visible_power_screen_through_shared_refresh_hook()
     )
     screen_manager.push_screen("power")
 
-    app._poll_power_status(now=0.0, force=True)
+    _force_power_refresh(app, now=0.0)
 
     assert app.power_screen.render_calls == 1
     assert app.power_screen.refresh_for_visible_tick_calls == 1
@@ -1236,8 +1242,7 @@ def test_power_poll_honors_interval_and_tracks_unavailable_backend() -> None:
         poll_interval_seconds=30.0,
     )
 
-    app._poll_power_status(now=0.0, force=True)
-    _complete_power_refresh(app)
+    _force_power_refresh(app, now=0.0)
     app._poll_power_status(now=10.0)
     app._poll_power_status(now=30.0)
     _wait_for(lambda: (app.get_status()["pending_main_thread_callbacks"] or 0) > 0)
@@ -1287,17 +1292,11 @@ def test_periodic_power_poll_runs_off_the_coordinator_thread() -> None:
     assert app.get_status()["power_refresh_in_flight"] is False
 
 
-def test_forced_power_poll_uses_cached_snapshot_without_waiting_for_refresh() -> None:
-    """Forced polls should publish the cached snapshot immediately, then refresh off-thread."""
+def test_forced_power_poll_skips_placeholder_snapshot_before_first_refresh() -> None:
+    """The initial forced poll should not publish the uninitialized power placeholder."""
 
     refresh_started = threading.Event()
     refresh_release = threading.Event()
-    cached_snapshot = _power_snapshot(
-        available=True,
-        battery_percent=41.0,
-        charging=False,
-        power_plugged=False,
-    )
     refreshed_snapshot = _power_snapshot(
         available=True,
         battery_percent=52.0,
@@ -1308,12 +1307,6 @@ def test_forced_power_poll_uses_cached_snapshot_without_waiting_for_refresh() ->
     class BlockingForcePollPowerManager(FakePowerManager):
         def __init__(self) -> None:
             super().__init__([refreshed_snapshot])
-            self.cached_snapshot = cached_snapshot
-
-        def get_snapshot(self, refresh: bool = False) -> PowerSnapshot:
-            if not refresh and self.refresh_calls == 0:
-                return self.cached_snapshot
-            return super().get_snapshot(refresh=refresh)
 
         def refresh(self) -> PowerSnapshot:
             refresh_started.set()
@@ -1328,11 +1321,9 @@ def test_forced_power_poll_uses_cached_snapshot_without_waiting_for_refresh() ->
     elapsed_seconds = time.monotonic() - started_at
 
     assert elapsed_seconds < 0.1
-    assert app.context.battery_percent == 41
-    assert app.context.battery_charging is False
-    assert app.context.external_power is False
-    assert app.coordinator_runtime.power_snapshot is cached_snapshot
-    assert app.menu_screen.render_calls == 1
+    assert app._power_available is None
+    assert app.coordinator_runtime.power_snapshot is None
+    assert app.menu_screen.render_calls == 0
     assert refresh_started.wait(timeout=1.0) is True
     assert app.get_status()["power_refresh_in_flight"] is True
 
@@ -1344,6 +1335,66 @@ def test_forced_power_poll_uses_cached_snapshot_without_waiting_for_refresh() ->
     assert app.context.battery_charging is True
     assert app.context.external_power is True
     assert app.coordinator_runtime.power_snapshot is refreshed_snapshot
+    assert app.menu_screen.render_calls == 1
+
+
+def test_forced_power_poll_uses_new_cached_snapshot_while_refresh_callback_is_pending() -> None:
+    """A forced poll should fast-forward a completed worker snapshot without duplicating it later."""
+
+    first_snapshot = _power_snapshot(
+        available=True,
+        battery_percent=41.0,
+        charging=False,
+        power_plugged=False,
+    )
+    second_snapshot = _power_snapshot(
+        available=True,
+        battery_percent=52.0,
+        charging=True,
+        power_plugged=True,
+    )
+
+    class TwoStepPowerManager(FakePowerManager):
+        def __init__(self) -> None:
+            super().__init__([first_snapshot, second_snapshot])
+            self.second_refresh_started = threading.Event()
+            self.second_refresh_release = threading.Event()
+
+        def refresh(self) -> PowerSnapshot:
+            if self.refresh_calls == 0:
+                return super().refresh()
+
+            self.second_refresh_started.set()
+            self.second_refresh_release.wait(timeout=1.0)
+            return super().refresh()
+
+    app, _, _ = _build_app(playback_state="stopped")
+    app.power_manager = TwoStepPowerManager()
+
+    _force_power_refresh(app, now=0.0)
+    assert app.context.battery_percent == 41
+    assert app.menu_screen.render_calls == 1
+
+    app._poll_power_status(now=30.0)
+    assert app.power_manager.second_refresh_started.wait(timeout=1.0) is True
+    assert app.get_status()["power_refresh_in_flight"] is True
+
+    app.power_manager.second_refresh_release.set()
+    _wait_for(lambda: (app.get_status()["pending_main_thread_callbacks"] or 0) > 0)
+
+    started_at = time.monotonic()
+    app._poll_power_status(now=31.0, force=True)
+    elapsed_seconds = time.monotonic() - started_at
+
+    assert elapsed_seconds < 0.1
+    assert app.context.battery_percent == 52
+    assert app.context.battery_charging is True
+    assert app.context.external_power is True
+    assert app.coordinator_runtime.power_snapshot is second_snapshot
+    assert app.menu_screen.render_calls == 2
+
+    app._process_pending_main_thread_actions()
+    assert app.get_status()["power_refresh_in_flight"] is False
     assert app.menu_screen.render_calls == 2
 
 
@@ -1581,7 +1632,7 @@ def test_low_battery_snapshot_sets_temporary_alert() -> None:
         )
     )
 
-    app._poll_power_status(now=0.0, force=True)
+    _force_power_refresh(app, now=0.0)
 
     assert app._pending_shutdown is None
     assert app._power_alert is not None
@@ -1607,7 +1658,7 @@ def test_critical_battery_snapshot_creates_pending_shutdown() -> None:
         )
     )
 
-    app._poll_power_status(now=0.0, force=True)
+    _force_power_refresh(app, now=0.0)
 
     assert app._pending_shutdown is not None
     assert app._pending_shutdown.reason == "critical_battery"
@@ -1638,12 +1689,10 @@ def test_power_restore_cancels_pending_shutdown() -> None:
         )
     )
 
-    app._poll_power_status(now=0.0, force=True)
+    _force_power_refresh(app, now=0.0)
     assert app._pending_shutdown is not None
 
-    _complete_power_refresh(app)
-    app._poll_power_status(now=30.0, force=True)
-    _complete_power_refresh(app)
+    _force_power_refresh(app, now=30.0)
 
     assert app._pending_shutdown is None
     assert app._power_alert is not None
@@ -1701,7 +1750,7 @@ def test_pending_shutdown_runs_hooks_and_requests_system_poweroff(tmp_path) -> N
 
     app.stop = fake_stop
     app._register_power_shutdown_hooks()
-    app._poll_power_status(now=0.0, force=True)
+    _force_power_refresh(app, now=0.0)
 
     assert [name for name, _ in power_manager.registered_shutdown_hooks] == ["save_shutdown_state"]
     assert app._pending_shutdown is not None
@@ -1746,7 +1795,7 @@ def test_shutdown_service_runs_hooks_and_requests_system_poweroff(tmp_path) -> N
 
     app.stop = fake_stop
     app.shutdown_service.register_power_shutdown_hooks()
-    app._poll_power_status(now=0.0, force=True)
+    _force_power_refresh(app, now=0.0)
 
     assert app._pending_shutdown is not None
 
@@ -1902,7 +1951,7 @@ def test_poweroff_path_suppresses_watchdog_feed_without_disabling_it() -> None:
     app.stop = fake_stop
     app._start_watchdog(now=0.0)
     app._register_power_shutdown_hooks()
-    app._poll_power_status(now=0.0, force=True)
+    _force_power_refresh(app, now=0.0)
     app._process_pending_shutdown(app._pending_shutdown.execute_at)
 
     assert stop_disable_watchdog == [False]

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -394,6 +394,14 @@ def _wait_for(predicate, *, timeout_seconds: float = 1.0) -> None:
     raise AssertionError("Timed out waiting for async condition")
 
 
+def _complete_power_refresh(app: YoyoPodApp) -> None:
+    """Drain one queued async power-refresh completion for the test app."""
+
+    _wait_for(lambda: (app.get_status()["pending_main_thread_callbacks"] or 0) > 0)
+    app._process_pending_main_thread_actions()
+    assert app.get_status()["power_refresh_in_flight"] is False
+
+
 def _navigate_from_worker(screen_manager: FakeScreenManager, screen_name: str) -> None:
     worker = threading.Thread(target=lambda: screen_manager.push_screen(screen_name))
     worker.start()
@@ -1174,6 +1182,7 @@ def test_power_poll_updates_context_runtime_and_visible_screen() -> None:
 
     app._poll_power_status(now=0.0, force=True)
 
+    _wait_for(lambda: app.power_manager.refresh_calls == 1)
     assert app.power_manager.refresh_calls == 1
     assert app.context.battery_percent == 55
     assert app.context.battery_charging is True
@@ -1228,6 +1237,7 @@ def test_power_poll_honors_interval_and_tracks_unavailable_backend() -> None:
     )
 
     app._poll_power_status(now=0.0, force=True)
+    _complete_power_refresh(app)
     app._poll_power_status(now=10.0)
     app._poll_power_status(now=30.0)
     _wait_for(lambda: (app.get_status()["pending_main_thread_callbacks"] or 0) > 0)
@@ -1275,6 +1285,66 @@ def test_periodic_power_poll_runs_off_the_coordinator_thread() -> None:
     assert app.context.battery_percent == 48
     assert app.menu_screen.render_calls == 1
     assert app.get_status()["power_refresh_in_flight"] is False
+
+
+def test_forced_power_poll_uses_cached_snapshot_without_waiting_for_refresh() -> None:
+    """Forced polls should publish the cached snapshot immediately, then refresh off-thread."""
+
+    refresh_started = threading.Event()
+    refresh_release = threading.Event()
+    cached_snapshot = _power_snapshot(
+        available=True,
+        battery_percent=41.0,
+        charging=False,
+        power_plugged=False,
+    )
+    refreshed_snapshot = _power_snapshot(
+        available=True,
+        battery_percent=52.0,
+        charging=True,
+        power_plugged=True,
+    )
+
+    class BlockingForcePollPowerManager(FakePowerManager):
+        def __init__(self) -> None:
+            super().__init__([refreshed_snapshot])
+            self.cached_snapshot = cached_snapshot
+
+        def get_snapshot(self, refresh: bool = False) -> PowerSnapshot:
+            if not refresh and self.refresh_calls == 0:
+                return self.cached_snapshot
+            return super().get_snapshot(refresh=refresh)
+
+        def refresh(self) -> PowerSnapshot:
+            refresh_started.set()
+            refresh_release.wait(timeout=1.0)
+            return super().refresh()
+
+    app, _, _ = _build_app(playback_state="stopped")
+    app.power_manager = BlockingForcePollPowerManager()
+
+    started_at = time.monotonic()
+    app._poll_power_status(now=0.0, force=True)
+    elapsed_seconds = time.monotonic() - started_at
+
+    assert elapsed_seconds < 0.1
+    assert app.context.battery_percent == 41
+    assert app.context.battery_charging is False
+    assert app.context.external_power is False
+    assert app.coordinator_runtime.power_snapshot is cached_snapshot
+    assert app.menu_screen.render_calls == 1
+    assert refresh_started.wait(timeout=1.0) is True
+    assert app.get_status()["power_refresh_in_flight"] is True
+
+    refresh_release.set()
+    _complete_power_refresh(app)
+
+    assert app.power_manager.refresh_calls == 1
+    assert app.context.battery_percent == 52
+    assert app.context.battery_charging is True
+    assert app.context.external_power is True
+    assert app.coordinator_runtime.power_snapshot is refreshed_snapshot
+    assert app.menu_screen.render_calls == 2
 
 
 def test_screen_timeout_turns_backlight_off_after_inactivity() -> None:
@@ -1571,7 +1641,9 @@ def test_power_restore_cancels_pending_shutdown() -> None:
     app._poll_power_status(now=0.0, force=True)
     assert app._pending_shutdown is not None
 
+    _complete_power_refresh(app)
     app._poll_power_status(now=30.0, force=True)
+    _complete_power_refresh(app)
 
     assert app._pending_shutdown is None
     assert app._power_alert is not None
@@ -1753,6 +1825,43 @@ def test_watchdog_feed_runs_off_the_coordinator_thread() -> None:
     assert power_manager.feed_watchdog_calls == 1
     assert app.get_status()["watchdog_active"] is True
     assert app.get_status()["watchdog_feed_in_flight"] is False
+
+
+def test_watchdog_start_does_not_wait_for_in_flight_power_refresh() -> None:
+    """Enabling the watchdog should not block behind the PiSugar refresh worker."""
+
+    refresh_started = threading.Event()
+    refresh_release = threading.Event()
+
+    class BlockingRefreshPowerManager(FakePowerManager):
+        def refresh(self) -> PowerSnapshot:
+            refresh_started.set()
+            refresh_release.wait(timeout=1.0)
+            return super().refresh()
+
+    power_manager = BlockingRefreshPowerManager(
+        [_power_snapshot(available=True, battery_percent=60.0)],
+        watchdog_enabled=True,
+        watchdog_timeout_seconds=60,
+        watchdog_feed_interval_seconds=10.0,
+    )
+    app, _, _ = _build_app_with_power(power_manager)
+    app.simulate = False
+
+    app._poll_power_status(now=0.0)
+    assert refresh_started.wait(timeout=1.0) is True
+    assert app.get_status()["power_refresh_in_flight"] is True
+
+    started_at = time.monotonic()
+    app._start_watchdog(now=0.0)
+    elapsed_seconds = time.monotonic() - started_at
+
+    assert elapsed_seconds < 0.1
+    assert power_manager.enable_watchdog_calls == 1
+    assert app.get_status()["watchdog_active"] is True
+
+    refresh_release.set()
+    _complete_power_refresh(app)
 
 
 def test_intentional_stop_disables_watchdog() -> None:


### PR DESCRIPTION
Implements issue #246. Generated by wrapper-owned workflow watchdog.