### PR TITLE
[codex] fix cellular PPP startup and add network self-heal

### DIFF
--- a/src/yoyopod/app.py
+++ b/src/yoyopod/app.py
@@ -179,6 +179,7 @@ class YoyoPodApp:
         # Runtime state tracked across services
         self._voip_recovery = RecoveryState()
         self._music_recovery = RecoveryState()
+        self._network_recovery = RecoveryState()
         self._next_power_poll_at = 0.0
         self._power_available: bool | None = None
         self._power_alert: PowerAlert | None = None
@@ -480,11 +481,20 @@ class YoyoPodApp:
     def _attempt_music_recovery(self, recovery_now: float) -> None:
         self.recovery_service.attempt_music_recovery(recovery_now)
 
+    def _attempt_network_recovery(self, recovery_now: float) -> None:
+        self.recovery_service.attempt_network_recovery(recovery_now)
+
     def _start_music_recovery_worker(self, recovery_now: float) -> None:
         self.recovery_service.start_music_recovery_worker(recovery_now)
 
+    def _start_network_recovery_worker(self, recovery_now: float) -> None:
+        self.recovery_service.start_network_recovery_worker(recovery_now)
+
     def _run_music_recovery_attempt(self, recovery_now: float) -> None:
         self.recovery_service.run_music_recovery_attempt(recovery_now)
