### PR TITLE
Harden YoYoPod remote playback on device

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 YoyoPod is an iPod-inspired Raspberry Pi application that combines SIP calling, local-first music playback, and a small-screen button UI.
 
 Current product surface:
-- `Listen` - local-only music with `Playlists`, `Recent`, and `Shuffle`
+- `Listen` - local music with `Playlists`, `Recent`, and `Shuffle`, including dashboard-imported device-local tracks
 - `Talk` - contact-first calls and voice notes
 - `Ask` - staged shell for future safe AI interactions
 - `Setup` - power, care, and device status
@@ -92,6 +92,7 @@ Setup and operations:
 Subsystem docs:
 - [Power Module](docs/POWER_MODULE.md)
 - [Audio Stack](docs/AUDIO_STACK.md)
+- [Remote Playback](docs/REMOTE_PLAYBACK.md)
 - [Local-First Music Plan](docs/LOCAL_FIRST_MUSIC_PLAN.md)
 - [mpv Dependencies](docs/MPV_DEPENDENCIES.md)
 - [Cloud Provisioning And Backend Integration](docs/CLOUD_PROVISIONING_AND_BACKEND.md)

--- a/config/device/hardware.yaml
+++ b/config/device/hardware.yaml
@@ -25,7 +25,7 @@ communication_audio:
   ring_output_device: ""
 
 media_audio:
-  alsa_device: "default"
+  alsa_device: "sysdefault:CARD=wm8960soundcard"
 
 voice_audio:
   speaker_device_id: "ALSA: wm8960-soundcard"

--- a/docs/AUDIO_STACK.md
+++ b/docs/AUDIO_STACK.md
@@ -1,234 +1,117 @@
 # YoyoPod Audio Stack
 
-**Last Verified:** 2026-04-08
-**Verified Against:** `origin/main` plus live `rpi-zero` runtime
+**Last Verified:** 2026-04-21  
+**Verified Against:** live `piz` runtime on `feat/music-management-playback`
 
 ## Overview
 
-YoyoPod now uses an app-managed `mpv` process for music playback and Liblinphone for call audio.
+YoYoPod uses an app-managed `mpv` process for music playback and targets the WM8960 codec directly over ALSA.
 
-For music playback, the runtime path is:
+Current deployed music path:
 
 ```text
 yoyopod.py
-  -> yoyopod.main
-     -> YoyoPodApp
-        -> LocalMusicService
-        -> MpvBackend
-           -> MpvProcess
-              -> mpv --idle --no-video --input-ipc-server=/tmp/yoyopod-mpv.sock --audio-device=alsa/default
-           -> MpvIpcClient
-              -> JSON IPC over /tmp/yoyopod-mpv.sock
-        -> ALSA default PCM
-        -> card 0: wm8960-soundcard
-        -> bcm2835 I2S -> WM8960 codec
-        -> speaker / headphone output
+  -> YoyoPodApp
+     -> LocalMusicService
+     -> MpvBackend
+        -> MpvProcess
+           -> mpv --idle --no-video --input-ipc-server=/tmp/yoyopod-mpv.sock --audio-device=alsa/sysdefault:CARD=wm8960soundcard
+        -> MpvIpcClient
+           -> JSON IPC over /tmp/yoyopod-mpv.sock
+     -> WM8960 ALSA playback device
+     -> speaker / headphone output
 ```
 
-For calls and voice notes, the audio runtime is separate:
+On the deployed Pi, `pipewire`, `pipewire-pulse`, and `wireplumber` are masked so they do not fight YoYoPod for the WM8960 card or rewrite codec mixer state underneath the app.
 
-```text
-YoyoPodApp
-  -> VoIPManager
-     -> LiblinphoneBackend
-        -> ALSA: wm8960-soundcard
-        -> same WM8960 codec / physical output path
-```
+## Config Ownership
 
-So music and VoIP use different software stacks, but they converge on the same Raspberry Pi audio hardware.
+- `config/audio/music.yaml` owns music policy such as `music_dir`, `mpv_socket`, and `default_volume`
+- `config/device/hardware.yaml` owns `media_audio.alsa_device`
+- `/etc/default/yoyopod` can override the final ALSA device through `YOYOPOD_ALSA_DEVICE`
 
-## Application Layer
-
-`YoyoPodApp` owns the audio stack startup in production.
-
-- `config/audio/music.yaml` owns `audio.music_dir`, `audio.recent_tracks_file`, `audio.mpv_socket`, `audio.mpv_binary`, and `audio.default_volume`.
-- `config/device/hardware.yaml` owns `media_audio.alsa_device`.
-- `ConfigManager.get_media_settings()` composes those layers into `MediaConfig.music` and `MediaConfig.audio`.
-- `MusicConfig.from_config_manager()` is the app-facing seam that turns the composed media config into mpv runtime settings.
-- startup output volume is applied through the shared output-volume controller.
-
-Current production config shape:
-
-```yaml
-audio:
-  music_dir: /home/tifo/Music
-  recent_tracks_file: data/media/recent_tracks.json
-  mpv_socket: /tmp/yoyopod-mpv.sock
-  mpv_binary: mpv
-  default_volume: 100
-```
+Current deployed value:
 
 ```yaml
 media_audio:
-  alsa_device: default
+  alsa_device: "sysdefault:CARD=wm8960soundcard"
 ```
 
-## Music Domain Models
+## Hardware Reality On `piz`
 
-`src/yoyopod/audio/music/models.py` is the canonical ownership point for shared music-domain data.
+Verified with `aplay -L` and `/proc/asound/cards`:
 
-- `Track` is the shared track model used by mpv metadata, recent-history persistence, and UI playback reads.
-- `Playlist` is the discovered local-playlist summary returned by library scans.
-- `PlaybackQueue` is the runtime ordered track queue used when the app needs selected-track state.
+- `card 0`: `vc4-hdmi`
+- `card 1`: `wm8960-soundcard`
 
-`AppContext` and demo helpers should reference these models instead of defining parallel `Track` or `Playlist` dataclasses.
-
-## Music Control Path
-
-### 1. Local library selection
-
-`LocalMusicService` is the app-facing music layer.
-
-It owns:
-
-- scanning `audio.music_dir`
-- finding `.m3u` playlists
-- loading recent tracks
-- building `Shuffle` queues from local files
-
-It does **not** decode or play audio itself. It hands filesystem paths to the backend.
-
-### 2. Playback backend
-
-`MpvBackend` is the production music backend.
-
-It owns:
-
-- starting and stopping the `mpv` process
-- loading tracks or playlist files
-- play/pause/stop/next/previous commands
-- reading current track metadata
-- receiving push events from mpv
-
-The backend is app-managed. There is no separate music daemon anymore.
-
-### 3. mpv process
-
-`MpvProcess` spawns mpv in idle mode with no video and a JSON IPC socket.
-
-Current launch shape:
-
-```text
-mpv --idle --no-video --input-ipc-server=/tmp/yoyopod-mpv.sock --audio-device=alsa/default
-```
-
-This was verified live on `rpi-zero` on 2026-04-08.
-
-### 4. mpv IPC
-
-`MpvIpcClient` talks to mpv over `/tmp/yoyopod-mpv.sock`.
-
-It is used for:
-
-- playback commands
-- volume commands
-- property reads
-- push event subscription for:
-  - `path`
-  - `metadata`
-  - `duration`
-  - `media-title`
-  - `pause`
-  - `idle-active`
-
-That is how `Now Playing` and runtime playback state stay current without polling an external daemon.
-
-## Volume Path
-
-`OutputVolumeController` owns one app-facing output volume across ALSA and mpv.
-
-It does two things:
-
-1. writes the system mixer through `amixer`
-2. pushes the same volume into the connected `mpv` backend
-
-In priority order it tries ALSA controls like:
-
-- `Master`
-- `Speaker`
-- `Headphone`
-
-On the current Pi, the active relevant mixer controls are:
-
-- `Speaker`
-- `Headphone`
-- `Playback`
-
-Verified live on `rpi-zero`:
-
-- `Speaker`: `100%` / `+6.00dB`
-- `Headphone`: `100%` / `+6.00dB`
-
-So the effective music loudness comes from:
-
-```text
-YoyoPod shared volume
-  -> ALSA mixer controls
-  -> mpv volume property
-  -> WM8960 analog output stage
-```
-
-## Hardware Path On The Pi
-
-Verified live with `aplay -l` on 2026-04-08:
-
-- `card 0`: `wm8960-soundcard`
-- `device 0`: `bcm2835-i2s-wm8960-hifi`
-
-That means the practical hardware output path is:
+So the correct YoYoPod music path is not ALSA `default`. It is the WM8960 card explicitly:
 
 ```text
 mpv
-  -> ALSA `default`
-  -> ALSA card 0 (`wm8960-soundcard`)
-  -> bcm2835 I2S digital audio
+  -> ALSA sysdefault:CARD=wm8960soundcard
+  -> bcm2835 I2S
   -> WM8960 codec
-  -> speaker / headphone analog output
+  -> analog speaker / headphone output
 ```
 
-There is also HDMI audio on card 1, but the current YoyoPod music runtime is using the WM8960 path, not HDMI.
+## Volume Strategy
 
-## Call Audio Relationship
+`OutputVolumeController` owns the shared app-facing output volume.
 
-VoIP is not routed through mpv.
+For WM8960-class hardware the effective production rule is:
 
-Liblinphone uses the communication audio selectors from
-`config/device/hardware.yaml`, typically:
+- keep codec output headroom high
+- use mpv volume as the user-facing playback loudness
 
-- playback: `ALSA: wm8960-soundcard`
-- ringer: `ALSA: wm8960-soundcard`
-- capture: `ALSA: wm8960-soundcard`
-- media: `ALSA: wm8960-soundcard`
+Current deployed headroom fix:
 
-So:
+- `Playback` pinned to `100%`
+- `Speaker` pinned to `100%`
+- `Headphone` pinned to `100%`
 
-- music path: `mpv -> media_audio.alsa_device -> wm8960`
-- VoIP path: `Liblinphone -> ALSA: wm8960-soundcard`
+Why:
 
-They are separate software paths that meet at the same codec/hardware.
+- on WM8960, app-style percentages like `50%` on the hardware `Playback` control map to very low analog output levels
+- using those hardware controls as the primary user volume made the device appear to be "playing with no sound"
+
+Current loudness path:
+
+```text
+YoYoPod shared volume
+  -> mpv volume property
+  -> WM8960 codec already held at calibrated headroom
+```
+
+## Local And Remote Music
+
+Local playlist playback and backend-issued remote playback both converge on the same `mpv` process.
+
+Remote playback behavior:
+
+- backend issues `play_track`
+- device downloads the authorized asset into the bounded remote cache
+- mpv plays from the cached local file
+
+Device-local import behavior:
+
+- backend issues `store_media`
+- device downloads the finalized household track
+- device persists it into `YOYOPOD_MUSIC_DIR/dashboard_uploads/`
+- device updates `Dashboard Uploads.m3u`
+- local `Listen` surfaces can then play it as a normal local playlist
 
 ## Operational Notes
 
-- There is no Mopidy or GStreamer dependency in the current production music path.
-- `mpv` is spawned by the app and dies with the app.
-- If music works but is quiet, check both:
-  - YoyoPod shared volume
-  - ALSA `Speaker` / `Headphone` mixer levels
-- If `Now Playing` is wrong, the most relevant layers are:
-  - `LocalMusicService`
-  - `MpvBackend`
-  - `MpvIpcClient`
-  - file tag fallback in `Track.from_mpv_metadata()`
+- if music says `playing` but the device is silent, check the actual ALSA device first; `alsa/default` is not acceptable on this hardware
+- if `Playback` drops back down unexpectedly after boot, verify `pipewire`, `pipewire-pulse`, and `wireplumber` are still inactive
+- if mpv is alive but no track advances, inspect `/tmp/yoyopod-mpv.sock`
+- if imported dashboard tracks do not appear locally, inspect `Dashboard Uploads.m3u` and the `dashboard_uploads/` directory under the configured music dir
 
 ## Source Files
 
-- `src/yoyopod/app.py`
-- `src/yoyopod/audio/local_service.py`
-- `src/yoyopod/audio/music/backend.py`
 - `src/yoyopod/audio/music/process.py`
-- `src/yoyopod/audio/music/ipc.py`
-- `src/yoyopod/audio/music/models.py`
+- `src/yoyopod/audio/music/backend.py`
 - `src/yoyopod/audio/volume.py`
