### PR TITLE
[codex] Font cache on whisplay has no eviction

### DIFF
--- a/src/yoyopod/ui/display/adapters/whisplay.py
+++ b/src/yoyopod/ui/display/adapters/whisplay.py
@@ -18,6 +18,7 @@ Date: 2025-11-30
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from functools import lru_cache
 from importlib import import_module
 from pathlib import Path
@@ -181,6 +182,7 @@ class WhisplayDisplayAdapter(DisplayHAL):
     _SLOW_FULL_FRAME_UPDATE_THRESHOLD_SECONDS = 0.03
     _SLOW_REGION_FLUSH_THRESHOLD_SECONDS = 0.008
     _PARTIAL_FLUSH_TIMING_LOG_INTERVAL = 60
+    _FONT_CACHE_MAX_SIZE = 16
 
     def __init__(
         self,
@@ -222,7 +224,7 @@ class WhisplayDisplayAdapter(DisplayHAL):
         self.lvgl_buffer_lines = max(1, int(lvgl_buffer_lines))
         self.ui_backend = None
         self._force_shadow_buffer_sync = False
-        self._font_cache: dict[tuple[str, int], object] = {}
+        self._font_cache: OrderedDict[tuple[str, int], object] = OrderedDict()
         self._timing_metrics: dict[str, float | int] = {
             "full_frame_updates": 0,
             "last_full_frame_convert_ms": 0.0,
@@ -351,6 +353,7 @@ class WhisplayDisplayAdapter(DisplayHAL):
         )
         cached_font = self._font_cache.get(cache_key)
         if cached_font is not None:
+            self._font_cache.move_to_end(cache_key)
             return cached_font
 
         try:
@@ -363,10 +366,13 @@ class WhisplayDisplayAdapter(DisplayHAL):
             cache_key = ("__pil_default__", font_size)
             cached_font = self._font_cache.get(cache_key)
             if cached_font is not None:
+                self._font_cache.move_to_end(cache_key)
                 return cached_font
             font = image_font_module.load_default()
 
         self._font_cache[cache_key] = font
+        if len(self._font_cache) > self._FONT_CACHE_MAX_SIZE:
+            self._font_cache.popitem(last=False)
         return font
 
     @staticmethod

--- a/tests/test_whisplay_adapter.py
+++ b/tests/test_whisplay_adapter.py
@@ -348,6 +348,56 @@ def test_whisplay_font_cache_reuses_loaded_fonts(monkeypatch) -> None:
     assert len(load_calls) == 1
 
 
+def test_whisplay_font_cache_evicts_least_recently_used_fonts(monkeypatch, tmp_path) -> None:
+    """The font cache should stay bounded and evict the stalest entries first."""
+
+    adapter = WhisplayDisplayAdapter(simulate=True, renderer="pil")
+    adapter._font_cache.clear()
+    fake_font_path = tmp_path / "bounded-cache.ttf"
+    fake_font_path.write_text("unused font payload")
+    monkeypatch.setattr(
+        "yoyopod.ui.display.adapters.whisplay.DEFAULT_FONT_PATH",
+        fake_font_path,
+    )
+
+    load_calls: list[tuple[str, int]] = []
+
+    def fake_truetype(path: str, size: int, *args, **kwargs) -> object:
+        load_calls.append((path, size))
+        return object()
+
+    monkeypatch.setattr(
+        "yoyopod.ui.display.adapters.whisplay._load_pillow_modules",
+        lambda: (
+            None,
+            None,
+            None,
+            SimpleNamespace(
+                truetype=fake_truetype,
+                load_default=ImageFont.load_default,
+            ),
+        ),
+    )
+
+    oldest_font = adapter._load_font(10)
+    for size in range(11, 26):
+        adapter._load_font(size)
+
+    assert len(adapter._font_cache) == adapter._FONT_CACHE_MAX_SIZE
+    assert oldest_font is adapter._load_font(10)
+
+    adapter._load_font(26)
+
+    assert len(adapter._font_cache) == adapter._FONT_CACHE_MAX_SIZE
+    assert 11 not in [size for _, size in adapter._font_cache.keys()]
+    assert 10 in [size for _, size in adapter._font_cache.keys()]
+
+    reloaded_font = adapter._load_font(11)
+
+    assert reloaded_font is not oldest_font
+    assert load_calls.count((str(fake_font_path.resolve()), 11)) == 2
+
+
 def test_rgb565_conversion_matches_expected_byte_order() -> None:
     """The optimized conversion should preserve the adapter's big-endian RGB565 contract."""
 


### PR DESCRIPTION
Implements issue #250. Generated by wrapper-owned workflow watchdog.