+
+    def _run_network_recovery_attempt(self, recovery_now: float) -> None:
+        self.recovery_service.run_network_recovery_attempt(recovery_now)
 
     def _finalize_recovery_attempt(
         self,

--- a/src/yoyopod/core/events.py
+++ b/src/yoyopod/core/events.py
@@ -58,7 +58,7 @@ class UserActivityEvent:
 class RecoveryAttemptCompletedEvent:
     """Published when a background backend recovery attempt finishes."""
 
-    manager: Literal["music"]
+    manager: Literal["music", "network"]
     recovered: bool
     recovery_now: float
 

--- a/src/yoyopod/network/backend.py
+++ b/src/yoyopod/network/backend.py
@@ -118,7 +118,7 @@ class Sim7600Backend:
         if self._config.gps_enabled:
             self._at.enable_gps()
 
-    def start_ppp(self) -> bool:
+    def start_ppp(self, *, wait_for_link: bool = True) -> bool:
         self._state.phase = ModemPhase.PPP_STARTING
         apn = str(self._config.apn or "").strip()
         if apn:
@@ -131,7 +131,16 @@ class Sim7600Backend:
             self._state.error = "PPP failed to start"
             return False
 
-        if not self._ppp.wait_for_link(timeout=self._config.ppp_timeout):
+        if not wait_for_link:
+            return True
+
+        return self.wait_for_ppp_link(timeout=self._config.ppp_timeout)
+
+    def wait_for_ppp_link(self, timeout: float | None = None) -> bool:
+        """Wait for the spawned PPP session to expose ppp0."""
+
+        effective_timeout = self._config.ppp_timeout if timeout is None else timeout
+        if not self._ppp.wait_for_link(timeout=effective_timeout):
             self._ppp.kill()
             self._state.phase = ModemPhase.REGISTERED
             self._state.error = "PPP negotiation timed out"

--- a/src/yoyopod/network/backend.py
+++ b/src/yoyopod/network/backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
 from loguru import logger
@@ -21,6 +22,7 @@ class NetworkBackend(Protocol):
 
     def probe(self) -> bool: ...
     def get_state(self) -> ModemState: ...
+    def is_online(self) -> bool: ...
 
 
 class Sim7600Backend:
@@ -50,6 +52,24 @@ class Sim7600Backend:
 
     def get_state(self) -> ModemState:
         return self._state
+
+    def is_online(self) -> bool:
+        """Return True when the active PPP session still looks healthy."""
+
+        if self._state.phase != ModemPhase.ONLINE:
+            return False
+
+        if not self._ppp.is_alive():
+            self._state.phase = ModemPhase.REGISTERED
+            self._state.error = "PPP process exited"
+            return False
+
+        if not Path("/sys/class/net/ppp0").exists():
+            self._state.phase = ModemPhase.REGISTERED
+            self._state.error = "PPP interface down"
+            return False
+
+        return True
 
     def open(self) -> None:
         self._transport.open()

--- a/src/yoyopod/network/backend.py
+++ b/src/yoyopod/network/backend.py
@@ -100,7 +100,11 @@ class Sim7600Backend:
 
     def start_ppp(self) -> bool:
         self._state.phase = ModemPhase.PPP_STARTING
-        self._at.configure_pdp(self._config.apn)
+        apn = self._config.apn.strip()
+        if apn:
+            self._at.configure_pdp(apn)
+        else:
+            logger.warning("Network APN is empty; leaving modem PDP context unchanged")
 
         if not self._ppp.spawn():
             self._state.phase = ModemPhase.REGISTERED

--- a/src/yoyopod/network/backend.py
+++ b/src/yoyopod/network/backend.py
@@ -120,7 +120,7 @@ class Sim7600Backend:
 
     def start_ppp(self) -> bool:
         self._state.phase = ModemPhase.PPP_STARTING
-        apn = self._config.apn.strip()
+        apn = str(self._config.apn or "").strip()
         if apn:
             self._at.configure_pdp(apn)
         else:

--- a/src/yoyopod/network/manager.py
+++ b/src/yoyopod/network/manager.py
@@ -40,11 +40,10 @@ class NetworkManager:
 
     def start(self) -> None:
         """Open modem, initialize, and start PPP."""
-        with self._lifecycle_lock:
-            self._start_unlocked()
+        self._start_flow()
 
-    def _start_unlocked(self) -> None:
-        """Run the one-shot modem bring-up flow while the lifecycle lock is held."""
+    def _start_flow(self) -> None:
+        """Run the one-shot modem bring-up flow."""
         from yoyopod.core import (
             NetworkModemReadyEvent,
             NetworkPppUpEvent,
@@ -57,10 +56,11 @@ class NetworkManager:
             return
 
         logger.info("Starting network manager")
-        self.backend.open()
-        self.backend.init_modem()
+        with self._lifecycle_lock:
+            self.backend.open()
+            self.backend.init_modem()
+            state = self.backend.get_state()
 
-        state = self.backend.get_state()
         if state.phase == ModemPhase.REGISTERED:
             self._publish(
                 NetworkModemReadyEvent(
@@ -88,7 +88,7 @@ class NetworkManager:
                 except Exception as exc:
                     logger.debug("Initial GPS query failed: {}", exc)
 
-            if self.backend.start_ppp():
+            if self._start_ppp():
                 self._publish(NetworkPppUpEvent(connection_type="4g"))
         else:
             logger.error("Modem init failed: {}", state.error)
@@ -119,11 +119,11 @@ class NetworkManager:
             except Exception as exc:
                 logger.debug("Ignoring network close error during recovery reset: {}", exc)
 
-            try:
-                self._start_unlocked()
-            except Exception as exc:
-                logger.error("Network recovery failed: {}", exc)
-            return self.is_online
+        try:
+            self._start_flow()
+        except Exception as exc:
+            logger.error("Network recovery failed: {}", exc)
+        return self.is_online
 
     @property
     def is_online(self) -> bool:
@@ -158,6 +158,19 @@ class NetworkManager:
             else:
                 self._publish(NetworkGpsNoFixEvent(reason="no_fix"))
             return coord
+
+    def _start_ppp(self) -> bool:
+        """Spawn PPP under lifecycle lock, then wait for the link without blocking shutdown."""
+
+        wait_for_ppp_link = getattr(self.backend, "wait_for_ppp_link", None)
+        with self._lifecycle_lock:
+            if wait_for_ppp_link is None:
+                return bool(self.backend.start_ppp())
+
+            if not self.backend.start_ppp(wait_for_link=False):
+                return False
+
+        return bool(wait_for_ppp_link(timeout=self.config.ppp_timeout))
 
     def _publish(self, event: object) -> None:
         """Publish an event if the bus is available."""

--- a/src/yoyopod/network/manager.py
+++ b/src/yoyopod/network/manager.py
@@ -144,19 +144,20 @@ class NetworkManager:
         """Query GPS coordinates (may briefly interrupt PPP)."""
         from yoyopod.core import NetworkGpsFixEvent, NetworkGpsNoFixEvent
 
-        coord = self.backend.query_gps()
-        if coord is not None:
-            self._publish(
-                NetworkGpsFixEvent(
-                    lat=coord.lat,
-                    lng=coord.lng,
-                    altitude=coord.altitude,
-                    speed=coord.speed,
+        with self._lifecycle_lock:
+            coord = self.backend.query_gps()
+            if coord is not None:
+                self._publish(
+                    NetworkGpsFixEvent(
+                        lat=coord.lat,
+                        lng=coord.lng,
+                        altitude=coord.altitude,
+                        speed=coord.speed,
+                    )
                 )
-            )
-        else:
-            self._publish(NetworkGpsNoFixEvent(reason="no_fix"))
-        return coord
+            else:
+                self._publish(NetworkGpsNoFixEvent(reason="no_fix"))
+            return coord
 
     def _publish(self, event: object) -> None:
         """Publish an event if the bus is available."""

--- a/src/yoyopod/network/manager.py
+++ b/src/yoyopod/network/manager.py
@@ -99,6 +99,9 @@ class NetworkManager:
                     logger.debug("Initial GPS query failed: {}", exc)
 
             if self._start_ppp(expected_generation=expected_generation):
+                if not self._lifecycle_generation_matches(expected_generation):
+                    logger.info("Skipping PPP-up publish after concurrent lifecycle change")
+                    return False
                 self._publish(NetworkPppUpEvent(connection_type="4g"))
         else:
             logger.error("Modem init failed: {}", state.error)

--- a/src/yoyopod/network/manager.py
+++ b/src/yoyopod/network/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -27,6 +28,7 @@ class NetworkManager:
         self.config = config
         self.backend = backend or Sim7600Backend(config)
         self.event_bus = event_bus
+        self._lifecycle_lock = threading.RLock()
 
     @classmethod
     def from_config_manager(
@@ -38,6 +40,11 @@ class NetworkManager:
 
     def start(self) -> None:
         """Open modem, initialize, and start PPP."""
+        with self._lifecycle_lock:
+            self._start_unlocked()
+
+    def _start_unlocked(self) -> None:
+        """Run the one-shot modem bring-up flow while the lifecycle lock is held."""
         from yoyopod.core import (
             NetworkModemReadyEvent,
             NetworkPppUpEvent,
@@ -90,22 +97,48 @@ class NetworkManager:
         """Stop PPP and close the modem."""
         from yoyopod.core import NetworkPppDownEvent
 
-        logger.info("Stopping network manager")
-        try:
-            self.backend.close()
-        except Exception as exc:
-            logger.error("Error stopping network: {}", exc)
-        self._publish(NetworkPppDownEvent(reason="shutdown"))
+        with self._lifecycle_lock:
+            logger.info("Stopping network manager")
+            try:
+                self.backend.close()
+            except Exception as exc:
+                logger.error("Error stopping network: {}", exc)
+            self._publish(NetworkPppDownEvent(reason="shutdown"))
+
+    def recover(self) -> bool:
+        """Reset the modem backend and retry the full bring-up flow."""
+
+        if not self.config.enabled:
+            logger.info("Network module disabled")
+            return False
+
+        with self._lifecycle_lock:
+            logger.info("Recovering network manager")
+            try:
+                self.backend.close()
+            except Exception as exc:
+                logger.debug("Ignoring network close error during recovery reset: {}", exc)
+
+            try:
+                self._start_unlocked()
+            except Exception as exc:
+                logger.error("Network recovery failed: {}", exc)
+            return self.is_online
 
     @property
     def is_online(self) -> bool:
         """Return True when PPP is up."""
-        return self.backend.get_state().phase == ModemPhase.ONLINE
+        with self._lifecycle_lock:
+            backend_is_online = getattr(self.backend, "is_online", None)
+            if callable(backend_is_online):
+                return bool(backend_is_online())
+            return self.backend.get_state().phase == ModemPhase.ONLINE
 
     @property
     def modem_state(self) -> ModemState:
         """Return the current modem state."""
-        return self.backend.get_state()
+        with self._lifecycle_lock:
+            return self.backend.get_state()
 
     def query_gps(self) -> GpsCoordinate | None:
         """Query GPS coordinates (may briefly interrupt PPP)."""

--- a/src/yoyopod/network/manager.py
+++ b/src/yoyopod/network/manager.py
@@ -99,10 +99,12 @@ class NetworkManager:
                     logger.debug("Initial GPS query failed: {}", exc)
 
             if self._start_ppp(expected_generation=expected_generation):
-                if not self._lifecycle_generation_matches(expected_generation):
+                if not self._publish_if_lifecycle_matches(
+                    NetworkPppUpEvent(connection_type="4g"),
+                    expected_generation=expected_generation,
+                ):
                     logger.info("Skipping PPP-up publish after concurrent lifecycle change")
                     return False
-                self._publish(NetworkPppUpEvent(connection_type="4g"))
         else:
             logger.error("Modem init failed: {}", state.error)
         return True
@@ -200,6 +202,20 @@ class NetworkManager:
 
         with self._lifecycle_lock:
             return expected_generation == self._lifecycle_generation
+
+    def _publish_if_lifecycle_matches(
+        self,
+        event: object,
+        *,
+        expected_generation: int,
+    ) -> bool:
+        """Publish only when no concurrent stop has invalidated the current lifecycle."""
+
+        with self._lifecycle_lock:
+            if expected_generation != self._lifecycle_generation:
+                return False
+            self._publish(event)
+            return True
 
     def _publish(self, event: object) -> None:
         """Publish an event if the bus is available."""

--- a/src/yoyopod/network/manager.py
+++ b/src/yoyopod/network/manager.py
@@ -58,15 +58,18 @@ class NetworkManager:
 
         logger.info("Starting network manager")
         with self._lifecycle_lock:
-            if (
-                expected_generation is not None
-                and expected_generation != self._lifecycle_generation
-            ):
+            if expected_generation is None:
+                expected_generation = self._lifecycle_generation
+            elif expected_generation != self._lifecycle_generation:
                 logger.info("Skipping network bring-up after concurrent lifecycle change")
                 return False
             self.backend.open()
             self.backend.init_modem()
             state = self.backend.get_state()
+
+        if not self._lifecycle_generation_matches(expected_generation):
+            logger.info("Skipping network post-init after concurrent lifecycle change")
+            return False
 
         if state.phase == ModemPhase.REGISTERED:
             self._publish(
@@ -95,7 +98,7 @@ class NetworkManager:
                 except Exception as exc:
                     logger.debug("Initial GPS query failed: {}", exc)
 
-            if self._start_ppp():
+            if self._start_ppp(expected_generation=expected_generation):
                 self._publish(NetworkPppUpEvent(connection_type="4g"))
         else:
             logger.error("Modem init failed: {}", state.error)
@@ -170,11 +173,17 @@ class NetworkManager:
                 self._publish(NetworkGpsNoFixEvent(reason="no_fix"))
             return coord
 
-    def _start_ppp(self) -> bool:
+    def _start_ppp(self, *, expected_generation: int | None = None) -> bool:
         """Spawn PPP under lifecycle lock, then wait for the link without blocking shutdown."""
 
         wait_for_ppp_link = getattr(self.backend, "wait_for_ppp_link", None)
         with self._lifecycle_lock:
+            if (
+                expected_generation is not None
+                and expected_generation != self._lifecycle_generation
+            ):
+                logger.info("Skipping PPP start after concurrent lifecycle change")
+                return False
             if wait_for_ppp_link is None:
                 return bool(self.backend.start_ppp())
 
@@ -182,6 +191,12 @@ class NetworkManager:
                 return False
 
         return bool(wait_for_ppp_link(timeout=self.config.ppp_timeout))
+
+    def _lifecycle_generation_matches(self, expected_generation: int) -> bool:
+        """Return True when no concurrent stop has invalidated the current bring-up."""
+
+        with self._lifecycle_lock:
+            return expected_generation == self._lifecycle_generation
 
     def _publish(self, event: object) -> None:
         """Publish an event if the bus is available."""

--- a/src/yoyopod/network/manager.py
+++ b/src/yoyopod/network/manager.py
@@ -29,6 +29,7 @@ class NetworkManager:
         self.backend = backend or Sim7600Backend(config)
         self.event_bus = event_bus
         self._lifecycle_lock = threading.RLock()
+        self._lifecycle_generation = 0
 
     @classmethod
     def from_config_manager(
@@ -42,7 +43,7 @@ class NetworkManager:
         """Open modem, initialize, and start PPP."""
         self._start_flow()
 
-    def _start_flow(self) -> None:
+    def _start_flow(self, *, expected_generation: int | None = None) -> bool:
         """Run the one-shot modem bring-up flow."""
         from yoyopod.core import (
             NetworkModemReadyEvent,
@@ -57,6 +58,12 @@ class NetworkManager:
 
         logger.info("Starting network manager")
         with self._lifecycle_lock:
+            if (
+                expected_generation is not None
+                and expected_generation != self._lifecycle_generation
+            ):
+                logger.info("Skipping network bring-up after concurrent lifecycle change")
+                return False
             self.backend.open()
             self.backend.init_modem()
             state = self.backend.get_state()
@@ -92,12 +99,14 @@ class NetworkManager:
                 self._publish(NetworkPppUpEvent(connection_type="4g"))
         else:
             logger.error("Modem init failed: {}", state.error)
+        return True
 
     def stop(self) -> None:
         """Stop PPP and close the modem."""
         from yoyopod.core import NetworkPppDownEvent
 
         with self._lifecycle_lock:
+            self._lifecycle_generation += 1
             logger.info("Stopping network manager")
             try:
                 self.backend.close()
@@ -114,13 +123,15 @@ class NetworkManager:
 
         with self._lifecycle_lock:
             logger.info("Recovering network manager")
+            expected_generation = self._lifecycle_generation
             try:
                 self.backend.close()
             except Exception as exc:
                 logger.debug("Ignoring network close error during recovery reset: {}", exc)
 
         try:
-            self._start_flow()
+            if not self._start_flow(expected_generation=expected_generation):
+                return False
         except Exception as exc:
             logger.error("Network recovery failed: {}", exc)
         return self.is_online

--- a/src/yoyopod/network/ppp.py
+++ b/src/yoyopod/network/ppp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import time
@@ -14,6 +15,7 @@ class PppProcess:
     """Spawn, monitor, and kill a pppd process for cellular data."""
 
     _PPP_BINARY_CANDIDATES = ("pppd", "/usr/sbin/pppd", "/sbin/pppd")
+    _SUDO_BINARY_CANDIDATES = ("sudo", "/usr/bin/sudo", "/bin/sudo")
 
     def __init__(self, serial_port: str, apn: str, baud_rate: int = 115200) -> None:
         self.serial_port = serial_port
@@ -32,7 +34,12 @@ class PppProcess:
             logger.error("pppd binary not found")
             return False
 
+        launch_prefix = self._resolve_launch_prefix()
+        if launch_prefix is None:
+            return False
+
         cmd = [
+            *launch_prefix,
             pppd_binary,
             self.serial_port,
             str(self.baud_rate),
@@ -64,6 +71,29 @@ class PppProcess:
         """Find pppd even when systemd omits sbin directories from PATH."""
 
         for candidate in self._PPP_BINARY_CANDIDATES:
+            resolved = shutil.which(candidate)
+            if resolved:
+                return resolved
+            if candidate.startswith("/") and Path(candidate).exists():
+                return candidate
+        return None
+
+    def _resolve_launch_prefix(self) -> list[str] | None:
+        """Return the optional privileged wrapper required by pppd."""
+
+        geteuid = getattr(os, "geteuid", None)
+        if callable(geteuid) and geteuid() != 0:
+            sudo_binary = self._resolve_sudo_binary()
+            if sudo_binary is None:
+                logger.error("pppd requires root privileges for noauth, but sudo is unavailable")
+                return None
+            return [sudo_binary, "-n"]
+        return []
+
+    def _resolve_sudo_binary(self) -> str | None:
+        """Find sudo for passwordless privileged PPP launches."""
+
+        for candidate in self._SUDO_BINARY_CANDIDATES:
             resolved = shutil.which(candidate)
             if resolved:
                 return resolved

--- a/src/yoyopod/runtime/recovery.py
+++ b/src/yoyopod/runtime/recovery.py
@@ -143,11 +143,11 @@ class RecoverySupervisor:
         ):
             return
 
-        if self.app.network_manager.is_online:
-            self.app._network_recovery.reset()
+        if self.app._network_recovery.in_flight:
             return
 
-        if self.app._network_recovery.in_flight:
+        if self.app.network_manager.is_online:
+            self.app._network_recovery.reset()
             return
 
         if recovery_now < self.app._network_recovery.next_attempt_at:

--- a/src/yoyopod/runtime/recovery.py
+++ b/src/yoyopod/runtime/recovery.py
@@ -26,25 +26,45 @@ class RecoverySupervisor:
         event: RecoveryAttemptCompletedEvent,
     ) -> None:
         """Finalize background recovery attempts on the coordinator thread."""
-        if event.manager != "music":
+        if event.manager == "music":
+            self.app._music_recovery.in_flight = False
+            if self.app._stopping:
+                return
+
+            if event.recovered and self.app.music_backend:
+                if hasattr(self.app.music_backend, "polling") and not getattr(
+                    self.app.music_backend,
+                    "polling",
+                ):
+                    start_polling = getattr(self.app.music_backend, "start_polling", None)
+                    if start_polling is not None:
+                        start_polling()
+
+            self.finalize_recovery_attempt(
+                "Music",
+                self.app._music_recovery,
+                event.recovered,
+                event.recovery_now,
+            )
             return
 
-        self.app._music_recovery.in_flight = False
+        if event.manager != "network":
+            return
+
+        self.app._network_recovery.in_flight = False
         if self.app._stopping:
             return
 
-        if event.recovered and self.app.music_backend:
-            if hasattr(self.app.music_backend, "polling") and not getattr(
-                self.app.music_backend,
-                "polling",
-            ):
-                start_polling = getattr(self.app.music_backend, "start_polling", None)
-                if start_polling is not None:
-                    start_polling()
+        if self.app.network_manager is not None:
+            self.app.event_wiring.network_events.sync_network_context_from_manager()
+            if self.app.cloud_manager is not None:
+                self.app.cloud_manager.note_network_change(
+                    connected=self.app.network_manager.is_online
+                )
 
         self.finalize_recovery_attempt(
-            "Music",
-            self.app._music_recovery,
+            "Network",
+            self.app._network_recovery,
             event.recovered,
             event.recovery_now,
         )
@@ -57,6 +77,7 @@ class RecoverySupervisor:
         recovery_now = time.monotonic() if now is None else now
         self.attempt_voip_recovery(recovery_now)
         self.attempt_music_recovery(recovery_now)
+        self.attempt_network_recovery(recovery_now)
 
     def attempt_voip_recovery(self, recovery_now: float) -> None:
         """Restart the VoIP backend when it is not running."""
@@ -112,6 +133,26 @@ class RecoverySupervisor:
         self.app._music_recovery.in_flight = True
         self.start_music_recovery_worker(recovery_now)
 
+    def attempt_network_recovery(self, recovery_now: float) -> None:
+        """Reinitialize the modem when cellular registration or PPP is down."""
+
+        if self.app.network_manager is None or not self.app.network_manager.config.enabled:
+            return
+
+        if self.app.network_manager.is_online:
+            self.app._network_recovery.reset()
+            return
+
+        if self.app._network_recovery.in_flight:
+            return
+
+        if recovery_now < self.app._network_recovery.next_attempt_at:
+            return
+
+        logger.info("Attempting network recovery")
+        self.app._network_recovery.in_flight = True
+        self.start_network_recovery_worker(recovery_now)
+
     def start_music_recovery_worker(self, recovery_now: float) -> None:
         """Launch the non-blocking music recovery attempt worker."""
         worker = threading.Thread(
@@ -119,6 +160,17 @@ class RecoverySupervisor:
             args=(recovery_now,),
             daemon=True,
             name="music-recovery",
+        )
+        worker.start()
+
+    def start_network_recovery_worker(self, recovery_now: float) -> None:
+        """Launch the non-blocking network recovery attempt worker."""
+
+        worker = threading.Thread(
+            target=self.run_network_recovery_attempt,
+            args=(recovery_now,),
+            daemon=True,
+            name="network-recovery",
         )
         worker.start()
 
@@ -131,6 +183,21 @@ class RecoverySupervisor:
         self.app.event_bus.publish(
             RecoveryAttemptCompletedEvent(
                 manager="music",
+                recovered=recovered,
+                recovery_now=recovery_now,
+            )
+        )
+
+    def run_network_recovery_attempt(self, recovery_now: float) -> None:
+        """Run one modem reinitialization attempt off the coordinator thread."""
+
+        recovered = False
+        if not self.app._stopping and self.app.network_manager is not None:
+            recovered = self.app.network_manager.recover()
+
+        self.app.event_bus.publish(
+            RecoveryAttemptCompletedEvent(
+                manager="network",
                 recovered=recovered,
                 recovery_now=recovery_now,
             )

--- a/src/yoyopod/runtime/recovery.py
+++ b/src/yoyopod/runtime/recovery.py
@@ -136,7 +136,11 @@ class RecoverySupervisor:
     def attempt_network_recovery(self, recovery_now: float) -> None:
         """Reinitialize the modem when cellular registration or PPP is down."""
 
-        if self.app.network_manager is None or not self.app.network_manager.config.enabled:
+        if (
+            self.app.simulate
+            or self.app.network_manager is None
+            or not self.app.network_manager.config.enabled
+        ):
             return
 
         if self.app.network_manager.is_online:

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -221,9 +221,16 @@ class FakeRecoveringMusicBackend(MockMusicBackend):
 class FakeRecoveringNetworkManager:
     """Minimal network-manager double for recovery backoff tests."""
 
-    def __init__(self, recover_results: list[bool]) -> None:
+    def __init__(
+        self,
+        recover_results: list[bool],
+        *,
+        fail_on_online_check: bool = False,
+    ) -> None:
         self._recover_results = recover_results
+        self._fail_on_online_check = fail_on_online_check
         self.recover_calls = 0
+        self.is_online_checks = 0
         self.config = SimpleNamespace(enabled=True)
         self._online = False
         self._state = ModemState(
@@ -243,6 +250,9 @@ class FakeRecoveringNetworkManager:
 
     @property
     def is_online(self) -> bool:
+        self.is_online_checks += 1
+        if self._fail_on_online_check:
+            raise AssertionError("is_online should not be queried while recovery is in flight")
         return self._online
 
     @property
@@ -1188,6 +1198,21 @@ def test_recovery_service_skips_network_recovery_in_simulation_mode() -> None:
 
     assert scheduled_attempts == []
     assert app._network_recovery.in_flight is False
+
+
+def test_recovery_service_skips_online_probe_while_network_recovery_is_in_flight() -> None:
+    """Coordinator ticks should not block on network state checks during background recovery."""
+
+    app = YoyoPodApp(simulate=False)
+    app.network_manager = FakeRecoveringNetworkManager(
+        [True],
+        fail_on_online_check=True,
+    )
+    app._network_recovery.in_flight = True
+
+    app.recovery_service.attempt_network_recovery(0.0)
+
+    assert app.network_manager.is_online_checks == 0
 
 
 def test_music_recovery_backoff_doubles_after_success() -> None:

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -40,6 +40,7 @@ from yoyopod.core import (
 from yoyopod.power import BatteryState, PowerSnapshot
 from yoyopod.runtime.loop import RuntimeLoopService
 from yoyopod.runtime.models import PowerAlert
+from yoyopod.network.models import ModemPhase, ModemState, SignalInfo
 from yoyopod.ui.input import InputManager, InteractionProfile
 
 
@@ -215,6 +216,38 @@ class FakeRecoveringMusicBackend(MockMusicBackend):
         result_index = min(self.start_calls - 1, len(self._start_results) - 1)
         self._connected = self._start_results[result_index]
         return self._connected
+
+
+class FakeRecoveringNetworkManager:
+    """Minimal network-manager double for recovery backoff tests."""
+
+    def __init__(self, recover_results: list[bool]) -> None:
+        self._recover_results = recover_results
+        self.recover_calls = 0
+        self.config = SimpleNamespace(enabled=True)
+        self._online = False
+        self._state = ModemState(
+            phase=ModemPhase.REGISTERED,
+            signal=SignalInfo(csq=20),
+            carrier="Telekom.de",
+            network_type="4G",
+            sim_ready=True,
+        )
+
+    def recover(self) -> bool:
+        self.recover_calls += 1
+        result_index = min(self.recover_calls - 1, len(self._recover_results) - 1)
+        self._online = self._recover_results[result_index]
+        self._state.phase = ModemPhase.ONLINE if self._online else ModemPhase.REGISTERED
+        return self._online
+
+    @property
+    def is_online(self) -> bool:
+        return self._online
+
+    @property
+    def modem_state(self) -> ModemState:
+        return self._state
 
 
 class FakeStoppingVoIPManager:
@@ -1123,6 +1156,23 @@ def test_recovery_service_no_longer_owns_power_runtime_helpers() -> None:
     assert not hasattr(app.recovery_service, "feed_watchdog_if_due")
 
 
+def test_recovery_service_schedules_network_reconnect_off_main_thread() -> None:
+    """Network recovery should schedule modem retries instead of blocking the loop thread."""
+
+    app = YoyoPodApp(simulate=True)
+    app.network_manager = FakeRecoveringNetworkManager([False, True])
+    scheduled_attempts: list[float] = []
+
+    app.recovery_service.start_network_recovery_worker = (
+        lambda recovery_now: scheduled_attempts.append(recovery_now)
+    )
+
+    app.recovery_service.attempt_network_recovery(0.0)
+
+    assert scheduled_attempts == [0.0]
+    assert app._network_recovery.in_flight is True
+
+
 def test_music_recovery_backoff_doubles_after_success() -> None:
     """Background music recovery results should update backoff on success and failure."""
     app = YoyoPodApp(simulate=True)
@@ -1152,6 +1202,37 @@ def test_music_recovery_backoff_doubles_after_success() -> None:
 
     assert app._music_recovery.next_attempt_at == 0.0
     assert app._music_recovery.delay_seconds == 1.0
+
+
+def test_network_recovery_backoff_updates_context_after_completion() -> None:
+    """Network recovery completion should refresh UI status and backoff state."""
+
+    app = YoyoPodApp(simulate=True)
+    app.context = AppContext()
+    app.network_manager = FakeRecoveringNetworkManager([False, True])
+
+    app._network_recovery.in_flight = True
+    app._handle_recovery_attempt_completed_event(
+        RecoveryAttemptCompletedEvent(manager="network", recovered=False, recovery_now=0.0)
+    )
+
+    assert app._network_recovery.next_attempt_at == 1.0
+    assert app._network_recovery.delay_seconds == 2.0
+    assert app.context.network.enabled is True
+    assert app.context.network.signal_strength == 3
+    assert app.context.network.connection_type == "4g"
+    assert app.context.network.connected is False
+
+    app.network_manager._online = True
+    app.network_manager._state.phase = ModemPhase.ONLINE
+    app._network_recovery.in_flight = True
+    app._handle_recovery_attempt_completed_event(
+        RecoveryAttemptCompletedEvent(manager="network", recovered=True, recovery_now=1.0)
+    )
+
+    assert app._network_recovery.next_attempt_at == 0.0
+    assert app._network_recovery.delay_seconds == 1.0
+    assert app.context.network.connected is True
 
 
 def test_app_stop_uses_silent_voip_teardown() -> None:

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -1159,7 +1159,7 @@ def test_recovery_service_no_longer_owns_power_runtime_helpers() -> None:
 def test_recovery_service_schedules_network_reconnect_off_main_thread() -> None:
     """Network recovery should schedule modem retries instead of blocking the loop thread."""
 
-    app = YoyoPodApp(simulate=True)
+    app = YoyoPodApp(simulate=False)
     app.network_manager = FakeRecoveringNetworkManager([False, True])
     scheduled_attempts: list[float] = []
 
@@ -1171,6 +1171,23 @@ def test_recovery_service_schedules_network_reconnect_off_main_thread() -> None:
 
     assert scheduled_attempts == [0.0]
     assert app._network_recovery.in_flight is True
+
+
+def test_recovery_service_skips_network_recovery_in_simulation_mode() -> None:
+    """Simulation mode should not launch modem recovery attempts."""
+
+    app = YoyoPodApp(simulate=True)
+    app.network_manager = FakeRecoveringNetworkManager([True])
+    scheduled_attempts: list[float] = []
+
+    app.recovery_service.start_network_recovery_worker = (
+        lambda recovery_now: scheduled_attempts.append(recovery_now)
+    )
+
+    app.recovery_service.attempt_network_recovery(0.0)
+
+    assert scheduled_attempts == []
+    assert app._network_recovery.in_flight is False
 
 
 def test_music_recovery_backoff_doubles_after_success() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 import yoyopod.main as main_module
 import yoyopod.runtime.diagnostics as diagnostics_module
 import yoyopod.runtime.screenshot as screenshot_module
@@ -339,6 +341,9 @@ def test_install_traceback_dump_handlers_registers_faulthandler_chain(
 ) -> None:
     """Traceback dumps should chain onto the existing screenshot signal handlers."""
 
+    if not all(hasattr(signal, name) for name in ("SIGUSR1", "SIGUSR2")):
+        pytest.skip("screenshot dump signals are unavailable on this platform")
+
     register_calls: list[tuple[int, bool, bool]] = []
     unregister_calls: list[int] = []
     logs: list[tuple[str, tuple[object, ...]]] = []
@@ -349,11 +354,13 @@ def test_install_traceback_dump_handlers_registers_faulthandler_chain(
         lambda signum, *, file, all_threads, chain: register_calls.append(
             (signum, all_threads, chain)
         ),
+        raising=False,
     )
     monkeypatch.setattr(
         diagnostics_module.faulthandler,
         "unregister",
         lambda signum: unregister_calls.append(signum),
+        raising=False,
     )
     fake_log = SimpleNamespace(
         info=lambda *args: logs.append(("info", args)),
@@ -385,6 +392,9 @@ def test_install_traceback_dump_handlers_registers_faulthandler_chain(
 
 def test_main_restores_previous_signal_handlers_before_stop(monkeypatch) -> None:
     """Main should restore SIGTERM and screenshot handlers during teardown."""
+
+    if not all(hasattr(signal, name) for name in ("SIGUSR1", "SIGUSR2")):
+        pytest.skip("screenshot dump signals are unavailable on this platform")
 
     events: list[tuple[object, ...]] = []
     previous_handlers = {

--- a/tests/test_network_backend.py
+++ b/tests/test_network_backend.py
@@ -290,3 +290,51 @@ def test_backend_start_ppp_skips_blank_apn_configuration() -> None:
     assert backend._state.phase == ModemPhase.ONLINE
     assert "spawn" in ppp.calls
     assert not any(call.startswith("configure_pdp:") for call in at.calls)
+
+
+def test_backend_is_online_marks_dead_ppp_process_offline() -> None:
+    """is_online() should reconcile stale ONLINE state when pppd has already exited."""
+
+    at = FakeAtCommands()
+    ppp = FakePpp()
+    ppp.alive = False
+    backend = Sim7600Backend.__new__(Sim7600Backend)
+    backend._at = at
+    backend._ppp = ppp
+    backend._gps = None
+    backend._state = ModemState(phase=ModemPhase.ONLINE)
+
+    class FakeConfig:
+        gps_enabled = False
+        apn = "internet"
+
+    backend._config = FakeConfig()
+
+    assert backend.is_online() is False
+    assert backend._state.phase == ModemPhase.REGISTERED
+    assert backend._state.error == "PPP process exited"
+
+
+def test_backend_is_online_marks_missing_ppp_interface_offline() -> None:
+    """is_online() should drop back to REGISTERED when the PPP interface disappears."""
+
+    at = FakeAtCommands()
+    ppp = FakePpp()
+    ppp.alive = True
+    backend = Sim7600Backend.__new__(Sim7600Backend)
+    backend._at = at
+    backend._ppp = ppp
+    backend._gps = None
+    backend._state = ModemState(phase=ModemPhase.ONLINE)
+
+    class FakeConfig:
+        gps_enabled = False
+        apn = "internet"
+
+    backend._config = FakeConfig()
+
+    with patch("yoyopod.network.backend.Path.exists", return_value=False):
+        assert backend.is_online() is False
+
+    assert backend._state.phase == ModemPhase.REGISTERED
+    assert backend._state.error == "PPP interface down"

--- a/tests/test_network_backend.py
+++ b/tests/test_network_backend.py
@@ -12,6 +12,7 @@ def test_ppp_spawn_constructs_correct_command():
     """PppProcess.spawn should invoke pppd with the correct arguments."""
     with (
         patch("yoyopod.network.ppp.shutil.which", return_value="pppd"),
+        patch("yoyopod.network.ppp.os.geteuid", return_value=0, create=True),
         patch("subprocess.Popen") as mock_popen,
     ):
         mock_proc = MagicMock()
@@ -36,6 +37,7 @@ def test_ppp_spawn_uses_sbin_fallback_when_path_omits_pppd():
             "yoyopod.network.ppp.shutil.which",
             side_effect=lambda candidate: "/usr/sbin/pppd" if candidate == "/usr/sbin/pppd" else None,
         ),
+        patch("yoyopod.network.ppp.os.geteuid", return_value=0, create=True),
         patch("subprocess.Popen") as mock_popen,
     ):
         mock_proc = MagicMock()
@@ -47,6 +49,51 @@ def test_ppp_spawn_uses_sbin_fallback_when_path_omits_pppd():
 
         assert ppp.spawn() is True
         assert mock_popen.call_args[0][0][0] == "/usr/sbin/pppd"
+
+
+def test_ppp_spawn_uses_sudo_wrapper_for_non_root_noauth() -> None:
+    """spawn() should wrap pppd in sudo when the caller is not root."""
+
+    def _which(candidate: str) -> str | None:
+        if candidate in {"pppd", "/usr/sbin/pppd"}:
+            return "/usr/sbin/pppd"
+        if candidate in {"sudo", "/usr/bin/sudo"}:
+            return "/usr/bin/sudo"
+        return None
+
+    with (
+        patch("yoyopod.network.ppp.shutil.which", side_effect=_which),
+        patch("yoyopod.network.ppp.os.geteuid", return_value=1000, create=True),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 12345
+        mock_popen.return_value = mock_proc
+
+        ppp = PppProcess(serial_port="/dev/ttyUSB3", apn="internet")
+
+        assert ppp.spawn() is True
+        assert mock_popen.call_args[0][0][:3] == ["/usr/bin/sudo", "-n", "/usr/sbin/pppd"]
+
+
+def test_ppp_spawn_fails_without_sudo_for_non_root() -> None:
+    """spawn() should fail early when noauth is needed but sudo is unavailable."""
+
+    def _which(candidate: str) -> str | None:
+        if candidate in {"pppd", "/usr/sbin/pppd"}:
+            return "/usr/sbin/pppd"
+        return None
+
+    with (
+        patch("yoyopod.network.ppp.shutil.which", side_effect=_which),
+        patch("yoyopod.network.ppp.os.geteuid", return_value=1000, create=True),
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        ppp = PppProcess(serial_port="/dev/ttyUSB3", apn="internet")
+
+        assert ppp.spawn() is False
+        mock_popen.assert_not_called()
 
 
 def test_ppp_kill_terminates_process():
@@ -220,3 +267,26 @@ def test_backend_start_ppp():
     assert backend._state.phase == ModemPhase.ONLINE
     assert "spawn" in ppp.calls
     assert "configure_pdp:internet" in at.calls
+
+
+def test_backend_start_ppp_skips_blank_apn_configuration() -> None:
+    """start_ppp() should not overwrite the modem PDP context with an empty APN."""
+
+    at = FakeAtCommands()
+    ppp = FakePpp()
+    backend = Sim7600Backend.__new__(Sim7600Backend)
+    backend._at = at
+    backend._ppp = ppp
+    backend._gps = None
+    backend._state = ModemState(phase=ModemPhase.REGISTERED)
+
+    class FakeConfig:
+        apn = "   "
+        ppp_timeout = 30
+
+    backend._config = FakeConfig()
+    backend.start_ppp()
+
+    assert backend._state.phase == ModemPhase.ONLINE
+    assert "spawn" in ppp.calls
+    assert not any(call.startswith("configure_pdp:") for call in at.calls)

--- a/tests/test_network_backend.py
+++ b/tests/test_network_backend.py
@@ -88,6 +88,7 @@ def test_ppp_spawn_fails_without_sudo_for_non_root() -> None:
     with (
         patch("yoyopod.network.ppp.shutil.which", side_effect=_which),
         patch("yoyopod.network.ppp.os.geteuid", return_value=1000, create=True),
+        patch("yoyopod.network.ppp.Path.exists", return_value=False),
         patch("subprocess.Popen") as mock_popen,
     ):
         ppp = PppProcess(serial_port="/dev/ttyUSB3", apn="internet")
@@ -282,6 +283,29 @@ def test_backend_start_ppp_skips_blank_apn_configuration() -> None:
 
     class FakeConfig:
         apn = "   "
+        ppp_timeout = 30
+
+    backend._config = FakeConfig()
+    backend.start_ppp()
+
+    assert backend._state.phase == ModemPhase.ONLINE
+    assert "spawn" in ppp.calls
+    assert not any(call.startswith("configure_pdp:") for call in at.calls)
+
+
+def test_backend_start_ppp_skips_null_apn_configuration() -> None:
+    """start_ppp() should tolerate null APN values from config overlays."""
+
+    at = FakeAtCommands()
+    ppp = FakePpp()
+    backend = Sim7600Backend.__new__(Sim7600Backend)
+    backend._at = at
+    backend._ppp = ppp
+    backend._gps = None
+    backend._state = ModemState(phase=ModemPhase.REGISTERED)
+
+    class FakeConfig:
+        apn = None
         ppp_timeout = 30
 
     backend._config = FakeConfig()

--- a/tests/test_network_manager.py
+++ b/tests/test_network_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import yaml
 
 from yoyopod.config import ConfigManager
@@ -28,6 +29,7 @@ class FakeBackend:
         self.inited = False
         self.ppp_started = False
         self.ppp_stopped = False
+        self.ppp_wait_calls = 0
         self.gps_query_calls = 0
         self.gps_coord: GpsCoordinate | None = None
         self.health_online = True
@@ -48,8 +50,15 @@ class FakeBackend:
         self.inited = True
         self.state.phase = ModemPhase.REGISTERED
 
-    def start_ppp(self) -> bool:
+    def start_ppp(self, *, wait_for_link: bool = True) -> bool:
         self.ppp_started = True
+        if not wait_for_link:
+            self.state.phase = ModemPhase.PPP_STARTING
+            return True
+        return self.wait_for_ppp_link()
+
+    def wait_for_ppp_link(self, timeout: float = 30.0) -> bool:
+        self.ppp_wait_calls += 1
         self.health_online = True
         self.state.phase = ModemPhase.ONLINE
         return True
@@ -82,6 +91,28 @@ class RecordingLock:
     def __exit__(self, exc_type, exc, tb) -> None:
         self.exit_calls += 1
         return None
+
+
+class BlockingPppBackend(FakeBackend):
+    """Backend double that pauses PPP link-up so stop() can race recover()."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.wait_entered = threading.Event()
+        self.release_wait = threading.Event()
+        self.close_called = threading.Event()
+
+    def wait_for_ppp_link(self, timeout: float = 30.0) -> bool:
+        self.ppp_wait_calls += 1
+        self.wait_entered.set()
+        self.release_wait.wait(timeout=timeout)
+        self.health_online = True
+        self.state.phase = ModemPhase.ONLINE
+        return True
+
+    def close(self) -> None:
+        self.close_called.set()
+        super().close()
 
 
 def test_manager_start_full_sequence():
@@ -157,6 +188,7 @@ def test_manager_recover_retries_full_bringup_after_failed_boot() -> None:
     assert backend.opened is True
     assert backend.inited is True
     assert backend.ppp_started is True
+    assert backend.ppp_wait_calls == 1
 
 
 def test_manager_warms_gps_fix_on_start_when_enabled():
@@ -223,6 +255,32 @@ def test_manager_query_gps_uses_lifecycle_lock() -> None:
     assert backend.gps_query_calls == 1
     assert lock.enter_calls == 1
     assert lock.exit_calls == 1
+
+
+def test_manager_stop_does_not_block_on_recovering_ppp_wait() -> None:
+    """stop() should still acquire the lifecycle lock while PPP wait runs in recover()."""
+
+    config = build_config_model(NetworkConfig, {"enabled": True, "apn": "internet"})
+    backend = BlockingPppBackend()
+    backend.state.phase = ModemPhase.REGISTERING
+    backend.health_online = False
+    manager = NetworkManager(config=config, backend=backend)
+
+    recovery_thread = threading.Thread(target=manager.recover, daemon=True)
+    recovery_thread.start()
+
+    assert backend.wait_entered.wait(timeout=1.0) is True
+
+    stop_thread = threading.Thread(target=manager.stop, daemon=True)
+    stop_thread.start()
+
+    assert backend.close_called.wait(timeout=0.5) is True
+    backend.release_wait.set()
+    recovery_thread.join(timeout=1.0)
+    stop_thread.join(timeout=1.0)
+
+    assert recovery_thread.is_alive() is False
+    assert stop_thread.is_alive() is False
 
 
 def test_manager_from_config_manager_uses_domain_owned_network_settings(tmp_path) -> None:

--- a/tests/test_network_manager.py
+++ b/tests/test_network_manager.py
@@ -30,6 +30,7 @@ class FakeBackend:
         self.ppp_stopped = False
         self.gps_query_calls = 0
         self.gps_coord: GpsCoordinate | None = None
+        self.health_online = True
 
     def probe(self) -> bool:
         return True
@@ -49,17 +50,22 @@ class FakeBackend:
 
     def start_ppp(self) -> bool:
         self.ppp_started = True
+        self.health_online = True
         self.state.phase = ModemPhase.ONLINE
         return True
 
     def stop_ppp(self) -> None:
         self.ppp_stopped = True
+        self.health_online = False
         self.state.phase = ModemPhase.REGISTERED
 
     def query_gps(self):
         self.gps_query_calls += 1
         self.state.gps = self.gps_coord
         return self.gps_coord
+
+    def is_online(self) -> bool:
+        return self.health_online and self.state.phase == ModemPhase.ONLINE
 
 
 def test_manager_start_full_sequence():
@@ -116,6 +122,25 @@ def test_manager_is_online():
 
     backend.state.phase = ModemPhase.REGISTERED
     assert manager.is_online is False
+
+
+def test_manager_recover_retries_full_bringup_after_failed_boot() -> None:
+    """recover() should reset the backend and rerun modem init plus PPP bring-up."""
+
+    config = build_config_model(NetworkConfig, {"enabled": True, "apn": "internet"})
+    backend = FakeBackend()
+    backend.state.phase = ModemPhase.REGISTERING
+    backend.health_online = False
+    bus = EventBus()
+    manager = NetworkManager(config=config, backend=backend, event_bus=bus)
+
+    recovered = manager.recover()
+
+    assert recovered is True
+    assert backend.closed is True
+    assert backend.opened is True
+    assert backend.inited is True
+    assert backend.ppp_started is True
 
 
 def test_manager_warms_gps_fix_on_start_when_enabled():

--- a/tests/test_network_manager.py
+++ b/tests/test_network_manager.py
@@ -356,6 +356,41 @@ def test_manager_stop_cancels_ppp_start_after_post_init_events() -> None:
     assert not any(isinstance(event, NetworkPppUpEvent) for event in published)
 
 
+def test_manager_stop_suppresses_ppp_up_event_after_ppp_link_ready() -> None:
+    """stop() should suppress stale PPP-up publish if teardown lands after link-up."""
+
+    config = build_config_model(NetworkConfig, {"enabled": True, "apn": "internet"})
+    backend = FakeBackend()
+    backend.state.phase = ModemPhase.REGISTERING
+    backend.health_online = False
+    manager = NetworkManager(config=config, backend=backend)
+    published: list[object] = []
+    original_start_ppp = manager._start_ppp
+    stop_requested = False
+
+    def intercept_publish(event: object) -> None:
+        published.append(event)
+
+    def stop_after_ppp(*, expected_generation: int | None = None) -> bool:
+        nonlocal stop_requested
+        result = original_start_ppp(expected_generation=expected_generation)
+        if result and not stop_requested:
+            stop_requested = True
+            manager.stop()
+        return result
+
+    manager._publish = intercept_publish
+    manager._start_ppp = stop_after_ppp
+
+    recovered = manager.recover()
+
+    assert recovered is False
+    assert backend.closed is True
+    assert backend.ppp_started is True
+    assert any(isinstance(event, NetworkPppDownEvent) for event in published)
+    assert not any(isinstance(event, NetworkPppUpEvent) for event in published)
+
+
 def test_manager_from_config_manager_uses_domain_owned_network_settings(tmp_path) -> None:
     """from_config_manager() should read the canonical network domain file."""
 

--- a/tests/test_network_manager.py
+++ b/tests/test_network_manager.py
@@ -68,6 +68,22 @@ class FakeBackend:
         return self.health_online and self.state.phase == ModemPhase.ONLINE
 
 
+class RecordingLock:
+    """Track lifecycle lock usage without changing manager behavior."""
+
+    def __init__(self) -> None:
+        self.enter_calls = 0
+        self.exit_calls = 0
+
+    def __enter__(self) -> "RecordingLock":
+        self.enter_calls += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.exit_calls += 1
+        return None
+
+
 def test_manager_start_full_sequence():
     """start() should open, init, and start PPP."""
     config = build_config_model(NetworkConfig, {"enabled": True, "apn": "internet"})
@@ -186,6 +202,27 @@ def test_manager_publishes_no_fix_and_clears_cached_gps_state() -> None:
     assert backend.state.gps is None
     assert len(no_fix_events) == 1
     assert isinstance(no_fix_events[0], NetworkGpsNoFixEvent)
+
+
+def test_manager_query_gps_uses_lifecycle_lock() -> None:
+    """query_gps() should serialize GPS reads with modem recovery work."""
+
+    config = build_config_model(
+        NetworkConfig,
+        {"enabled": True, "apn": "internet", "gps_enabled": True},
+    )
+    backend = FakeBackend()
+    backend.gps_coord = GpsCoordinate(lat=48.7083, lng=9.6610, altitude=328.2, speed=0.0)
+    manager = NetworkManager(config=config, backend=backend)
+    lock = RecordingLock()
+    manager._lifecycle_lock = lock
+
+    coord = manager.query_gps()
+
+    assert coord == backend.gps_coord
+    assert backend.gps_query_calls == 1
+    assert lock.enter_calls == 1
+    assert lock.exit_calls == 1
 
 
 def test_manager_from_config_manager_uses_domain_owned_network_settings(tmp_path) -> None:

--- a/tests/test_network_manager.py
+++ b/tests/test_network_manager.py
@@ -283,6 +283,43 @@ def test_manager_stop_does_not_block_on_recovering_ppp_wait() -> None:
     assert stop_thread.is_alive() is False
 
 
+def test_manager_stop_cancels_recovery_restart_after_reset() -> None:
+    """stop() should invalidate a recovery attempt before it reopens the modem."""
+
+    config = build_config_model(NetworkConfig, {"enabled": True, "apn": "internet"})
+    backend = FakeBackend()
+    backend.state.phase = ModemPhase.REGISTERING
+    backend.health_online = False
+    manager = NetworkManager(config=config, backend=backend)
+    start_attempted = threading.Event()
+    release_start = threading.Event()
+    original_start_flow = manager._start_flow
+    recover_result: list[bool] = []
+
+    def gated_start_flow(*, expected_generation: int | None = None) -> bool:
+        start_attempted.set()
+        assert release_start.wait(timeout=1.0) is True
+        return original_start_flow(expected_generation=expected_generation)
+
+    manager._start_flow = gated_start_flow
+
+    recovery_thread = threading.Thread(
+        target=lambda: recover_result.append(manager.recover()),
+        daemon=True,
+    )
+    recovery_thread.start()
+
+    assert start_attempted.wait(timeout=1.0) is True
+
+    manager.stop()
+    release_start.set()
+    recovery_thread.join(timeout=1.0)
+
+    assert recovery_thread.is_alive() is False
+    assert recover_result == [False]
+    assert backend.opened is False
+
+
 def test_manager_from_config_manager_uses_domain_owned_network_settings(tmp_path) -> None:
     """from_config_manager() should read the canonical network domain file."""
 

--- a/tests/test_network_manager.py
+++ b/tests/test_network_manager.py
@@ -8,7 +8,13 @@ import yaml
 from yoyopod.config import ConfigManager
 from yoyopod.config.models import build_config_model
 from yoyopod.core import EventBus
-from yoyopod.core import NetworkGpsFixEvent, NetworkGpsNoFixEvent, NetworkPppUpEvent
+from yoyopod.core import (
+    NetworkGpsFixEvent,
+    NetworkGpsNoFixEvent,
+    NetworkPppDownEvent,
+    NetworkPppUpEvent,
+    NetworkRegisteredEvent,
+)
 from yoyopod.network import NetworkConfig, NetworkManager
 from yoyopod.network.models import GpsCoordinate, ModemPhase, ModemState, SignalInfo
 
@@ -318,6 +324,36 @@ def test_manager_stop_cancels_recovery_restart_after_reset() -> None:
     assert recovery_thread.is_alive() is False
     assert recover_result == [False]
     assert backend.opened is False
+
+
+def test_manager_stop_cancels_ppp_start_after_post_init_events() -> None:
+    """stop() should prevent PPP startup if shutdown lands after modem init succeeds."""
+
+    config = build_config_model(NetworkConfig, {"enabled": True, "apn": "internet"})
+    backend = FakeBackend()
+    backend.state.phase = ModemPhase.REGISTERING
+    backend.health_online = False
+    manager = NetworkManager(config=config, backend=backend)
+    published: list[object] = []
+    stop_requested = False
+
+    def intercept_publish(event: object) -> None:
+        nonlocal stop_requested
+        published.append(event)
+        if not stop_requested and isinstance(event, NetworkRegisteredEvent):
+            stop_requested = True
+            manager.stop()
+
+    manager._publish = intercept_publish
+
+    recovered = manager.recover()
+
+    assert recovered is False
+    assert backend.closed is True
+    assert backend.ppp_started is False
+    assert any(isinstance(event, NetworkRegisteredEvent) for event in published)
+    assert any(isinstance(event, NetworkPppDownEvent) for event in published)
+    assert not any(isinstance(event, NetworkPppUpEvent) for event in published)
 
 
 def test_manager_from_config_manager_uses_domain_owned_network_settings(tmp_path) -> None:

--- a/tests/test_voip_backend.py
+++ b/tests/test_voip_backend.py
@@ -245,9 +245,7 @@ def test_liblinphone_backend_starts_and_drains_native_events() -> None:
     assert binding.start_kwargs["lime_server_url"] == ""
     assert binding.start_kwargs["mic_gain"] == 0
     assert binding.start_kwargs["output_volume"] == 100
-    assert binding.start_kwargs["factory_config_path"].endswith(
-        "config\\liblinphone_factory.conf"
-    ) or binding.start_kwargs["factory_config_path"].endswith(
+    assert binding.start_kwargs["factory_config_path"].replace("\\", "/").endswith(
         "config/communication/integrations/liblinphone_factory.conf"
     )
 

--- a/tests/test_whisplay_adapter.py
+++ b/tests/test_whisplay_adapter.py
@@ -315,18 +315,24 @@ def test_simulated_whisplay_adapter_does_not_own_browser_preview() -> None:
     assert not hasattr(adapter, "web_server")
 
 
-def test_whisplay_font_cache_reuses_loaded_fonts(monkeypatch) -> None:
+def test_whisplay_font_cache_reuses_loaded_fonts(monkeypatch, tmp_path) -> None:
     """Repeated text draws should not reload the same font on every call."""
 
     adapter = WhisplayDisplayAdapter(simulate=True, renderer="pil")
     adapter._font_cache.clear()
+    fake_font_path = tmp_path / "cache-font.ttf"
+    fake_font_path.write_text("unused font payload")
 
-    original_truetype = ImageFont.truetype
     load_calls: list[tuple[str, int]] = []
 
     def counting_truetype(path: str, size: int, *args, **kwargs):
         load_calls.append((path, size))
-        return original_truetype(path, size, *args, **kwargs)
+        return ImageFont.load_default()
+
+    monkeypatch.setattr(
+        "yoyopod.ui.display.adapters.whisplay.DEFAULT_FONT_PATH",
+        fake_font_path,
+    )
 
     monkeypatch.setattr(
         "yoyopod.ui.display.adapters.whisplay._load_pillow_modules",


### PR DESCRIPTION
## Summary
- run `pppd` through passwordless `sudo -n` when the app service is not running as root so the existing `noauth` launch path can succeed on Raspberry Pi
- avoid overwriting the modem PDP context when YoyoPod has no APN configured locally
- add background network self-heal with backoff so failed registration or PPP bring-up can recover after transient hardware or signal issues without restarting the app
- extend regression coverage for PPP startup, network recovery, and a few cross-platform test assumptions so the full quality gate stays green from this checkout

## Root Cause
During the `rpi-zero` investigation we confirmed three separate issues in the cellular path:

1. the app launched `pppd` directly from the non-root service user while also passing `noauth`, and the Pi journal showed `using the noauth option requires root privilege`
2. the runtime network config still had `apn: ""`, so the backend rewrote the PDP context with an empty APN before starting PPP
3. after a failed modem registration at boot, the network manager had no runtime recovery path, so reconnecting the antenna later never triggered another registration or PPP attempt until the app restarted

## Impact
- restores PPP startup under the current systemd service model used on the Pi
- preserves an already working modem PDP profile when YoyoPod does not yet have a local APN configured
- allows cellular registration and PPP to self-heal after temporary modem, antenna, or signal problems instead of staying stuck in the failed boot state
- keeps shared UI network status aligned with recovery attempts and current PPP health

## Validation
- `uv run pytest -q tests/test_network_backend.py tests/test_network_manager.py tests/test_network_status_sync.py tests/test_app_orchestration.py`
- `uv run python scripts/quality.py ci`
- prior on-device validation on `rpi-zero` confirmed the PPP startup fix path: `pppd spawned`, `ppp0 interface is up`, and `ping -I ppp0 1.1.1.1` succeeded

## Follow-up
- the new self-heal path has local regression coverage, but it has not been revalidated on-device after this follow-up commit yet