-- `config/audio/music.yaml`
+- `src/yoyopod/cloud/manager.py`
 - `config/device/hardware.yaml`
-- `config/communication/calling.yaml`
+- `/etc/default/yoyopod`

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,8 @@ Plan docs are useful, but they are not automatically the current implementation 
 - [`DISPLAY_HAL_ARCHITECTURE.md`](DISPLAY_HAL_ARCHITECTURE.md), display abstraction and adapters
 - [`INPUT_HAL_ARCHITECTURE.md`](INPUT_HAL_ARCHITECTURE.md), semantic input model and adapters
 - [`POWER_MODULE.md`](POWER_MODULE.md), power, battery, RTC, watchdog
-- [`AUDIO_STACK.md`](AUDIO_STACK.md), local playback and output-volume behavior
+- [`AUDIO_STACK.md`](AUDIO_STACK.md), deployed ALSA routing, WM8960 headroom, and mpv output behavior
+- [`REMOTE_PLAYBACK.md`](REMOTE_PLAYBACK.md), backend-issued playback, cache, and device-local media import contract
 - [`LOCAL_FIRST_MUSIC_PLAN.md`](LOCAL_FIRST_MUSIC_PLAN.md), current music direction and constraints
 - [`MPV_DEPENDENCIES.md`](MPV_DEPENDENCIES.md), mpv-specific dependency and integration notes
 

--- a/docs/REMOTE_PLAYBACK.md
+++ b/docs/REMOTE_PLAYBACK.md
@@ -73,6 +73,7 @@ Remote playback uses a bounded local cache before mpv starts playback.
 - checksum is verified when provided
 - cache downloads run off the coordinator thread before mpv load starts
 - least-recently-used pruning uses file mtime and evicts oldest files first
+- the just-fetched asset is protected from immediate self-eviction even when it exceeds the nominal cache cap
 - playback runs from the cached local file, not the signed backend URL
 
 Relevant config fields:
@@ -93,7 +94,7 @@ Dashboard upload now supports device-local persistence through the backend-media
 Current import behavior:
 
 1. backend finalizes the uploaded household track
-2. backend sends `store_media` to the selected device
+2. backend sends `store_media` to the selected device over the same MQTT command dispatcher used for playback commands
 3. device downloads the authorized asset through the same cache path used by remote playback
 4. device persists the file under `YOYOPOD_MUSIC_DIR/dashboard_uploads/`
 5. device updates `YOYOPOD_MUSIC_DIR/Dashboard Uploads.m3u`
@@ -106,6 +107,7 @@ This keeps backend as the policy authority while making the resulting media avai
 - only one active remote playback session is tracked
 - a new valid `play_track` interrupts the current remote playback
 - pending downloads are correlated by `commandId` and activation generation so stale stop callbacks do not clear the next session
+- if `stop` arrives while a remote asset is still buffering, the pending asset is discarded and playback does not start after the stop ACK
 - `pause` and `resume` run through the current mpv backend path
 - duplicate `commandId` values are ACKed as duplicates and are not replayed
 - `store_media` also participates in duplicate command suppression

--- a/docs/REMOTE_PLAYBACK.md
+++ b/docs/REMOTE_PLAYBACK.md
@@ -1,8 +1,8 @@
 # YoYoPod Remote Playback On Device
 
-This document describes the device-side playback behavior for `yoyo-py`.
+This document describes the current device-side playback and media-import behavior for `yoyo-py`.
 
-## Contract
+## MQTT Contract
 
 Topics:
 
@@ -12,15 +12,17 @@ Topics:
 
 Rules:
 
-- `ack` topic is only for command acceptance or rejection
-- `evt` topic is only for playback lifecycle
+- `ack` emits command acceptance only
+- `evt` emits lifecycle only
+- `ack` and `nack` must never be replayed as lifecycle events on `evt`
 
-Accepted playback commands:
+Accepted commands:
 
 - `play_track`
 - `pause`
 - `resume`
 - `stop`
+- `store_media`
 
 ## ACK Payloads
 
