### PR TITLE
[codex] Split fsm.py: MusicFSM and CallFSM are unrelated machines

### DIFF
--- a/src/yoyopod/fsm.py
+++ b/src/yoyopod/fsm.py
@@ -1,11 +1,5 @@
 """Compatibility exports for relocated FSM primitives."""
 
-from dataclasses import dataclass
-from enum import Enum
-from typing import Optional
-
-from loguru import logger
-
 from yoyopod.core.fsm import (
     CallFSM,
     CallInterruptionPolicy,


### PR DESCRIPTION
Implements issue #204. Generated by wrapper-owned workflow watchdog.