### PR TITLE
[codex] Dual-render UI (screens/*.py + screens/*/lvgl/*_view.py) is still carrying the old PIL code

### DIFF
--- a/src/yoyopod/ui/screens/music/lvgl/now_playing_view.py
+++ b/src/yoyopod/ui/screens/music/lvgl/now_playing_view.py
@@ -55,7 +55,7 @@ class LvglNowPlayingView:
         self.backend.binding.now_playing_sync(
             title_text=state.title,
             artist_text=state.artist,
-            state_text=self.screen._display_state_text(state.state_label),
+            state_text=self.screen.display_state_text(state.state_label),
             footer=footer,
             progress_permille=max(0, min(1000, int(state.progress * 1000))),
             voip_state=self._voip_state(context),

--- a/src/yoyopod/ui/screens/music/now_playing.py
+++ b/src/yoyopod/ui/screens/music/now_playing.py
@@ -223,13 +223,13 @@ class NowPlayingScreen(Screen):
         return "A play | B back | X/Y tracks"
 
     @staticmethod
-    def _display_state_text(state_label: str) -> str:
+    def display_state_text(state_label: str) -> str:
         """Return the human-facing chip label for the current playback state."""
 
         return state_label.title()
 
     @staticmethod
-    def _state_visuals(state_label: str) -> dict[str, tuple[int, int, int]]:
+    def state_visuals(state_label: str) -> dict[str, tuple[int, int, int]]:
         """Return the compact now-playing palette for one playback state."""
 
         if state_label == "PAUSED":

--- a/src/yoyopod/ui/screens/music/now_playing.py
+++ b/src/yoyopod/ui/screens/music/now_playing.py
@@ -9,6 +9,7 @@ from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.music.lvgl import LvglNowPlayingView
+from yoyopod.ui.screens.music.now_playing_pil_view import render_now_playing_pil
 from yoyopod.ui.screens.theme import (
     BACKGROUND,
     ERROR,
@@ -17,14 +18,7 @@ from yoyopod.ui.screens.theme import (
     MUTED,
     MUTED_DIM,
     SURFACE_RAISED,
-    draw_icon,
     mix,
-    render_backdrop,
-    render_footer,
-    render_status_bar,
-    rounded_panel,
-    text_fit,
-    wrap_text,
 )
 
 if TYPE_CHECKING:
@@ -217,113 +211,7 @@ class NowPlayingScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        state = self.current_state()
-        state_text = self._display_state_text(state.state_label)
-        footer = self.get_footer_text(is_playing=state.is_playing, state_label=state.state_label)
-        visuals = self._state_visuals(state.state_label)
-
-        render_backdrop(self.display, "listen")
-        render_status_bar(self.display, self.context, show_time=True)
-
-        halo_width = 92
-        halo_height = 66
-        halo_left = (self.display.WIDTH - halo_width) // 2
-        halo_top = self.display.STATUS_BAR_HEIGHT + 16
-        rounded_panel(
-            self.display,
-            halo_left,
-            halo_top,
-            halo_left + halo_width,
-            halo_top + halo_height,
-            fill=visuals["icon_fill"],
-            outline=visuals["icon_outline"],
-            radius=20,
-        )
-        draw_icon(
-            self.display,
-            "music_note",
-            halo_left + 24,
-            halo_top + 13,
-            42,
-            visuals["icon_color"],
-        )
-
-        title_y = halo_top + halo_height + 18
-        title_lines = wrap_text(
-            self.display,
-            state.title,
-            self.display.WIDTH - 32,
-            18,
-            max_lines=2,
-        ) or [text_fit(self.display, state.title, self.display.WIDTH - 32, 18)]
-        title_line_height = self.display.get_text_size("Ag", 18)[1]
-        for index, line in enumerate(title_lines):
-            title_width, _ = self.display.get_text_size(line, 18)
-            self.display.text(
-                line,
-                (self.display.WIDTH - title_width) // 2,
-                title_y + (index * title_line_height),
-                color=INK,
-                font_size=18,
-            )
-
-        title_bottom = title_y + (len(title_lines) * title_line_height)
-        artist_y = title_bottom + 8
-        artist_text = text_fit(self.display, state.artist, self.display.WIDTH - 36, 11)
-        artist_width, _ = self.display.get_text_size(artist_text, 11)
-        self.display.text(
-            artist_text,
-            (self.display.WIDTH - artist_width) // 2,
-            artist_y,
-            color=MUTED,
-            font_size=11,
-        )
-
-        state_width, state_height = self.display.get_text_size(state_text, 10)
-        chip_width = state_width + 26
-        chip_left = (self.display.WIDTH - chip_width) // 2
-        chip_top = artist_y + 22
-        rounded_panel(
-            self.display,
-            chip_left,
-            chip_top,
-            chip_left + chip_width,
-            chip_top + state_height + 10,
-            fill=visuals["chip_fill"],
-            outline=None,
-            radius=12,
-        )
-        self.display.text(
-            state_text,
-            (self.display.WIDTH - state_width) // 2,
-            chip_top + 4,
-            color=visuals["chip_text"],
-            font_size=10,
-        )
-
-        progress_width = 168
-        progress_x = (self.display.WIDTH - progress_width) // 2
-        progress_y = min(self.display.HEIGHT - 52, chip_top + state_height + 18)
-        self.display.rectangle(
-            progress_x,
-            progress_y,
-            progress_x + progress_width,
-            progress_y + 8,
-            fill=mix(BACKGROUND, SURFACE_RAISED, 0.5),
-        )
-        fill_width = max(0, min(progress_width, int(progress_width * state.progress)))
-        if fill_width > 0:
-            self.display.rectangle(
-                progress_x,
-                progress_y,
-                progress_x + fill_width,
-                progress_y + 8,
-                fill=visuals["progress_fill"],
-            )
-
-        render_footer(self.display, footer, mode="listen")
-        self.display.update()
+        render_now_playing_pil(self)
 
     def get_footer_text(self, *, is_playing: bool, state_label: str | None = None) -> str:
         """Return the gesture hint for the active playback state."""

--- a/src/yoyopod/ui/screens/music/now_playing_pil_view.py
+++ b/src/yoyopod/ui/screens/music/now_playing_pil_view.py
@@ -27,9 +27,9 @@ def render_now_playing_pil(screen: "NowPlayingScreen") -> None:
     """Render the now-playing screen through the PIL display path."""
 
     state = screen.current_state()
-    state_text = screen._display_state_text(state.state_label)
+    state_text = screen.display_state_text(state.state_label)
     footer = screen.get_footer_text(is_playing=state.is_playing, state_label=state.state_label)
-    visuals = screen._state_visuals(state.state_label)
+    visuals = screen.state_visuals(state.state_label)
 
     render_backdrop(screen.display, "listen")
     render_status_bar(screen.display, screen.context, show_time=True)

--- a/src/yoyopod/ui/screens/music/now_playing_pil_view.py
+++ b/src/yoyopod/ui/screens/music/now_playing_pil_view.py
@@ -1,0 +1,134 @@
+"""PIL fallback view for the now-playing screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    BACKGROUND,
+    INK,
+    MUTED,
+    SURFACE_RAISED,
+    draw_icon,
+    mix,
+    render_backdrop,
+    render_footer,
+    render_status_bar,
+    rounded_panel,
+    text_fit,
+    wrap_text,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.music.now_playing import NowPlayingScreen
+
+
+def render_now_playing_pil(screen: "NowPlayingScreen") -> None:
+    """Render the now-playing screen through the PIL display path."""
+
+    state = screen.current_state()
+    state_text = screen._display_state_text(state.state_label)
+    footer = screen.get_footer_text(is_playing=state.is_playing, state_label=state.state_label)
+    visuals = screen._state_visuals(state.state_label)
+
+    render_backdrop(screen.display, "listen")
+    render_status_bar(screen.display, screen.context, show_time=True)
+
+    halo_width = 92
+    halo_height = 66
+    halo_left = (screen.display.WIDTH - halo_width) // 2
+    halo_top = screen.display.STATUS_BAR_HEIGHT + 16
+    rounded_panel(
+        screen.display,
+        halo_left,
+        halo_top,
+        halo_left + halo_width,
+        halo_top + halo_height,
+        fill=visuals["icon_fill"],
+        outline=visuals["icon_outline"],
+        radius=20,
+    )
+    draw_icon(
+        screen.display,
+        "music_note",
+        halo_left + 24,
+        halo_top + 13,
+        42,
+        visuals["icon_color"],
+    )
+
+    title_y = halo_top + halo_height + 18
+    title_lines = wrap_text(
+        screen.display,
+        state.title,
+        screen.display.WIDTH - 32,
+        18,
+        max_lines=2,
+    ) or [text_fit(screen.display, state.title, screen.display.WIDTH - 32, 18)]
+    title_line_height = screen.display.get_text_size("Ag", 18)[1]
+    for index, line in enumerate(title_lines):
+        title_width, _ = screen.display.get_text_size(line, 18)
+        screen.display.text(
+            line,
+            (screen.display.WIDTH - title_width) // 2,
+            title_y + (index * title_line_height),
+            color=INK,
+            font_size=18,
+        )
+
+    title_bottom = title_y + (len(title_lines) * title_line_height)
+    artist_y = title_bottom + 8
+    artist_text = text_fit(screen.display, state.artist, screen.display.WIDTH - 36, 11)
+    artist_width, _ = screen.display.get_text_size(artist_text, 11)
+    screen.display.text(
+        artist_text,
+        (screen.display.WIDTH - artist_width) // 2,
+        artist_y,
+        color=MUTED,
+        font_size=11,
+    )
+
+    state_width, state_height = screen.display.get_text_size(state_text, 10)
+    chip_width = state_width + 26
+    chip_left = (screen.display.WIDTH - chip_width) // 2
+    chip_top = artist_y + 22
+    rounded_panel(
+        screen.display,
+        chip_left,
+        chip_top,
+        chip_left + chip_width,
+        chip_top + state_height + 10,
+        fill=visuals["chip_fill"],
+        outline=None,
+        radius=12,
+    )
+    screen.display.text(
+        state_text,
+        (screen.display.WIDTH - state_width) // 2,
+        chip_top + 4,
+        color=visuals["chip_text"],
+        font_size=10,
+    )
+
+    progress_width = 168
+    progress_x = (screen.display.WIDTH - progress_width) // 2
+    progress_y = min(screen.display.HEIGHT - 52, chip_top + state_height + 18)
+    screen.display.rectangle(
+        progress_x,
+        progress_y,
+        progress_x + progress_width,
+        progress_y + 8,
+        fill=mix(BACKGROUND, SURFACE_RAISED, 0.5),
+    )
+    fill_width = max(0, min(progress_width, int(progress_width * state.progress)))
+    if fill_width > 0:
+        screen.display.rectangle(
+            progress_x,
+            progress_y,
+            progress_x + fill_width,
+            progress_y + 8,
+            fill=visuals["progress_fill"],
+        )
+
+    render_footer(screen.display, footer, mode="listen")
+    screen.display.update()

--- a/src/yoyopod/ui/screens/music/playlist.py
+++ b/src/yoyopod/ui/screens/music/playlist.py
@@ -11,13 +11,7 @@ from yoyopod.ui.display import Display
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.music.lvgl import LvglPlaylistView
-from yoyopod.ui.screens.theme import (
-    draw_empty_state,
-    draw_list_item,
-    render_footer,
-    render_header,
-    text_fit,
-)
+from yoyopod.ui.screens.music.playlist_pil_view import render_playlist_pil
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
@@ -169,85 +163,7 @@ class PlaylistScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        content_top = render_header(
-            self.display,
-            self.context,
-            mode="listen",
-            title="Playlists",
-            show_time=False,
-            show_mode_chip=False,
-        )
-
-        if self.loading:
-            draw_empty_state(
-                self.display,
-                mode="listen",
-                title="Loading playlists",
-                subtitle="Hold on while your mixes come in.",
-                icon="playlist",
-                top=content_top,
-            )
-            render_footer(self.display, "Hold back", mode="listen")
-            self.display.update()
-            return
-
-        if self.error_message:
-            draw_empty_state(
-                self.display,
-                mode="listen",
-                title="Music hiccup",
-                subtitle=self.error_message,
-                icon="playlist",
-                top=content_top,
-            )
-            render_footer(self.display, "Hold back", mode="listen")
-            self.display.update()
-            return
-
-        if not self.playlists:
-            draw_empty_state(
-                self.display,
-                mode="listen",
-                title="No playlists",
-                subtitle="Add local playlists to see them here.",
-                icon="playlist",
-                top=content_top,
-            )
-            render_footer(self.display, "Hold back", mode="listen")
-            self.display.update()
-            return
-
-        self._update_scroll_window()
-
-        item_height = 52
-        list_top = content_top + 8
-        for row in range(self.max_visible_items):
-            playlist_index = self.scroll_offset + row
-            if playlist_index >= len(self.playlists):
-                break
-
-            playlist = self.playlists[playlist_index]
-            y1 = list_top + (row * item_height)
-            y2 = y1 + 44
-            badge = f"{playlist.track_count}" if getattr(playlist, "track_count", 0) else None
-            draw_list_item(
-                self.display,
-                x1=18,
-                y1=y1,
-                x2=self.display.WIDTH - 18,
-                y2=y2,
-                title=text_fit(self.display, playlist.name, self.display.WIDTH - 92, 15),
-                subtitle="",
-                mode="listen",
-                selected=playlist_index == self.selected_index,
-                badge=badge,
-                icon="playlist",
-            )
-
-        help_text = f"{self.get_footer_text()} / Hold back" if self.is_one_button_mode() else self.get_footer_text()
-        render_footer(self.display, help_text, mode="listen")
-        self.display.update()
+        render_playlist_pil(self)
 
     def select_next(self) -> None:
         """Move to the next playlist."""

--- a/src/yoyopod/ui/screens/music/playlist_pil_view.py
+++ b/src/yoyopod/ui/screens/music/playlist_pil_view.py
@@ -67,31 +67,27 @@ def render_playlist_pil(screen: "PlaylistScreen") -> None:
         screen.display.update()
         return
 
-    screen._update_scroll_window()
+    visible_titles, visible_badges, selected_visible_index = screen.get_visible_window()
+    visible_subtitles = screen.get_visible_subtitles()
+    visible_icon_keys = screen.get_visible_icon_keys()
 
     item_height = 52
     list_top = content_top + 8
-    for row in range(screen.max_visible_items):
-        playlist_index = screen.scroll_offset + row
-        if playlist_index >= len(screen.playlists):
-            break
-
-        playlist = screen.playlists[playlist_index]
+    for row, playlist_title in enumerate(visible_titles):
         y1 = list_top + (row * item_height)
         y2 = y1 + 44
-        badge = f"{playlist.track_count}" if getattr(playlist, "track_count", 0) else None
         draw_list_item(
             screen.display,
             x1=18,
             y1=y1,
             x2=screen.display.WIDTH - 18,
             y2=y2,
-            title=text_fit(screen.display, playlist.name, screen.display.WIDTH - 92, 15),
-            subtitle="",
+            title=text_fit(screen.display, playlist_title, screen.display.WIDTH - 92, 15),
+            subtitle=visible_subtitles[row] if row < len(visible_subtitles) else "",
             mode="listen",
-            selected=playlist_index == screen.selected_index,
-            badge=badge,
-            icon="playlist",
+            selected=row == selected_visible_index,
+            badge=visible_badges[row] or None,
+            icon=visible_icon_keys[row] if row < len(visible_icon_keys) else "playlist",
         )
 
     help_text = (

--- a/src/yoyopod/ui/screens/music/playlist_pil_view.py
+++ b/src/yoyopod/ui/screens/music/playlist_pil_view.py
@@ -1,0 +1,103 @@
+"""PIL fallback view for the playlist browser screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    draw_empty_state,
+    draw_list_item,
+    render_footer,
+    render_header,
+    text_fit,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.music.playlist import PlaylistScreen
+
+
+def render_playlist_pil(screen: "PlaylistScreen") -> None:
+    """Render the local playlist browser through the PIL display path."""
+
+    content_top = render_header(
+        screen.display,
+        screen.context,
+        mode="listen",
+        title="Playlists",
+        show_time=False,
+        show_mode_chip=False,
+    )
+
+    if screen.loading:
+        draw_empty_state(
+            screen.display,
+            mode="listen",
+            title="Loading playlists",
+            subtitle="Hold on while your mixes come in.",
+            icon="playlist",
+            top=content_top,
+        )
+        render_footer(screen.display, "Hold back", mode="listen")
+        screen.display.update()
+        return
+
+    if screen.error_message:
+        draw_empty_state(
+            screen.display,
+            mode="listen",
+            title="Music hiccup",
+            subtitle=screen.error_message,
+            icon="playlist",
+            top=content_top,
+        )
+        render_footer(screen.display, "Hold back", mode="listen")
+        screen.display.update()
+        return
+
+    if not screen.playlists:
+        draw_empty_state(
+            screen.display,
+            mode="listen",
+            title="No playlists",
+            subtitle="Add local playlists to see them here.",
+            icon="playlist",
+            top=content_top,
+        )
+        render_footer(screen.display, "Hold back", mode="listen")
+        screen.display.update()
+        return
+
+    screen._update_scroll_window()
+
+    item_height = 52
+    list_top = content_top + 8
+    for row in range(screen.max_visible_items):
+        playlist_index = screen.scroll_offset + row
+        if playlist_index >= len(screen.playlists):
+            break
+
+        playlist = screen.playlists[playlist_index]
+        y1 = list_top + (row * item_height)
+        y2 = y1 + 44
+        badge = f"{playlist.track_count}" if getattr(playlist, "track_count", 0) else None
+        draw_list_item(
+            screen.display,
+            x1=18,
+            y1=y1,
+            x2=screen.display.WIDTH - 18,
+            y2=y2,
+            title=text_fit(screen.display, playlist.name, screen.display.WIDTH - 92, 15),
+            subtitle="",
+            mode="listen",
+            selected=playlist_index == screen.selected_index,
+            badge=badge,
+            icon="playlist",
+        )
+
+    help_text = (
+        f"{screen.get_footer_text()} / Hold back"
+        if screen.is_one_button_mode()
+        else screen.get_footer_text()
+    )
+    render_footer(screen.display, help_text, mode="listen")
+    screen.display.update()

--- a/src/yoyopod/ui/screens/music/recent.py
+++ b/src/yoyopod/ui/screens/music/recent.py
@@ -11,13 +11,7 @@ from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.music.lvgl import LvglPlaylistView
-from yoyopod.ui.screens.theme import (
-    draw_empty_state,
-    draw_list_item,
-    render_footer,
-    render_header,
-    text_fit,
-)
+from yoyopod.ui.screens.music.recent_pil_view import render_recent_tracks_pil
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
@@ -164,70 +158,7 @@ class RecentTracksScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        content_top = render_header(
-            self.display,
-            self.context,
-            mode="listen",
-            title="Recent",
-            show_time=False,
-            show_mode_chip=False,
-        )
-
-        if self.error_message:
-            draw_empty_state(
-                self.display,
-                mode="listen",
-                title="Music hiccup",
-                subtitle=self.error_message,
-                icon="playlist",
-                top=content_top,
-            )
-            render_footer(self.display, "Hold back", mode="listen")
-            self.display.update()
-            return
-
-        if not self.tracks:
-            draw_empty_state(
-                self.display,
-                mode="listen",
-                title="No recent tracks",
-                subtitle="Play local music to fill this list.",
-                icon="playlist",
-                top=content_top,
-            )
-            render_footer(self.display, "Hold back", mode="listen")
-            self.display.update()
-            return
-
-        self._update_scroll_window()
-
-        item_height = 52
-        list_top = content_top + 8
-        for row in range(self.max_visible_items):
-            track_index = self.scroll_offset + row
-            if track_index >= len(self.tracks):
-                break
-
-            track = self.tracks[track_index]
-            y1 = list_top + (row * item_height)
-            y2 = y1 + 44
-            draw_list_item(
-                self.display,
-                x1=18,
-                y1=y1,
-                x2=self.display.WIDTH - 18,
-                y2=y2,
-                title=text_fit(self.display, track.title, self.display.WIDTH - 48, 15),
-                subtitle=text_fit(self.display, track.subtitle, self.display.WIDTH - 48, 11),
-                mode="listen",
-                selected=track_index == self.selected_index,
-                icon="music_note",
-            )
-
-        help_text = f"{self.get_footer_text()} / Hold back" if self.is_one_button_mode() else self.get_footer_text()
-        render_footer(self.display, help_text, mode="listen")
-        self.display.update()
+        render_recent_tracks_pil(self)
 
     def on_select(self, data=None) -> None:
         """Load and play the selected recent track."""

--- a/src/yoyopod/ui/screens/music/recent_pil_view.py
+++ b/src/yoyopod/ui/screens/music/recent_pil_view.py
@@ -54,16 +54,13 @@ def render_recent_tracks_pil(screen: "RecentTracksScreen") -> None:
         screen.display.update()
         return
 
-    screen._update_scroll_window()
+    visible_titles, _visible_badges, selected_visible_index = screen.get_visible_window()
+    visible_subtitles = screen.get_visible_subtitles()
+    visible_icon_keys = screen.get_visible_icon_keys()
 
     item_height = 52
     list_top = content_top + 8
-    for row in range(screen.max_visible_items):
-        track_index = screen.scroll_offset + row
-        if track_index >= len(screen.tracks):
-            break
-
-        track = screen.tracks[track_index]
+    for row, track_title in enumerate(visible_titles):
         y1 = list_top + (row * item_height)
         y2 = y1 + 44
         draw_list_item(
@@ -72,11 +69,16 @@ def render_recent_tracks_pil(screen: "RecentTracksScreen") -> None:
             y1=y1,
             x2=screen.display.WIDTH - 18,
             y2=y2,
-            title=text_fit(screen.display, track.title, screen.display.WIDTH - 48, 15),
-            subtitle=text_fit(screen.display, track.subtitle, screen.display.WIDTH - 48, 11),
+            title=text_fit(screen.display, track_title, screen.display.WIDTH - 48, 15),
+            subtitle=text_fit(
+                screen.display,
+                visible_subtitles[row] if row < len(visible_subtitles) else "",
+                screen.display.WIDTH - 48,
+                11,
+            ),
             mode="listen",
-            selected=track_index == screen.selected_index,
-            icon="music_note",
+            selected=row == selected_visible_index,
+            icon=visible_icon_keys[row] if row < len(visible_icon_keys) else "music_note",
         )
 
     help_text = (

--- a/src/yoyopod/ui/screens/music/recent_pil_view.py
+++ b/src/yoyopod/ui/screens/music/recent_pil_view.py
@@ -1,0 +1,88 @@
+"""PIL fallback view for the recent tracks browser screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    draw_empty_state,
+    draw_list_item,
+    render_footer,
+    render_header,
+    text_fit,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.music.recent import RecentTracksScreen
+
+
+def render_recent_tracks_pil(screen: "RecentTracksScreen") -> None:
+    """Render the recent-tracks browser through the PIL display path."""
+
+    content_top = render_header(
+        screen.display,
+        screen.context,
+        mode="listen",
+        title="Recent",
+        show_time=False,
+        show_mode_chip=False,
+    )
+
+    if screen.error_message:
+        draw_empty_state(
+            screen.display,
+            mode="listen",
+            title="Music hiccup",
+            subtitle=screen.error_message,
+            icon="playlist",
+            top=content_top,
+        )
+        render_footer(screen.display, "Hold back", mode="listen")
+        screen.display.update()
+        return
+
+    if not screen.tracks:
+        draw_empty_state(
+            screen.display,
+            mode="listen",
+            title="No recent tracks",
+            subtitle="Play local music to fill this list.",
+            icon="playlist",
+            top=content_top,
+        )
+        render_footer(screen.display, "Hold back", mode="listen")
+        screen.display.update()
+        return
+
+    screen._update_scroll_window()
+
+    item_height = 52
+    list_top = content_top + 8
+    for row in range(screen.max_visible_items):
+        track_index = screen.scroll_offset + row
+        if track_index >= len(screen.tracks):
+            break
+
+        track = screen.tracks[track_index]
+        y1 = list_top + (row * item_height)
+        y2 = y1 + 44
+        draw_list_item(
+            screen.display,
+            x1=18,
+            y1=y1,
+            x2=screen.display.WIDTH - 18,
+            y2=y2,
+            title=text_fit(screen.display, track.title, screen.display.WIDTH - 48, 15),
+            subtitle=text_fit(screen.display, track.subtitle, screen.display.WIDTH - 48, 11),
+            mode="listen",
+            selected=track_index == screen.selected_index,
+            icon="music_note",
+        )
+
+    help_text = (
+        f"{screen.get_footer_text()} / Hold back"
+        if screen.is_one_button_mode()
+        else screen.get_footer_text()
+    )
+    render_footer(screen.display, help_text, mode="listen")
+    screen.display.update()

--- a/src/yoyopod/ui/screens/navigation/hub.py
+++ b/src/yoyopod/ui/screens/navigation/hub.py
@@ -97,7 +97,7 @@ class HubScreen(Screen):
         except Exception:
             self._playlist_count = None
 
-    def _cards(self) -> list[HubCard]:
+    def cards(self) -> list[HubCard]:
         """Build the live root-card list."""
         return [
             HubCard("Listen", self._listen_subtitle(), "listen", "listen"),
@@ -153,13 +153,13 @@ class HubScreen(Screen):
         return format_battery_compact(self.context)
 
     @staticmethod
-    def _tile_fill_color(mode: str) -> tuple[int, int, int]:
+    def tile_fill_color(mode: str) -> tuple[int, int, int]:
         """Return the main hero-tile fill for the selected hub card."""
         theme = theme_for(mode)
         return mix(theme.accent, theme.hero_end, 0.35)
 
     @staticmethod
-    def _tile_glow_color(mode: str) -> tuple[int, int, int]:
+    def tile_glow_color(mode: str) -> tuple[int, int, int]:
         """Return a soft mode glow behind the hero tile."""
         theme = theme_for(mode)
         return mix(theme.accent, BACKGROUND, 0.72)
@@ -174,11 +174,11 @@ class HubScreen(Screen):
 
     def on_advance(self, data=None) -> None:
         """Cycle to the next card."""
-        self.selected_index = (self.selected_index + 1) % len(self._cards())
+        self.selected_index = (self.selected_index + 1) % len(self.cards())
 
     def on_select(self, data=None) -> None:
         """Open the selected root card."""
-        self.request_route("select", payload=self._cards()[self.selected_index].title)
+        self.request_route("select", payload=self.cards()[self.selected_index].title)
 
     def on_back(self, data=None) -> None:
         """Open Ask in quick-command mode (hold-to-ask shortcut)."""

--- a/src/yoyopod/ui/screens/navigation/hub.py
+++ b/src/yoyopod/ui/screens/navigation/hub.py
@@ -9,17 +9,11 @@ from yoyopod.ui.display import Display
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.navigation.lvgl import LvglHubView
+from yoyopod.ui.screens.navigation.hub_pil_view import render_hub_pil
 from yoyopod.ui.screens.theme import (
     BACKGROUND,
-    FOOTER_BAR,
-    INK,
-    MUTED_DIM,
-    draw_icon,
     format_battery_compact,
     mix,
-    render_backdrop,
-    render_status_bar,
-    rounded_panel,
     text_fit,
     theme_for,
 )
@@ -176,85 +170,7 @@ class HubScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        cards = self._cards()
-        self.selected_index %= len(cards)
-        selected_card = cards[self.selected_index]
-        render_backdrop(self.display, selected_card.mode)
-        render_status_bar(self.display, self.context, show_time=True)
-
-        tile_size = 96
-        tile_left = (self.display.WIDTH - tile_size) // 2
-        tile_top = self.display.STATUS_BAR_HEIGHT + 30
-        glow_padding = 10
-
-        rounded_panel(
-            self.display,
-            tile_left - glow_padding,
-            tile_top - glow_padding,
-            tile_left + tile_size + glow_padding,
-            tile_top + tile_size + glow_padding,
-            fill=self._tile_glow_color(selected_card.mode),
-            outline=None,
-            radius=24,
-            shadow=False,
-        )
-
-        rounded_panel(
-            self.display,
-            tile_left,
-            tile_top,
-            tile_left + tile_size,
-            tile_top + tile_size,
-            fill=self._tile_fill_color(selected_card.mode),
-            outline=None,
-            radius=16,
-            shadow=True,
-        )
-
-        draw_icon(
-            self.display,
-            selected_card.icon,
-            tile_left + 20,
-            tile_top + 20,
-            56,
-            INK,
-        )
-
-        title_y = tile_top + tile_size + 24
-        title_text = selected_card.title
-        title_width, title_height = self.display.get_text_size(title_text, 22)
-        self.display.text(
-            title_text,
-            (self.display.WIDTH - title_width) // 2,
-            title_y,
-            color=INK,
-            font_size=22,
-        )
-
-        dots_y = title_y + title_height + 30
-        dot_gap = 10
-        dots_width = ((len(cards) - 1) * dot_gap) + 4
-        dots_x = (self.display.WIDTH - dots_width) // 2
-        inactive_dot = mix(INK, BACKGROUND, 0.8)
-        for index in range(len(cards)):
-            dot_color = INK if index == self.selected_index else inactive_dot
-            self.display.circle(dots_x + (index * dot_gap), dots_y, 2, fill=dot_color)
-
-        footer_top = self.display.HEIGHT - 32
-        self.display.rectangle(
-            0, footer_top, self.display.WIDTH, self.display.HEIGHT, fill=FOOTER_BAR
-        )
-        footer_text = "Tap = Next \u00b7 2\u00d7 = Open \u00b7 Hold = Ask"
-        footer_width, footer_height = self.display.get_text_size(footer_text, 10)
-        self.display.text(
-            footer_text,
-            (self.display.WIDTH - footer_width) // 2,
-            footer_top + ((32 - footer_height) // 2) - 1,
-            color=MUTED_DIM,
-            font_size=10,
-        )
-        self.display.update()
+        render_hub_pil(self)
 
     def on_advance(self, data=None) -> None:
         """Cycle to the next card."""

--- a/src/yoyopod/ui/screens/navigation/hub_pil_view.py
+++ b/src/yoyopod/ui/screens/navigation/hub_pil_view.py
@@ -1,0 +1,103 @@
+"""PIL fallback view for the root Hub screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    BACKGROUND,
+    FOOTER_BAR,
+    INK,
+    MUTED_DIM,
+    draw_icon,
+    mix,
+    render_backdrop,
+    render_status_bar,
+    rounded_panel,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.navigation.hub import HubScreen
+
+
+def render_hub_pil(screen: "HubScreen") -> None:
+    """Render the selected Hub card through the PIL display path."""
+
+    cards = screen._cards()
+    screen.selected_index %= len(cards)
+    selected_card = cards[screen.selected_index]
+    render_backdrop(screen.display, selected_card.mode)
+    render_status_bar(screen.display, screen.context, show_time=True)
+
+    tile_size = 96
+    tile_left = (screen.display.WIDTH - tile_size) // 2
+    tile_top = screen.display.STATUS_BAR_HEIGHT + 30
+    glow_padding = 10
+
+    rounded_panel(
+        screen.display,
+        tile_left - glow_padding,
+        tile_top - glow_padding,
+        tile_left + tile_size + glow_padding,
+        tile_top + tile_size + glow_padding,
+        fill=screen._tile_glow_color(selected_card.mode),
+        outline=None,
+        radius=24,
+        shadow=False,
+    )
+
+    rounded_panel(
+        screen.display,
+        tile_left,
+        tile_top,
+        tile_left + tile_size,
+        tile_top + tile_size,
+        fill=screen._tile_fill_color(selected_card.mode),
+        outline=None,
+        radius=16,
+        shadow=True,
+    )
+
+    draw_icon(
+        screen.display,
+        selected_card.icon,
+        tile_left + 20,
+        tile_top + 20,
+        56,
+        INK,
+    )
+
+    title_y = tile_top + tile_size + 24
+    title_text = selected_card.title
+    title_width, title_height = screen.display.get_text_size(title_text, 22)
+    screen.display.text(
+        title_text,
+        (screen.display.WIDTH - title_width) // 2,
+        title_y,
+        color=INK,
+        font_size=22,
+    )
+
+    dots_y = title_y + title_height + 30
+    dot_gap = 10
+    dots_width = ((len(cards) - 1) * dot_gap) + 4
+    dots_x = (screen.display.WIDTH - dots_width) // 2
+    inactive_dot = mix(INK, BACKGROUND, 0.8)
+    for index in range(len(cards)):
+        dot_color = INK if index == screen.selected_index else inactive_dot
+        screen.display.circle(dots_x + (index * dot_gap), dots_y, 2, fill=dot_color)
+
+    footer_top = screen.display.HEIGHT - 32
+    screen.display.rectangle(
+        0, footer_top, screen.display.WIDTH, screen.display.HEIGHT, fill=FOOTER_BAR
+    )
+    footer_text = "Tap = Next / 2x = Open / Hold = Ask"
+    footer_width, footer_height = screen.display.get_text_size(footer_text, 10)
+    screen.display.text(
+        footer_text,
+        (screen.display.WIDTH - footer_width) // 2,
+        footer_top + ((32 - footer_height) // 2) - 1,
+        color=MUTED_DIM,
+        font_size=10,
+    )
+    screen.display.update()

--- a/src/yoyopod/ui/screens/navigation/hub_pil_view.py
+++ b/src/yoyopod/ui/screens/navigation/hub_pil_view.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 def render_hub_pil(screen: "HubScreen") -> None:
     """Render the selected Hub card through the PIL display path."""
 
-    cards = screen._cards()
+    cards = screen.cards()
     screen.selected_index %= len(cards)
     selected_card = cards[screen.selected_index]
     render_backdrop(screen.display, selected_card.mode)
@@ -40,7 +40,7 @@ def render_hub_pil(screen: "HubScreen") -> None:
         tile_top - glow_padding,
         tile_left + tile_size + glow_padding,
         tile_top + tile_size + glow_padding,
-        fill=screen._tile_glow_color(selected_card.mode),
+        fill=screen.tile_glow_color(selected_card.mode),
         outline=None,
         radius=24,
         shadow=False,
@@ -52,7 +52,7 @@ def render_hub_pil(screen: "HubScreen") -> None:
         tile_top,
         tile_left + tile_size,
         tile_top + tile_size,
-        fill=screen._tile_fill_color(selected_card.mode),
+        fill=screen.tile_fill_color(selected_card.mode),
         outline=None,
         radius=16,
         shadow=True,

--- a/src/yoyopod/ui/screens/navigation/listen.py
+++ b/src/yoyopod/ui/screens/navigation/listen.py
@@ -87,7 +87,7 @@ class ListenScreen(Screen):
         render_listen_pil(self)
 
     @staticmethod
-    def _item_icon_key(key: str) -> str:
+    def item_icon_key(key: str) -> str:
         """Return the icon key used for each Listen landing row."""
 
         if key == "playlists":

--- a/src/yoyopod/ui/screens/navigation/listen.py
+++ b/src/yoyopod/ui/screens/navigation/listen.py
@@ -9,11 +9,7 @@ from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.navigation.lvgl import LvglListenView
-from yoyopod.ui.screens.theme import (
-    draw_list_item,
-    render_footer,
-    render_header,
-)
+from yoyopod.ui.screens.navigation.listen_pil_view import render_listen_pil
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
@@ -88,45 +84,7 @@ class ListenScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        content_top = render_header(
-            self.display,
-            self.context,
-            mode="listen",
-            title="Your Music",
-            subtitle="Local library",
-            show_time=False,
-            show_mode_chip=False,
-        )
-
-        list_top = content_top + 8
-        item_height = 76
-        for index, item in enumerate(self.items):
-            y1 = list_top + (index * item_height)
-            y2 = y1 + 68
-            if y2 > self.display.HEIGHT - 38:
-                break
-
-            draw_list_item(
-                self.display,
-                x1=18,
-                y1=y1,
-                x2=self.display.WIDTH - 18,
-                y2=y2,
-                title=item.title,
-                subtitle=item.subtitle,
-                mode="listen",
-                selected=index == self.selected_index,
-                icon=self._item_icon_key(item.key),
-            )
-
-        help_text = (
-            "Tap = Next  ·  2× Tap = Open  ·  Hold = Back"
-            if self.is_one_button_mode()
-            else "A open | B back | X/Y move"
-        )
-        render_footer(self.display, help_text, mode="listen")
-        self.display.update()
+        render_listen_pil(self)
 
     @staticmethod
     def _item_icon_key(key: str) -> str:

--- a/src/yoyopod/ui/screens/navigation/listen_pil_view.py
+++ b/src/yoyopod/ui/screens/navigation/listen_pil_view.py
@@ -1,0 +1,57 @@
+"""PIL fallback view for the Listen landing screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    draw_list_item,
+    render_footer,
+    render_header,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.navigation.listen import ListenScreen
+
+
+def render_listen_pil(screen: "ListenScreen") -> None:
+    """Render the local library menu through the PIL display path."""
+
+    content_top = render_header(
+        screen.display,
+        screen.context,
+        mode="listen",
+        title="Your Music",
+        subtitle="Local library",
+        show_time=False,
+        show_mode_chip=False,
+    )
+
+    list_top = content_top + 8
+    item_height = 76
+    for index, item in enumerate(screen.items):
+        y1 = list_top + (index * item_height)
+        y2 = y1 + 68
+        if y2 > screen.display.HEIGHT - 38:
+            break
+
+        draw_list_item(
+            screen.display,
+            x1=18,
+            y1=y1,
+            x2=screen.display.WIDTH - 18,
+            y2=y2,
+            title=item.title,
+            subtitle=item.subtitle,
+            mode="listen",
+            selected=index == screen.selected_index,
+            icon=screen._item_icon_key(item.key),
+        )
+
+    help_text = (
+        "Tap = Next / 2x Tap = Open / Hold = Back"
+        if screen.is_one_button_mode()
+        else "A open | B back | X/Y move"
+    )
+    render_footer(screen.display, help_text, mode="listen")
+    screen.display.update()

--- a/src/yoyopod/ui/screens/navigation/listen_pil_view.py
+++ b/src/yoyopod/ui/screens/navigation/listen_pil_view.py
@@ -45,7 +45,7 @@ def render_listen_pil(screen: "ListenScreen") -> None:
             subtitle=item.subtitle,
             mode="listen",
             selected=index == screen.selected_index,
-            icon=screen._item_icon_key(item.key),
+            icon=screen.item_icon_key(item.key),
         )
 
     help_text = (

--- a/src/yoyopod/ui/screens/navigation/lvgl/hub_view.py
+++ b/src/yoyopod/ui/screens/navigation/lvgl/hub_view.py
@@ -45,7 +45,7 @@ class LvglHubView:
         if not ensure_retained_view_built(self):
             return
 
-        cards = self.screen._cards()
+        cards = self.screen.cards()
         selected_card = cards[self.screen.selected_index % len(cards)]
         theme = theme_for(selected_card.mode)
         context = self.screen.context

--- a/src/yoyopod/ui/screens/navigation/lvgl/listen_view.py
+++ b/src/yoyopod/ui/screens/navigation/lvgl/listen_view.py
@@ -46,7 +46,7 @@ class LvglListenView:
 
         items = [item.title for item in self.screen.items[:4]]
         subtitles = [item.subtitle for item in self.screen.items[:4]]
-        icon_keys = [self.screen._item_icon_key(item.key) for item in self.screen.items[:4]]
+        icon_keys = [self.screen.item_icon_key(item.key) for item in self.screen.items[:4]]
 
         footer = (
             "Tap next / 2x open / Hold back"

--- a/src/yoyopod/ui/screens/voip/call_history.py
+++ b/src/yoyopod/ui/screens/voip/call_history.py
@@ -9,13 +9,7 @@ from loguru import logger
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
-from yoyopod.ui.screens.theme import (
-    draw_empty_state,
-    draw_list_item,
-    render_footer,
-    render_header,
-    text_fit,
-)
+from yoyopod.ui.screens.voip.call_history_pil_view import render_call_history_pil
 from yoyopod.ui.screens.voip.lvgl.call_history_view import LvglCallHistoryView
 
 if TYPE_CHECKING:
@@ -124,61 +118,7 @@ class CallHistoryScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        content_top = render_header(
-            self.display,
-            self.context,
-            mode="talk",
-            title="Recents",
-            page_text=None,
-            show_time=False,
-            show_mode_chip=False,
-        )
-
-        if not self.entries:
-            draw_empty_state(
-                self.display,
-                mode="talk",
-                title="No recent calls",
-                subtitle="Calls will show up here after the first one.",
-                icon="talk",
-                top=content_top,
-            )
-            render_footer(self.display, "Hold back", mode="talk")
-            self.display.update()
-            return
-
-        if self.selected_index < self.scroll_offset:
-            self.scroll_offset = self.selected_index
-        elif self.selected_index >= self.scroll_offset + self.max_visible_items:
-            self.scroll_offset = self.selected_index - self.max_visible_items + 1
-
-        item_height = 52
-        list_top = content_top + 8
-        for row in range(self.max_visible_items):
-            entry_index = self.scroll_offset + row
-            if entry_index >= len(self.entries):
-                break
-
-            entry = self.entries[entry_index]
-            y1 = list_top + (row * item_height)
-            y2 = y1 + 44
-            draw_list_item(
-                self.display,
-                x1=18,
-                y1=y1,
-                x2=self.display.WIDTH - 18,
-                y2=y2,
-                title=text_fit(self.display, entry.title, self.display.WIDTH - 90, 15),
-                subtitle=entry.subtitle,
-                mode="talk",
-                selected=entry_index == self.selected_index,
-                badge=None,
-                icon="call" if entry.direction == "outgoing" else "talk",
-            )
-
-        render_footer(self.display, self._instruction_text(), mode="talk")
-        self.display.update()
+        render_call_history_pil(self)
 
     def get_visible_window(self) -> tuple[list[str], list[str], int]:
         """Return the visible recent-call titles for the shared LVGL list scene."""

--- a/src/yoyopod/ui/screens/voip/call_history.py
+++ b/src/yoyopod/ui/screens/voip/call_history.py
@@ -104,7 +104,7 @@ class CallHistoryScreen(Screen):
             return None
         return self.entries[self.selected_index]
 
-    def _instruction_text(self) -> str:
+    def instruction_text(self) -> str:
         """Return compact footer hints for recents."""
         if not self.entries:
             return "Hold back" if self.is_one_button_mode() else "B back"

--- a/src/yoyopod/ui/screens/voip/call_history_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/call_history_pil_view.py
@@ -42,19 +42,13 @@ def render_call_history_pil(screen: "CallHistoryScreen") -> None:
         screen.display.update()
         return
 
-    if screen.selected_index < screen.scroll_offset:
-        screen.scroll_offset = screen.selected_index
-    elif screen.selected_index >= screen.scroll_offset + screen.max_visible_items:
-        screen.scroll_offset = screen.selected_index - screen.max_visible_items + 1
+    visible_titles, _visible_badges, selected_visible_index = screen.get_visible_window()
+    visible_subtitles = screen.get_visible_subtitles()
+    visible_icon_keys = screen.get_visible_icon_keys()
 
     item_height = 52
     list_top = content_top + 8
-    for row in range(screen.max_visible_items):
-        entry_index = screen.scroll_offset + row
-        if entry_index >= len(screen.entries):
-            break
-
-        entry = screen.entries[entry_index]
+    for row, entry_title in enumerate(visible_titles):
         y1 = list_top + (row * item_height)
         y2 = y1 + 44
         draw_list_item(
@@ -63,13 +57,13 @@ def render_call_history_pil(screen: "CallHistoryScreen") -> None:
             y1=y1,
             x2=screen.display.WIDTH - 18,
             y2=y2,
-            title=text_fit(screen.display, entry.title, screen.display.WIDTH - 90, 15),
-            subtitle=entry.subtitle,
+            title=text_fit(screen.display, entry_title, screen.display.WIDTH - 90, 15),
+            subtitle=visible_subtitles[row] if row < len(visible_subtitles) else "",
             mode="talk",
-            selected=entry_index == screen.selected_index,
+            selected=row == selected_visible_index,
             badge=None,
-            icon="call" if entry.direction == "outgoing" else "talk",
+            icon=visible_icon_keys[row] if row < len(visible_icon_keys) else "talk",
         )
 
-    render_footer(screen.display, screen._instruction_text(), mode="talk")
+    render_footer(screen.display, screen.instruction_text(), mode="talk")
     screen.display.update()

--- a/src/yoyopod/ui/screens/voip/call_history_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/call_history_pil_view.py
@@ -1,0 +1,75 @@
+"""PIL fallback view for the call history screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    draw_empty_state,
+    draw_list_item,
+    render_footer,
+    render_header,
+    text_fit,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.voip.call_history import CallHistoryScreen
+
+
+def render_call_history_pil(screen: "CallHistoryScreen") -> None:
+    """Render the recent-calls list through the PIL display path."""
+
+    content_top = render_header(
+        screen.display,
+        screen.context,
+        mode="talk",
+        title="Recents",
+        page_text=None,
+        show_time=False,
+        show_mode_chip=False,
+    )
+
+    if not screen.entries:
+        draw_empty_state(
+            screen.display,
+            mode="talk",
+            title="No recent calls",
+            subtitle="Calls will show up here after the first one.",
+            icon="talk",
+            top=content_top,
+        )
+        render_footer(screen.display, "Hold back", mode="talk")
+        screen.display.update()
+        return
+
+    if screen.selected_index < screen.scroll_offset:
+        screen.scroll_offset = screen.selected_index
+    elif screen.selected_index >= screen.scroll_offset + screen.max_visible_items:
+        screen.scroll_offset = screen.selected_index - screen.max_visible_items + 1
+
+    item_height = 52
+    list_top = content_top + 8
+    for row in range(screen.max_visible_items):
+        entry_index = screen.scroll_offset + row
+        if entry_index >= len(screen.entries):
+            break
+
+        entry = screen.entries[entry_index]
+        y1 = list_top + (row * item_height)
+        y2 = y1 + 44
+        draw_list_item(
+            screen.display,
+            x1=18,
+            y1=y1,
+            x2=screen.display.WIDTH - 18,
+            y2=y2,
+            title=text_fit(screen.display, entry.title, screen.display.WIDTH - 90, 15),
+            subtitle=entry.subtitle,
+            mode="talk",
+            selected=entry_index == screen.selected_index,
+            badge=None,
+            icon="call" if entry.direction == "outgoing" else "talk",
+        )
+
+    render_footer(screen.display, screen._instruction_text(), mode="talk")
+    screen.display.update()

--- a/src/yoyopod/ui/screens/voip/contact_list.py
+++ b/src/yoyopod/ui/screens/voip/contact_list.py
@@ -157,7 +157,7 @@ class ContactListScreen(Screen):
             icons.append(f"mono:{talk_monogram(self.contacts[contact_index].display_name)}")
         return icons
 
-    def _instruction_text(self) -> str:
+    def instruction_text(self) -> str:
         """Return footer hints for the current action mode."""
 
         if self.is_one_button_mode():

--- a/src/yoyopod/ui/screens/voip/contact_list.py
+++ b/src/yoyopod/ui/screens/voip/contact_list.py
@@ -9,14 +9,8 @@ from loguru import logger
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
-from yoyopod.ui.screens.theme import (
-    draw_empty_state,
-    draw_list_item,
-    render_footer,
-    render_header,
-    talk_monogram,
-    text_fit,
-)
+from yoyopod.ui.screens.theme import talk_monogram
+from yoyopod.ui.screens.voip.contact_list_pil_view import render_contact_list_pil
 from yoyopod.ui.screens.voip.lvgl import LvglContactListView
 
 if TYPE_CHECKING:
@@ -114,61 +108,7 @@ class ContactListScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        content_top = render_header(
-            self.display,
-            self.context,
-            mode="talk",
-            title=self.title_text,
-            page_text=None,
-            show_time=False,
-            show_mode_chip=False,
-        )
-
-        if not self.contacts:
-            draw_empty_state(
-                self.display,
-                mode="talk",
-                title=self.empty_title,
-                subtitle=self.empty_subtitle,
-                icon="talk",
-                top=content_top,
-            )
-            render_footer(self.display, "Hold back", mode="talk")
-            self.display.update()
-            return
-
-        if self.selected_index < self.scroll_offset:
-            self.scroll_offset = self.selected_index
-        elif self.selected_index >= self.scroll_offset + self.max_visible_items:
-            self.scroll_offset = self.selected_index - self.max_visible_items + 1
-
-        item_height = 52
-        list_top = content_top + 8
-        for row in range(self.max_visible_items):
-            contact_index = self.scroll_offset + row
-            if contact_index >= len(self.contacts):
-                break
-
-            contact = self.contacts[contact_index]
-            y1 = list_top + (row * item_height)
-            y2 = y1 + 44
-            draw_list_item(
-                self.display,
-                x1=18,
-                y1=y1,
-                x2=self.display.WIDTH - 18,
-                y2=y2,
-                title=text_fit(self.display, contact.display_name, self.display.WIDTH - 90, 15),
-                subtitle="",
-                mode="talk",
-                selected=contact_index == self.selected_index,
-                badge=None,
-                icon=f"mono:{talk_monogram(contact.display_name)}",
-            )
-
-        render_footer(self.display, self._instruction_text(), mode="talk")
-        self.display.update()
+        render_contact_list_pil(self)
 
     def get_page_text(self) -> str | None:
         """Contact lists now intentionally omit page counters."""

--- a/src/yoyopod/ui/screens/voip/contact_list_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/contact_list_pil_view.py
@@ -43,19 +43,13 @@ def render_contact_list_pil(screen: "ContactListScreen") -> None:
         screen.display.update()
         return
 
-    if screen.selected_index < screen.scroll_offset:
-        screen.scroll_offset = screen.selected_index
-    elif screen.selected_index >= screen.scroll_offset + screen.max_visible_items:
-        screen.scroll_offset = screen.selected_index - screen.max_visible_items + 1
+    visible_titles, _visible_badges, selected_visible_index = screen.get_visible_window()
+    visible_subtitles = screen.get_visible_subtitles()
+    visible_icon_keys = screen.get_visible_icon_keys()
 
     item_height = 52
     list_top = content_top + 8
-    for row in range(screen.max_visible_items):
-        contact_index = screen.scroll_offset + row
-        if contact_index >= len(screen.contacts):
-            break
-
-        contact = screen.contacts[contact_index]
+    for row, contact_name in enumerate(visible_titles):
         y1 = list_top + (row * item_height)
         y2 = y1 + 44
         draw_list_item(
@@ -64,13 +58,15 @@ def render_contact_list_pil(screen: "ContactListScreen") -> None:
             y1=y1,
             x2=screen.display.WIDTH - 18,
             y2=y2,
-            title=text_fit(screen.display, contact.display_name, screen.display.WIDTH - 90, 15),
-            subtitle="",
+            title=text_fit(screen.display, contact_name, screen.display.WIDTH - 90, 15),
+            subtitle=visible_subtitles[row] if row < len(visible_subtitles) else "",
             mode="talk",
-            selected=contact_index == screen.selected_index,
+            selected=row == selected_visible_index,
             badge=None,
-            icon=f"mono:{talk_monogram(contact.display_name)}",
+            icon=visible_icon_keys[row]
+            if row < len(visible_icon_keys)
+            else f"mono:{talk_monogram(contact_name)}",
         )
 
-    render_footer(screen.display, screen._instruction_text(), mode="talk")
+    render_footer(screen.display, screen.instruction_text(), mode="talk")
     screen.display.update()

--- a/src/yoyopod/ui/screens/voip/contact_list_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/contact_list_pil_view.py
@@ -1,0 +1,76 @@
+"""PIL fallback view for the contact list screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    draw_empty_state,
+    draw_list_item,
+    render_footer,
+    render_header,
+    talk_monogram,
+    text_fit,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.voip.contact_list import ContactListScreen
+
+
+def render_contact_list_pil(screen: "ContactListScreen") -> None:
+    """Render the contact list through the PIL display path."""
+
+    content_top = render_header(
+        screen.display,
+        screen.context,
+        mode="talk",
+        title=screen.title_text,
+        page_text=None,
+        show_time=False,
+        show_mode_chip=False,
+    )
+
+    if not screen.contacts:
+        draw_empty_state(
+            screen.display,
+            mode="talk",
+            title=screen.empty_title,
+            subtitle=screen.empty_subtitle,
+            icon="talk",
+            top=content_top,
+        )
+        render_footer(screen.display, "Hold back", mode="talk")
+        screen.display.update()
+        return
+
+    if screen.selected_index < screen.scroll_offset:
+        screen.scroll_offset = screen.selected_index
+    elif screen.selected_index >= screen.scroll_offset + screen.max_visible_items:
+        screen.scroll_offset = screen.selected_index - screen.max_visible_items + 1
+
+    item_height = 52
+    list_top = content_top + 8
+    for row in range(screen.max_visible_items):
+        contact_index = screen.scroll_offset + row
+        if contact_index >= len(screen.contacts):
+            break
+
+        contact = screen.contacts[contact_index]
+        y1 = list_top + (row * item_height)
+        y2 = y1 + 44
+        draw_list_item(
+            screen.display,
+            x1=18,
+            y1=y1,
+            x2=screen.display.WIDTH - 18,
+            y2=y2,
+            title=text_fit(screen.display, contact.display_name, screen.display.WIDTH - 90, 15),
+            subtitle="",
+            mode="talk",
+            selected=contact_index == screen.selected_index,
+            badge=None,
+            icon=f"mono:{talk_monogram(contact.display_name)}",
+        )
+
+    render_footer(screen.display, screen._instruction_text(), mode="talk")
+    screen.display.update()

--- a/src/yoyopod/ui/screens/voip/in_call.py
+++ b/src/yoyopod/ui/screens/voip/in_call.py
@@ -9,17 +9,7 @@ from loguru import logger
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
-from yoyopod.ui.screens.theme import (
-    ERROR,
-    INK,
-    SUCCESS,
-    TALK,
-    draw_talk_large_card,
-    draw_talk_status_chip,
-    render_footer,
-    render_status_bar,
-    talk_monogram,
-)
+from yoyopod.ui.screens.voip.in_call_pil_view import render_in_call_pil
 from yoyopod.ui.screens.voip.lvgl import LvglInCallView
 
 if TYPE_CHECKING:
@@ -87,57 +77,7 @@ class InCallScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        caller_info = {"display_name": "Unknown", "address": ""}
-        duration = 0
-        is_muted = False
-        if self.voip_manager:
-            caller_info = self.voip_manager.get_caller_info()
-            duration = self.voip_manager.get_call_duration()
-            is_muted = self.voip_manager.is_muted
-
-        render_status_bar(self.display, self.context, show_time=True)
-        caller_name = caller_info.get("display_name", "Unknown")
-        card_top = self.display.STATUS_BAR_HEIGHT + 42
-        card_left = (self.display.WIDTH - 112) // 2
-        draw_talk_large_card(
-            self.display,
-            left=card_left,
-            top=card_top,
-            size=112,
-            color=TALK.accent,
-            label=talk_monogram(caller_name),
-        )
-        name_width, name_height = self.display.get_text_size(caller_name, 20)
-        title_y = card_top + 126
-        self.display.text(caller_name, (self.display.WIDTH - name_width) // 2, title_y, color=INK, font_size=20)
-
-        duration_text = self.format_duration(duration)
-        chip_bottom = draw_talk_status_chip(
-            self.display,
-            center_x=self.display.WIDTH // 2,
-            top=title_y + name_height + 10,
-            text=f"IN CALL | {duration_text}",
-            color=SUCCESS,
-        )
-
-        if is_muted:
-            draw_talk_status_chip(
-                self.display,
-                center_x=self.display.WIDTH // 2,
-                top=chip_bottom + 8,
-                text="MUTED",
-                color=ERROR,
-                icon="mic_off",
-            )
-
-        footer = (
-            f"Tap = {'Unmute' if is_muted else 'Mute'} | Hold = End"
-            if self.is_one_button_mode()
-            else f"X {'unmute' if is_muted else 'mute'} | B end call"
-        )
-        render_footer(self.display, footer, mode="talk")
-        self.display.update()
+        render_in_call_pil(self)
 
     def _hangup_call(self) -> None:
         """End the current call."""

--- a/src/yoyopod/ui/screens/voip/in_call_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/in_call_pil_view.py
@@ -1,0 +1,81 @@
+"""PIL fallback view for the in-call screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    ERROR,
+    INK,
+    SUCCESS,
+    TALK,
+    draw_talk_large_card,
+    draw_talk_status_chip,
+    render_footer,
+    render_status_bar,
+    talk_monogram,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.voip.in_call import InCallScreen
+
+
+def render_in_call_pil(screen: "InCallScreen") -> None:
+    """Render the active-call screen through the PIL display path."""
+
+    caller_info = {"display_name": "Unknown", "address": ""}
+    duration = 0
+    is_muted = False
+    if screen.voip_manager:
+        caller_info = screen.voip_manager.get_caller_info()
+        duration = screen.voip_manager.get_call_duration()
+        is_muted = screen.voip_manager.is_muted
+
+    render_status_bar(screen.display, screen.context, show_time=True)
+    caller_name = caller_info.get("display_name", "Unknown")
+    card_top = screen.display.STATUS_BAR_HEIGHT + 42
+    card_left = (screen.display.WIDTH - 112) // 2
+    draw_talk_large_card(
+        screen.display,
+        left=card_left,
+        top=card_top,
+        size=112,
+        color=TALK.accent,
+        label=talk_monogram(caller_name),
+    )
+    name_width, name_height = screen.display.get_text_size(caller_name, 20)
+    title_y = card_top + 126
+    screen.display.text(
+        caller_name,
+        (screen.display.WIDTH - name_width) // 2,
+        title_y,
+        color=INK,
+        font_size=20,
+    )
+
+    duration_text = screen.format_duration(duration)
+    chip_bottom = draw_talk_status_chip(
+        screen.display,
+        center_x=screen.display.WIDTH // 2,
+        top=title_y + name_height + 10,
+        text=f"IN CALL | {duration_text}",
+        color=SUCCESS,
+    )
+
+    if is_muted:
+        draw_talk_status_chip(
+            screen.display,
+            center_x=screen.display.WIDTH // 2,
+            top=chip_bottom + 8,
+            text="MUTED",
+            color=ERROR,
+            icon="mic_off",
+        )
+
+    footer = (
+        f"Tap = {'Unmute' if is_muted else 'Mute'} | Hold = End"
+        if screen.is_one_button_mode()
+        else f"X {'unmute' if is_muted else 'mute'} | B end call"
+    )
+    render_footer(screen.display, footer, mode="talk")
+    screen.display.update()

--- a/src/yoyopod/ui/screens/voip/incoming_call.py
+++ b/src/yoyopod/ui/screens/voip/incoming_call.py
@@ -9,16 +9,8 @@ from loguru import logger
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.voip.incoming_call_pil_view import render_incoming_call_pil
 from yoyopod.ui.screens.voip.lvgl import LvglIncomingCallView
-from yoyopod.ui.screens.theme import (
-    INK,
-    TALK,
-    draw_talk_large_card,
-    draw_talk_status_chip,
-    render_footer,
-    render_status_bar,
-    talk_monogram,
-)
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
@@ -80,37 +72,7 @@ class IncomingCallScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        render_status_bar(self.display, self.context, show_time=True)
-        card_top = self.display.STATUS_BAR_HEIGHT + 42
-        card_left = (self.display.WIDTH - 112) // 2
-        draw_talk_large_card(
-            self.display,
-            left=card_left,
-            top=card_top,
-            size=112,
-            color=TALK.accent,
-            label=talk_monogram(self.caller_name or "Unknown"),
-        )
-        self.ring_animation_frame += 1
-
-        display_name = self.caller_name or "Unknown"
-        if len(display_name) > 14:
-            display_name = f"{display_name[:13]}..."
-        name_width, name_height = self.display.get_text_size(display_name, 20)
-        title_y = card_top + 126
-        self.display.text(display_name, (self.display.WIDTH - name_width) // 2, title_y, color=INK, font_size=20)
-        draw_talk_status_chip(
-            self.display,
-            center_x=self.display.WIDTH // 2,
-            top=title_y + name_height + 10,
-            text="INCOMING CALL",
-            color=TALK.accent,
-        )
-
-        footer = "Tap = Answer | Hold = Decline" if self.is_one_button_mode() else "A answer | B reject"
-        render_footer(self.display, footer, mode="talk")
-        self.display.update()
+        render_incoming_call_pil(self)
 
     def _answer_call(self) -> None:
         """Answer the incoming call."""

--- a/src/yoyopod/ui/screens/voip/incoming_call_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/incoming_call_pil_view.py
@@ -1,0 +1,63 @@
+"""PIL fallback view for the incoming-call screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    INK,
+    TALK,
+    draw_talk_large_card,
+    draw_talk_status_chip,
+    render_footer,
+    render_status_bar,
+    talk_monogram,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.voip.incoming_call import IncomingCallScreen
+
+
+def render_incoming_call_pil(screen: "IncomingCallScreen") -> None:
+    """Render the incoming-call screen through the PIL display path."""
+
+    render_status_bar(screen.display, screen.context, show_time=True)
+    card_top = screen.display.STATUS_BAR_HEIGHT + 42
+    card_left = (screen.display.WIDTH - 112) // 2
+    draw_talk_large_card(
+        screen.display,
+        left=card_left,
+        top=card_top,
+        size=112,
+        color=TALK.accent,
+        label=talk_monogram(screen.caller_name or "Unknown"),
+    )
+    screen.ring_animation_frame += 1
+
+    display_name = screen.caller_name or "Unknown"
+    if len(display_name) > 14:
+        display_name = f"{display_name[:13]}..."
+    name_width, name_height = screen.display.get_text_size(display_name, 20)
+    title_y = card_top + 126
+    screen.display.text(
+        display_name,
+        (screen.display.WIDTH - name_width) // 2,
+        title_y,
+        color=INK,
+        font_size=20,
+    )
+    draw_talk_status_chip(
+        screen.display,
+        center_x=screen.display.WIDTH // 2,
+        top=title_y + name_height + 10,
+        text="INCOMING CALL",
+        color=TALK.accent,
+    )
+
+    footer = (
+        "Tap = Answer | Hold = Decline"
+        if screen.is_one_button_mode()
+        else "A answer | B reject"
+    )
+    render_footer(screen.display, footer, mode="talk")
+    screen.display.update()

--- a/src/yoyopod/ui/screens/voip/lvgl/call_history_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/call_history_view.py
@@ -50,7 +50,7 @@ class LvglCallHistoryView:
         self.backend.binding.playlist_sync(
             title_text="Recents",
             page_text=None,
-            footer=self.screen._instruction_text(),
+            footer=self.screen.instruction_text(),
             items=visible_items,
             subtitles=visible_subtitles,
             badges=visible_badges,

--- a/src/yoyopod/ui/screens/voip/lvgl/contact_list_view.py
+++ b/src/yoyopod/ui/screens/voip/lvgl/contact_list_view.py
@@ -50,7 +50,7 @@ class LvglContactListView:
         self.backend.binding.playlist_sync(
             title_text=self.screen.title_text,
             page_text=None,
-            footer=self.screen._instruction_text(),
+            footer=self.screen.instruction_text(),
             items=visible_items,
             subtitles=visible_subtitles,
             badges=visible_badges,

--- a/src/yoyopod/ui/screens/voip/outgoing_call.py
+++ b/src/yoyopod/ui/screens/voip/outgoing_call.py
@@ -9,16 +9,8 @@ from loguru import logger
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.voip.outgoing_call_pil_view import render_outgoing_call_pil
 from yoyopod.ui.screens.voip.lvgl import LvglOutgoingCallView
-from yoyopod.ui.screens.theme import (
-    INK,
-    TALK,
-    draw_talk_large_card,
-    draw_talk_status_chip,
-    render_footer,
-    render_status_bar,
-    talk_monogram,
-)
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
@@ -80,45 +72,7 @@ class OutgoingCallScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        callee_name = self.callee_name
-        callee_address = self.callee_address
-        if self.voip_manager:
-            caller_info = self.voip_manager.get_caller_info()
-            callee_name = caller_info.get("display_name", callee_name)
-            callee_address = caller_info.get("address", callee_address)
-
-        render_status_bar(self.display, self.context, show_time=True)
-        card_top = self.display.STATUS_BAR_HEIGHT + 42
-        card_left = (self.display.WIDTH - 112) // 2
-        draw_talk_large_card(
-            self.display,
-            left=card_left,
-            top=card_top,
-            size=112,
-            color=TALK.accent,
-            label=talk_monogram(callee_name or "Unknown"),
-            outlined=True,
-        )
-        self.ring_animation_frame += 1
-
-        display_name = callee_name or "Unknown"
-        if len(display_name) > 14:
-            display_name = f"{display_name[:13]}..."
-        name_width, name_height = self.display.get_text_size(display_name, 20)
-        title_y = card_top + 126
-        self.display.text(display_name, (self.display.WIDTH - name_width) // 2, title_y, color=INK, font_size=20)
-        draw_talk_status_chip(
-            self.display,
-            center_x=self.display.WIDTH // 2,
-            top=title_y + name_height + 10,
-            text="CALLING...",
-            color=TALK.accent,
-        )
-
-        footer = "Hold = Cancel" if self.is_one_button_mode() else "B cancel"
-        render_footer(self.display, footer, mode="talk")
-        self.display.update()
+        render_outgoing_call_pil(self)
 
     def _cancel_call(self) -> None:
         """Cancel the outgoing call."""

--- a/src/yoyopod/ui/screens/voip/outgoing_call_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/outgoing_call_pil_view.py
@@ -1,0 +1,65 @@
+"""PIL fallback view for the outgoing-call screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    INK,
+    TALK,
+    draw_talk_large_card,
+    draw_talk_status_chip,
+    render_footer,
+    render_status_bar,
+    talk_monogram,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.voip.outgoing_call import OutgoingCallScreen
+
+
+def render_outgoing_call_pil(screen: "OutgoingCallScreen") -> None:
+    """Render the outgoing-call screen through the PIL display path."""
+
+    callee_name = screen.callee_name
+    if screen.voip_manager:
+        caller_info = screen.voip_manager.get_caller_info()
+        callee_name = caller_info.get("display_name", callee_name)
+
+    render_status_bar(screen.display, screen.context, show_time=True)
+    card_top = screen.display.STATUS_BAR_HEIGHT + 42
+    card_left = (screen.display.WIDTH - 112) // 2
+    draw_talk_large_card(
+        screen.display,
+        left=card_left,
+        top=card_top,
+        size=112,
+        color=TALK.accent,
+        label=talk_monogram(callee_name or "Unknown"),
+        outlined=True,
+    )
+    screen.ring_animation_frame += 1
+
+    display_name = callee_name or "Unknown"
+    if len(display_name) > 14:
+        display_name = f"{display_name[:13]}..."
+    name_width, name_height = screen.display.get_text_size(display_name, 20)
+    title_y = card_top + 126
+    screen.display.text(
+        display_name,
+        (screen.display.WIDTH - name_width) // 2,
+        title_y,
+        color=INK,
+        font_size=20,
+    )
+    draw_talk_status_chip(
+        screen.display,
+        center_x=screen.display.WIDTH // 2,
+        top=title_y + name_height + 10,
+        text="CALLING...",
+        color=TALK.accent,
+    )
+
+    footer = "Hold = Cancel" if screen.is_one_button_mode() else "B cancel"
+    render_footer(screen.display, footer, mode="talk")
+    screen.display.update()

--- a/src/yoyopod/ui/screens/voip/talk_contact.py
+++ b/src/yoyopod/ui/screens/voip/talk_contact.py
@@ -116,11 +116,12 @@ class TalkContactScreen(Screen):
         """Return visible action rows for the LVGL scene."""
 
         actions = self.actions()
-        return (
-            [action.title for action in actions],
-            [action.subtitle for action in actions],
-            self.selected_index,
-        )
+        titles = [action.title for action in actions]
+        subtitles = [action.subtitle for action in actions]
+        if not titles:
+            return titles, subtitles, 0
+        selected_index = min(self.selected_index, len(titles) - 1)
+        return titles, subtitles, selected_index
 
     def get_visible_action_icons(self) -> list[str]:
         """Return the visible icon key for each action row."""

--- a/src/yoyopod/ui/screens/voip/talk_contact.py
+++ b/src/yoyopod/ui/screens/voip/talk_contact.py
@@ -120,7 +120,7 @@ class TalkContactScreen(Screen):
         subtitles = [action.subtitle for action in actions]
         if not titles:
             return titles, subtitles, 0
-        selected_index = min(self.selected_index, len(titles) - 1)
+        selected_index = self._selected_action_index(actions)
         return titles, subtitles, selected_index
 
     def get_visible_action_icons(self) -> list[str]:
@@ -161,7 +161,12 @@ class TalkContactScreen(Screen):
         """Return the active action row."""
 
         actions = self.actions()
-        return actions[self.selected_index % len(actions)]
+        return actions[self._selected_action_index(actions)]
+
+    def _selected_action_index(self, actions: list[TalkAction]) -> int:
+        """Map the raw cursor to a visible Talk action index."""
+
+        return min(self.selected_index, len(actions) - 1)
 
     def _start_call(self) -> None:
         """Call the selected contact immediately."""

--- a/src/yoyopod/ui/screens/voip/talk_contact.py
+++ b/src/yoyopod/ui/screens/voip/talk_contact.py
@@ -10,17 +10,9 @@ from loguru import logger
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
-from yoyopod.ui.screens.theme import (
-    INK,
-    TALK,
-    draw_talk_action_button,
-    draw_talk_page_dots,
-    draw_talk_person_header,
-    render_footer,
-    render_status_bar,
-    talk_monogram,
-)
+from yoyopod.ui.screens.theme import talk_monogram
 from yoyopod.ui.screens.voip.lvgl.talk_contact_view import LvglTalkContactView
+from yoyopod.ui.screens.voip.talk_contact_pil_view import render_talk_contact_pil
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
@@ -157,58 +149,7 @@ class TalkContactScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        render_status_bar(self.display, self.context, show_time=True)
-        actions = self.actions()
-        action_icons = self.get_visible_action_icons()
-        button_size = self.action_button_size()
-        bottom = draw_talk_person_header(
-            self.display,
-            center_x=self.display.WIDTH // 2,
-            top=self.display.STATUS_BAR_HEIGHT + 28,
-            name=self.current_contact_name(),
-            label=self.current_contact_monogram(),
-        )
-
-        diameter = 64 if button_size == "medium" else 56
-        gap = 16 if button_size == "medium" else 12
-        center_y = bottom + 54
-        row_width = (len(actions) * diameter) + (max(0, len(actions) - 1) * gap)
-        start_center = ((self.display.WIDTH - row_width) // 2) + (diameter // 2)
-
-        for row, _action in enumerate(actions):
-            draw_talk_action_button(
-                self.display,
-                center_x=start_center + (row * (diameter + gap)),
-                center_y=center_y,
-                button_size=button_size,
-                color=TALK.accent,
-                icon=action_icons[row],
-                filled=row == self.selected_index,
-                active=row == self.selected_index,
-            )
-
-        selected_title = self._selected_action().title
-        title_width, title_height = self.display.get_text_size(selected_title, 18)
-        title_y = center_y + (diameter // 2) + 16
-        self.display.text(
-            selected_title,
-            (self.display.WIDTH - title_width) // 2,
-            title_y,
-            color=INK,
-            font_size=18,
-        )
-        draw_talk_page_dots(
-            self.display,
-            center_x=self.display.WIDTH // 2,
-            top=title_y + title_height + 16,
-            total=len(actions),
-            current=self.selected_index,
-            color=TALK.accent,
-        )
-
-        render_footer(self.display, "Tap Next | 2x Select | Hold Back", mode="talk")
-        self.display.update()
+        render_talk_contact_pil(self)
 
     def _selected_action(self) -> TalkAction:
         """Return the active action row."""

--- a/src/yoyopod/ui/screens/voip/talk_contact.py
+++ b/src/yoyopod/ui/screens/voip/talk_contact.py
@@ -142,6 +142,11 @@ class TalkContactScreen(Screen):
 
         return "small" if len(self.actions()) >= 3 else "medium"
 
+    def footer_text(self) -> str:
+        """Return the footer hint for the Talk contact action screen."""
+
+        return "Tap Next | 2x Select | Hold Back"
+
     def render(self) -> None:
         """Render the contact action picker."""
 

--- a/src/yoyopod/ui/screens/voip/talk_contact_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/talk_contact_pil_view.py
@@ -25,6 +25,7 @@ def render_talk_contact_pil(screen: "TalkContactScreen") -> None:
     actions = screen.actions()
     action_icons = screen.get_visible_action_icons()
     button_size = screen.action_button_size()
+    selected_index = min(screen.selected_index, len(actions) - 1) if actions else 0
     bottom = draw_talk_person_header(
         screen.display,
         center_x=screen.display.WIDTH // 2,
@@ -47,12 +48,16 @@ def render_talk_contact_pil(screen: "TalkContactScreen") -> None:
             button_size=button_size,
             color=TALK.accent,
             icon=action_icons[row],
-            filled=row == screen.selected_index,
-            active=row == screen.selected_index,
+            filled=row == selected_index,
+            active=row == selected_index,
         )
 
     visible_items, _visible_subtitles, selected_visible_index = screen.get_visible_actions()
-    selected_title = visible_items[selected_visible_index] if visible_items else ""
+    if visible_items:
+        selected_visible_index = min(selected_visible_index, len(visible_items) - 1)
+        selected_title = visible_items[selected_visible_index]
+    else:
+        selected_title = ""
     title_width, title_height = screen.display.get_text_size(selected_title, 18)
     title_y = center_y + (diameter // 2) + 16
     screen.display.text(
@@ -67,7 +72,7 @@ def render_talk_contact_pil(screen: "TalkContactScreen") -> None:
         center_x=screen.display.WIDTH // 2,
         top=title_y + title_height + 16,
         total=len(actions),
-        current=screen.selected_index,
+        current=selected_index,
         color=TALK.accent,
     )
 

--- a/src/yoyopod/ui/screens/voip/talk_contact_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/talk_contact_pil_view.py
@@ -1,0 +1,74 @@
+"""PIL fallback view for the Talk contact action screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    INK,
+    TALK,
+    draw_talk_action_button,
+    draw_talk_page_dots,
+    draw_talk_person_header,
+    render_footer,
+    render_status_bar,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.voip.talk_contact import TalkContactScreen
+
+
+def render_talk_contact_pil(screen: "TalkContactScreen") -> None:
+    """Render the Talk contact action picker through the PIL display path."""
+
+    render_status_bar(screen.display, screen.context, show_time=True)
+    actions = screen.actions()
+    action_icons = screen.get_visible_action_icons()
+    button_size = screen.action_button_size()
+    bottom = draw_talk_person_header(
+        screen.display,
+        center_x=screen.display.WIDTH // 2,
+        top=screen.display.STATUS_BAR_HEIGHT + 28,
+        name=screen.current_contact_name(),
+        label=screen.current_contact_monogram(),
+    )
+
+    diameter = 64 if button_size == "medium" else 56
+    gap = 16 if button_size == "medium" else 12
+    center_y = bottom + 54
+    row_width = (len(actions) * diameter) + (max(0, len(actions) - 1) * gap)
+    start_center = ((screen.display.WIDTH - row_width) // 2) + (diameter // 2)
+
+    for row, _action in enumerate(actions):
+        draw_talk_action_button(
+            screen.display,
+            center_x=start_center + (row * (diameter + gap)),
+            center_y=center_y,
+            button_size=button_size,
+            color=TALK.accent,
+            icon=action_icons[row],
+            filled=row == screen.selected_index,
+            active=row == screen.selected_index,
+        )
+
+    selected_title = screen._selected_action().title
+    title_width, title_height = screen.display.get_text_size(selected_title, 18)
+    title_y = center_y + (diameter // 2) + 16
+    screen.display.text(
+        selected_title,
+        (screen.display.WIDTH - title_width) // 2,
+        title_y,
+        color=INK,
+        font_size=18,
+    )
+    draw_talk_page_dots(
+        screen.display,
+        center_x=screen.display.WIDTH // 2,
+        top=title_y + title_height + 16,
+        total=len(actions),
+        current=screen.selected_index,
+        color=TALK.accent,
+    )
+
+    render_footer(screen.display, "Tap Next | 2x Select | Hold Back", mode="talk")
+    screen.display.update()

--- a/src/yoyopod/ui/screens/voip/talk_contact_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/talk_contact_pil_view.py
@@ -51,7 +51,8 @@ def render_talk_contact_pil(screen: "TalkContactScreen") -> None:
             active=row == screen.selected_index,
         )
 
-    selected_title = screen._selected_action().title
+    visible_items, _visible_subtitles, selected_visible_index = screen.get_visible_actions()
+    selected_title = visible_items[selected_visible_index] if visible_items else ""
     title_width, title_height = screen.display.get_text_size(selected_title, 18)
     title_y = center_y + (diameter // 2) + 16
     screen.display.text(
@@ -70,5 +71,5 @@ def render_talk_contact_pil(screen: "TalkContactScreen") -> None:
         color=TALK.accent,
     )
 
-    render_footer(screen.display, "Tap Next | 2x Select | Hold Back", mode="talk")
+    render_footer(screen.display, screen.footer_text(), mode="talk")
     screen.display.update()

--- a/src/yoyopod/ui/screens/voip/voice_note.py
+++ b/src/yoyopod/ui/screens/voip/voice_note.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
-from yoyopod.ui.screens.theme import talk_monogram
+from yoyopod.ui.screens.theme import SUCCESS, WARNING, talk_monogram
 from yoyopod.ui.screens.voip.lvgl.voice_note_view import LvglVoiceNoteView
 from yoyopod.ui.screens.voip.voice_note_models import (
     VoiceNoteAction,
@@ -94,7 +94,7 @@ class VoiceNoteScreen(Screen):
 
         return self.is_one_button_mode() and self._state in {"ready", "recording"}
 
-    def _view_model(self) -> VoiceNoteViewModel:
+    def view_model(self) -> VoiceNoteViewModel:
         """Build the pure voice-note view model for rendering."""
 
         return VoiceNoteViewModel(
@@ -167,67 +167,72 @@ class VoiceNoteScreen(Screen):
     def actions(self) -> list[VoiceNoteAction]:
         """Return the selectable actions for the current voice-note state."""
 
-        return self._view_model().actions()
+        return self.view_model().actions()
 
     def current_actions_for_view(self) -> tuple[list[str], list[str], int]:
         """Return visible action rows for the current state."""
 
-        return self._view_model().current_actions_for_view()
+        return self.view_model().current_actions_for_view()
 
     def current_action_subtitles(self) -> list[str]:
         """Return subtitles for the current action list."""
 
-        return self._view_model().current_action_subtitles()
+        return self.view_model().current_action_subtitles()
 
     def current_action_icons(self) -> list[str]:
         """Return icon keys for the current action list."""
 
-        return self._view_model().current_action_icons()
+        return self.view_model().current_action_icons()
 
     def current_action_colors(self) -> list[tuple[int, int, int]]:
         """Return the Talk action colors for the current button row."""
 
-        return self._view_model().current_action_colors()
+        return self.view_model().current_action_colors()
 
     def current_action_color_kinds(self) -> list[int]:
         """Return native LVGL color kinds for the current action row."""
 
-        return self._view_model().current_action_color_kinds()
+        return self.view_model().current_action_color_kinds()
 
     def current_primary_icon(self) -> str:
         """Return the large centered action icon for non-review states."""
 
-        return self._view_model().current_primary_icon()
+        return self.view_model().current_primary_icon()
 
     def current_primary_color(self) -> tuple[int, int, int]:
         """Return the large centered action color for non-review states."""
 
-        return self._view_model().current_primary_color()
+        return self.view_model().current_primary_color()
 
     def current_primary_color_kind(self) -> int:
         """Return the native LVGL color kind for the centered action."""
 
-        return self._view_model().current_primary_color_kind()
+        return self.view_model().current_primary_color_kind()
 
     def current_primary_status(self) -> tuple[str, tuple[int, int, int]]:
         """Return the main status label and color for non-review states."""
 
-        return self._view_model().current_primary_status()
+        return self.view_model().current_primary_status()
 
     def current_primary_status_kind(self) -> int:
         """Return the native LVGL color kind for the centered status label."""
 
-        return self._view_model().current_primary_status_kind()
+        return self.view_model().current_primary_status_kind()
 
     def current_status_chip(self) -> tuple[str | None, int]:
         """Return the current state-chip label and style kind."""
 
-        return self._view_model().current_status_chip()
+        return self.view_model().current_status_chip()
 
     def current_view_model(self) -> tuple[str, str, str, str]:
         """Return title, subtitle, footer, and icon for the current voice-note state."""
 
-        return self._view_model().current_view_model()
+        return self.view_model().current_view_model()
+
+    def page_dot_color(self) -> tuple[int, int, int]:
+        """Return the Talk page-dot color for the current voice-note state."""
+
+        return SUCCESS if self._state == "review" else WARNING
 
     def render(self) -> None:
         """Render the current voice-note flow state."""

--- a/src/yoyopod/ui/screens/voip/voice_note.py
+++ b/src/yoyopod/ui/screens/voip/voice_note.py
@@ -7,18 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 from yoyopod.ui.display import Display
 from yoyopod.ui.screens.base import Screen
 from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
-from yoyopod.ui.screens.theme import (
-    INK,
-    SUCCESS,
-    WARNING,
-    draw_talk_action_button,
-    draw_talk_page_dots,
-    draw_talk_person_header,
-    draw_talk_status_chip,
-    render_footer,
-    render_status_bar,
-    talk_monogram,
-)
+from yoyopod.ui.screens.theme import talk_monogram
 from yoyopod.ui.screens.voip.lvgl.voice_note_view import LvglVoiceNoteView
 from yoyopod.ui.screens.voip.voice_note_models import (
     VoiceNoteAction,
@@ -28,6 +17,7 @@ from yoyopod.ui.screens.voip.voice_note_models import (
     build_voice_note_state_provider,
 )
 from yoyopod.ui.screens.voip.voice_note_recording import VoiceNoteRecordingController
+from yoyopod.ui.screens.voip.voice_note_pil_view import render_voice_note_pil
 from yoyopod.ui.screens.voip.voice_note_viewmodel import VoiceNoteViewModel
 
 if TYPE_CHECKING:
@@ -247,80 +237,7 @@ class VoiceNoteScreen(Screen):
         if lvgl_view is not None:
             lvgl_view.sync()
             return
-
-        view_model = self._view_model()
-        title_text, _subtitle_text, footer_text, _icon_key = view_model.current_view_model()
-        render_status_bar(self.display, self.context, show_time=True)
-        bottom = draw_talk_person_header(
-            self.display,
-            center_x=self.display.WIDTH // 2,
-            top=self.display.STATUS_BAR_HEIGHT + 26,
-            name=self.recipient_name(),
-            label=self.recipient_monogram(),
-        )
-
-        items, _badges, selected_index = view_model.current_actions_for_view()
-        if items:
-            icons = view_model.current_action_icons()
-            colors = view_model.current_action_colors()
-            diameter = 56
-            gap = 12
-            center_y = bottom + 52
-            row_width = (len(items) * diameter) + (max(0, len(items) - 1) * gap)
-            start_center = ((self.display.WIDTH - row_width) // 2) + (diameter // 2)
-            for row, _item_title in enumerate(items):
-                draw_talk_action_button(
-                    self.display,
-                    center_x=start_center + (row * (diameter + gap)),
-                    center_y=center_y,
-                    button_size="small",
-                    color=colors[row],
-                    icon=icons[row],
-                    filled=row == selected_index,
-                    active=row == selected_index,
-                )
-
-            label = items[selected_index]
-            label_width, label_height = self.display.get_text_size(label, 16)
-            label_y = center_y + (diameter // 2) + 14
-            self.display.text(
-                label,
-                (self.display.WIDTH - label_width) // 2,
-                label_y,
-                color=INK,
-                font_size=16,
-            )
-            draw_talk_page_dots(
-                self.display,
-                center_x=self.display.WIDTH // 2,
-                top=label_y + label_height + 14,
-                total=len(items),
-                current=selected_index,
-                color=SUCCESS if self._state == "review" else WARNING,
-            )
-        else:
-            center_y = bottom + 64
-            draw_talk_action_button(
-                self.display,
-                center_x=self.display.WIDTH // 2,
-                center_y=center_y,
-                button_size="large",
-                color=view_model.current_primary_color(),
-                icon=view_model.current_primary_icon(),
-                filled=False,
-                active=True,
-            )
-            status_text, status_color = view_model.current_primary_status()
-            draw_talk_status_chip(
-                self.display,
-                center_x=self.display.WIDTH // 2,
-                top=center_y + 54,
-                text=status_text,
-                color=status_color,
-            )
-
-        render_footer(self.display, footer_text, mode="talk")
-        self.display.update()
+        render_voice_note_pil(self)
 
     def _selected_action(self) -> VoiceNoteAction | None:
         """Return the currently highlighted voice-note action."""

--- a/src/yoyopod/ui/screens/voip/voice_note_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/voice_note_pil_view.py
@@ -1,0 +1,98 @@
+"""PIL fallback view for the voice-note flow screen."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from yoyopod.ui.screens.theme import (
+    INK,
+    SUCCESS,
+    WARNING,
+    draw_talk_action_button,
+    draw_talk_page_dots,
+    draw_talk_person_header,
+    draw_talk_status_chip,
+    render_footer,
+    render_status_bar,
+)
+
+if TYPE_CHECKING:
+    from yoyopod.ui.screens.voip.voice_note import VoiceNoteScreen
+
+
+def render_voice_note_pil(screen: "VoiceNoteScreen") -> None:
+    """Render the voice-note flow through the PIL display path."""
+
+    view_model = screen._view_model()
+    _title_text, _subtitle_text, footer_text, _icon_key = view_model.current_view_model()
+    render_status_bar(screen.display, screen.context, show_time=True)
+    bottom = draw_talk_person_header(
+        screen.display,
+        center_x=screen.display.WIDTH // 2,
+        top=screen.display.STATUS_BAR_HEIGHT + 26,
+        name=screen.recipient_name(),
+        label=screen.recipient_monogram(),
+    )
+
+    items, _badges, selected_index = view_model.current_actions_for_view()
+    if items:
+        icons = view_model.current_action_icons()
+        colors = view_model.current_action_colors()
+        diameter = 56
+        gap = 12
+        center_y = bottom + 52
+        row_width = (len(items) * diameter) + (max(0, len(items) - 1) * gap)
+        start_center = ((screen.display.WIDTH - row_width) // 2) + (diameter // 2)
+        for row, _item_title in enumerate(items):
+            draw_talk_action_button(
+                screen.display,
+                center_x=start_center + (row * (diameter + gap)),
+                center_y=center_y,
+                button_size="small",
+                color=colors[row],
+                icon=icons[row],
+                filled=row == selected_index,
+                active=row == selected_index,
+            )
+
+        label = items[selected_index]
+        label_width, label_height = screen.display.get_text_size(label, 16)
+        label_y = center_y + (diameter // 2) + 14
+        screen.display.text(
+            label,
+            (screen.display.WIDTH - label_width) // 2,
+            label_y,
+            color=INK,
+            font_size=16,
+        )
+        draw_talk_page_dots(
+            screen.display,
+            center_x=screen.display.WIDTH // 2,
+            top=label_y + label_height + 14,
+            total=len(items),
+            current=selected_index,
+            color=SUCCESS if screen._state == "review" else WARNING,
+        )
+    else:
+        center_y = bottom + 64
+        draw_talk_action_button(
+            screen.display,
+            center_x=screen.display.WIDTH // 2,
+            center_y=center_y,
+            button_size="large",
+            color=view_model.current_primary_color(),
+            icon=view_model.current_primary_icon(),
+            filled=False,
+            active=True,
+        )
+        status_text, status_color = view_model.current_primary_status()
+        draw_talk_status_chip(
+            screen.display,
+            center_x=screen.display.WIDTH // 2,
+            top=center_y + 54,
+            text=status_text,
+            color=status_color,
+        )
+
+    render_footer(screen.display, footer_text, mode="talk")
+    screen.display.update()

--- a/src/yoyopod/ui/screens/voip/voice_note_pil_view.py
+++ b/src/yoyopod/ui/screens/voip/voice_note_pil_view.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING
 
 from yoyopod.ui.screens.theme import (
     INK,
-    SUCCESS,
-    WARNING,
     draw_talk_action_button,
     draw_talk_page_dots,
     draw_talk_person_header,
@@ -23,7 +21,7 @@ if TYPE_CHECKING:
 def render_voice_note_pil(screen: "VoiceNoteScreen") -> None:
     """Render the voice-note flow through the PIL display path."""
 
-    view_model = screen._view_model()
+    view_model = screen.view_model()
     _title_text, _subtitle_text, footer_text, _icon_key = view_model.current_view_model()
     render_status_bar(screen.display, screen.context, show_time=True)
     bottom = draw_talk_person_header(
@@ -71,7 +69,7 @@ def render_voice_note_pil(screen: "VoiceNoteScreen") -> None:
             top=label_y + label_height + 14,
             total=len(items),
             current=selected_index,
-            color=SUCCESS if screen._state == "review" else WARNING,
+            color=screen.page_dot_color(),
         )
     else:
         center_y = bottom + 64

--- a/tests/test_call_screen.py
+++ b/tests/test_call_screen.py
@@ -231,6 +231,22 @@ def test_talk_contact_screen_adds_play_note_action_when_latest_note_exists(
     assert voip_manager.seen_contacts == ["sip:alice@example.com"]
 
 
+def test_talk_contact_screen_clamps_visible_action_index(display: Display) -> None:
+    """Visible Talk actions should clamp stale selection indices."""
+
+    context = AppContext()
+    context.set_talk_contact(name="Mama", sip_address="sip:alice@example.com")
+    screen = TalkContactScreen(display, context, voip_manager=FakeVoIPManager())
+
+    screen.selected_index = 9
+
+    titles, subtitles, selected_index = screen.get_visible_actions()
+
+    assert titles == ["Call", "Voice Note"]
+    assert subtitles == ["Start a voice call", "Record a short message"]
+    assert selected_index == 1
+
+
 def test_voice_note_screen_records_reviews_and_sends(display: Display) -> None:
     """Voice notes should move through record, review, and sending states."""
 

--- a/tests/test_call_screen.py
+++ b/tests/test_call_screen.py
@@ -231,6 +231,42 @@ def test_talk_contact_screen_adds_play_note_action_when_latest_note_exists(
     assert voip_manager.seen_contacts == ["sip:alice@example.com"]
 
 
+def test_talk_contact_screen_keeps_rendered_selection_and_on_select_aligned(
+    display: Display,
+) -> None:
+    """Shrinking actions should keep the highlighted and executed Talk action aligned."""
+
+    context = AppContext()
+    context.set_talk_contact(name="Mama", sip_address="sip:alice@example.com")
+    voip_manager = FakeVoIPManager()
+    voip_manager.latest_notes["sip:alice@example.com"] = VoIPMessageRecord(
+        id="note-1",
+        peer_sip_address="sip:alice@example.com",
+        sender_sip_address="sip:alice@example.com",
+        recipient_sip_address="sip:kid@example.com",
+        kind=MessageKind.VOICE_NOTE,
+        direction=MessageDirection.INCOMING,
+        delivery_state=MessageDeliveryState.DELIVERED,
+        created_at="2026-04-06T00:00:00+00:00",
+        updated_at="2026-04-06T00:00:00+00:00",
+        local_file_path="data/voice_notes/incoming.wav",
+        duration_ms=2100,
+        unread=True,
+    )
+    screen = TalkContactScreen(display, context, voip_manager=voip_manager)
+
+    screen.selected_index = 2
+    del voip_manager.latest_notes["sip:alice@example.com"]
+
+    _titles, _subtitles, selected_index = screen.get_visible_actions()
+    screen.on_select()
+
+    assert selected_index == 1
+    assert context.talk.active_voice_note.recipient_name == "Mama"
+    assert context.talk.active_voice_note.recipient_address == "sip:alice@example.com"
+    assert screen.consume_navigation_request() == NavigationRequest.route("voice_note")
+
+
 def test_talk_contact_screen_clamps_visible_action_index(display: Display) -> None:
     """Visible Talk actions should clamp stale selection indices."""
 

--- a/tests/test_pil_screen_views.py
+++ b/tests/test_pil_screen_views.py
@@ -1,0 +1,436 @@
+"""Direct tests for extracted PIL fallback screen views."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from yoyopod.audio.music import LocalLibraryItem
+from yoyopod.ui.screens.music.now_playing import NowPlayingState
+from yoyopod.ui.screens.music.now_playing_pil_view import render_now_playing_pil
+from yoyopod.ui.screens.music.playlist_pil_view import render_playlist_pil
+from yoyopod.ui.screens.music.recent_pil_view import render_recent_tracks_pil
+from yoyopod.ui.screens.navigation.hub import HubCard
+from yoyopod.ui.screens.navigation.hub_pil_view import render_hub_pil
+from yoyopod.ui.screens.navigation.listen_pil_view import render_listen_pil
+from yoyopod.ui.screens.voip.call_history_pil_view import render_call_history_pil
+from yoyopod.ui.screens.voip.contact_list_pil_view import render_contact_list_pil
+from yoyopod.ui.screens.voip.in_call_pil_view import render_in_call_pil
+from yoyopod.ui.screens.voip.incoming_call_pil_view import render_incoming_call_pil
+from yoyopod.ui.screens.voip.outgoing_call_pil_view import render_outgoing_call_pil
+from yoyopod.ui.screens.voip.talk_contact_pil_view import render_talk_contact_pil
+from yoyopod.ui.screens.voip.voice_note_pil_view import render_voice_note_pil
+
+
+class RecordingDisplay:
+    """Minimal display double that records drawn text."""
+
+    WIDTH = 240
+    HEIGHT = 280
+    STATUS_BAR_HEIGHT = 28
+    COLOR_BLACK = (0, 0, 0)
+
+    def __init__(self) -> None:
+        self.updated = False
+        self.text_calls: list[str] = []
+
+    def is_portrait(self) -> bool:
+        return True
+
+    def get_adapter(self) -> None:
+        return None
+
+    def clear(self, *args, **kwargs) -> None:
+        pass
+
+    def rectangle(self, *args, **kwargs) -> None:
+        pass
+
+    def circle(self, *args, **kwargs) -> None:
+        pass
+
+    def line(self, *args, **kwargs) -> None:
+        pass
+
+    def text(self, text: str, *args, **kwargs) -> None:
+        self.text_calls.append(text)
+
+    def update(self) -> None:
+        self.updated = True
+
+    def get_text_size(
+        self,
+        text: str,
+        font_size: int = 16,
+        size: int | None = None,
+    ) -> tuple[int, int]:
+        resolved_size = size if size is not None else font_size
+        return (max(1, len(text)) * max(4, resolved_size // 2), resolved_size)
+
+
+def _assert_rendered(display: RecordingDisplay, expected_text: str) -> None:
+    assert display.updated
+    assert any(expected_text in text for text in display.text_calls)
+
+
+def _make_now_playing_screen() -> object:
+    display = RecordingDisplay()
+
+    class ScreenStub:
+        context = None
+
+        def __init__(self) -> None:
+            self.display = display
+
+        def current_state(self) -> NowPlayingState:
+            return NowPlayingState(
+                title="Paper Planes",
+                artist="M.I.A.",
+                progress=0.5,
+                state_label="PLAYING",
+                is_playing=True,
+            )
+
+        def display_state_text(self, state_label: str) -> str:
+            return state_label.title()
+
+        def get_footer_text(self, *, is_playing: bool, state_label: str | None = None) -> str:
+            return "A play | B back | X/Y tracks"
+
+        def state_visuals(self, state_label: str) -> dict[str, tuple[int, int, int]]:
+            return {
+                "icon_fill": (20, 30, 40),
+                "icon_outline": (50, 60, 70),
+                "icon_color": (80, 90, 100),
+                "chip_fill": (110, 120, 130),
+                "chip_text": (140, 150, 160),
+                "progress_fill": (170, 180, 190),
+            }
+
+    return ScreenStub()
+
+
+def _make_playlist_screen() -> object:
+    display = RecordingDisplay()
+
+    class ScreenStub:
+        context = None
+        loading = False
+        error_message = None
+        playlists = ["Road Trip"]
+
+        def __init__(self) -> None:
+            self.display = display
+
+        def is_one_button_mode(self) -> bool:
+            return False
+
+        def get_footer_text(self) -> str:
+            return "A load | B back | X/Y move"
+
+        def get_visible_window(self) -> tuple[list[str], list[str], int]:
+            return (["Road Trip"], ["12"], 0)
+
+        def get_visible_subtitles(self) -> list[str]:
+            return [""]
+
+        def get_visible_icon_keys(self) -> list[str]:
+            return ["playlist"]
+
+    return ScreenStub()
+
+
+def _make_recent_screen() -> object:
+    display = RecordingDisplay()
+
+    class ScreenStub:
+        context = None
+        error_message = None
+        tracks = ["Ocean Eyes"]
+
+        def __init__(self) -> None:
+            self.display = display
+
+        def is_one_button_mode(self) -> bool:
+            return False
+
+        def get_footer_text(self) -> str:
+            return "A play | B back | X/Y move"
+
+        def get_visible_window(self) -> tuple[list[str], list[str], int]:
+            return (["Ocean Eyes"], [""], 0)
+
+        def get_visible_subtitles(self) -> list[str]:
+            return ["Billie Eilish"]
+
+        def get_visible_icon_keys(self) -> list[str]:
+            return ["music_note"]
+
+    return ScreenStub()
+
+
+def _make_in_call_screen() -> object:
+    display = RecordingDisplay()
+    voip_manager = SimpleNamespace(
+        get_caller_info=lambda: {"display_name": "Avery"},
+        get_call_duration=lambda: 65,
+        is_muted=True,
+    )
+
+    class ScreenStub:
+        context = None
+
+        def __init__(self) -> None:
+            self.display = display
+            self.voip_manager = voip_manager
+
+        def is_one_button_mode(self) -> bool:
+            return False
+
+        def format_duration(self, seconds: int) -> str:
+            return f"{seconds // 60:02d}:{seconds % 60:02d}"
+
+    return ScreenStub()
+
+
+def _make_incoming_call_screen() -> object:
+    display = RecordingDisplay()
+
+    class ScreenStub:
+        context = None
+
+        def __init__(self) -> None:
+            self.display = display
+            self.caller_name = "Harper"
+            self.ring_animation_frame = 0
+
+        def is_one_button_mode(self) -> bool:
+            return False
+
+    return ScreenStub()
+
+
+def _make_outgoing_call_screen() -> object:
+    display = RecordingDisplay()
+    voip_manager = SimpleNamespace(
+        get_caller_info=lambda: {"display_name": "Theo", "address": "sip:theo@test"},
+    )
+
+    class ScreenStub:
+        context = None
+
+        def __init__(self) -> None:
+            self.display = display
+            self.voip_manager = voip_manager
+            self.callee_name = "Theo"
+            self.callee_address = "sip:theo@test"
+            self.ring_animation_frame = 0
+
+        def is_one_button_mode(self) -> bool:
+            return False
+
+    return ScreenStub()
+
+
+def _make_contact_list_screen() -> object:
+    display = RecordingDisplay()
+
+    class ScreenStub:
+        context = None
+
+        def __init__(self) -> None:
+            self.display = display
+            self.title_text = "More People"
+            self.empty_title = "No contacts"
+            self.empty_subtitle = "Add contacts to call them here."
+            self.contacts = ["Mila"]
+
+        def get_visible_window(self) -> tuple[list[str], list[str], int]:
+            return (["Mila"], [""], 0)
+
+        def get_visible_subtitles(self) -> list[str]:
+            return [""]
+
+        def get_visible_icon_keys(self) -> list[str]:
+            return ["mono:MI"]
+
+        def instruction_text(self) -> str:
+            return "A open | B back | X/Y move"
+
+    return ScreenStub()
+
+
+def _make_voice_note_screen() -> object:
+    display = RecordingDisplay()
+    view_model = SimpleNamespace(
+        current_view_model=lambda: (
+            "Review",
+            "Listen, send, or record again.",
+            "Select choose / Back",
+            "voice_note",
+        ),
+        current_actions_for_view=lambda: (["Send", "Play", "Again"], ["3s", "", ""], 0),
+        current_action_icons=lambda: ["check", "play", "close"],
+        current_action_colors=lambda: [(10, 20, 30), (40, 50, 60), (70, 80, 90)],
+        current_primary_color=lambda: (100, 110, 120),
+        current_primary_icon=lambda: "voice_note",
+        current_primary_status=lambda: ("Recording", (130, 140, 150)),
+    )
+
+    class ScreenStub:
+        context = None
+
+        def __init__(self) -> None:
+            self.display = display
+
+        def view_model(self) -> object:
+            return view_model
+
+        def recipient_name(self) -> str:
+            return "Zoe"
+
+        def recipient_monogram(self) -> str:
+            return "ZO"
+
+        def page_dot_color(self) -> tuple[int, int, int]:
+            return (160, 170, 180)
+
+    return ScreenStub()
+
+
+def _make_talk_contact_screen() -> object:
+    display = RecordingDisplay()
+
+    class ScreenStub:
+        context = None
+
+        def __init__(self) -> None:
+            self.display = display
+            self.selected_index = 1
+
+        def actions(self) -> list[str]:
+            return ["Call", "Voice Note"]
+
+        def get_visible_action_icons(self) -> list[str]:
+            return ["call", "voice_note"]
+
+        def action_button_size(self) -> str:
+            return "medium"
+
+        def current_contact_name(self) -> str:
+            return "Owen"
+
+        def current_contact_monogram(self) -> str:
+            return "OW"
+
+        def get_visible_actions(self) -> tuple[list[str], list[str], int]:
+            return (["Call", "Voice Note"], ["Start a voice call", "Record a short message"], 1)
+
+        def footer_text(self) -> str:
+            return "Tap Next | 2x Select | Hold Back"
+
+    return ScreenStub()
+
+
+def _make_call_history_screen() -> object:
+    display = RecordingDisplay()
+
+    class ScreenStub:
+        context = None
+
+        def __init__(self) -> None:
+            self.display = display
+            self.entries = ["Grandma"]
+
+        def get_visible_window(self) -> tuple[list[str], list[str], int]:
+            return (["Grandma"], [""], 0)
+
+        def get_visible_subtitles(self) -> list[str]:
+            return ["Yesterday"]
+
+        def get_visible_icon_keys(self) -> list[str]:
+            return ["talk"]
+
+        def instruction_text(self) -> str:
+            return "A call | B back | X/Y move"
+
+    return ScreenStub()
+
+
+def _make_hub_screen() -> object:
+    display = RecordingDisplay()
+
+    class ScreenStub:
+        context = None
+
+        def __init__(self) -> None:
+            self.display = display
+            self.selected_index = 0
+
+        def cards(self) -> list[HubCard]:
+            return [
+                HubCard("Listen", "On-device music", "listen", "listen"),
+                HubCard("Talk", "Calls ready", "talk", "talk"),
+            ]
+
+        def tile_glow_color(self, mode: str) -> tuple[int, int, int]:
+            return (10, 20, 30)
+
+        def tile_fill_color(self, mode: str) -> tuple[int, int, int]:
+            return (40, 50, 60)
+
+    return ScreenStub()
+
+
+def _make_listen_screen() -> object:
+    display = RecordingDisplay()
+
+    class ScreenStub:
+        context = None
+
+        def __init__(self) -> None:
+            self.display = display
+            self.selected_index = 0
+            self.items = [
+                LocalLibraryItem("playlists", "Playlists", "Saved mixes"),
+                LocalLibraryItem("recent", "Recent", "Played lately"),
+            ]
+
+        def is_one_button_mode(self) -> bool:
+            return False
+
+        def item_icon_key(self, key: str) -> str:
+            return "playlist" if key == "playlists" else "music_note"
+
+    return ScreenStub()
+
+
+@pytest.mark.parametrize(
+    ("render_fn", "screen_factory", "expected_text"),
+    [
+        (render_now_playing_pil, _make_now_playing_screen, "Paper Planes"),
+        (render_playlist_pil, _make_playlist_screen, "Road Trip"),
+        (render_recent_tracks_pil, _make_recent_screen, "Ocean Eyes"),
+        (render_in_call_pil, _make_in_call_screen, "Avery"),
+        (render_incoming_call_pil, _make_incoming_call_screen, "Harper"),
+        (render_outgoing_call_pil, _make_outgoing_call_screen, "Theo"),
+        (render_contact_list_pil, _make_contact_list_screen, "Mila"),
+        (render_voice_note_pil, _make_voice_note_screen, "Send"),
+        (render_talk_contact_pil, _make_talk_contact_screen, "Voice Note"),
+        (render_call_history_pil, _make_call_history_screen, "Grandma"),
+        (render_hub_pil, _make_hub_screen, "Listen"),
+        (render_listen_pil, _make_listen_screen, "Playlists"),
+    ],
+)
+def test_extracted_pil_views_render_with_public_screen_surface(
+    render_fn,
+    screen_factory,
+    expected_text: str,
+) -> None:
+    """Each PIL view should render directly from a narrow public screen surface."""
+
+    screen = screen_factory()
+    render_fn(screen)
+
+    _assert_rendered(screen.display, expected_text)

--- a/tests/test_pil_screen_views.py
+++ b/tests/test_pil_screen_views.py
@@ -307,7 +307,7 @@ def _make_talk_contact_screen() -> object:
 
         def __init__(self) -> None:
             self.display = display
-            self.selected_index = 1
+            self.selected_index = 9
 
         def actions(self) -> list[str]:
             return ["Call", "Voice Note"]
@@ -325,7 +325,7 @@ def _make_talk_contact_screen() -> object:
             return "OW"
 
         def get_visible_actions(self) -> tuple[list[str], list[str], int]:
-            return (["Call", "Voice Note"], ["Start a voice call", "Record a short message"], 1)
+            return (["Call", "Voice Note"], ["Start a voice call", "Record a short message"], 9)
 
         def footer_text(self) -> str:
             return "Tap Next | 2x Select | Hold Back"


### PR DESCRIPTION
Implements issue #209. Generated by wrapper-owned workflow watchdog.