### PR TITLE
[codex] mpv event-queue dispatch wakes every 100ms when idle

### DIFF
--- a/src/yoyopod/audio/music/ipc.py
+++ b/src/yoyopod/audio/music/ipc.py
@@ -195,12 +195,8 @@ class MpvIpcClient:
         if event_queue is None:
             return
 
-        while not self._reader_stop.is_set():
-            try:
-                event = event_queue.get(timeout=0.1)
-            except queue.Empty:
-                continue
-
+        while True:
+            event = event_queue.get()
             if event is None:
                 break
 

--- a/tests/test_mpv_ipc.py
+++ b/tests/test_mpv_ipc.py
@@ -210,3 +210,20 @@ def test_event_callback_can_send_command_without_blocking_reader_thread(tmp_path
 def test_disconnect_is_safe_when_not_connected(tmp_path: Path) -> None:
     client = MpvIpcClient(str(tmp_path / "no.sock"))
     client.disconnect()
+
+
+def test_disconnect_wakes_blocked_dispatch_thread(tmp_path: Path) -> None:
+    client = MpvIpcClient(str(tmp_path / "no.sock"))
+    client._event_queue = queue.Queue()
+    client._dispatch_thread = threading.Thread(target=client._dispatch_loop, daemon=True)
+    client._dispatch_thread.start()
+
+    deadline = time.time() + 1.0
+    while time.time() < deadline and not client._dispatch_thread.is_alive():
+        time.sleep(0.01)
+
+    assert client._dispatch_thread.is_alive() is True
+
+    client.disconnect()
+
+    assert client._dispatch_thread is None


### PR DESCRIPTION
Implements issue #247. Generated by wrapper-owned workflow watchdog.