@@ -43,9 +45,9 @@ Accepted playback commands:
 }
 ```
 
-## Playback Event Payloads
+## Event Payloads
 
-Lifecycle events are published on `evt` with `type: "playback"`.
+Playback lifecycle is published on `evt` with `type: "playback"`.
 
 Supported `eventType` values:
 
@@ -56,14 +58,21 @@ Supported `eventType` values:
 - `completed`
 - `failed`
 
-## Caching
+Device-local media import lifecycle is also published on `evt`, but with `type: "media_library"`.
 
-Remote playback now uses a bounded local cache:
+Supported media-library `eventType` values:
+
+- `imported`
+- `failed`
+
+## Remote Playback Cache
+
+Remote playback uses a bounded local cache before mpv starts playback.
 
 - cache key includes `track_id`
 - checksum is verified when provided
-- least-recently-used pruning is based on file mtime
-- cache size is bounded by config
+- least-recently-used pruning uses file mtime
+- playback runs from the cached local file, not the signed backend URL
 
 Relevant config fields:
 
@@ -73,23 +82,35 @@ Relevant config fields:
 Operational behavior:
 
 - first remote play downloads and verifies the asset
-- repeated plays use the cached local file when available
-- playback runs against the local cached file, not the signed backend URL
+- repeated plays reuse the cached local asset when possible
+- short backend token lifetime does not interrupt playback after fetch completes
+
+## Device-Local Media Import
+
+Dashboard upload now supports device-local persistence through the backend-mediated `store_media` command.
+
+Current import behavior:
+
+1. backend finalizes the uploaded household track
+2. backend sends `store_media` to the selected device
+3. device downloads the authorized asset through the same cache path used by remote playback
+4. device persists the file under `YOYOPOD_MUSIC_DIR/dashboard_uploads/`
+5. device updates `YOYOPOD_MUSIC_DIR/Dashboard Uploads.m3u`
+6. device emits `media_library.imported` or `media_library.failed`
+
+This keeps backend as the policy authority while making the resulting media available through the device-local `Listen` surface.
 
 ## Playback Behavior
 
 - only one active remote playback session is tracked
-- a new valid `play_track` interrupts current playback
-- `pause` and `resume` use the current mpv backend path
-- duplicate `commandId` values are ACKed as duplicates and not replayed
+- a new valid `play_track` interrupts the current remote playback
+- `pause` and `resume` run through the current mpv backend path
+- duplicate `commandId` values are ACKed as duplicates and are not replayed
+- `store_media` also participates in duplicate command suppression
 
-## Current Operational Caveat
+## Real Validation Notes
 
-The real Pi used for validation currently lacks a working LVGL production shim build, so cloud/media validation was performed with the app running on the actual Pi in `--simulate` display mode. Audio, MQTT, remote fetch, and cache behavior were validated on-device; the display contract remains a separate operational restore task.
-
-## Validation Notes
-
-Observed real-device validation on `piz` confirmed:
+Observed on the real `piz` device:
 
 - `ack`
 - `buffering`
@@ -97,6 +118,10 @@ Observed real-device validation on `piz` confirmed:
 - `paused`
 - `resume -> playing`
 - `stop -> stopped`
-- long-track playback beyond the short device token lifetime
-- cache miss on first long-track play
-- cache hit on repeated long-track play
+- `store_media -> media_library.imported`
+- repeated import/play paths using cached assets
+
+Operational note:
+
+- the current Pi runtime still logs VoIP recovery warnings because the Liblinphone native backend is unavailable on that device image
+- this does not block local music playback or media import

--- a/docs/REMOTE_PLAYBACK.md
+++ b/docs/REMOTE_PLAYBACK.md
@@ -69,9 +69,10 @@ Supported media-library `eventType` values:
 
 Remote playback uses a bounded local cache before mpv starts playback.
 
-- cache key includes `track_id`
+- cache key includes a sanitized `track_id`
 - checksum is verified when provided
-- least-recently-used pruning uses file mtime
+- cache downloads run off the coordinator thread before mpv load starts
+- least-recently-used pruning uses file mtime and evicts oldest files first
 - playback runs from the cached local file, not the signed backend URL
 
 Relevant config fields:
@@ -104,6 +105,7 @@ This keeps backend as the policy authority while making the resulting media avai
 
 - only one active remote playback session is tracked
 - a new valid `play_track` interrupts the current remote playback
+- pending downloads are correlated by `commandId` and activation generation so stale stop callbacks do not clear the next session
 - `pause` and `resume` run through the current mpv backend path
 - duplicate `commandId` values are ACKed as duplicates and are not replayed
 - `store_media` also participates in duplicate command suppression

--- a/docs/REMOTE_PLAYBACK.md
+++ b/docs/REMOTE_PLAYBACK.md
@@ -1,0 +1,102 @@
+# YoYoPod Remote Playback On Device
+
+This document describes the device-side playback behavior for `yoyo-py`.
+
+## Contract
+
+Topics:
+
+- `yoyopod/{deviceId}/cmd`
+- `yoyopod/{deviceId}/ack`
+- `yoyopod/{deviceId}/evt`
+
+Rules:
+
+- `ack` topic is only for command acceptance or rejection
+- `evt` topic is only for playback lifecycle
+
+Accepted playback commands:
+
+- `play_track`
+- `pause`
+- `resume`
+- `stop`
+
+## ACK Payloads
+
+```json
+{
+  "command_id": "cmd_123",
+  "status": "ack",
+  "payload": {
+    "command": "play_track"
+  }
+}
+```
+
+```json
+{
+  "command_id": "cmd_123",
+  "status": "nack",
+  "reason": "invalid_command",
+  "payload": {}
+}
+```
+
+## Playback Event Payloads
+
+Lifecycle events are published on `evt` with `type: "playback"`.
+
+Supported `eventType` values:
+
+- `buffering`
+- `playing`
+- `paused`
+- `stopped`
+- `completed`
+- `failed`
+
+## Caching
+
+Remote playback now uses a bounded local cache:
+
+- cache key includes `track_id`
+- checksum is verified when provided
+- least-recently-used pruning is based on file mtime
+- cache size is bounded by config
+
+Relevant config fields:
+
+- `media.music.remote_cache_dir`
+- `media.music.remote_cache_max_bytes`
+
+Operational behavior:
+
+- first remote play downloads and verifies the asset
+- repeated plays use the cached local file when available
+- playback runs against the local cached file, not the signed backend URL
+
+## Playback Behavior
+
+- only one active remote playback session is tracked
+- a new valid `play_track` interrupts current playback
+- `pause` and `resume` use the current mpv backend path
+- duplicate `commandId` values are ACKed as duplicates and not replayed
+
+## Current Operational Caveat
+
+The real Pi used for validation currently lacks a working LVGL production shim build, so cloud/media validation was performed with the app running on the actual Pi in `--simulate` display mode. Audio, MQTT, remote fetch, and cache behavior were validated on-device; the display contract remains a separate operational restore task.
+
+## Validation Notes
+
+Observed real-device validation on `piz` confirmed:
+
+- `ack`
+- `buffering`
+- `playing`
+- `paused`
+- `resume -> playing`
+- `stop -> stopped`
+- long-track playback beyond the short device token lifetime
+- cache miss on first long-track play
+- cache hit on repeated long-track play

--- a/src/yoyopod/audio/volume.py
+++ b/src/yoyopod/audio/volume.py
@@ -41,6 +41,12 @@ class OutputVolumeController:
 
     def get_volume(self) -> int | None:
         """Return the best current app-facing output volume."""
+        if self.music_backend is not None:
+            backend_volume = self.music_backend.get_volume()
+            if backend_volume is not None:
+                self._last_requested_volume = backend_volume
+                return backend_volume
+
         system_volume = self.get_system_volume()
         if system_volume is not None:
             self._last_requested_volume = system_volume
@@ -48,12 +54,6 @@ class OutputVolumeController:
 
         if self._last_requested_volume is not None:
             return self._last_requested_volume
-
-        if self.music_backend is not None:
-            backend_volume = self.music_backend.get_volume()
-            if backend_volume is not None:
-                self._last_requested_volume = backend_volume
-                return backend_volume
 
         return self._last_requested_volume
 
@@ -110,24 +110,37 @@ class OutputVolumeController:
         return None
 
     def set_system_volume(self, volume: int) -> bool:
-        """Write one ALSA mixer percentage for the configured control."""
+        """Keep WM8960 output stages at calibrated headroom when available."""
+        if self._ensure_wm8960_output_headroom():
+            self._last_system_volume_available = True
+            return True
+
         target = max(0, min(100, int(volume)))
-        applied = False
         for command in self._amixer_set_candidates(f"{target}%"):
             result = self._run_amixer(command)
             if result is None:
                 return False
             if result.returncode == 0:
-                applied = True
-
-        if applied:
-            self._last_system_volume_available = True
-            return True
+                self._last_system_volume_available = True
+                return True
 
         if self._last_system_volume_available is not False:
             logger.warning("Failed to set ALSA output volume to {}%", target)
         self._last_system_volume_available = False
         return False
+
+    def _ensure_wm8960_output_headroom(self) -> bool:
+        """Pin WM8960 output stages high and leave user volume to mpv."""
+        successes = 0
+        for command in (
+            [self.amixer_binary, "-c", "1", "sset", "Playback", "100%"],
+            [self.amixer_binary, "-c", "1", "sset", "Speaker", "100%"],
+            [self.amixer_binary, "-c", "1", "sset", "Headphone", "100%"],
+        ):
+            result = self._run_amixer(command)
+            if result is not None and result.returncode == 0:
+                successes += 1
+        return successes > 0
 
     def _amixer_get_candidates(self) -> list[list[str]]:
         """Return candidate amixer reads in priority order."""
@@ -138,6 +151,9 @@ class OutputVolumeController:
                 (None, self.mixer_control),
                 ("1", self.mixer_control),
                 ("0", self.mixer_control),
+                (None, "Playback"),
+                ("1", "Playback"),
+                ("0", "Playback"),
                 ("1", "Headset"),
                 ("0", "Headset"),
                 ("1", "Speaker"),
@@ -156,6 +172,9 @@ class OutputVolumeController:
                 (None, self.mixer_control),
                 ("1", self.mixer_control),
                 ("0", self.mixer_control),
+                (None, "Playback"),
+                ("1", "Playback"),
+                ("0", "Playback"),
                 ("1", "Headset"),
                 ("0", "Headset"),
                 ("1", "Speaker"),

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -1199,7 +1199,7 @@ class CloudManager:
         if session is None:
             return
 
-        if state == "stopped" and session.get("activation_pending"):
+        if state == "stopped" and session.get("activation_pending") and not session.get("cached_path"):
             return
 
         position_ms = self._current_playback_position_ms()
@@ -1568,7 +1568,12 @@ class CloudManager:
     def _safe_media_filename(value: str, *, default_stem: str, suffix: str) -> str:
         stem = Path(value).stem if value else default_stem
         normalized = "".join(char if char.isalnum() or char in {"-", "_"} else "-" for char in stem)
-        normalized = normalized.strip(".-_") or default_stem
+        normalized = normalized.strip(".-_")
+        if not normalized:
+            fallback = "".join(
+                char if char.isalnum() or char in {"-", "_"} else "-" for char in default_stem
+            ).strip(".-_")
+            normalized = fallback or "track"
         safe_suffix = suffix if suffix.startswith(".") else f".{suffix}"
         return f"{normalized}{safe_suffix[:16]}"
 

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import threading
 import time
 from collections import deque
@@ -1011,6 +1012,8 @@ class CloudManager:
             logger.info("MQTT: backend requested immediate config fetch")
         elif cmd_type in {"play_track", "stop", "pause", "resume"}:
             self._apply_playback_command(command)
+        elif cmd_type == "store_media":
+            self._apply_store_media_command(command)
         else:
             logger.info("MQTT: unhandled command type {}", cmd_type)
 
@@ -1277,6 +1280,26 @@ class CloudManager:
         }
         self._mqtt.publish_playback_event(event_payload)
 
+    def _publish_media_library_event(
+        self,
+        event_type: str,
+        *,
+        command_id: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        if self._mqtt is None or not self._mqtt.is_connected:
+            return
+
+        event_payload: dict[str, Any] = {
+            "messageType": "media_library.event",
+            "commandId": command_id,
+            "deviceId": self.config_manager.get_cloud_device_id().strip(),
+            "eventType": event_type,
+            "occurredAt": self._utc_now(),
+            "payload": payload or {},
+        }
+        self._mqtt.publish_event("media_library", event_payload)
+
     def _run_prepare_remote_playback_asset(
         self,
         *,
@@ -1358,6 +1381,19 @@ class CloudManager:
             )
             return
 
+        if session.get("stop_requested"):
+            self._remote_playback_session = None
+            self._last_remote_playback_state = None
+            self._publish_playback_event(
+                "stopped",
+                command_id=command_id,
+                payload={
+                    "trackId": track_id,
+                    "positionMs": 0,
+                },
+            )
+            return
+
         session["cached_path"] = cached_asset.path
         if not music_backend.load_tracks([cached_asset.path]):
             self._remote_playback_session = None
@@ -1370,6 +1406,171 @@ class CloudManager:
                     "reason": "decode_failed",
                 },
             )
+
+    def _apply_store_media_command(self, command: dict[str, Any]) -> None:
+        mqtt = self._mqtt
+        command_id = str(command.get("commandId") or command.get("command_id") or "").strip()
+        payload = command.get("payload")
+        payload = payload if isinstance(payload, dict) else {}
+
+        if not command_id or mqtt is None or not mqtt.is_connected:
+            return
+
+        if command_id in self._recent_remote_command_ids:
+            mqtt.publish_ack(command_id=command_id, ok=True, payload={"duplicate": True})
+            return
+
+        media_url = str(payload.get("mediaUrl") or payload.get("media_url") or "").strip()
+        track_id = str(payload.get("trackId") or payload.get("track_id") or "").strip()
+        if not media_url or not track_id:
+            mqtt.publish_ack(command_id=command_id, ok=False, reason="invalid_command")
+            return
+
+        self._recent_remote_command_ids.append(command_id)
+        mqtt.publish_ack(command_id=command_id, ok=True, payload={"command": "store_media"})
+
+        checksum_sha256 = (
+            str(payload.get("checksumSha256") or payload.get("checksum_sha256") or "").strip()
+            or None
+        )
+        self._start_worker(
+            name=f"cloud-store-media-{command_id[:8]}",
+            work=lambda: self._run_store_media_command(
+                command_id=command_id,
+                track_id=track_id,
+                media_url=media_url,
+                checksum_sha256=checksum_sha256,
+                payload=payload,
+            ),
+        )
+
+    def _run_store_media_command(
+        self,
+        *,
+        command_id: str,
+        track_id: str,
+        media_url: str,
+        checksum_sha256: str | None,
+        payload: dict[str, Any],
+    ) -> None:
+        try:
+            cached_asset = self._remote_playback_cache.prepare(
+                track_id=track_id,
+                media_url=media_url,
+                checksum_sha256=checksum_sha256,
+            )
+            target_path = self._persist_device_media_asset(
+                track_id=track_id,
+                cached_path=Path(cached_asset.path),
+                payload=payload,
+            )
+        except Exception as exc:
+            logger.warning("Device media import failed for {}: {}", track_id, exc)
+            self._queue_main_thread_callback(
+                lambda exc=exc: self._complete_store_media_command(
+                    command_id=command_id,
+                    track_id=track_id,
+                    error=exc,
+                )
+            )
+            return
+
+        self._queue_main_thread_callback(
+            lambda target_path=target_path: self._complete_store_media_command(
+                command_id=command_id,
+                track_id=track_id,
+                target_path=target_path,
+            )
+        )
+
+    def _complete_store_media_command(
+        self,
+        *,
+        command_id: str,
+        track_id: str,
+        target_path: Path | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        if error is not None or target_path is None:
+            self._publish_media_library_event(
+                "failed",
+                command_id=command_id,
+                payload={
+                    "trackId": track_id,
+                    "reason": "media_fetch_failed",
+                },
+            )
+            return
+
+        self._publish_media_library_event(
+            "imported",
+            command_id=command_id,
+            payload={
+                "trackId": track_id,
+                "path": str(target_path),
+            },
+        )
+
+    def _persist_device_media_asset(
+        self,
+        *,
+        track_id: str,
+        cached_path: Path,
+        payload: dict[str, Any],
+    ) -> Path:
+        music_dir = self._device_music_dir()
+        uploads_dir = music_dir / "dashboard_uploads"
+        uploads_dir.mkdir(parents=True, exist_ok=True)
+
+        preferred_name = (
+            str(payload.get("filename") or payload.get("originalFilename") or payload.get("title") or "").strip()
+        )
+        source_suffix = cached_path.suffix or ".mp3"
+        safe_name = self._safe_media_filename(preferred_name, default_stem=track_id, suffix=source_suffix)
+        target_path = uploads_dir / safe_name
+
+        shutil.copy2(cached_path, target_path)
+        self._append_dashboard_uploads_playlist(target_path)
+        return target_path
+
+    def _append_dashboard_uploads_playlist(self, target_path: Path) -> None:
+        playlist_path = self._device_music_dir() / "Dashboard Uploads.m3u"
+        playlist_path.parent.mkdir(parents=True, exist_ok=True)
+        existing_entries: set[str] = set()
+        if playlist_path.exists():
+            try:
+                existing_entries = {
+                    line.strip()
+                    for line in playlist_path.read_text(encoding="utf-8").splitlines()
+                    if line.strip()
+                }
+            except Exception:
+                existing_entries = set()
+
+        entry = str(target_path)
+        if entry in existing_entries:
+            return
+
+        with playlist_path.open("a", encoding="utf-8") as handle:
+            if playlist_path.stat().st_size > 0:
+                handle.write("\n")
+            handle.write(entry)
+
+    def _device_music_dir(self) -> Path:
+        get_media_settings = getattr(self.config_manager, "get_media_settings", None)
+        if callable(get_media_settings):
+            music_dir = get_media_settings().music.music_dir
+        else:
+            music_dir = "/home/pi/Music"
+        return Path(self.config_manager.resolve_runtime_path(music_dir)).expanduser()
+
+    @staticmethod
+    def _safe_media_filename(value: str, *, default_stem: str, suffix: str) -> str:
+        stem = Path(value).stem if value else default_stem
+        normalized = "".join(char if char.isalnum() or char in {"-", "_"} else "-" for char in stem)
+        normalized = normalized.strip(".-_") or default_stem
+        safe_suffix = suffix if suffix.startswith(".") else f".{suffix}"
+        return f"{normalized}{safe_suffix[:16]}"
 
     def _is_backend_configured(self) -> bool:
         return bool(self.config_manager.get_cloud_settings().backend.api_base_url.strip())

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -1526,7 +1526,12 @@ class CloudManager:
             str(payload.get("filename") or payload.get("originalFilename") or payload.get("title") or "").strip()
         )
         source_suffix = cached_path.suffix or ".mp3"
-        safe_name = self._safe_media_filename(preferred_name, default_stem=track_id, suffix=source_suffix)
+        display_stem = self._safe_media_stem(preferred_name, default_stem=track_id)
+        unique_stem = self._safe_media_stem(track_id, default_stem="track")
+        if display_stem == unique_stem:
+            safe_name = f"{display_stem}{self._safe_media_suffix(source_suffix)}"
+        else:
+            safe_name = f"{display_stem}-{unique_stem}{self._safe_media_suffix(source_suffix)}"
         target_path = uploads_dir / safe_name
 
         shutil.copy2(cached_path, target_path)
@@ -1566,6 +1571,10 @@ class CloudManager:
 
     @staticmethod
     def _safe_media_filename(value: str, *, default_stem: str, suffix: str) -> str:
+        return f"{CloudManager._safe_media_stem(value, default_stem=default_stem)}{CloudManager._safe_media_suffix(suffix)}"
+
+    @staticmethod
+    def _safe_media_stem(value: str, *, default_stem: str) -> str:
         stem = Path(value).stem if value else default_stem
         normalized = "".join(char if char.isalnum() or char in {"-", "_"} else "-" for char in stem)
         normalized = normalized.strip(".-_")
@@ -1574,8 +1583,12 @@ class CloudManager:
                 char if char.isalnum() or char in {"-", "_"} else "-" for char in default_stem
             ).strip(".-_")
             normalized = fallback or "track"
+        return normalized
+
+    @staticmethod
+    def _safe_media_suffix(suffix: str) -> str:
         safe_suffix = suffix if suffix.startswith(".") else f".{suffix}"
-        return f"{normalized}{safe_suffix[:16]}"
+        return safe_suffix[:16]
 
     def _is_backend_configured(self) -> bool:
         return bool(self.config_manager.get_cloud_settings().backend.api_base_url.strip())

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import json
 import threading
 import time
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
+from urllib.parse import unquote, urlparse
 
 from loguru import logger
 
 from yoyopod.cloud.client import CloudClientError, CloudDeviceClient
 from yoyopod.cloud.models import CloudAccessToken, CloudStatusSnapshot
 from yoyopod.cloud.mqtt_client import DeviceMqttClient
+from yoyopod.cloud.playback_cache import RemotePlaybackCache
 
 if TYPE_CHECKING:
     from yoyopod.app import YoyoPodApp
@@ -59,10 +62,20 @@ class CloudManager:
         self._mqtt: DeviceMqttClient | None = None
         self._next_battery_report_at = 0.0
         self._contacts_bootstrap_attempted = False
+        self._playback_callbacks_bound = False
+        self._remote_playback_session: dict[str, Any] | None = None
+        self._recent_remote_command_ids: deque[str] = deque(maxlen=32)
+        self._last_remote_playback_state: str | None = None
+        media_settings = self.config_manager.get_media_settings().music
+        self._remote_playback_cache = RemotePlaybackCache(
+            self.config_manager.resolve_runtime_path(media_settings.remote_cache_dir),
+            media_settings.remote_cache_max_bytes,
+        )
 
     def prepare_boot(self) -> None:
         """Load secrets/cache and start MQTT before the runtime loop begins."""
 
+        self._bind_playback_callbacks()
         self._reload_provisioning(force=True, now=time.monotonic())
 
     def tick(self, now: float | None = None) -> None:
@@ -979,17 +992,286 @@ class CloudManager:
         )
 
     def _handle_mqtt_command(self, command: dict[str, Any]) -> None:
-        cmd_type = command.get("type", "unknown")
+        cmd_type = command.get("command") or command.get("type", "unknown")
         logger.info("MQTT command received from backend: {}", cmd_type)
         self._queue_main_thread_callback(lambda cmd=command: self._apply_mqtt_command(cmd))
 
     def _apply_mqtt_command(self, command: dict[str, Any]) -> None:
-        cmd_type = command.get("type", "")
+        cmd_type = str(command.get("command") or command.get("type") or "").strip()
         if cmd_type == "fetch_config":
             self._next_config_poll_at = 0.0
             logger.info("MQTT: backend requested immediate config fetch")
+        elif cmd_type in {"play_track", "stop", "pause", "resume"}:
+            self._apply_playback_command(command)
         else:
-            logger.info("MQTT: unhandled command type '{}'", cmd_type)
+            logger.info("MQTT: unhandled command type {}", cmd_type)
+
+    def _bind_playback_callbacks(self) -> None:
+        if self._playback_callbacks_bound:
+            return
+
+        music_backend = getattr(self.app, "music_backend", None)
+        if music_backend is None:
+            return
+
+        track_change = getattr(music_backend, "on_track_change", None)
+        if callable(track_change):
+            track_change(self._handle_music_track_change)
+
+        playback_change = getattr(music_backend, "on_playback_state_change", None)
+        if callable(playback_change):
+            playback_change(self._handle_music_playback_state_change)
+
+        self._playback_callbacks_bound = True
+
+    def _apply_playback_command(self, command: dict[str, Any]) -> None:
+        mqtt = self._mqtt
+        music_backend = getattr(self.app, "music_backend", None)
+        command_id = str(command.get("commandId") or command.get("command_id") or "").strip()
+        cmd_type = str(command.get("command") or command.get("type") or "").strip()
+        payload = command.get("payload")
+        payload = payload if isinstance(payload, dict) else {}
+
+        if not command_id:
+            return
+
+        if mqtt is None or not mqtt.is_connected:
+            return
+
+        if command_id in self._recent_remote_command_ids:
+            mqtt.publish_ack(command_id=command_id, ok=True, payload={"duplicate": True})
+            return
+
+        if music_backend is None or not getattr(music_backend, "is_connected", False):
+            mqtt.publish_ack(
+                command_id=command_id,
+                ok=False,
+                reason="playback_backend_error",
+            )
+            return
+
+        if cmd_type == "play_track":
+            media_url = str(payload.get("mediaUrl") or payload.get("media_url") or "").strip()
+            track_id = str(payload.get("trackId") or payload.get("track_id") or "").strip()
+            if not media_url or not track_id:
+                mqtt.publish_ack(command_id=command_id, ok=False, reason="invalid_command")
+                return
+
+            stop_playback = getattr(music_backend, "stop_playback", None)
+            if callable(stop_playback):
+                stop_playback()
+
+            self._remote_playback_session = {
+                "command_id": command_id,
+                "track_id": track_id,
+                "title": payload.get("title"),
+                "artist": payload.get("artist"),
+                "duration_ms": payload.get("durationMs"),
+                "media_url": media_url,
+                "cached_path": None,
+            }
+            self._recent_remote_command_ids.append(command_id)
+            mqtt.publish_ack(command_id=command_id, ok=True, payload={"command": cmd_type})
+            self._publish_playback_event(
+                "buffering",
+                command_id=command_id,
+                payload={"trackId": track_id, "positionMs": 0},
+            )
+
+            try:
+                cached_asset = self._remote_playback_cache.prepare(
+                    track_id=track_id,
+                    media_url=media_url,
+                    checksum_sha256=(
+                        str(payload.get("checksumSha256") or payload.get("checksum_sha256") or "").strip()
+                        or None
+                    ),
+                )
+            except Exception:
+                self._remote_playback_session = None
+                self._last_remote_playback_state = None
+                self._publish_playback_event(
+                    "failed",
+                    command_id=command_id,
+                    payload={
+                        "trackId": track_id,
+                        "reason": "media_fetch_failed",
+                    },
+                )
+                return
+
+            self._remote_playback_session["cached_path"] = cached_asset.path
+            self._last_remote_playback_state = "buffering"
+
+            if not music_backend.load_tracks([cached_asset.path]):
+                self._remote_playback_session = None
+                self._last_remote_playback_state = None
+                self._publish_playback_event(
+                    "failed",
+                    command_id=command_id,
+                    payload={
+                        "trackId": track_id,
+                        "reason": "decode_failed",
+                    },
+                )
+                return
+            return
+
+        session = self._remote_playback_session
+        if session is None:
+            mqtt.publish_ack(command_id=command_id, ok=False, reason="invalid_command")
+            return
+
+        operation = {
+            "stop": getattr(music_backend, "stop_playback", None),
+            "pause": getattr(music_backend, "pause", None),
+            "resume": getattr(music_backend, "play", None),
+        }.get(cmd_type)
+
+        if cmd_type == "stop":
+            session["stop_requested"] = True
+
+        if not callable(operation) or not operation():
+            mqtt.publish_ack(command_id=command_id, ok=False, reason="playback_backend_error")
+            self._publish_playback_event(
+                "failed",
+                command_id=session["command_id"],
+                payload={
+                    "trackId": session["track_id"],
+                    "reason": "playback_backend_error",
+                },
+            )
+            return
+
+        self._recent_remote_command_ids.append(command_id)
+        mqtt.publish_ack(command_id=command_id, ok=True, payload={"command": cmd_type})
+
+    def _handle_music_track_change(self, track: Any) -> None:
+        if self._remote_playback_session is None or track is None:
+            return
+
+        current_uri = getattr(track, "uri", None)
+        session_uri = self._remote_playback_session.get("cached_path")
+        current_path = self._normalize_local_media_path(current_uri)
+        session_path = self._normalize_local_media_path(session_uri)
+        track_id = str(self._remote_playback_session.get("track_id") or "").strip()
+        normalized_current_uri = str(current_uri or "")
+        is_file_like_uri = (
+            normalized_current_uri.startswith("file://")
+            or "/" in normalized_current_uri
+            or bool(Path(normalized_current_uri).suffix)
+        )
+
+        if current_path is not None and session_path is not None:
+            if current_path == session_path or current_path.name == session_path.name:
+                return
+
+        if track_id and track_id in normalized_current_uri:
+            return
+
+        if not is_file_like_uri:
+            return
+
+        if current_uri and session_uri and current_uri != session_uri:
+            self._remote_playback_session = None
+            self._last_remote_playback_state = None
+
+    @staticmethod
+    def _normalize_local_media_path(value: Any) -> Path | None:
+        if value in (None, ""):
+            return None
+
+        normalized = str(value).strip()
+        if not normalized:
+            return None
+
+        if normalized.startswith("file://"):
+            normalized = unquote(urlparse(normalized).path)
+
+        try:
+            return Path(normalized).expanduser().resolve(strict=False)
+        except Exception:
+            return Path(normalized)
+
+    def _handle_music_playback_state_change(self, state: str) -> None:
+        session = self._remote_playback_session
+        if session is None:
+            return
+
+        position_ms = self._current_playback_position_ms()
+        duration_ms = session.get("duration_ms")
+        event_type = state
+
+        if state == "playing" and session.get("playing_started_at_monotonic") is None:
+            session["playing_started_at_monotonic"] = time.monotonic()
+
+        if state == "stopped":
+            started_at_monotonic = session.get("playing_started_at_monotonic")
+            elapsed_ms = None
+            if isinstance(started_at_monotonic, (int, float)):
+                elapsed_ms = int(max(0.0, (time.monotonic() - started_at_monotonic) * 1000))
+
+            if (
+                not session.get("stop_requested")
+                and isinstance(duration_ms, int)
+                and duration_ms > 0
+                and elapsed_ms is not None
+                and elapsed_ms >= max(0, duration_ms - 2500)
+            ):
+                event_type = "completed"
+            elif (
+                isinstance(duration_ms, int)
+                and duration_ms > 0
+                and position_ms >= max(0, duration_ms - 2500)
+            ):
+                event_type = "completed"
+            self._remote_playback_session = None
+            self._last_remote_playback_state = None
+        else:
+            self._last_remote_playback_state = state
+
+        self._publish_playback_event(
+            event_type,
+            command_id=session["command_id"],
+            payload={
+                "trackId": session["track_id"],
+                "positionMs": position_ms,
+            },
+        )
+
+    def _current_playback_position_ms(self) -> int:
+        music_backend = getattr(self.app, "music_backend", None)
+        if music_backend is None:
+            return 0
+
+        getter = getattr(music_backend, "get_time_position", None)
+        if not callable(getter):
+            return 0
+
+        try:
+            return int(getter())
+        except Exception:
+            return 0
+
+    def _publish_playback_event(
+        self,
+        event_type: str,
+        *,
+        command_id: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        if self._mqtt is None or not self._mqtt.is_connected:
+            return
+
+        event_payload: dict[str, Any] = {
+            "messageType": "playback.event",
+            "commandId": command_id,
+            "deviceId": self.config_manager.get_cloud_device_id().strip(),
+            "eventType": event_type,
+            "occurredAt": self._utc_now(),
+            "payload": payload or {},
+        }
+        self._mqtt.publish_playback_event(event_payload)
 
     def _is_backend_configured(self) -> bool:
         return bool(self.config_manager.get_cloud_settings().backend.api_base_url.strip())

--- a/src/yoyopod/cloud/manager.py
+++ b/src/yoyopod/cloud/manager.py
@@ -64,12 +64,20 @@ class CloudManager:
         self._contacts_bootstrap_attempted = False
         self._playback_callbacks_bound = False
         self._remote_playback_session: dict[str, Any] | None = None
+        self._remote_playback_activation_generation = 0
         self._recent_remote_command_ids: deque[str] = deque(maxlen=32)
         self._last_remote_playback_state: str | None = None
-        media_settings = self.config_manager.get_media_settings().music
+        get_media_settings = getattr(self.config_manager, "get_media_settings", None)
+        if callable(get_media_settings):
+            media_settings = get_media_settings().music
+            remote_cache_dir = media_settings.remote_cache_dir
+            remote_cache_max_bytes = media_settings.remote_cache_max_bytes
+        else:
+            remote_cache_dir = "data/media/remote_cache"
+            remote_cache_max_bytes = 64 * 1024 * 1024
         self._remote_playback_cache = RemotePlaybackCache(
-            self.config_manager.resolve_runtime_path(media_settings.remote_cache_dir),
-            media_settings.remote_cache_max_bytes,
+            self.config_manager.resolve_runtime_path(remote_cache_dir),
+            remote_cache_max_bytes,
         )
 
     def prepare_boot(self) -> None:
@@ -1061,6 +1069,7 @@ class CloudManager:
             if callable(stop_playback):
                 stop_playback()
 
+            self._remote_playback_activation_generation += 1
             self._remote_playback_session = {
                 "command_id": command_id,
                 "track_id": track_id,
@@ -1069,6 +1078,9 @@ class CloudManager:
                 "duration_ms": payload.get("durationMs"),
                 "media_url": media_url,
                 "cached_path": None,
+                "activation_generation": self._remote_playback_activation_generation,
+                "activation_pending": True,
+                "stop_requested": False,
             }
             self._recent_remote_command_ids.append(command_id)
             mqtt.publish_ack(command_id=command_id, ok=True, payload={"command": cmd_type})
@@ -1078,43 +1090,22 @@ class CloudManager:
                 payload={"trackId": track_id, "positionMs": 0},
             )
 
-            try:
-                cached_asset = self._remote_playback_cache.prepare(
+            self._last_remote_playback_state = "buffering"
+            activation_generation = self._remote_playback_activation_generation
+            checksum_sha256 = (
+                str(payload.get("checksumSha256") or payload.get("checksum_sha256") or "").strip()
+                or None
+            )
+            self._start_worker(
+                name=f"cloud-playback-fetch-{command_id[:8]}",
+                work=lambda: self._run_prepare_remote_playback_asset(
+                    command_id=command_id,
                     track_id=track_id,
                     media_url=media_url,
-                    checksum_sha256=(
-                        str(payload.get("checksumSha256") or payload.get("checksum_sha256") or "").strip()
-                        or None
-                    ),
-                )
-            except Exception:
-                self._remote_playback_session = None
-                self._last_remote_playback_state = None
-                self._publish_playback_event(
-                    "failed",
-                    command_id=command_id,
-                    payload={
-                        "trackId": track_id,
-                        "reason": "media_fetch_failed",
-                    },
-                )
-                return
-
-            self._remote_playback_session["cached_path"] = cached_asset.path
-            self._last_remote_playback_state = "buffering"
-
-            if not music_backend.load_tracks([cached_asset.path]):
-                self._remote_playback_session = None
-                self._last_remote_playback_state = None
-                self._publish_playback_event(
-                    "failed",
-                    command_id=command_id,
-                    payload={
-                        "trackId": track_id,
-                        "reason": "decode_failed",
-                    },
-                )
-                return
+                    checksum_sha256=checksum_sha256,
+                    activation_generation=activation_generation,
+                ),
+            )
             return
 
         session = self._remote_playback_session
@@ -1150,6 +1141,11 @@ class CloudManager:
         if self._remote_playback_session is None or track is None:
             return
 
+        if self._remote_playback_session.get("activation_pending") and not self._remote_playback_session.get(
+            "cached_path"
+        ):
+            return
+
         current_uri = getattr(track, "uri", None)
         session_uri = self._remote_playback_session.get("cached_path")
         current_path = self._normalize_local_media_path(current_uri)
@@ -1164,9 +1160,11 @@ class CloudManager:
 
         if current_path is not None and session_path is not None:
             if current_path == session_path or current_path.name == session_path.name:
+                self._remote_playback_session["activation_pending"] = False
                 return
 
         if track_id and track_id in normalized_current_uri:
+            self._remote_playback_session["activation_pending"] = False
             return
 
         if not is_file_like_uri:
@@ -1198,12 +1196,18 @@ class CloudManager:
         if session is None:
             return
 
+        if state == "stopped" and session.get("activation_pending"):
+            return
+
         position_ms = self._current_playback_position_ms()
         duration_ms = session.get("duration_ms")
         event_type = state
 
         if state == "playing" and session.get("playing_started_at_monotonic") is None:
             session["playing_started_at_monotonic"] = time.monotonic()
+            session["activation_pending"] = False
+        elif state in {"paused", "buffering"}:
+            session["activation_pending"] = False
 
         if state == "stopped":
             started_at_monotonic = session.get("playing_started_at_monotonic")
@@ -1272,6 +1276,100 @@ class CloudManager:
             "payload": payload or {},
         }
         self._mqtt.publish_playback_event(event_payload)
+
+    def _run_prepare_remote_playback_asset(
+        self,
+        *,
+        command_id: str,
+        track_id: str,
+        media_url: str,
+        checksum_sha256: str | None,
+        activation_generation: int,
+    ) -> None:
+        try:
+            cached_asset = self._remote_playback_cache.prepare(
+                track_id=track_id,
+                media_url=media_url,
+                checksum_sha256=checksum_sha256,
+            )
+        except Exception as exc:
+            logger.warning("Remote playback fetch failed for {}: {}", track_id, exc)
+            self._queue_main_thread_callback(
+                lambda exc=exc: self._complete_prepare_remote_playback_asset(
+                    command_id=command_id,
+                    track_id=track_id,
+                    activation_generation=activation_generation,
+                    error=exc,
+                )
+            )
+            return
+
+        self._queue_main_thread_callback(
+            lambda cached_asset=cached_asset: self._complete_prepare_remote_playback_asset(
+                command_id=command_id,
+                track_id=track_id,
+                activation_generation=activation_generation,
+                cached_asset=cached_asset,
+            )
+        )
+
+    def _complete_prepare_remote_playback_asset(
+        self,
+        *,
+        command_id: str,
+        track_id: str,
+        activation_generation: int,
+        cached_asset: Any | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        session = self._remote_playback_session
+        if (
+            session is None
+            or session.get("command_id") != command_id
+            or session.get("track_id") != track_id
+            or session.get("activation_generation") != activation_generation
+        ):
+            return
+
+        if error is not None:
+            self._remote_playback_session = None
+            self._last_remote_playback_state = None
+            self._publish_playback_event(
+                "failed",
+                command_id=command_id,
+                payload={
+                    "trackId": track_id,
+                    "reason": "media_fetch_failed",
+                },
+            )
+            return
+
+        music_backend = getattr(self.app, "music_backend", None)
+        if music_backend is None or not getattr(music_backend, "is_connected", False):
+            self._remote_playback_session = None
+            self._last_remote_playback_state = None
+            self._publish_playback_event(
+                "failed",
+                command_id=command_id,
+                payload={
+                    "trackId": track_id,
+                    "reason": "playback_backend_error",
+                },
+            )
+            return
+
+        session["cached_path"] = cached_asset.path
+        if not music_backend.load_tracks([cached_asset.path]):
+            self._remote_playback_session = None
+            self._last_remote_playback_state = None
+            self._publish_playback_event(
+                "failed",
+                command_id=command_id,
+                payload={
+                    "trackId": track_id,
+                    "reason": "decode_failed",
+                },
+            )
 
     def _is_backend_configured(self) -> bool:
         return bool(self.config_manager.get_cloud_settings().backend.api_base_url.strip())

--- a/src/yoyopod/cloud/mqtt_client.py
+++ b/src/yoyopod/cloud/mqtt_client.py
@@ -132,6 +132,10 @@ class DeviceMqttClient:
         """Publish one remote-playback event through the normal device event topic."""
         return self._publish("playback", payload)
 
+    def publish_event(self, event_type: str, payload: dict[str, Any]) -> bool:
+        """Publish one typed event envelope through the device event topic."""
+        return self._publish(event_type, payload)
+
     def publish_ack(
         self,
         *,

--- a/src/yoyopod/cloud/mqtt_client.py
+++ b/src/yoyopod/cloud/mqtt_client.py
@@ -17,7 +17,7 @@ _KEEPALIVE_SECONDS = 60
 class DeviceMqttClient:
     """Publish device telemetry events to the backend MQTT broker.
 
-    The device publishes to  ``yoyopod/{device_id}/evt``.
+    The device publishes to ``yoyopod/{device_id}/evt``.
     The backend sends commands on ``yoyopod/{device_id}/cmd``; those are
     forwarded to the registered command callback.
     """
@@ -48,10 +48,6 @@ class DeviceMqttClient:
         self._stopped = False
         self._lock = threading.Lock()
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
     def start(self) -> None:
         """Start the MQTT client and connect in the background."""
         try:
@@ -75,8 +71,6 @@ class DeviceMqttClient:
         if self._use_tls:
             client.tls_set()
 
-        # Keep reconnect behavior inside the single Paho network loop so
-        # replacement clients do not leave behind their own retry threads.
         client.reconnect_delay_set(
             min_delay=1,
             max_delay=int(_RECONNECT_DELAY_SECONDS),
@@ -119,10 +113,6 @@ class DeviceMqttClient:
             except Exception:
                 pass
 
-    # ------------------------------------------------------------------
-    # Publishing
-    # ------------------------------------------------------------------
-
     def publish_battery(self, *, level: int, charging: bool) -> bool:
         """Publish a battery telemetry event."""
         return self._publish("battery", {"level": level, "charging": charging})
@@ -138,9 +128,45 @@ class DeviceMqttClient:
         """Publish a connectivity change (wifi / 4g)."""
         return self._publish("connectivity", {"type": connection_type})
 
-    # ------------------------------------------------------------------
-    # Internal
-    # ------------------------------------------------------------------
+    def publish_playback_event(self, payload: dict[str, Any]) -> bool:
+        """Publish one remote-playback event through the normal device event topic."""
+        return self._publish("playback", payload)
+
+    def publish_ack(
+        self,
+        *,
+        command_id: str,
+        ok: bool,
+        reason: str | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> bool:
+        """Publish one command ACK/NACK to ``yoyopod/{device_id}/ack``."""
+        with self._lock:
+            client = self._client
+            connected = self._connected
+
+        if client is None or not connected:
+            logger.debug("MQTT not connected — skipping ack for {}", command_id)
+            return False
+
+        topic = f"yoyopod/{self._device_id}/ack"
+        message_payload: dict[str, Any] = {
+            "command_id": command_id,
+            "status": "ack" if ok else "nack",
+            "payload": payload or {},
+        }
+        if reason:
+            message_payload["reason"] = reason
+
+        try:
+            result = client.publish(topic, json.dumps(message_payload), qos=1)
+            if result.rc != 0:
+                logger.warning("MQTT publish failed for ack {}: rc={}", command_id, result.rc)
+                return False
+            return True
+        except Exception as exc:
+            logger.warning("MQTT ack publish error for {}: {}", command_id, exc)
+            return False
 
     def _publish(self, event_type: str, payload: dict[str, Any]) -> bool:
         """Publish one event envelope to ``yoyopod/{device_id}/evt``."""
@@ -190,7 +216,10 @@ class DeviceMqttClient:
         """Handle an incoming command from the backend."""
         try:
             payload = json.loads(msg.payload.decode())
-            logger.info("MQTT command received: {}", payload.get("type", "unknown"))
+            logger.info(
+                "MQTT command received: {}",
+                payload.get("command") or payload.get("type", "unknown"),
+            )
             if self._command_callback is not None:
                 self._command_callback(payload)
         except Exception as exc:

--- a/src/yoyopod/cloud/playback_cache.py
+++ b/src/yoyopod/cloud/playback_cache.py
@@ -45,7 +45,7 @@ class RemotePlaybackCache:
         if target_path.exists():
             os.utime(target_path, None)
             logger.info("Remote playback cache hit for {}", track_id)
-            self._prune()
+            self._prune(protected_paths={target_path})
             return CachedPlaybackAsset(path=str(target_path), cache_hit=True)
 
         logger.info("Remote playback cache miss for {}, downloading asset", track_id)
@@ -54,7 +54,7 @@ class RemotePlaybackCache:
             target_path=target_path,
             checksum_sha256=checksum_sha256,
         )
-        self._prune()
+        self._prune(protected_paths={downloaded_path})
         return CachedPlaybackAsset(path=str(downloaded_path), cache_hit=False)
 
     def _download(
@@ -92,14 +92,17 @@ class RemotePlaybackCache:
             tmp_path.unlink(missing_ok=True)
             raise
 
-    def _prune(self) -> None:
+    def _prune(self, *, protected_paths: set[Path] | None = None) -> None:
         files = [entry for entry in self.root.glob("*") if entry.is_file()]
         files.sort(key=lambda entry: entry.stat().st_mtime)
+        protected = {path.resolve(strict=False) for path in (protected_paths or set())}
 
         total_size = sum(entry.stat().st_size for entry in files)
         for entry in files:
             if total_size <= self.max_bytes:
                 break
+            if entry.resolve(strict=False) in protected:
+                continue
             size = entry.stat().st_size
             entry.unlink(missing_ok=True)
             total_size -= size

--- a/src/yoyopod/cloud/playback_cache.py
+++ b/src/yoyopod/cloud/playback_cache.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import re
 import tempfile
+import threading
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,6 +27,7 @@ class RemotePlaybackCache:
         self.root = Path(root)
         self.max_bytes = max(32 * 1024 * 1024, int(max_bytes))
         self.root.mkdir(parents=True, exist_ok=True)
+        self._prune_lock = threading.Lock()
 
     def prepare(
         self,
@@ -93,19 +95,31 @@ class RemotePlaybackCache:
             raise
 
     def _prune(self, *, protected_paths: set[Path] | None = None) -> None:
-        files = [entry for entry in self.root.glob("*") if entry.is_file()]
-        files.sort(key=lambda entry: entry.stat().st_mtime)
         protected = {path.resolve(strict=False) for path in (protected_paths or set())}
 
-        total_size = sum(entry.stat().st_size for entry in files)
-        for entry in files:
-            if total_size <= self.max_bytes:
-                break
-            if entry.resolve(strict=False) in protected:
-                continue
-            size = entry.stat().st_size
-            entry.unlink(missing_ok=True)
-            total_size -= size
+        with self._prune_lock:
+            files: list[tuple[Path, float, int]] = []
+            for entry in self.root.glob("*"):
+                try:
+                    if not entry.is_file():
+                        continue
+                    stat = entry.stat()
+                except FileNotFoundError:
+                    continue
+                files.append((entry, stat.st_mtime, stat.st_size))
+
+            files.sort(key=lambda item: item[1])
+            total_size = sum(item[2] for item in files)
+            for entry, _mtime, size in files:
+                if total_size <= self.max_bytes:
+                    break
+                try:
+                    if entry.resolve(strict=False) in protected:
+                        continue
+                    entry.unlink(missing_ok=True)
+                    total_size -= size
+                except FileNotFoundError:
+                    continue
 
     def _target_path_for(
         self,

--- a/src/yoyopod/cloud/playback_cache.py
+++ b/src/yoyopod/cloud/playback_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import tempfile
 import urllib.request
 from dataclasses import dataclass
@@ -35,7 +36,11 @@ class RemotePlaybackCache:
         extension: str = ".mp3",
     ) -> CachedPlaybackAsset:
         checksum_suffix = (checksum_sha256 or "nochecksum")[:16]
-        target_path = self.root / f"{track_id}-{checksum_suffix}{extension}"
+        target_path = self._target_path_for(
+            track_id=track_id,
+            checksum_suffix=checksum_suffix,
+            extension=extension,
+        )
 
         if target_path.exists():
             os.utime(target_path, None)
@@ -89,7 +94,7 @@ class RemotePlaybackCache:
 
     def _prune(self) -> None:
         files = [entry for entry in self.root.glob("*") if entry.is_file()]
-        files.sort(key=lambda entry: entry.stat().st_mtime, reverse=True)
+        files.sort(key=lambda entry: entry.stat().st_mtime)
 
         total_size = sum(entry.stat().st_size for entry in files)
         for entry in files:
@@ -98,3 +103,35 @@ class RemotePlaybackCache:
             size = entry.stat().st_size
             entry.unlink(missing_ok=True)
             total_size -= size
+
+    def _target_path_for(
+        self,
+        *,
+        track_id: str,
+        checksum_suffix: str,
+        extension: str,
+    ) -> Path:
+        safe_track_id = self._sanitize_filename_component(track_id)
+        safe_extension = self._sanitize_extension(extension)
+        target_path = self.root / f"{safe_track_id}-{checksum_suffix}{safe_extension}"
+
+        resolved_root = self.root.resolve(strict=False)
+        resolved_target = target_path.resolve(strict=False)
+        if resolved_target.parent != resolved_root:
+            raise ValueError("unsafe_cache_path")
+        return resolved_target
+
+    @staticmethod
+    def _sanitize_filename_component(value: str) -> str:
+        normalized = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value).strip())
+        normalized = normalized.strip(".-")
+        return normalized or "track"
+
+    @staticmethod
+    def _sanitize_extension(value: str) -> str:
+        normalized = re.sub(r"[^A-Za-z0-9.]+", "", str(value).strip())
+        if not normalized:
+            return ".mp3"
+        if not normalized.startswith("."):
+            normalized = f".{normalized}"
+        return normalized[:16]

--- a/src/yoyopod/cloud/playback_cache.py
+++ b/src/yoyopod/cloud/playback_cache.py
@@ -1,0 +1,100 @@
+"""Bounded remote-audio cache for backend-issued playback URLs."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+from loguru import logger
+
+
+@dataclass(frozen=True, slots=True)
+class CachedPlaybackAsset:
+    path: str
+    cache_hit: bool
+
+
+class RemotePlaybackCache:
+    """Store remote playback assets on disk with a simple size-bounded LRU policy."""
+
+    def __init__(self, root: Path, max_bytes: int) -> None:
+        self.root = Path(root)
+        self.max_bytes = max(32 * 1024 * 1024, int(max_bytes))
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def prepare(
+        self,
+        *,
+        track_id: str,
+        media_url: str,
+        checksum_sha256: str | None = None,
+        extension: str = ".mp3",
+    ) -> CachedPlaybackAsset:
+        checksum_suffix = (checksum_sha256 or "nochecksum")[:16]
+        target_path = self.root / f"{track_id}-{checksum_suffix}{extension}"
+
+        if target_path.exists():
+            os.utime(target_path, None)
+            logger.info("Remote playback cache hit for {}", track_id)
+            self._prune()
+            return CachedPlaybackAsset(path=str(target_path), cache_hit=True)
+
+        logger.info("Remote playback cache miss for {}, downloading asset", track_id)
+        downloaded_path = self._download(
+            media_url=media_url,
+            target_path=target_path,
+            checksum_sha256=checksum_sha256,
+        )
+        self._prune()
+        return CachedPlaybackAsset(path=str(downloaded_path), cache_hit=False)
+
+    def _download(
+        self,
+        *,
+        media_url: str,
+        target_path: Path,
+        checksum_sha256: str | None,
+    ) -> Path:
+        fd, tmp_path_raw = tempfile.mkstemp(prefix="yoyopod-cache-", suffix=".part", dir=self.root)
+        os.close(fd)
+        tmp_path = Path(tmp_path_raw)
+
+        hash_obj = hashlib.sha256()
+
+        try:
+            request = urllib.request.Request(
+                media_url,
+                headers={"User-Agent": "YoYoPod/remote-playback-cache"},
+            )
+            with urllib.request.urlopen(request, timeout=30) as response, tmp_path.open("wb") as handle:
+                while True:
+                    chunk = response.read(64 * 1024)
+                    if not chunk:
+                        break
+                    handle.write(chunk)
+                    hash_obj.update(chunk)
+
+            if checksum_sha256 and hash_obj.hexdigest() != checksum_sha256:
+                raise ValueError("checksum_mismatch")
+
+            tmp_path.replace(target_path)
+            return target_path
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+    def _prune(self) -> None:
+        files = [entry for entry in self.root.glob("*") if entry.is_file()]
+        files.sort(key=lambda entry: entry.stat().st_mtime, reverse=True)
+
+        total_size = sum(entry.stat().st_size for entry in files)
+        for entry in files:
+            if total_size <= self.max_bytes:
+                break
+            size = entry.stat().st_size
+            entry.unlink(missing_ok=True)
+            total_size -= size

--- a/src/yoyopod/config/models/media.py
+++ b/src/yoyopod/config/models/media.py
@@ -26,6 +26,14 @@ class MediaMusicConfig:
         default="data/media/recent_tracks.json",
         env="YOYOPOD_RECENT_TRACKS_FILE",
     )
+    remote_cache_dir: str = config_value(
+        default="data/media/remote_cache",
+        env="YOYOPOD_REMOTE_CACHE_DIR",
+    )
+    remote_cache_max_bytes: int = config_value(
+        default=536870912,
+        env="YOYOPOD_REMOTE_CACHE_MAX_BYTES",
+    )
 
 
 @dataclass(slots=True)

--- a/tests/test_cloud_contact_bootstrap.py
+++ b/tests/test_cloud_contact_bootstrap.py
@@ -43,6 +43,14 @@ class _FakeConfigManager:
     def get_cloud_settings(self):
         return SimpleNamespace(backend=self._backend)
 
+    def get_media_settings(self):
+        return SimpleNamespace(
+            music=SimpleNamespace(
+                remote_cache_dir="data/media/remote_cache",
+                remote_cache_max_bytes=64 * 1024 * 1024,
+            )
+        )
+
     def get_cloud_device_id(self) -> str:
         return "YYP-DEV-0001"
 
@@ -51,6 +59,9 @@ class _FakeConfigManager:
 
     def load_cloud_config(self) -> None:
         return None
+
+    def resolve_runtime_path(self, value: str) -> str:
+        return value
 
 
 class _FakeClient:

--- a/tests/test_cloud_playback_cache.py
+++ b/tests/test_cloud_playback_cache.py
@@ -45,3 +45,21 @@ def test_prune_removes_oldest_files_first(tmp_path: Path) -> None:
 
     assert not oldest.exists()
     assert newest.exists()
+
+
+def test_prepare_keeps_new_download_when_it_exceeds_cache_limit(tmp_path: Path) -> None:
+    cache = RemotePlaybackCache(tmp_path, 32 * 1024 * 1024)
+    cache.max_bytes = 4
+
+    def fake_download(*, media_url: str, target_path: Path, checksum_sha256: str | None) -> Path:
+        target_path.write_bytes(b"12345")
+        return target_path
+
+    cache._download = fake_download  # type: ignore[method-assign]
+
+    asset = cache.prepare(
+        track_id="oversized-track",
+        media_url="https://media.example.test/file.mp3",
+    )
+
+    assert Path(asset.path).exists()

--- a/tests/test_cloud_playback_cache.py
+++ b/tests/test_cloud_playback_cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 from yoyopod.cloud.playback_cache import RemotePlaybackCache
 
@@ -63,3 +64,45 @@ def test_prepare_keeps_new_download_when_it_exceeds_cache_limit(tmp_path: Path) 
     )
 
     assert Path(asset.path).exists()
+
+
+def test_prune_tolerates_files_disappearing_during_concurrent_maintenance(
+    tmp_path: Path, monkeypatch
+) -> None:
+    cache = RemotePlaybackCache(tmp_path, 32 * 1024 * 1024)
+    protected = tmp_path / "protected.mp3"
+    protected.write_bytes(b"1234")
+
+    class _FakeEntry:
+        def __init__(self, name: str, *, size: int, missing_on_stat: bool = False) -> None:
+            self.name = name
+            self._size = size
+            self._missing_on_stat = missing_on_stat
+
+        def is_file(self) -> bool:
+            return True
+
+        def stat(self):
+            if self._missing_on_stat:
+                raise FileNotFoundError(self.name)
+            return SimpleNamespace(st_mtime=1, st_size=self._size)
+
+        def resolve(self, strict: bool = False) -> Path:
+            return tmp_path / self.name
+
+        def unlink(self, missing_ok: bool = False) -> None:
+            return None
+
+    fake_entries = [_FakeEntry("gone.mp3", size=2, missing_on_stat=True), _FakeEntry("old.mp3", size=8)]
+
+    original_glob = Path.glob
+
+    def fake_glob(self: Path, pattern: str):
+        if self == cache.root and pattern == "*":
+            return iter(fake_entries)
+        return original_glob(self, pattern)
+
+    monkeypatch.setattr(Path, "glob", fake_glob)
+
+    cache.max_bytes = 4
+    cache._prune(protected_paths={protected})

--- a/tests/test_cloud_playback_cache.py
+++ b/tests/test_cloud_playback_cache.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from yoyopod.cloud.playback_cache import RemotePlaybackCache
+
+
+def test_prepare_sanitizes_track_id_and_stays_within_cache_root(tmp_path: Path) -> None:
+    cache = RemotePlaybackCache(tmp_path, 64 * 1024 * 1024)
+
+    def fake_download(*, media_url: str, target_path: Path, checksum_sha256: str | None) -> Path:
+        target_path.write_bytes(b"audio")
+        return target_path
+
+    cache._download = fake_download  # type: ignore[method-assign]
+
+    asset = cache.prepare(
+        track_id="../../evil/nested-track",
+        media_url="https://media.example.test/file.mp3",
+        checksum_sha256="abc123",
+    )
+
+    resolved_root = tmp_path.resolve()
+    resolved_path = Path(asset.path).resolve()
+
+    assert resolved_path.parent == resolved_root
+    assert ".." not in resolved_path.name
+    assert resolved_path.name.startswith("evil-nested-track-abc123")
+
+
+def test_prune_removes_oldest_files_first(tmp_path: Path) -> None:
+    cache = RemotePlaybackCache(tmp_path, 32 * 1024 * 1024)
+    cache.max_bytes = 8
+
+    oldest = tmp_path / "oldest.mp3"
+    newest = tmp_path / "newest.mp3"
+    oldest.write_bytes(b"12345")
+    newest.write_bytes(b"67890")
+
+    os.utime(oldest, (100, 100))
+    os.utime(newest, (200, 200))
+
+    cache._prune()
+
+    assert not oldest.exists()
+    assert newest.exists()

--- a/tests/test_cloud_playback_commands.py
+++ b/tests/test_cloud_playback_commands.py
@@ -19,6 +19,10 @@ class _FakeMqttClient:
         self.events.append(payload)
         return True
 
+    def publish_event(self, event_type: str, payload: dict[str, object]) -> bool:
+        self.events.append({"type": event_type, "payload": payload})
+        return True
+
 
 class _FakeMusicBackend:
     def __init__(self) -> None:
@@ -258,3 +262,90 @@ def test_stopped_callback_during_pending_remote_fetch_does_not_clear_session() -
     assert manager._remote_playback_session is not None
     assert music_backend.loaded == []
     assert len(queued_work) == 1
+
+
+def test_stop_during_buffering_prevents_late_load_after_fetch_completes() -> None:
+    music_backend = _FakeMusicBackend()
+    manager = CloudManager(
+        app=_FakeApp(music_backend),
+        config_manager=_FakeConfigManager(),
+        client=SimpleNamespace(),
+    )
+    manager._mqtt = _FakeMqttClient()
+    manager._bind_playback_callbacks()
+
+    queued_work: list[object] = []
+    manager._start_worker = lambda *, name, work: queued_work.append(work)  # type: ignore[method-assign]
+    manager._remote_playback_cache = _FakePlaybackCache()
+
+    manager._apply_mqtt_command(
+        {
+            "commandId": "cmd-5",
+            "command": "play_track",
+            "payload": {
+                "trackId": "track-5",
+                "mediaUrl": "https://media.example.test/file.mp3",
+            },
+        }
+    )
+    manager._apply_mqtt_command(
+        {
+            "commandId": "cmd-6",
+            "command": "stop",
+            "payload": {"trackId": "track-5"},
+        }
+    )
+
+    assert manager._remote_playback_session is not None
+    assert manager._remote_playback_session["stop_requested"] is True
+
+    queued_work[0]()
+
+    assert music_backend.loaded == []
+    assert manager._remote_playback_session is None
+    assert manager._mqtt.events[-1]["eventType"] == "stopped"
+
+
+def test_store_media_command_acks_and_publishes_imported_event(tmp_path) -> None:
+    music_backend = _FakeMusicBackend()
+    config_manager = _FakeConfigManager()
+    config_manager.get_media_settings = lambda: SimpleNamespace(  # type: ignore[method-assign]
+        music=SimpleNamespace(
+            remote_cache_dir=str(tmp_path / "cache"),
+            remote_cache_max_bytes=64 * 1024 * 1024,
+            music_dir=str(tmp_path / "Music"),
+        )
+    )
+    manager = CloudManager(
+        app=_FakeApp(music_backend),
+        config_manager=config_manager,
+        client=SimpleNamespace(),
+    )
+    manager._mqtt = _FakeMqttClient()
+    cached_path = tmp_path / "cache-track.mp3"
+    cached_path.write_bytes(b"audio")
+    manager._remote_playback_cache = SimpleNamespace(
+        prepare=lambda **kwargs: SimpleNamespace(path=str(cached_path), cache_hit=False)
+    )
+    manager._start_worker = lambda *, name, work: work()  # type: ignore[method-assign]
+
+    manager._apply_mqtt_command(
+        {
+            "commandId": "cmd-7",
+            "command": "store_media",
+            "payload": {
+                "trackId": "track-7",
+                "mediaUrl": "https://media.example.test/file.mp3",
+                "title": "Track Seven",
+            },
+        }
+    )
+
+    assert manager._mqtt.acks[-1] == {
+        "command_id": "cmd-7",
+        "ok": True,
+        "payload": {"command": "store_media"},
+    }
+    assert manager._mqtt.events[-1]["type"] == "media_library"
+    assert manager._mqtt.events[-1]["payload"]["eventType"] == "imported"
+    assert (tmp_path / "Music" / "Dashboard Uploads.m3u").exists()

--- a/tests/test_cloud_playback_commands.py
+++ b/tests/test_cloud_playback_commands.py
@@ -349,3 +349,75 @@ def test_store_media_command_acks_and_publishes_imported_event(tmp_path) -> None
     assert manager._mqtt.events[-1]["type"] == "media_library"
     assert manager._mqtt.events[-1]["payload"]["eventType"] == "imported"
     assert (tmp_path / "Music" / "Dashboard Uploads.m3u").exists()
+
+
+def test_store_media_sanitizes_fallback_track_id_in_target_filename(tmp_path) -> None:
+    music_backend = _FakeMusicBackend()
+    config_manager = _FakeConfigManager()
+    config_manager.get_media_settings = lambda: SimpleNamespace(  # type: ignore[method-assign]
+        music=SimpleNamespace(
+            remote_cache_dir=str(tmp_path / "cache"),
+            remote_cache_max_bytes=64 * 1024 * 1024,
+            music_dir=str(tmp_path / "Music"),
+        )
+    )
+    manager = CloudManager(
+        app=_FakeApp(music_backend),
+        config_manager=config_manager,
+        client=SimpleNamespace(),
+    )
+    manager._mqtt = _FakeMqttClient()
+    cached_path = tmp_path / "cache-track.mp3"
+    cached_path.write_bytes(b"audio")
+    manager._remote_playback_cache = SimpleNamespace(
+        prepare=lambda **kwargs: SimpleNamespace(path=str(cached_path), cache_hit=False)
+    )
+    manager._start_worker = lambda *, name, work: work()  # type: ignore[method-assign]
+
+    manager._apply_mqtt_command(
+        {
+            "commandId": "cmd-8",
+            "command": "store_media",
+            "payload": {
+                "trackId": "///",
+                "mediaUrl": "https://media.example.test/file.mp3",
+            },
+        }
+    )
+
+    imported_path = manager._mqtt.events[-1]["payload"]["payload"]["path"]
+    assert str(tmp_path / "Music" / "dashboard_uploads") in imported_path
+    assert imported_path.endswith("track.mp3")
+
+
+def test_stopped_after_asset_load_is_not_dropped_when_activation_pending() -> None:
+    music_backend = _FakeMusicBackend()
+    manager = CloudManager(
+        app=_FakeApp(music_backend),
+        config_manager=_FakeConfigManager(),
+        client=SimpleNamespace(),
+    )
+    manager._mqtt = _FakeMqttClient()
+    manager._bind_playback_callbacks()
+    manager._start_worker = lambda *, name, work: work()  # type: ignore[method-assign]
+    manager._remote_playback_cache = _FakePlaybackCache()
+
+    manager._apply_mqtt_command(
+        {
+            "commandId": "cmd-9",
+            "command": "play_track",
+            "payload": {
+                "trackId": "track-9",
+                "mediaUrl": "https://media.example.test/file.mp3",
+            },
+        }
+    )
+
+    assert manager._remote_playback_session is not None
+    assert manager._remote_playback_session["activation_pending"] is True
+    assert manager._remote_playback_session["cached_path"] == "/tmp/cached-track.mp3"
+
+    music_backend.emit_playback("stopped")
+
+    assert manager._remote_playback_session is None
+    assert manager._mqtt.events[-1]["eventType"] == "stopped"

--- a/tests/test_cloud_playback_commands.py
+++ b/tests/test_cloud_playback_commands.py
@@ -349,6 +349,8 @@ def test_store_media_command_acks_and_publishes_imported_event(tmp_path) -> None
     assert manager._mqtt.events[-1]["type"] == "media_library"
     assert manager._mqtt.events[-1]["payload"]["eventType"] == "imported"
     assert (tmp_path / "Music" / "Dashboard Uploads.m3u").exists()
+    imported_path = manager._mqtt.events[-1]["payload"]["payload"]["path"]
+    assert imported_path.endswith("Track-Seven-track-7.mp3")
 
 
 def test_store_media_sanitizes_fallback_track_id_in_target_filename(tmp_path) -> None:
@@ -421,3 +423,50 @@ def test_stopped_after_asset_load_is_not_dropped_when_activation_pending() -> No
 
     assert manager._remote_playback_session is None
     assert manager._mqtt.events[-1]["eventType"] == "stopped"
+
+
+def test_store_media_keeps_distinct_files_for_same_title(tmp_path) -> None:
+    music_backend = _FakeMusicBackend()
+    config_manager = _FakeConfigManager()
+    config_manager.get_media_settings = lambda: SimpleNamespace(  # type: ignore[method-assign]
+        music=SimpleNamespace(
+            remote_cache_dir=str(tmp_path / "cache"),
+            remote_cache_max_bytes=64 * 1024 * 1024,
+            music_dir=str(tmp_path / "Music"),
+        )
+    )
+    manager = CloudManager(
+        app=_FakeApp(music_backend),
+        config_manager=config_manager,
+        client=SimpleNamespace(),
+    )
+    manager._mqtt = _FakeMqttClient()
+    cached_path = tmp_path / "cache-track.mp3"
+    cached_path.write_bytes(b"audio")
+    manager._remote_playback_cache = SimpleNamespace(
+        prepare=lambda **kwargs: SimpleNamespace(path=str(cached_path), cache_hit=False)
+    )
+    manager._start_worker = lambda *, name, work: work()  # type: ignore[method-assign]
+
+    for command_id, track_id in (("cmd-10", "track-10"), ("cmd-11", "track-11")):
+        manager._apply_mqtt_command(
+            {
+                "commandId": command_id,
+                "command": "store_media",
+                "payload": {
+                    "trackId": track_id,
+                    "mediaUrl": "https://media.example.test/file.mp3",
+                    "title": "Shared Name",
+                },
+            }
+        )
+
+    imported_paths = [
+        event["payload"]["payload"]["path"]
+        for event in manager._mqtt.events
+        if event.get("type") == "media_library"
+    ]
+    assert len(imported_paths) == 2
+    assert imported_paths[0] != imported_paths[1]
+    assert imported_paths[0].endswith("Shared-Name-track-10.mp3")
+    assert imported_paths[1].endswith("Shared-Name-track-11.mp3")

--- a/tests/test_cloud_playback_commands.py
+++ b/tests/test_cloud_playback_commands.py
@@ -130,6 +130,7 @@ def test_play_track_command_acks_and_publishes_buffering_then_playing() -> None:
     manager._mqtt = _FakeMqttClient()
     manager._remote_playback_cache = _FakePlaybackCache()
     manager._bind_playback_callbacks()
+    manager._start_worker = lambda *, name, work: work()  # type: ignore[method-assign]
 
     manager._apply_mqtt_command(
         {
@@ -150,6 +151,7 @@ def test_play_track_command_acks_and_publishes_buffering_then_playing() -> None:
     assert manager._mqtt.acks[0]["command_id"] == "cmd-1"
     assert manager._mqtt.acks[0]["ok"] is True
     assert manager._mqtt.events[0]["eventType"] == "buffering"
+    assert manager._remote_playback_session["cached_path"] == "/tmp/cached-track.mp3"
 
     music_backend.position_ms = 500
     music_backend.emit_playback("playing")
@@ -220,3 +222,39 @@ def test_invalid_play_command_nacks() -> None:
             "reason": "invalid_command",
         }
     ]
+
+
+def test_stopped_callback_during_pending_remote_fetch_does_not_clear_session() -> None:
+    music_backend = _FakeMusicBackend()
+    manager = CloudManager(
+        app=_FakeApp(music_backend),
+        config_manager=_FakeConfigManager(),
+        client=SimpleNamespace(),
+    )
+    manager._mqtt = _FakeMqttClient()
+    manager._bind_playback_callbacks()
+
+    queued_work: list[object] = []
+    manager._start_worker = lambda *, name, work: queued_work.append(work)  # type: ignore[method-assign]
+
+    manager._apply_mqtt_command(
+        {
+            "messageType": "playback.command",
+            "commandId": "cmd-4",
+            "command": "play_track",
+            "payload": {
+                "trackId": "track-4",
+                "mediaUrl": "https://media.example.test/file.mp3",
+                "title": "Song",
+            },
+        }
+    )
+
+    assert manager._remote_playback_session is not None
+    assert manager._remote_playback_session["activation_pending"] is True
+
+    music_backend.emit_playback("stopped")
+
+    assert manager._remote_playback_session is not None
+    assert music_backend.loaded == []
+    assert len(queued_work) == 1

--- a/tests/test_cloud_playback_commands.py
+++ b/tests/test_cloud_playback_commands.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from yoyopod.cloud.manager import CloudManager
+
+
+class _FakeMqttClient:
+    def __init__(self) -> None:
+        self.is_connected = True
+        self.acks: list[dict[str, object]] = []
+        self.events: list[dict[str, object]] = []
+
+    def publish_ack(self, **payload) -> bool:
+        self.acks.append(payload)
+        return True
+
+    def publish_playback_event(self, payload: dict[str, object]) -> bool:
+        self.events.append(payload)
+        return True
+
+
+class _FakeMusicBackend:
+    def __init__(self) -> None:
+        self.is_connected = True
+        self.loaded: list[list[str]] = []
+        self.playback_state_callbacks = []
+        self.track_callbacks = []
+        self.position_ms = 0
+        self.stop_calls = 0
+        self.pause_calls = 0
+        self.play_calls = 0
+
+    def on_track_change(self, callback) -> None:
+        self.track_callbacks.append(callback)
+
+    def on_playback_state_change(self, callback) -> None:
+        self.playback_state_callbacks.append(callback)
+
+    def load_tracks(self, uris: list[str]) -> bool:
+        self.loaded.append(uris)
+        return True
+
+    def stop_playback(self) -> bool:
+        self.stop_calls += 1
+        return True
+
+    def pause(self) -> bool:
+        self.pause_calls += 1
+        return True
+
+    def play(self) -> bool:
+        self.play_calls += 1
+        return True
+
+    def get_time_position(self) -> int:
+        return self.position_ms
+
+    def emit_playback(self, state: str) -> None:
+        for callback in self.playback_state_callbacks:
+            callback(state)
+
+
+class _FakeConfigManager:
+    def __init__(self) -> None:
+        backend = SimpleNamespace(
+            api_base_url="https://backend.example.test",
+            auth_path="/v1/auth/device",
+            refresh_path="/v1/auth/device/refresh",
+            config_path_template="/v1/devices/{device_id}/config",
+            contacts_bootstrap_path_template="/v1/devices/{device_id}/contacts/bootstrap",
+            timeout_seconds=3.0,
+            battery_report_interval_seconds=60,
+            mqtt_broker_host="broker.example.test",
+            mqtt_broker_port=1883,
+            mqtt_username="",
+            mqtt_password="",
+            mqtt_use_tls=False,
+            mqtt_transport="tcp",
+        )
+        self._cloud = SimpleNamespace(backend=backend)
+        self.cloud_secrets_error = ""
+
+    def get_cloud_settings(self):
+        return self._cloud
+
+    def get_cloud_device_id(self) -> str:
+        return "YYP-DEV-0001"
+
+    def get_cloud_device_secret(self) -> str:
+        return "secret"
+
+    def get_media_settings(self):
+        return SimpleNamespace(
+            music=SimpleNamespace(
+                remote_cache_dir="data/media/remote_cache",
+                remote_cache_max_bytes=64 * 1024 * 1024,
+            )
+        )
+
+    def resolve_runtime_path(self, value: str) -> str:
+        return value
+
+
+class _FakePlaybackCache:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def prepare(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(path="/tmp/cached-track.mp3", cache_hit=False)
+
+
+class _FakeApp:
+    def __init__(self, music_backend: _FakeMusicBackend) -> None:
+        self.music_backend = music_backend
+        self.context = None
+
+    def _queue_main_thread_callback(self, callback) -> None:
+        callback()
+
+
+def test_play_track_command_acks_and_publishes_buffering_then_playing() -> None:
+    music_backend = _FakeMusicBackend()
+    manager = CloudManager(
+        app=_FakeApp(music_backend),
+        config_manager=_FakeConfigManager(),
+        client=SimpleNamespace(),
+    )
+    manager._mqtt = _FakeMqttClient()
+    manager._remote_playback_cache = _FakePlaybackCache()
+    manager._bind_playback_callbacks()
+
+    manager._apply_mqtt_command(
+        {
+            "messageType": "playback.command",
+            "commandId": "cmd-1",
+            "command": "play_track",
+            "payload": {
+                "trackId": "track-1",
+                "mediaUrl": "https://media.example.test/file.mp3",
+                "title": "Song",
+                "artist": "Artist",
+                "durationMs": 120000,
+            },
+        }
+    )
+
+    assert music_backend.loaded == [["/tmp/cached-track.mp3"]]
+    assert manager._mqtt.acks[0]["command_id"] == "cmd-1"
+    assert manager._mqtt.acks[0]["ok"] is True
+    assert manager._mqtt.events[0]["eventType"] == "buffering"
+
+    music_backend.position_ms = 500
+    music_backend.emit_playback("playing")
+
+    assert manager._mqtt.events[-1]["eventType"] == "playing"
+    assert manager._mqtt.events[-1]["payload"]["positionMs"] == 500
+
+
+def test_stop_command_acks_and_emits_completed_when_near_end() -> None:
+    music_backend = _FakeMusicBackend()
+    manager = CloudManager(
+        app=_FakeApp(music_backend),
+        config_manager=_FakeConfigManager(),
+        client=SimpleNamespace(),
+    )
+    manager._mqtt = _FakeMqttClient()
+    manager._remote_playback_cache = _FakePlaybackCache()
+    manager._bind_playback_callbacks()
+
+    manager._remote_playback_session = {
+        "command_id": "cmd-1",
+        "track_id": "track-1",
+        "duration_ms": 10000,
+        "media_url": "https://media.example.test/file.mp3",
+    }
+
+    manager._apply_mqtt_command(
+        {
+            "commandId": "cmd-2",
+            "command": "stop",
+            "payload": {"trackId": "track-1"},
+        }
+    )
+
+    assert music_backend.stop_calls == 1
+    assert manager._mqtt.acks[-1]["command_id"] == "cmd-2"
+
+    music_backend.position_ms = 9800
+    music_backend.emit_playback("stopped")
+
+    assert manager._mqtt.events[-1]["commandId"] == "cmd-1"
+    assert manager._mqtt.events[-1]["eventType"] == "completed"
+
+
+def test_invalid_play_command_nacks() -> None:
+    music_backend = _FakeMusicBackend()
+    manager = CloudManager(
+        app=_FakeApp(music_backend),
+        config_manager=_FakeConfigManager(),
+        client=SimpleNamespace(),
+    )
+    manager._mqtt = _FakeMqttClient()
+    manager._remote_playback_cache = _FakePlaybackCache()
+    manager._bind_playback_callbacks()
+
+    manager._apply_mqtt_command(
+        {
+            "commandId": "cmd-3",
+            "command": "play_track",
+            "payload": {"trackId": "track-1"},
+        }
+    )
+
+    assert manager._mqtt.acks == [
+        {
+            "command_id": "cmd-3",
+            "ok": False,
+            "reason": "invalid_command",
+        }
+    ]

--- a/tests/test_output_volume.py
+++ b/tests/test_output_volume.py
@@ -41,7 +41,11 @@ def test_output_volume_controller_sets_system_and_music_volume(monkeypatch) -> N
     controller = OutputVolumeController(music_backend=backend)
 
     assert controller.set_volume(55) is True
-    assert calls[0] == ["amixer", "sset", "Master", "55%"]
+    assert calls[:3] == [
+        ["amixer", "-c", "1", "sset", "Playback", "100%"],
+        ["amixer", "-c", "1", "sset", "Speaker", "100%"],
+        ["amixer", "-c", "1", "sset", "Headphone", "100%"],
+    ]
     assert backend.get_volume() == 55
 
 
@@ -73,6 +77,9 @@ def test_output_volume_controller_falls_back_to_card_one_when_default_card_fails
             ["amixer", "sget", "Master"],
             ["amixer", "-c", "1", "sget", "Master"],
             ["amixer", "-c", "0", "sget", "Master"],
+            ["amixer", "sget", "Playback"],
+            ["amixer", "-c", "1", "sget", "Playback"],
+            ["amixer", "-c", "0", "sget", "Playback"],
         ):
             return subprocess.CompletedProcess(
                 args=args,
@@ -95,10 +102,13 @@ Simple mixer control 'Master',0
     controller = OutputVolumeController()
 
     assert controller.get_system_volume() == 100
-    assert calls[:4] == [
+    assert calls[:7] == [
         ["amixer", "sget", "Master"],
         ["amixer", "-c", "1", "sget", "Master"],
         ["amixer", "-c", "0", "sget", "Master"],
+        ["amixer", "sget", "Playback"],
+        ["amixer", "-c", "1", "sget", "Playback"],
+        ["amixer", "-c", "0", "sget", "Playback"],
         ["amixer", "-c", "1", "sget", "Headset"],
     ]
 


### PR DESCRIPTION
## Summary
This PR carries the rebased YoYoPod device-side media/playback work on top of the latest `main`.

It ships:
- strict `ack` / `nack` separation from playback lifecycle events
- bounded remote playback caching with duplicate-command suppression
- `store_media` handling so backend-finalized dashboard tracks can be persisted locally on the device
- device-local playlist refresh for imported media (`Dashboard Uploads`)
- WM8960 audio-routing fixes for the real Pi runtime
- docs refresh for remote playback, ALSA routing, and deployed Pi audio ownership

## What changed since the earlier PR draft
- rebased cleanly onto the latest `origin/main`
- adapted the old remote-playback config changes to the new modular config layout
- fixed live audio routing to use `alsa/sysdefault:CARD=wm8960soundcard`
- updated output-volume handling so WM8960 hardware headroom stays pinned high and user loudness comes from mpv volume instead of near-silent codec attenuation
- documented the production decision to keep `pipewire`, `pipewire-pulse`, and `wireplumber` out of the deployed YoYoPod speaker path
- addressed PR review feedback by sanitizing cache filenames, moving remote asset fetch off the coordinator thread, fixing cache eviction order, and stabilizing pending playback sessions during interrupt/reload handoff

## Messaging contract
- `ack` topic emits only `ack` / `nack`
- `evt` carries lifecycle only
- playback lifecycle remains `buffering`, `playing`, `paused`, `stopped`, `completed`, `failed`
- device-local import completion is emitted as `media_library` lifecycle (`imported` / `failed`)

## Deployment notes
- this branch was force-pushed after a clean rebase onto the latest `main`
- deployed Pi runtime must use `media_audio.alsa_device: sysdefault:CARD=wm8960soundcard`
- deployed Pi runtime should not run `pipewire`, `pipewire-pulse`, or `wireplumber` alongside YoYoPod’s direct ALSA music path
- restart `yoyopod@raouf.service` after syncing this branch so the new audio-routing and volume behavior is live

## Testing
- `python3 -m py_compile src/yoyopod/cloud/manager.py src/yoyopod/cloud/playback_cache.py src/yoyopod/audio/volume.py`
- `./.venv/bin/pytest -q tests/test_cloud_contact_bootstrap.py tests/test_output_volume.py tests/test_cloud_playback_commands.py tests/test_cloud_playback_cache.py`
- `./.venv/bin/pytest -q` (`860 passed, 1 warning`)
- live Pi validation previously confirmed command delivery, media import, and playback state transitions

## Sibling PRs
- Backend PR: https://github.com/eng-samanody/yoyo_end/pull/2
- Dashboard PR: https://github.com/eng-samanody/yoyo_dash/pull/2

## Note on warning
- the full local pytest run still reports one pre-existing test warning from a simulation web server thread binding to an in-use port during `tests/test_call_screen.py`; the suite still passes and this PR does not touch that area