### PR TITLE
Architecture rework: Phase A + Phase B specs and implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-04-20-cli-polish.md
+++ b/docs/superpowers/plans/2026-04-20-cli-polish.md
@@ -1,0 +1,3235 @@
+# CLI Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure the YoyoPod CLI into a flat `yoyopod_cli/` package at the repo root, rename the entry point `yoyoctl` → `yoyopod`, prune ~15 unused commands, consolidate path constants into `paths.py`, and apply one uniform command template across every file.
+
+**Architecture:** New flat package at `yoyopod_cli/` (sibling of `src/`). Every command follows a single template: typed Typer handler → `pi_conn(ctx)` for shared Pi connection → inline f-string shell command → `raise typer.Exit(run_remote(...))`. No intermediate builder layer for simple commands; complex multi-line shell remains a private helper in the same file. `pyproject.toml` scripts collapse from `yoyopod` + `yoyoctl` to just `yoyopod`, with a root callback launching the app when no subcommand is passed. The current `src/yoyopod/cli/` tree is deleted wholesale once the new one is green.
+
+**Tech Stack:** Python 3.12, Typer, loguru, pyyaml, pytest, uv, hatch.
+
+**Spec:** [docs/superpowers/specs/2026-04-20-cli-polish-design.md](../specs/2026-04-20-cli-polish-design.md)
+
+---
+
+## Shared Patterns (reference — read before any task)
+
+Every command file in `yoyopod_cli/` follows the **same template**. You will see this shape 11 times across the plan; each task shows the specific command body, but the surrounding structure is always this:
+
+### Remote command template (`remote_*.py`)
+
+```python
+# yoyopod_cli/remote_<group>.py
+from __future__ import annotations
+
+import shlex
+import typer
+
+from yoyopod_cli.common import configure_logging
+from yoyopod_cli.paths import load_pi_paths
+from yoyopod_cli.remote_shared import build_remote_app, pi_conn
+from yoyopod_cli.remote_transport import run_remote
+
+app = build_remote_app("<group>", "<group help text>.")
+
+
+@app.command()
+def <command_name>(
+    ctx: typer.Context,
+    # command-specific options here
+    verbose: bool = typer.Option(False, "--verbose", help="Enable DEBUG logging."),
+) -> None:
+    """<command docstring>."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    pi = load_pi_paths()
+
+    # build the shell command (inline f-string for simple commands)
+    cmd = f"..."
+
+    raise typer.Exit(run_remote(conn, cmd))
+```
+
+### Pi command template (`pi_*.py`)
+
+On-Pi commands don't need `pi_conn(ctx)` — they run directly. They still use `configure_logging` and read app config via `resolve_config_dir`.
+
+```python
+# yoyopod_cli/pi_<group>.py
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from yoyopod_cli.common import configure_logging, resolve_config_dir
+
+app = typer.Typer(name="<group>", help="<group help text>.", no_args_is_help=True)
+
+
+@app.command()
+def <command_name>(
+    config_dir: Annotated[str, typer.Option("--config-dir", help="Configuration directory.")] = "config",
+    verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
+) -> None:
+    """<command docstring>."""
+    from yoyopod.config import ConfigManager
+    # ...heavy imports lazy-loaded inside the function
+
+    configure_logging(verbose)
+    config_path = resolve_config_dir(config_dir)
+    # ...command logic
+```
+
+### Complex shell — private helpers, same file
+
+Simple shell commands go inline. Complex multi-line shell scripts (startup verification, native shim refresh, deploy validation — the ones in current `ops/commands.py`) live as **private helpers above the command** that uses them in the same file. The rule: the reader holds one file to understand one command. No central `commands.py` re-export file.
+
+```python
+def _build_startup_verification(pi: PiPaths, attempts: int = 20) -> str:
+    """Build the multi-line shell script that waits for the startup marker."""
+    pid_file = shlex.quote(pi.pid_file)
+    # ... complex logic
+    return " && ".join([...])
+
+
+@app.command()
+def status(ctx: typer.Context) -> None:
+    conn = pi_conn(ctx)
+    pi = load_pi_paths()
+    cmd = _build_startup_verification(pi)
+    raise typer.Exit(run_remote(conn, cmd))
+```
+
+### Testing approach
+
+**Unit-test private helpers** (the `_build_*` functions) for shell-string correctness. **Integration-test commands** by invoking the Typer app via `runner.invoke(app, [...])` with mocked `run_remote`. No `argparse.Namespace` anywhere.
+
+---
+
+## Task 1: Scaffold `yoyopod_cli/` package skeleton
+
+**Files:**
+- Create: `yoyopod_cli/__init__.py`
+- Create: `yoyopod_cli/common.py`
+- Test: `tests/test_yoyopod_cli_bootstrap.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_bootstrap.py
+"""Smoke test for the new yoyopod_cli package scaffold."""
+from __future__ import annotations
+
+import importlib
+
+
+def test_package_imports() -> None:
+    module = importlib.import_module("yoyopod_cli")
+    assert module.__name__ == "yoyopod_cli"
+
+
+def test_version_exposed() -> None:
+    module = importlib.import_module("yoyopod_cli")
+    assert isinstance(module.__version__, str)
+    assert module.__version__
+
+
+def test_common_imports() -> None:
+    module = importlib.import_module("yoyopod_cli.common")
+    assert callable(module.configure_logging)
+    assert callable(module.resolve_config_dir)
+    assert module.REPO_ROOT.exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_bootstrap.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'yoyopod_cli'`
+
+- [ ] **Step 3: Create `yoyopod_cli/__init__.py`**
+
+```python
+# yoyopod_cli/__init__.py
+"""yoyopod_cli — flat CLI package for YoyoPod.
+
+Entry point is `yoyopod_cli.main:run`. See COMMANDS.md for the full command reference.
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+```
+
+- [ ] **Step 4: Create `yoyopod_cli/common.py`**
+
+```python
+# yoyopod_cli/common.py
+"""Shared CLI helpers (logging, repo root, config dir resolution)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from loguru import logger
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def configure_logging(verbose: bool) -> None:
+    """Configure loguru for CLI commands."""
+    logger.remove()
+    level = "DEBUG" if verbose else "INFO"
+    logger.add(sys.stderr, level=level, format="{time:HH:mm:ss} | {level:<7} | {message}")
+
+
+def resolve_config_dir(config_dir: str) -> Path:
+    """Resolve a config directory relative to the repo root."""
+    path = Path(config_dir)
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    return path
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_yoyopod_cli_bootstrap.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add yoyopod_cli/__init__.py yoyopod_cli/common.py tests/test_yoyopod_cli_bootstrap.py
+git commit -m "feat(cli): scaffold yoyopod_cli package skeleton"
+```
+
+---
+
+## Task 2: Create `yoyopod_cli/paths.py` with dataclasses and YAML merger
+
+**Files:**
+- Create: `yoyopod_cli/paths.py`
+- Test: `tests/test_yoyopod_cli_paths.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_paths.py
+"""Tests for yoyopod_cli.paths — the single source of truth for path constants."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from yoyopod_cli.paths import (
+    CONFIGS,
+    HOST,
+    PI_DEFAULTS,
+    PROCS,
+    PiPaths,
+    load_pi_paths,
+)
+
+
+def test_host_paths_resolve() -> None:
+    assert HOST.repo_root.exists()
+    assert HOST.deploy_config == HOST.repo_root / "deploy" / "pi-deploy.yaml"
+    assert HOST.deploy_config_local == HOST.repo_root / "deploy" / "pi-deploy.local.yaml"
+
+
+def test_pi_defaults_populated() -> None:
+    assert PI_DEFAULTS.project_dir == "~/YoyoPod_Core"
+    assert PI_DEFAULTS.log_file == "logs/yoyopod.log"
+    assert PI_DEFAULTS.pid_file == "/tmp/yoyopod.pid"
+    assert "python" in PI_DEFAULTS.kill_processes
+
+
+def test_configs_paths_exist() -> None:
+    assert CONFIGS.core.exists()
+    assert CONFIGS.music.exists()
+    assert CONFIGS.calling.exists()
+
+
+def test_procs_known() -> None:
+    assert PROCS.app == "python yoyopod.py"
+    assert PROCS.mpv == "mpv"
+
+
+def test_load_pi_paths_returns_defaults_when_no_override(tmp_path, monkeypatch) -> None:
+    base_yaml = tmp_path / "base.yaml"
+    base_yaml.write_text(
+        "log_file: logs/yoyopod.log\n"
+        "error_log_file: logs/yoyopod_errors.log\n"
+        "pid_file: /tmp/yoyopod.pid\n"
+        "startup_marker: YoyoPod starting\n"
+    )
+    local_yaml = tmp_path / "local.yaml"  # does not exist
+
+    result = load_pi_paths(base_path=base_yaml, local_path=local_yaml)
+    assert isinstance(result, PiPaths)
+    assert result.log_file == "logs/yoyopod.log"
+    assert result.project_dir == "~/YoyoPod_Core"  # default, no override
+
+
+def test_load_pi_paths_applies_local_override(tmp_path) -> None:
+    base_yaml = tmp_path / "base.yaml"
+    base_yaml.write_text(
+        "log_file: logs/yoyopod.log\n"
+        "error_log_file: logs/yoyopod_errors.log\n"
+        "pid_file: /tmp/yoyopod.pid\n"
+        "startup_marker: YoyoPod starting\n"
+    )
+    local_yaml = tmp_path / "local.yaml"
+    local_yaml.write_text("host: rpi-zero\nproject_dir: /opt/yoyopod\n")
+
+    result = load_pi_paths(base_path=base_yaml, local_path=local_yaml)
+    assert result.project_dir == "/opt/yoyopod"  # overridden
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_paths.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'yoyopod_cli.paths'`
+
+- [ ] **Step 3: Create `yoyopod_cli/paths.py`**
+
+```python
+# yoyopod_cli/paths.py
+"""All CLI paths and process constants — single source of truth.
+
+If a path or process name changes, edit this file and only this file.
+Per-host overrides still live in deploy/pi-deploy.local.yaml.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class HostPaths:
+    """Paths on the dev machine."""
+
+    repo_root: Path = REPO_ROOT
+    deploy_config: Path = REPO_ROOT / "deploy" / "pi-deploy.yaml"
+    deploy_config_local: Path = REPO_ROOT / "deploy" / "pi-deploy.local.yaml"
+    systemd_unit_template: Path = REPO_ROOT / "deploy" / "systemd" / "yoyopod@.service"
+
+
+@dataclass(frozen=True)
+class PiPaths:
+    """Default Pi-side paths (overridable via pi-deploy.local.yaml)."""
+
+    project_dir: str = "~/YoyoPod_Core"
+    venv: str = ".venv"
+    start_cmd: str = "python yoyopod.py"
+    log_file: str = "logs/yoyopod.log"
+    error_log_file: str = "logs/yoyopod_errors.log"
+    pid_file: str = "/tmp/yoyopod.pid"
+    screenshot_path: str = "/tmp/yoyopod_screenshot.png"
+    test_music_target_dir: str = "logs/test-music"
+    startup_marker: str = "YoyoPod starting"
+    kill_processes: tuple[str, ...] = ("python", "linphonec")
+    rsync_exclude: tuple[str, ...] = (
+        ".git/",
+        ".cache/",
+        "__pycache__/",
+        "*.pyc",
+        ".venv/",
+        "build/",
+        "logs/",
+        "models/",
+        "node_modules/",
+        "*.egg-info/",
+    )
+
+
+@dataclass(frozen=True)
+class ConfigFiles:
+    """YAML configs the app reads; referenced by CLI commands."""
+
+    core: Path = REPO_ROOT / "config" / "app" / "core.yaml"
+    music: Path = REPO_ROOT / "config" / "audio" / "music.yaml"
+    hardware: Path = REPO_ROOT / "config" / "device" / "hardware.yaml"
+    cellular: Path = REPO_ROOT / "config" / "network" / "cellular.yaml"
+    voice: Path = REPO_ROOT / "config" / "voice" / "assistant.yaml"
+    calling: Path = REPO_ROOT / "config" / "communication" / "calling.yaml"
+    messaging: Path = REPO_ROOT / "config" / "communication" / "messaging.yaml"
+    people: Path = REPO_ROOT / "config" / "people" / "directory.yaml"
+    cloud_backend: Path = REPO_ROOT / "config" / "cloud" / "backend.yaml"
+
+
+@dataclass(frozen=True)
+class ProcessNames:
+    """Process names used in kill/grep operations."""
+
+    app: str = "python yoyopod.py"
+    mpv: str = "mpv"
+    linphonec: str = "linphonec"
+
+
+HOST = HostPaths()
+PI_DEFAULTS = PiPaths()
+CONFIGS = ConfigFiles()
+PROCS = ProcessNames()
+
+
+def _load_yaml(path: Path) -> dict[str, object]:
+    """Load one YAML mapping from disk; return {} if missing."""
+    if not path.exists():
+        return {}
+    with open(path, "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise SystemExit(f"Expected YAML mapping in {path}")
+    return data
+
+
+def _as_str_tuple(value: object, default: tuple[str, ...]) -> tuple[str, ...]:
+    """Normalize a YAML list into a tuple of non-empty strings."""
+    if isinstance(value, str):
+        candidates: Sequence[object] = (value,)
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        candidates = value
+    else:
+        return default
+    normalized = tuple(str(item).strip() for item in candidates if str(item).strip())
+    return normalized or default
+
+
+def load_pi_paths(
+    *,
+    base_path: Path | None = None,
+    local_path: Path | None = None,
+) -> PiPaths:
+    """Return PiPaths with base + local YAML overrides applied.
+
+    Reads fresh on every call — CLI commands are short-lived processes.
+    """
+    base = base_path if base_path is not None else HOST.deploy_config
+    local = local_path if local_path is not None else HOST.deploy_config_local
+
+    merged: dict[str, object] = {}
+    merged.update(_load_yaml(base))
+    merged.update(_load_yaml(local))
+
+    return replace(
+        PI_DEFAULTS,
+        project_dir=str(merged.get("project_dir", PI_DEFAULTS.project_dir)).strip() or PI_DEFAULTS.project_dir,
+        venv=str(merged.get("venv", PI_DEFAULTS.venv)).strip() or PI_DEFAULTS.venv,
+        start_cmd=str(merged.get("start_cmd", PI_DEFAULTS.start_cmd)).strip() or PI_DEFAULTS.start_cmd,
+        log_file=str(merged.get("log_file", PI_DEFAULTS.log_file)).strip() or PI_DEFAULTS.log_file,
+        error_log_file=str(merged.get("error_log_file", PI_DEFAULTS.error_log_file)).strip() or PI_DEFAULTS.error_log_file,
+        pid_file=str(merged.get("pid_file", PI_DEFAULTS.pid_file)).strip() or PI_DEFAULTS.pid_file,
+        screenshot_path=str(merged.get("screenshot_path", PI_DEFAULTS.screenshot_path)).strip() or PI_DEFAULTS.screenshot_path,
+        test_music_target_dir=str(merged.get("test_music_target_dir", PI_DEFAULTS.test_music_target_dir)).strip() or PI_DEFAULTS.test_music_target_dir,
+        startup_marker=str(merged.get("startup_marker", PI_DEFAULTS.startup_marker)).strip() or PI_DEFAULTS.startup_marker,
+        kill_processes=_as_str_tuple(merged.get("kill_processes"), PI_DEFAULTS.kill_processes),
+        rsync_exclude=_as_str_tuple(merged.get("rsync_exclude"), PI_DEFAULTS.rsync_exclude),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_yoyopod_cli_paths.py -v`
+Expected: PASS (6 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/paths.py tests/test_yoyopod_cli_paths.py
+git commit -m "feat(cli): add yoyopod_cli/paths.py single source of truth"
+```
+
+---
+
+## Task 3: Create `yoyopod_cli/remote_transport.py`
+
+**Files:**
+- Create: `yoyopod_cli/remote_transport.py`
+- Test: `tests/test_yoyopod_cli_remote_transport.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_remote_transport.py
+"""Unit tests for SSH transport helpers."""
+from __future__ import annotations
+
+from yoyopod_cli.remote_transport import (
+    build_ssh_command,
+    quote_remote_project_dir,
+    shell_quote,
+)
+from yoyopod_cli.remote_shared import RemoteConnection
+
+
+def test_shell_quote_escapes() -> None:
+    assert shell_quote("foo bar") == "'foo bar'"
+    assert shell_quote("clean") == "clean"
+
+
+def test_quote_remote_project_dir_tilde() -> None:
+    assert quote_remote_project_dir("~") == '"$HOME"'
+    assert quote_remote_project_dir("~/YoyoPod_Core") == '"$HOME/YoyoPod_Core"'
+
+
+def test_quote_remote_project_dir_absolute() -> None:
+    assert quote_remote_project_dir("/opt/yoyopod") == "/opt/yoyopod"
+
+
+def test_build_ssh_command_without_tty() -> None:
+    conn = RemoteConnection(host="rpi-zero", user="pi", project_dir="~/YoyoPod_Core", branch="main")
+    parts = build_ssh_command(conn, "ls")
+    assert parts[0] == "ssh"
+    assert "-t" not in parts
+    assert parts[1] == "pi@rpi-zero"
+    assert "cd \"$HOME/YoyoPod_Core\" && ls" in parts[2]
+
+
+def test_build_ssh_command_with_tty() -> None:
+    conn = RemoteConnection(host="rpi-zero", user="", project_dir="~", branch="main")
+    parts = build_ssh_command(conn, "htop", tty=True)
+    assert parts[0] == "ssh"
+    assert parts[1] == "-t"
+    assert parts[2] == "rpi-zero"  # no user → host only
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_transport.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'yoyopod_cli.remote_transport'`
+
+- [ ] **Step 3: Create `yoyopod_cli/remote_transport.py`**
+
+```python
+# yoyopod_cli/remote_transport.py
+"""SSH and local subprocess helpers for remote Pi operations."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from collections.abc import Sequence
+
+from yoyopod_cli.remote_shared import RemoteConnection
+
+
+def shell_quote(value: str) -> str:
+    """Shell-escape a literal value."""
+    return shlex.quote(value)
+
+
+def quote_remote_project_dir(project_dir: str) -> str:
+    """Quote the remote project path while preserving ``~`` expansion."""
+    if project_dir == "~":
+        return '"$HOME"'
+    if project_dir.startswith("~/"):
+        suffix = project_dir[2:].replace('"', '\\"')
+        return f'"$HOME/{suffix}"'
+    return shlex.quote(project_dir)
+
+
+def build_ssh_command(
+    conn: RemoteConnection,
+    remote_command: str,
+    *,
+    tty: bool = False,
+) -> list[str]:
+    """Build an SSH command targeting the Pi."""
+    wrapped = f"cd {quote_remote_project_dir(conn.project_dir)} && {remote_command}"
+    cmd = ["ssh"]
+    if tty:
+        cmd.append("-t")
+    cmd.extend([conn.ssh_target, f"bash -lc {shlex.quote(wrapped)}"])
+    return cmd
+
+
+def run_remote(conn: RemoteConnection, remote_command: str, tty: bool = False) -> int:
+    """Execute a command on the Pi via SSH. Returns the exit code."""
+    ssh_cmd = build_ssh_command(conn, remote_command, tty=tty)
+    print("")
+    print(f"[yoyopod-remote] host={conn.ssh_target}")
+    print(f"[yoyopod-remote] dir={conn.project_dir}")
+    print(f"[yoyopod-remote] cmd={remote_command}")
+    print("")
+    completed = subprocess.run(ssh_cmd, check=False)
+    return completed.returncode
+
+
+def run_remote_capture(
+    conn: RemoteConnection,
+    remote_command: str,
+) -> subprocess.CompletedProcess[str]:
+    """Execute an SSH command and capture stdout/stderr."""
+    ssh_cmd = build_ssh_command(conn, remote_command)
+    return subprocess.run(ssh_cmd, check=False, capture_output=True, text=True)
+
+
+def run_local(command: Sequence[str], label: str) -> int:
+    """Execute a local command and stream its output."""
+    print("")
+    print(f"[yoyopod-remote] local={label}")
+    print(f"[yoyopod-remote] cmd={shlex.join(command)}")
+    print("")
+    completed = subprocess.run(list(command), check=False)
+    return completed.returncode
+
+
+def run_local_capture(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """Execute a local command and capture stdout/stderr."""
+    return subprocess.run(list(command), check=False, capture_output=True, text=True)
+
+
+def validate_config(conn: RemoteConnection) -> None:
+    """Ensure required connection details are present."""
+    if not conn.host:
+        raise SystemExit(
+            "Missing Raspberry Pi host. Set it with "
+            "`yoyopod remote config edit`, pass --host, or set YOYOPOD_PI_HOST."
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_transport.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/remote_transport.py tests/test_yoyopod_cli_remote_transport.py
+git commit -m "feat(cli): add yoyopod_cli/remote_transport.py SSH helpers"
+```
+
+---
+
+## Task 4: Create `yoyopod_cli/remote_shared.py`
+
+**Files:**
+- Create: `yoyopod_cli/remote_shared.py`
+- Test: `tests/test_yoyopod_cli_remote_shared.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_remote_shared.py
+"""Tests for the shared Pi-connection options callback."""
+from __future__ import annotations
+
+import typer
+from typer.testing import CliRunner
+
+from yoyopod_cli.remote_shared import (
+    RemoteConnection,
+    build_remote_app,
+    pi_conn,
+)
+
+
+def test_remote_connection_ssh_target_with_user() -> None:
+    conn = RemoteConnection(host="rpi-zero", user="pi", project_dir="~", branch="main")
+    assert conn.ssh_target == "pi@rpi-zero"
+
+
+def test_remote_connection_ssh_target_without_user() -> None:
+    conn = RemoteConnection(host="rpi-zero", user="", project_dir="~", branch="main")
+    assert conn.ssh_target == "rpi-zero"
+
+
+def test_build_remote_app_captures_cli_flags() -> None:
+    app = build_remote_app("ops", "Test ops group.")
+
+    captured: dict[str, object] = {}
+
+    @app.command()
+    def echo(ctx: typer.Context) -> None:
+        conn = pi_conn(ctx)
+        captured["host"] = conn.host
+        captured["user"] = conn.user
+        captured["project_dir"] = conn.project_dir
+        captured["branch"] = conn.branch
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "--host",
+            "rpi-zero",
+            "--user",
+            "pi",
+            "--project-dir",
+            "/opt/yoyopod",
+            "--branch",
+            "feature-x",
+            "echo",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["host"] == "rpi-zero"
+    assert captured["user"] == "pi"
+    assert captured["project_dir"] == "/opt/yoyopod"
+    assert captured["branch"] == "feature-x"
+
+
+def test_build_remote_app_defaults_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("YOYOPOD_PI_HOST", "env-host")
+    monkeypatch.setenv("YOYOPOD_PI_USER", "env-user")
+
+    app = build_remote_app("ops", "Test ops group.")
+
+    captured: dict[str, object] = {}
+
+    @app.command()
+    def echo(ctx: typer.Context) -> None:
+        conn = pi_conn(ctx)
+        captured["host"] = conn.host
+        captured["user"] = conn.user
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["echo"])
+    assert result.exit_code == 0, result.output
+    assert captured["host"] == "env-host"
+    assert captured["user"] == "env-user"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_shared.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'yoyopod_cli.remote_shared'`
+
+- [ ] **Step 3: Create `yoyopod_cli/remote_shared.py`**
+
+```python
+# yoyopod_cli/remote_shared.py
+"""Shared Pi-connection state for remote CLI groups.
+
+Every `yoyopod remote <group>` has a typer.callback() that captures the four
+Pi-connection flags once. Individual command handlers pull the typed
+`RemoteConnection` via `pi_conn(ctx)` — no duplication.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import typer
+
+from yoyopod_cli.paths import HOST, load_pi_paths
+
+
+@dataclass(frozen=True)
+class RemoteConnection:
+    """Connection details resolved from CLI flags + env vars + YAML defaults."""
+
+    host: str
+    user: str
+    project_dir: str
+    branch: str
+
+    @property
+    def ssh_target(self) -> str:
+        """Return the SSH target as `user@host` or just `host`."""
+        if self.user:
+            return f"{self.user}@{self.host}"
+        return self.host
+
+
+def _resolve_remote_connection(
+    host: str,
+    user: str,
+    project_dir: str,
+    branch: str,
+) -> RemoteConnection:
+    """Merge CLI flags (highest) → env (already handled by Typer) → YAML defaults."""
+    pi = load_pi_paths()
+    # NB: host/user/branch defaults live in pi-deploy.yaml but are RemoteConnection concerns,
+    # not PiPaths. Read them directly from the same YAML via load_pi_paths's upstream yaml load.
+    import yaml
+
+    defaults: dict[str, object] = {}
+    for candidate in (HOST.deploy_config, HOST.deploy_config_local):
+        if candidate.exists():
+            with open(candidate, "r", encoding="utf-8") as handle:
+                data = yaml.safe_load(handle) or {}
+            if isinstance(data, dict):
+                defaults.update(data)
+
+    return RemoteConnection(
+        host=host or str(defaults.get("host", "")).strip(),
+        user=user or str(defaults.get("user", "")).strip(),
+        project_dir=(project_dir or str(defaults.get("project_dir", pi.project_dir)).strip()) or pi.project_dir,
+        branch=(branch or str(defaults.get("branch", "main")).strip()) or "main",
+    )
+
+
+def build_remote_app(name: str, help: str) -> typer.Typer:
+    """Build a Typer sub-app with the shared Pi-connection callback."""
+    app = typer.Typer(name=name, help=help, no_args_is_help=True)
+
+    @app.callback()
+    def _capture_connection(
+        ctx: typer.Context,
+        host: str = typer.Option("", "--host", envvar="YOYOPOD_PI_HOST", help="SSH host or alias."),
+        user: str = typer.Option("", "--user", envvar="YOYOPOD_PI_USER", help="SSH user (optional)."),
+        project_dir: str = typer.Option(
+            "", "--project-dir", envvar="YOYOPOD_PI_PROJECT_DIR", help="Project dir on the Pi."
+        ),
+        branch: str = typer.Option("", "--branch", envvar="YOYOPOD_PI_BRANCH", help="Git branch to target."),
+    ) -> None:
+        ctx.obj = _resolve_remote_connection(host, user, project_dir, branch)
+
+    return app
+
+
+def pi_conn(ctx: typer.Context) -> RemoteConnection:
+    """Typed accessor for the shared Pi connection."""
+    return ctx.ensure_object(RemoteConnection)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_shared.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/remote_shared.py tests/test_yoyopod_cli_remote_shared.py
+git commit -m "feat(cli): add yoyopod_cli/remote_shared.py for unified Pi options"
+```
+
+---
+
+## Task 5: Create `yoyopod_cli/main.py` and wire entry point
+
+**Files:**
+- Create: `yoyopod_cli/main.py`
+- Modify: `pyproject.toml`
+- Test: `tests/test_yoyopod_cli_main.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_main.py
+"""Tests for the yoyopod entry point and bare-invocation behavior."""
+from __future__ import annotations
+
+import typer
+from typer.testing import CliRunner
+
+from yoyopod_cli.main import app
+
+
+def test_help_lists_subcommands() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    # Subapps registered at this task are still empty placeholders —
+    # after later tasks these will include real groups. For now just
+    # verify `--help` emits without error.
+    assert "yoyopod" in result.output.lower()
+
+
+def test_version_flag_present() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert "0.1.0" in result.output
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_main.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'yoyopod_cli.main'`
+
+- [ ] **Step 3: Create `yoyopod_cli/main.py`**
+
+```python
+# yoyopod_cli/main.py
+"""
+yoyopod — app launcher and CLI dispatcher.
+
+Usage:
+    yoyopod                      # Launch the YoyoPod app
+    yoyopod deploy               # Sync code to the Pi and restart
+    yoyopod status               # Pi health dashboard
+    yoyopod logs [-f --errors]   # Tail logs from the Pi
+    yoyopod restart              # Restart the app on the Pi
+    yoyopod validate             # Run the validation suite on the Pi
+    yoyopod remote <cmd>         # Dev-machine → Pi commands
+    yoyopod pi <cmd>             # On-device commands
+    yoyopod build <cmd>          # Native extension builds
+    yoyopod setup <cmd>          # Host and Pi setup
+"""
+
+from __future__ import annotations
+
+import typer
+
+from yoyopod_cli import __version__
+
+app = typer.Typer(
+    name="yoyopod",
+    help="YoyoPod app launcher and CLI.",
+    no_args_is_help=False,
+    add_completion=False,
+)
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"yoyopod {__version__}")
+        raise typer.Exit()
+
+
+@app.callback(invoke_without_command=True)
+def _root(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show version and exit.",
+    ),
+) -> None:
+    """Launch the YoyoPod app when invoked with no subcommand."""
+    if ctx.invoked_subcommand is None:
+        from yoyopod.main import main as launch_app
+
+        launch_app()
+
+
+def run() -> None:
+    """Entry-point shim used by `[project.scripts]`."""
+    app()
+```
+
+- [ ] **Step 4: Update `pyproject.toml` scripts section**
+
+Edit `pyproject.toml` lines 50–53:
+
+```toml
+[project.scripts]
+yoyopod = "yoyopod_cli.main:run"
+```
+
+Remove the `yoyoctl = "yoyopod.cli:run"` line. Leave `yoyopod` pointing at the new CLI.
+
+- [ ] **Step 5: Re-install the package so the new script is available**
+
+Run: `uv sync --extra dev`
+
+Expected: `yoyopod` is now reinstalled to point at `yoyopod_cli.main:run`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_main.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 7: Sanity-check CLI**
+
+Run: `uv run yoyopod --version`
+Expected: `yoyopod 0.1.0`
+
+Run: `uv run yoyopod --help`
+Expected: Help text showing the root command (subapps still empty).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add yoyopod_cli/main.py pyproject.toml tests/test_yoyopod_cli_main.py
+git commit -m "feat(cli): add yoyopod_cli/main.py entry point and rewire yoyopod script"
+```
+
+---
+
+## Task 6: Port `yoyopod_cli/build.py`
+
+**Files:**
+- Create: `yoyopod_cli/build.py`
+- Modify: `yoyopod_cli/main.py` (register subapp)
+- Test: `tests/test_yoyopod_cli_build.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_build.py
+"""Tests for yoyopod_cli.build — native extension build commands."""
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.build import app
+
+
+def test_lvgl_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["lvgl", "--help"])
+    assert result.exit_code == 0
+    assert "lvgl" in result.output.lower()
+
+
+def test_liblinphone_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["liblinphone", "--help"])
+    assert result.exit_code == 0
+    assert "liblinphone" in result.output.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_build.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'yoyopod_cli.build'`
+
+- [ ] **Step 3: Copy current build logic to `yoyopod_cli/build.py`**
+
+Copy file `src/yoyopod/cli/build.py` → `yoyopod_cli/build.py`, then apply these rewrites:
+
+- Replace `_REPO_ROOT = Path(__file__).resolve().parents[3]` with `from yoyopod_cli.paths import HOST; _REPO_ROOT = HOST.repo_root`.
+- Rename `build_app = typer.Typer(...)` to `app = typer.Typer(...)`.
+- Update module docstring to reference the new path.
+
+No other changes — build commands don't use the Pi-connection infrastructure.
+
+- [ ] **Step 4: Register `build` subapp in `main.py`**
+
+Edit `yoyopod_cli/main.py` to add after the `_root` callback:
+
+```python
+from yoyopod_cli import build as _build
+
+app.add_typer(_build.app, name="build")
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_build.py tests/test_yoyopod_cli_main.py -v`
+Expected: PASS (4 passed)
+
+Run: `uv run yoyopod build --help`
+Expected: Lists `lvgl` and `liblinphone` subcommands.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add yoyopod_cli/build.py yoyopod_cli/main.py tests/test_yoyopod_cli_build.py
+git commit -m "feat(cli): port build commands to yoyopod_cli/build.py"
+```
+
+---
+
+## Task 7: Port `yoyopod_cli/setup.py`
+
+**Files:**
+- Create: `yoyopod_cli/setup.py`
+- Modify: `yoyopod_cli/main.py` (register subapp)
+- Test: `tests/test_yoyopod_cli_setup.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_setup.py
+"""Tests for yoyopod_cli.setup — host + Pi setup commands."""
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.setup import app
+
+
+def test_host_verify_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["verify-host", "--help"])
+    assert result.exit_code == 0
+
+
+def test_pi_verify_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["verify-pi", "--help"])
+    assert result.exit_code == 0
+
+
+def test_setup_lists_all_four_commands() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "host" in result.output
+    assert "pi" in result.output
+    assert "verify-host" in result.output
+    assert "verify-pi" in result.output
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_setup.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'yoyopod_cli.setup'`
+
+- [ ] **Step 3: Copy and rewrite setup logic**
+
+Copy file `src/yoyopod/cli/setup.py` → `yoyopod_cli/setup.py`, then apply:
+
+- Replace `from yoyopod.cli.common import REPO_ROOT` with `from yoyopod_cli.paths import HOST; REPO_ROOT = HOST.repo_root`.
+- Rename `setup_app = typer.Typer(...)` to `app = typer.Typer(...)`.
+- Update all internal references `setup_app` → `app`.
+- Update module docstring to reference the new path.
+
+Command-body logic stays identical; these are host-only subprocess runners that don't touch the Pi connection infrastructure.
+
+- [ ] **Step 4: Register `setup` subapp in `main.py`**
+
+Edit `yoyopod_cli/main.py` to add:
+
+```python
+from yoyopod_cli import setup as _setup
+
+app.add_typer(_setup.app, name="setup")
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_setup.py -v`
+Expected: PASS (3 passed)
+
+Run: `uv run yoyopod setup --help`
+Expected: Lists `host`, `pi`, `verify-host`, `verify-pi`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add yoyopod_cli/setup.py yoyopod_cli/main.py tests/test_yoyopod_cli_setup.py
+git commit -m "feat(cli): port setup commands to yoyopod_cli/setup.py"
+```
+
+---
+
+## Task 8: Port `yoyopod_cli/remote_ops.py` (status, sync, restart, logs, screenshot)
+
+This is the hot-path task — the first one that exercises the full shared-options + transport pattern. Every later remote port follows the same shape.
+
+**Files:**
+- Create: `yoyopod_cli/remote_ops.py`
+- Test: `tests/test_yoyopod_cli_remote_ops.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_remote_ops.py
+"""Tests for yoyopod_cli.remote_ops — runtime ops over SSH."""
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.remote_ops import app, _build_status, _build_restart, _build_logs_tail
+from yoyopod_cli.paths import PiPaths
+
+
+def test_build_status_includes_repo_sha_and_log_tail() -> None:
+    pi = PiPaths()
+    shell = _build_status(pi)
+    assert "git rev-parse HEAD" in shell
+    assert pi.log_file in shell
+    assert pi.pid_file in shell
+
+
+def test_build_restart_uses_configured_processes() -> None:
+    pi = PiPaths(kill_processes=("python", "linphonec"))
+    shell = _build_restart(pi)
+    assert "python" in shell
+    assert "linphonec" in shell
+    assert "pkill" in shell
+
+
+def test_build_logs_tail_defaults() -> None:
+    pi = PiPaths()
+    shell = _build_logs_tail(pi, lines=50, follow=False, errors=False, filter_pattern="")
+    assert "tail -n 50" in shell
+    assert pi.log_file in shell
+    assert "-f" not in shell
+
+
+def test_build_logs_tail_follow_errors_filter() -> None:
+    pi = PiPaths()
+    shell = _build_logs_tail(pi, lines=20, follow=True, errors=True, filter_pattern="ERROR")
+    assert "tail -n 20 -f" in shell
+    assert pi.error_log_file in shell
+    assert "grep 'ERROR'" in shell
+
+
+def test_status_cli_invokes_run_remote(monkeypatch) -> None:
+    calls: list[tuple[object, str]] = []
+
+    def fake_run_remote(conn, cmd, tty=False):
+        calls.append((conn, cmd))
+        return 0
+
+    monkeypatch.setattr("yoyopod_cli.remote_ops.run_remote", fake_run_remote)
+    monkeypatch.setenv("YOYOPOD_PI_HOST", "rpi-zero")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1
+    conn, cmd = calls[0]
+    assert conn.host == "rpi-zero"
+    assert "git rev-parse HEAD" in cmd
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_ops.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'yoyopod_cli.remote_ops'`
+
+- [ ] **Step 3: Create `yoyopod_cli/remote_ops.py`**
+
+```python
+# yoyopod_cli/remote_ops.py
+"""Runtime ops on the Pi via SSH — status, sync, restart, logs, screenshot."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+import typer
+
+from yoyopod_cli.common import configure_logging
+from yoyopod_cli.paths import HOST, PROCS, PiPaths, load_pi_paths
+from yoyopod_cli.remote_shared import RemoteConnection, build_remote_app, pi_conn
+from yoyopod_cli.remote_transport import (
+    quote_remote_project_dir,
+    run_remote,
+    run_remote_capture,
+    shell_quote,
+    validate_config,
+)
+
+app = build_remote_app("ops", "Runtime ops on the Pi via SSH.")
+
+
+# ---- shell builders (private, single-file) ----------------------------------
+
+def _build_status(pi: PiPaths) -> str:
+    """Build the shell that prints repo SHA, process list, and log tail."""
+    log = shell_quote(pi.log_file)
+    pid = shell_quote(pi.pid_file)
+    return (
+        f"echo '=== git ===' && git rev-parse HEAD && "
+        f"echo '=== processes ===' && (ps aux | grep -E 'python|mpv|linphonec' | grep -v grep || true) && "
+        f"echo '=== pid ===' && (cat {pid} 2>/dev/null || echo 'no pid file') && "
+        f"echo '=== log tail ===' && (tail -n 20 {log} 2>/dev/null || echo 'no log file')"
+    )
+
+
+def _build_restart(pi: PiPaths) -> str:
+    """Build the shell that kills the app processes; systemd restarts them."""
+    kills = " ; ".join(f"pkill -f {shell_quote(proc)} || true" for proc in pi.kill_processes)
+    return f"{kills} ; echo 'processes signalled — systemd will respawn'"
+
+
+def _build_logs_tail(pi: PiPaths, *, lines: int, follow: bool, errors: bool, filter_pattern: str) -> str:
+    """Build the log-tail shell with optional follow/errors/filter."""
+    log = pi.error_log_file if errors else pi.log_file
+    cmd = f"tail -n {lines}{' -f' if follow else ''} {shell_quote(log)}"
+    if filter_pattern:
+        cmd += f" | grep {shell_quote(filter_pattern)}"
+    return cmd
+
+
+def _build_sync(pi: PiPaths, branch: str) -> str:
+    """Build the shell that fast-forwards the branch and restarts via kill."""
+    return (
+        f"git fetch origin && "
+        f"git checkout {shell_quote(branch)} && "
+        f"git reset --hard origin/{shell_quote(branch)} && "
+        f"{_build_restart(pi)}"
+    )
+
+
+# ---- commands ---------------------------------------------------------------
+
+@app.command()
+def status(ctx: typer.Context, verbose: bool = typer.Option(False, "--verbose")) -> None:
+    """Show repo SHA, processes, and log tail on the Pi."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    validate_config(conn)
+    pi = load_pi_paths()
+    raise typer.Exit(run_remote(conn, _build_status(pi)))
+
+
+@app.command()
+def restart(ctx: typer.Context, verbose: bool = typer.Option(False, "--verbose")) -> None:
+    """Restart the yoyopod app on the Pi."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    validate_config(conn)
+    pi = load_pi_paths()
+    raise typer.Exit(run_remote(conn, _build_restart(pi)))
+
+
+@app.command()
+def logs(
+    ctx: typer.Context,
+    lines: int = typer.Option(50, "--lines", help="Number of lines to tail."),
+    follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output."),
+    errors: bool = typer.Option(False, "--errors", help="Tail the error log."),
+    filter: str = typer.Option("", "--filter", help="Grep filter applied to the output."),
+    verbose: bool = typer.Option(False, "--verbose"),
+) -> None:
+    """Tail yoyopod logs on the Pi."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    validate_config(conn)
+    pi = load_pi_paths()
+    cmd = _build_logs_tail(pi, lines=lines, follow=follow, errors=errors, filter_pattern=filter)
+    raise typer.Exit(run_remote(conn, cmd, tty=follow))
+
+
+@app.command()
+def sync(ctx: typer.Context, verbose: bool = typer.Option(False, "--verbose")) -> None:
+    """Fetch + hard-reset branch on the Pi and restart the app (fast deploy)."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    validate_config(conn)
+    pi = load_pi_paths()
+    raise typer.Exit(run_remote(conn, _build_sync(pi, conn.branch)))
+
+
+@app.command()
+def screenshot(
+    ctx: typer.Context,
+    out: str = typer.Option("", "--out", help="Local file path. Default: logs/screenshots/<timestamp>.png"),
+    verbose: bool = typer.Option(False, "--verbose"),
+) -> None:
+    """Capture the display shadow buffer from the Pi and copy it locally."""
+    from datetime import datetime
+
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    validate_config(conn)
+    pi = load_pi_paths()
+
+    remote_png = pi.screenshot_path
+    cmd = (
+        f"python -c 'from yoyopod.ui.display.factory import capture_shadow_png; "
+        f"capture_shadow_png({shell_quote(remote_png)})'"
+    )
+    rc = run_remote(conn, cmd)
+    if rc != 0:
+        raise typer.Exit(rc)
+
+    local_target = Path(out) if out else HOST.repo_root / "logs" / "screenshots" / f"{datetime.now():%Y%m%d-%H%M%S}.png"
+    local_target.parent.mkdir(parents=True, exist_ok=True)
+
+    scp_cmd = ["scp", f"{conn.ssh_target}:{remote_png}", str(local_target)]
+    completed = subprocess.run(scp_cmd, check=False)
+    if completed.returncode != 0:
+        raise typer.Exit(completed.returncode)
+    typer.echo(f"screenshot saved to {local_target}")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_ops.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/remote_ops.py tests/test_yoyopod_cli_remote_ops.py
+git commit -m "feat(cli): port remote ops (status/sync/restart/logs/screenshot)"
+```
+
+---
+
+## Task 9: Port `yoyopod_cli/remote_config.py`
+
+**Files:**
+- Create: `yoyopod_cli/remote_config.py`
+- Test: `tests/test_yoyopod_cli_remote_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_remote_config.py
+"""Tests for yoyopod_cli.remote_config — show/edit pi-deploy.local.yaml."""
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.remote_config import app
+
+
+def test_show_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["show", "--help"])
+    assert result.exit_code == 0
+
+
+def test_edit_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["edit", "--help"])
+    assert result.exit_code == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_config.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'yoyopod_cli.remote_config'`
+
+- [ ] **Step 3: Copy and rewrite**
+
+Port `src/yoyopod/cli/remote/config.py`'s `config` command (and its helpers `show`/`edit`) into a new `yoyopod_cli/remote_config.py`. Apply these rewrites:
+
+- Use `app = typer.Typer(name="config", ...)` — config doesn't need the shared Pi callback; it manipulates local files only.
+- Replace imports from `yoyopod.cli.*` with `yoyopod_cli.*`.
+- Use `HOST.deploy_config` / `HOST.deploy_config_local` from `yoyopod_cli.paths` instead of the old constants.
+
+```python
+# yoyopod_cli/remote_config.py
+"""Show or edit deploy/pi-deploy.local.yaml (the per-host override file)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import typer
+
+from yoyopod_cli.paths import HOST
+
+app = typer.Typer(name="config", help="Show or edit pi-deploy.local.yaml.", no_args_is_help=True)
+
+
+@app.command()
+def show() -> None:
+    """Print the effective pi-deploy YAML (base merged with local override)."""
+    import yaml
+
+    from yoyopod_cli.paths import load_pi_paths
+    from yoyopod_cli.remote_shared import _resolve_remote_connection
+
+    conn = _resolve_remote_connection("", "", "", "")
+    pi = load_pi_paths()
+
+    effective = {
+        "host": conn.host,
+        "user": conn.user,
+        "project_dir": conn.project_dir,
+        "branch": conn.branch,
+        "venv": pi.venv,
+        "start_cmd": pi.start_cmd,
+        "log_file": pi.log_file,
+        "error_log_file": pi.error_log_file,
+        "pid_file": pi.pid_file,
+        "screenshot_path": pi.screenshot_path,
+        "startup_marker": pi.startup_marker,
+        "kill_processes": list(pi.kill_processes),
+        "rsync_exclude": list(pi.rsync_exclude),
+    }
+    typer.echo(yaml.safe_dump(effective, sort_keys=False))
+
+
+@app.command()
+def edit() -> None:
+    """Open deploy/pi-deploy.local.yaml in $EDITOR."""
+    path = HOST.deploy_config_local
+    if not path.exists():
+        path.write_text(
+            "# Host-specific overrides for deploy/pi-deploy.yaml\n"
+            "# host: rpi-zero\n"
+            "# user: pi\n"
+            "# project_dir: ~/YoyoPod_Core\n"
+        )
+    editor = os.environ.get("EDITOR", "nano")
+    subprocess.run([editor, str(path)], check=False)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_config.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/remote_config.py tests/test_yoyopod_cli_remote_config.py
+git commit -m "feat(cli): port remote config show/edit"
+```
+
+---
+
+## Task 10: Port `yoyopod_cli/remote_infra.py` (power, rtc, service)
+
+**Files:**
+- Create: `yoyopod_cli/remote_infra.py`
+- Test: `tests/test_yoyopod_cli_remote_infra.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_remote_infra.py
+"""Tests for yoyopod_cli.remote_infra — power, rtc, service."""
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.remote_infra import app, _build_power, _build_rtc, _build_service_install
+from yoyopod_cli.paths import HOST
+
+
+def test_build_power_calls_battery() -> None:
+    shell = _build_power()
+    assert "yoyopod pi power battery" in shell or "yoyoctl" not in shell
+
+
+def test_build_rtc_with_status() -> None:
+    shell = _build_rtc("status", time_iso="", repeat_mask=127)
+    assert "yoyopod pi power rtc status" in shell
+
+
+def test_build_rtc_with_set_alarm_time() -> None:
+    shell = _build_rtc("set-alarm", time_iso="2026-04-20T07:00:00", repeat_mask=127)
+    assert "set-alarm" in shell
+    assert "2026-04-20T07:00:00" in shell
+    assert "127" in shell
+
+
+def test_build_service_install_uses_template_path() -> None:
+    shell = _build_service_install()
+    assert str(HOST.systemd_unit_template.name) in shell or "yoyopod@.service" in shell
+
+
+def test_power_cli_invokes_run_remote(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr("yoyopod_cli.remote_infra.run_remote", lambda conn, cmd, tty=False: (calls.append((conn, cmd)), 0)[1])
+    monkeypatch.setenv("YOYOPOD_PI_HOST", "rpi-zero")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["power"])
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_infra.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'yoyopod_cli.remote_infra'`
+
+- [ ] **Step 3: Create `yoyopod_cli/remote_infra.py`**
+
+Port `src/yoyopod/cli/remote/infra.py` (294 lines), applying the standard rewrites:
+- `build_remote_app("infra", ...)` — but since `power`, `rtc`, and `service` become peer commands under `remote` not `remote infra`, register each directly on `remote_app` (done in Task 14).
+- Kill `argparse.Namespace`; use typed Typer params.
+- Extract shell builders as `_build_*` private helpers.
+
+```python
+# yoyopod_cli/remote_infra.py
+"""Remote infra commands: power snapshot, rtc, systemd service management."""
+
+from __future__ import annotations
+
+import shlex
+
+import typer
+
+from yoyopod_cli.common import configure_logging
+from yoyopod_cli.paths import HOST
+from yoyopod_cli.remote_shared import build_remote_app, pi_conn
+from yoyopod_cli.remote_transport import run_remote, shell_quote, validate_config
+
+app = build_remote_app("infra", "Remote power, rtc, and service commands.")
+
+
+def _build_power() -> str:
+    """Invoke `yoyopod pi power battery` on the Pi."""
+    return "yoyopod pi power battery"
+
+
+def _build_rtc(action: str, *, time_iso: str, repeat_mask: int) -> str:
+    """Build `yoyopod pi power rtc <action> …` on the Pi."""
+    cmd = f"yoyopod pi power rtc {shell_quote(action)}"
+    if action == "set-alarm":
+        if not time_iso:
+            raise typer.BadParameter("set-alarm requires --time")
+        cmd += f" --time {shell_quote(time_iso)} --repeat-mask {repeat_mask}"
+    return cmd
+
+
+def _build_service_install() -> str:
+    """Build the shell that installs the systemd unit."""
+    return (
+        f"sudo cp {shell_quote(str(HOST.systemd_unit_template))} /etc/systemd/system/ && "
+        "sudo systemctl daemon-reload && "
+        "sudo systemctl enable --now yoyopod@$USER"
+    )
+
+
+def _build_service_action(action: str) -> str:
+    """Build `sudo systemctl <action> yoyopod@<user>` where $USER is resolved remotely."""
+    return f"sudo systemctl {shell_quote(action)} yoyopod@$USER"
+
+
+@app.command()
+def power(ctx: typer.Context, verbose: bool = typer.Option(False, "--verbose")) -> None:
+    """Query PiSugar state remotely."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    validate_config(conn)
+    raise typer.Exit(run_remote(conn, _build_power()))
+
+
+@app.command()
+def rtc(
+    ctx: typer.Context,
+    action: str = typer.Argument("status", help="status | sync-to | sync-from | set-alarm | disable-alarm"),
+    time: str = typer.Option("", "--time", help="ISO 8601 timestamp for set-alarm."),
+    repeat_mask: int = typer.Option(127, "--repeat-mask", help="Repeat-bitmask (default every day)."),
+    verbose: bool = typer.Option(False, "--verbose"),
+) -> None:
+    """Inspect or control PiSugar RTC remotely."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    validate_config(conn)
+    raise typer.Exit(run_remote(conn, _build_rtc(action, time_iso=time, repeat_mask=repeat_mask)))
+
+
+@app.command()
+def service(
+    ctx: typer.Context,
+    action: str = typer.Argument(..., help="install | uninstall | status | start | stop"),
+    verbose: bool = typer.Option(False, "--verbose"),
+) -> None:
+    """Manage the yoyopod@<user> systemd unit on the Pi."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    validate_config(conn)
+    if action == "install":
+        cmd = _build_service_install()
+    elif action == "uninstall":
+        cmd = "sudo systemctl disable --now yoyopod@$USER && sudo rm -f /etc/systemd/system/yoyopod@.service && sudo systemctl daemon-reload"
+    elif action in ("status", "start", "stop"):
+        cmd = _build_service_action(action)
+    else:
+        raise typer.BadParameter(f"unknown action: {action}")
+    raise typer.Exit(run_remote(conn, cmd))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_infra.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/remote_infra.py tests/test_yoyopod_cli_remote_infra.py
+git commit -m "feat(cli): port remote infra (power/rtc/service)"
+```
+
+---
+
+## Task 11: Port `yoyopod_cli/remote_setup.py`
+
+**Files:**
+- Create: `yoyopod_cli/remote_setup.py`
+- Test: `tests/test_yoyopod_cli_remote_setup.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_remote_setup.py
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.remote_setup import app, _build_setup, _build_verify_setup
+
+
+def test_build_setup_calls_pi_setup() -> None:
+    shell = _build_setup()
+    assert "yoyopod setup pi" in shell
+
+
+def test_build_verify_setup_calls_pi_verify() -> None:
+    shell = _build_verify_setup()
+    assert "yoyopod setup verify-pi" in shell
+
+
+def test_setup_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["setup", "--help"])
+    assert result.exit_code == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_setup.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'yoyopod_cli.remote_setup'`
+
+- [ ] **Step 3: Create `yoyopod_cli/remote_setup.py`**
+
+Port `src/yoyopod/cli/remote/setup.py` (147 lines):
+
+```python
+# yoyopod_cli/remote_setup.py
+"""Run Pi setup + verification remotely via SSH."""
+
+from __future__ import annotations
+
+import typer
+
+from yoyopod_cli.common import configure_logging
+from yoyopod_cli.remote_shared import build_remote_app, pi_conn
+from yoyopod_cli.remote_transport import run_remote, validate_config
+
+app = build_remote_app("setup_remote", "Run setup on the Pi via SSH.")
+
+
+def _build_setup() -> str:
+    return "yoyopod setup pi"
+
+
+def _build_verify_setup() -> str:
+    return "yoyopod setup verify-pi"
+
+
+@app.command()
+def setup(ctx: typer.Context, verbose: bool = typer.Option(False, "--verbose")) -> None:
+    """Run full Pi setup remotely."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    validate_config(conn)
+    raise typer.Exit(run_remote(conn, _build_setup(), tty=True))
+
+
+@app.command(name="verify-setup")
+def verify_setup(ctx: typer.Context, verbose: bool = typer.Option(False, "--verbose")) -> None:
+    """Verify Pi setup remotely."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    validate_config(conn)
+    raise typer.Exit(run_remote(conn, _build_verify_setup()))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_setup.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/remote_setup.py tests/test_yoyopod_cli_remote_setup.py
+git commit -m "feat(cli): port remote setup/verify-setup"
+```
+
+---
+
+## Task 12: Port `yoyopod_cli/remote_validate.py` (folds lvgl-soak + navigation-soak as flags)
+
+**Files:**
+- Create: `yoyopod_cli/remote_validate.py`
+- Test: `tests/test_yoyopod_cli_remote_validate.py`
+
+The new `remote validate` absorbs two previously-separate commands: `remote lvgl-soak` becomes `remote validate --with-lvgl-soak`, and `remote navigation-soak` becomes `remote validate --with-navigation`. It also absorbs `remote preflight` and `remote sync` fast-path sanity checks.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_remote_validate.py
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.remote_validate import (
+    app,
+    _build_validate,
+    _build_preflight,
+)
+
+
+def test_build_preflight_checks_git_and_lint() -> None:
+    shell = _build_preflight()
+    assert "git diff" in shell or "git status" in shell
+    assert "uv run" in shell or "scripts/quality.py" in shell
+
+
+def test_build_validate_minimal() -> None:
+    shell = _build_validate(with_music=False, with_voip=False, with_lvgl_soak=False, with_navigation=False)
+    assert "yoyopod pi validate deploy" in shell
+    assert "yoyopod pi validate smoke" in shell
+    assert "voip" not in shell
+    assert "lvgl" not in shell
+
+
+def test_build_validate_all_flags() -> None:
+    shell = _build_validate(with_music=True, with_voip=True, with_lvgl_soak=True, with_navigation=True)
+    assert "yoyopod pi validate music" in shell
+    assert "yoyopod pi validate voip" in shell
+    assert "yoyopod pi validate lvgl" in shell
+    assert "yoyopod pi validate navigation" in shell
+
+
+def test_preflight_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["preflight", "--help"])
+    assert result.exit_code == 0
+
+
+def test_validate_help_shows_flags() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["validate", "--help"])
+    assert result.exit_code == 0
+    assert "--with-music" in result.output
+    assert "--with-voip" in result.output
+    assert "--with-lvgl-soak" in result.output
+    assert "--with-navigation" in result.output
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_validate.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Create `yoyopod_cli/remote_validate.py`**
+
+```python
+# yoyopod_cli/remote_validate.py
+"""Remote validate + preflight — run Pi validation stages over SSH.
+
+Absorbs previous `remote lvgl-soak` as `--with-lvgl-soak`,
+previous `remote navigation-soak` as `--with-navigation`.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from yoyopod_cli.common import configure_logging
+from yoyopod_cli.remote_shared import build_remote_app, pi_conn
+from yoyopod_cli.remote_transport import (
+    run_local,
+    run_remote,
+    validate_config,
+)
+
+app = build_remote_app("validate_app", "Validate commit + health on the Pi.")
+
+
+def _build_preflight() -> str:
+    """Local shell that fails fast on dirty tree + bad quality gate before any SSH work."""
+    return (
+        "git diff --quiet && git diff --cached --quiet && "
+        "uv run python scripts/quality.py ci"
+    )
+
+
+def _build_validate(
+    *,
+    with_music: bool,
+    with_voip: bool,
+    with_lvgl_soak: bool,
+    with_navigation: bool,
+) -> str:
+    """Shell that runs staged validation on the Pi."""
+    steps = [
+        "yoyopod pi validate deploy",
+        "yoyopod pi validate smoke",
+        "yoyopod pi validate stability",
+    ]
+    if with_music:
+        steps.insert(2, "yoyopod pi validate music")
+    if with_voip:
+        steps.insert(-1, "yoyopod pi validate voip")
+    if with_lvgl_soak:
+        steps.append("yoyopod pi validate lvgl")
+    if with_navigation:
+        steps.append("yoyopod pi validate navigation")
+    return " && ".join(steps)
+
+
+@app.command()
+def preflight(verbose: bool = typer.Option(False, "--verbose")) -> None:
+    """Run host-side preflight checks (dirty tree + quality gate) before any remote work."""
+    configure_logging(verbose)
+    import shlex
+
+    raise typer.Exit(run_local(shlex.split(_build_preflight()), "preflight"))
+
+
+@app.command()
+def validate(
+    ctx: typer.Context,
+    with_music: bool = typer.Option(False, "--with-music"),
+    with_voip: bool = typer.Option(False, "--with-voip"),
+    with_lvgl_soak: bool = typer.Option(False, "--with-lvgl-soak"),
+    with_navigation: bool = typer.Option(False, "--with-navigation"),
+    verbose: bool = typer.Option(False, "--verbose"),
+) -> None:
+    """Run staged Pi validation. Pass --with-* to add optional stages."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    validate_config(conn)
+    cmd = _build_validate(
+        with_music=with_music,
+        with_voip=with_voip,
+        with_lvgl_soak=with_lvgl_soak,
+        with_navigation=with_navigation,
+    )
+    raise typer.Exit(run_remote(conn, cmd, tty=True))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_validate.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/remote_validate.py tests/test_yoyopod_cli_remote_validate.py
+git commit -m "feat(cli): port remote validate with --with-lvgl-soak/--with-navigation flags"
+```
+
+---
+
+## Task 13: Wire the `remote` subapp in `main.py`
+
+**Files:**
+- Modify: `yoyopod_cli/main.py`
+- Test: `tests/test_yoyopod_cli_remote_tree.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_remote_tree.py
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.main import app
+
+
+def test_remote_lists_all_commands() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["remote", "--help"])
+    assert result.exit_code == 0
+    for cmd in ("status", "sync", "restart", "logs", "screenshot",
+                "config", "power", "rtc", "service",
+                "setup", "verify-setup", "preflight", "validate"):
+        assert cmd in result.output, f"missing: {cmd}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_tree.py -v`
+Expected: FAIL — `remote` subapp not yet wired.
+
+- [ ] **Step 3: Update `main.py` to register the `remote` subapp**
+
+Edit `yoyopod_cli/main.py` to add between the `_root` callback and the `run()` definition:
+
+```python
+from yoyopod_cli import (
+    build as _build,
+    remote_config as _remote_config,
+    remote_infra as _remote_infra,
+    remote_ops as _remote_ops,
+    remote_setup as _remote_setup,
+    remote_validate as _remote_validate,
+    setup as _setup,
+)
+from yoyopod_cli.remote_shared import build_remote_app
+
+# --- remote group assembled from flat sub-modules
+remote_app = build_remote_app("remote", "Dev-machine → Pi commands via SSH.")
+
+# register ops commands directly as `remote status`, `remote sync`, etc.
+for command_name in ("status", "sync", "restart", "logs", "screenshot"):
+    handler = getattr(_remote_ops.app, "registered_commands", None)
+    # Typer doesn't expose commands cleanly for re-registration; so we directly register:
+remote_app.command(name="status")(_remote_ops.status)
+remote_app.command(name="sync")(_remote_ops.sync)
+remote_app.command(name="restart")(_remote_ops.restart)
+remote_app.command(name="logs")(_remote_ops.logs)
+remote_app.command(name="screenshot")(_remote_ops.screenshot)
+
+remote_app.command(name="preflight")(_remote_validate.preflight)
+remote_app.command(name="validate")(_remote_validate.validate)
+
+remote_app.command(name="power")(_remote_infra.power)
+remote_app.command(name="rtc")(_remote_infra.rtc)
+remote_app.command(name="service")(_remote_infra.service)
+
+remote_app.add_typer(_remote_config.app, name="config")
+
+remote_app.command(name="setup")(_remote_setup.setup)
+remote_app.command(name="verify-setup")(_remote_setup.verify_setup)
+
+app.add_typer(remote_app, name="remote")
+app.add_typer(_build.app, name="build")
+app.add_typer(_setup.app, name="setup")
+```
+
+(Adjust the earlier two `app.add_typer` statements from Tasks 6 and 7 to match this single block.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_remote_tree.py -v`
+Expected: PASS (1 passed)
+
+Run: `uv run yoyopod remote --help`
+Expected: Full list of remote commands.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/main.py tests/test_yoyopod_cli_remote_tree.py
+git commit -m "feat(cli): wire remote subapp in main.py"
+```
+
+---
+
+## Task 14: Port `yoyopod_cli/pi_voip.py` (check, debug — soaks cut)
+
+**Files:**
+- Create: `yoyopod_cli/pi_voip.py`
+- Test: `tests/test_yoyopod_cli_pi_voip.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_pi_voip.py
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.pi_voip import app
+
+
+def test_check_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", "--help"])
+    assert result.exit_code == 0
+    assert "registration" in result.output.lower()
+
+
+def test_debug_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["debug", "--help"])
+    assert result.exit_code == 0
+
+
+def test_soak_commands_removed() -> None:
+    runner = CliRunner()
+    for cmd in ("registration-stability", "reconnect-drill", "call-soak"):
+        result = runner.invoke(app, [cmd, "--help"])
+        assert result.exit_code != 0, f"{cmd} should have been removed"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_pi_voip.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Create `yoyopod_cli/pi_voip.py`**
+
+Port only `check` (line 483) and `debug` (line 537) from `src/yoyopod/cli/pi/voip.py`. The three soak commands (`registration-stability`, `reconnect-drill`, `call-soak`) do **not** come across — they're absorbed into `pi_validate.py --soak` in Task 17.
+
+Also port the shared helper functions: `_build_voip_manager`, `_wait_for_registration_ok`, `_print_result`, `_VoIPDrillRecorder`. These go into `pi_voip.py` only if `check`/`debug` use them; otherwise they move to `pi_validate.py` with the soak logic in Task 17. Check each:
+
+- `check` uses `_build_voip_manager`, `_wait_for_registration_ok`, `_print_result` — keep those in `pi_voip.py`.
+- `debug` uses `_build_voip_manager` — shared.
+- The soak-specific helpers (`_VoIPDrillRecorder`, `_hold_registration_ok`, `_wait_for_call_state`) move to `pi_validate.py` in Task 17.
+
+Apply the standard rewrites:
+- `from yoyopod.cli.common import configure_logging, resolve_config_dir` → `from yoyopod_cli.common import configure_logging, resolve_config_dir`
+- `voip_app = typer.Typer(...)` → `app = typer.Typer(name="voip", ...)`
+- All `@voip_app.command()` → `@app.command()`
+
+```python
+# yoyopod_cli/pi_voip.py
+"""On-device VoIP diagnostics — check registration, debug incoming calls."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from yoyopod_cli.common import configure_logging, resolve_config_dir
+
+app = typer.Typer(name="voip", help="On-device VoIP diagnostics.", no_args_is_help=True)
+
+
+# ... copy _build_voip_manager, _wait_for_registration_ok, _print_result helpers from
+#     src/yoyopod/cli/pi/voip.py, with imports adjusted.
+
+
+@app.command()
+def check(
+    config_dir: Annotated[str, typer.Option("--config-dir")] = "config",
+    registration_timeout: Annotated[float, typer.Option("--registration-timeout")] = 30.0,
+    verbose: Annotated[bool, typer.Option("--verbose")] = False,
+) -> None:
+    """One-shot SIP registration check."""
+    # ... copied body from src/yoyopod/cli/pi/voip.py:483-536 ...
+
+
+@app.command()
+def debug(
+    config_dir: Annotated[str, typer.Option("--config-dir")] = "config",
+    duration_seconds: Annotated[float, typer.Option("--duration-seconds")] = 60.0,
+    verbose: Annotated[bool, typer.Option("--verbose")] = False,
+) -> None:
+    """Live incoming-call debug — log every SIP event for N seconds."""
+    # ... copied body from src/yoyopod/cli/pi/voip.py:537-586 ...
+```
+
+Detailed transcription: open `src/yoyopod/cli/pi/voip.py`, copy lines 1–50 (imports + helpers used by check/debug), then lines 483–586 (the two commands). Rewrite imports as above. Do **not** copy lines 588–1066 (soak commands + their helpers).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_pi_voip.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/pi_voip.py tests/test_yoyopod_cli_pi_voip.py
+git commit -m "feat(cli): port pi voip check/debug (soaks deferred to pi_validate)"
+```
+
+---
+
+## Task 15: Port `yoyopod_cli/pi_power.py`
+
+**Files:**
+- Create: `yoyopod_cli/pi_power.py`
+- Test: `tests/test_yoyopod_cli_pi_power.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_pi_power.py
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.pi_power import app
+
+
+def test_battery_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["battery", "--help"])
+    assert result.exit_code == 0
+
+
+def test_rtc_status_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["rtc", "status", "--help"])
+    assert result.exit_code == 0
+
+
+def test_rtc_all_subcommands() -> None:
+    runner = CliRunner()
+    for sub in ("status", "sync-to", "sync-from", "set-alarm", "disable-alarm"):
+        result = runner.invoke(app, ["rtc", sub, "--help"])
+        assert result.exit_code == 0, f"rtc {sub} help failed"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_pi_power.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Create `yoyopod_cli/pi_power.py`**
+
+Copy `src/yoyopod/cli/pi/power.py` (198 lines) → `yoyopod_cli/pi_power.py`. Apply rewrites:
+
+- `from yoyopod.cli.common ...` → `from yoyopod_cli.common ...`
+- `power_app = typer.Typer(...)` → `app = typer.Typer(name="power", ...)`
+- `rtc_app` stays as-is; registered on `app` (the new name for `power_app`):
+  ```python
+  app.add_typer(rtc_app)
+  ```
+- All `@power_app.command()` decorators → `@app.command()`
+- `@rtc_app.command()` decorators unchanged.
+
+Command body logic is identical (it reads app config and talks to the PowerManager directly — no CLI infra dependency changes).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_pi_power.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/pi_power.py tests/test_yoyopod_cli_pi_power.py
+git commit -m "feat(cli): port pi power (battery + rtc subgroup)"
+```
+
+---
+
+## Task 16: Port `yoyopod_cli/pi_network.py`
+
+**Files:**
+- Create: `yoyopod_cli/pi_network.py`
+- Test: `tests/test_yoyopod_cli_pi_network.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_pi_network.py
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.pi_network import app
+
+
+def test_probe_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["probe", "--help"])
+    assert result.exit_code == 0
+
+
+def test_status_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["status", "--help"])
+    assert result.exit_code == 0
+
+
+def test_gps_command_removed() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["gps", "--help"])
+    assert result.exit_code != 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_pi_network.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Create `yoyopod_cli/pi_network.py`**
+
+Copy `src/yoyopod/cli/pi/network.py` (155 lines) → `yoyopod_cli/pi_network.py`. Keep `probe` (line 16) and `status` (line 61). **Do NOT copy** `gps` (line 111).
+
+Apply rewrites:
+- `from yoyopod.cli.common ...` → `from yoyopod_cli.common ...`
+- `network_app = typer.Typer(...)` → `app = typer.Typer(name="network", ...)`
+- All `@network_app.command()` → `@app.command()`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_pi_network.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/pi_network.py tests/test_yoyopod_cli_pi_network.py
+git commit -m "feat(cli): port pi network (probe + status; gps cut)"
+```
+
+---
+
+## Task 17: Port `yoyopod_cli/pi_validate.py` (with folded `voip --soak` and new `lvgl`)
+
+This is the biggest task. It:
+- Ports existing `pi validate` subcommands: `deploy`, `smoke`, `music`, `voip`, `stability`, `navigation`
+- Adds new `lvgl` subcommand (absorbing logic from `src/yoyopod/cli/pi/lvgl.py` + `src/yoyopod/cli/pi/stability.py`'s lvgl parts)
+- Adds `--soak {registration,reconnect,call}` flag to `voip` subcommand, absorbing the three cut VoIP soak commands' logic from `src/yoyopod/cli/pi/voip.py` lines 588–1066
+
+**Files:**
+- Create: `yoyopod_cli/pi_validate.py`
+- Test: `tests/test_yoyopod_cli_pi_validate.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_pi_validate.py
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.pi_validate import app
+
+
+def test_all_subcommands_present() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for cmd in ("deploy", "smoke", "music", "voip", "stability", "navigation", "lvgl"):
+        assert cmd in result.output, f"missing validate subcommand: {cmd}"
+
+
+def test_voip_soak_flag_registered() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["voip", "--help"])
+    assert result.exit_code == 0
+    assert "--soak" in result.output
+    assert "registration" in result.output
+    assert "reconnect" in result.output
+    assert "call" in result.output
+
+
+def test_lvgl_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["lvgl", "--help"])
+    assert result.exit_code == 0
+
+
+def test_deploy_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["deploy", "--help"])
+    assert result.exit_code == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_pi_validate.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Create `yoyopod_cli/pi_validate.py`**
+
+Open `src/yoyopod/cli/pi/validate.py` (469 lines) and copy the whole file into `yoyopod_cli/pi_validate.py`. Apply rewrites:
+
+- `from yoyopod.cli.common ...` → `from yoyopod_cli.common ...`
+- `from yoyopod.cli.pi.smoke import ...` → inline or copy into this file (cut `pi smoke` in §4 of the spec).
+- `from yoyopod.cli.pi.stability import run_navigation_idle_soak` → keep behavior; copy `run_navigation_idle_soak` and its helpers from `src/yoyopod/cli/pi/stability.py` into `pi_validate.py` as private functions.
+- `validate_app = typer.Typer(...)` → `app = typer.Typer(name="validate", ...)`
+- All `@validate_app.command()` → `@app.command()`
+
+Add the `voip --soak` flag: the existing `voip` command currently runs a check-and-exit; extend its signature with `soak: str = typer.Option("", "--soak", help="registration | reconnect | call")`. When `--soak` is set, route to the soak logic:
+
+```python
+@app.command()
+def voip(
+    config_dir: Annotated[str, typer.Option("--config-dir")] = "config",
+    registration_timeout: Annotated[float, typer.Option("--registration-timeout")] = 30.0,
+    soak: Annotated[str, typer.Option("--soak", help="Optional soak mode: registration | reconnect | call")] = "",
+    # soak-specific options below
+    hold_seconds: Annotated[float, typer.Option("--hold-seconds")] = 60.0,
+    disconnect_seconds: Annotated[float, typer.Option("--disconnect-seconds")] = 8.0,
+    drop_detect_timeout: Annotated[float, typer.Option("--drop-detect-timeout")] = 20.0,
+    recovery_timeout: Annotated[float, typer.Option("--recovery-timeout")] = 45.0,
+    drop_command: Annotated[str, typer.Option("--drop-command")] = "",
+    restore_command: Annotated[str, typer.Option("--restore-command")] = "",
+    soak_target: Annotated[str, typer.Option("--soak-target")] = "",
+    soak_contact_name: Annotated[str, typer.Option("--soak-contact-name")] = "",
+    soak_seconds: Annotated[float, typer.Option("--soak-seconds")] = 300.0,
+    connect_timeout: Annotated[float, typer.Option("--connect-timeout")] = 60.0,
+    hangup_timeout: Annotated[float, typer.Option("--hangup-timeout")] = 15.0,
+    artifacts_dir: Annotated[str, typer.Option("--artifacts-dir")] = "logs/voip-validation",
+    sample_interval: Annotated[float, typer.Option("--sample-interval")] = 1.0,
+    verbose: Annotated[bool, typer.Option("--verbose")] = False,
+) -> None:
+    """VoIP validation: quick check (default) or soak drill (--soak)."""
+    configure_logging(verbose)
+    if not soak:
+        return _run_quick_voip_check(config_dir, registration_timeout)
+    if soak == "registration":
+        return _run_voip_registration_stability(config_dir, registration_timeout, hold_seconds, artifacts_dir, sample_interval)
+    if soak == "reconnect":
+        return _run_voip_reconnect_drill(
+            config_dir, registration_timeout, disconnect_seconds, drop_detect_timeout,
+            recovery_timeout, drop_command, restore_command, artifacts_dir, sample_interval,
+        )
+    if soak == "call":
+        if not soak_target:
+            raise typer.BadParameter("--soak call requires --soak-target")
+        return _run_voip_call_soak(
+            config_dir, soak_target, soak_contact_name, registration_timeout,
+            connect_timeout, soak_seconds, hangup_timeout, artifacts_dir, sample_interval,
+        )
+    raise typer.BadParameter(f"unknown --soak value: {soak}")
+```
+
+Then copy the three soak-implementation functions from `src/yoyopod/cli/pi/voip.py` (lines 588–1066) as private `_run_voip_registration_stability`, `_run_voip_reconnect_drill`, `_run_voip_call_soak` in `pi_validate.py`. Also copy the helper classes `_VoIPDrillRecorder`, `_wait_for_call_state`, `_hold_registration_ok`, etc. from that file.
+
+Add the `lvgl` subcommand — absorb from `src/yoyopod/cli/pi/lvgl.py` `soak` command (line 17):
+
+```python
+@app.command()
+def lvgl(
+    config_dir: Annotated[str, typer.Option("--config-dir")] = "config",
+    duration_seconds: Annotated[float, typer.Option("--duration-seconds")] = 60.0,
+    cycles: Annotated[int, typer.Option("--cycles")] = 1,
+    verbose: Annotated[bool, typer.Option("--verbose")] = False,
+) -> None:
+    """LVGL render-path soak validation on the Pi."""
+    configure_logging(verbose)
+    # Copy body from src/yoyopod/cli/pi/lvgl.py:17-75 (the `soak` command)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_pi_validate.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Run full quality gate to catch import issues**
+
+Run: `uv run python scripts/quality.py ci`
+Expected: PASS (may fail on new-file format/lint — fix inline).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add yoyopod_cli/pi_validate.py tests/test_yoyopod_cli_pi_validate.py
+git commit -m "feat(cli): port pi validate with folded voip --soak and lvgl subcommand"
+```
+
+---
+
+## Task 18: Wire the `pi` subapp in `main.py`
+
+**Files:**
+- Modify: `yoyopod_cli/main.py`
+- Test: `tests/test_yoyopod_cli_pi_tree.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_pi_tree.py
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.main import app
+
+
+def test_pi_lists_all_groups() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["pi", "--help"])
+    assert result.exit_code == 0
+    for group in ("validate", "voip", "power", "network"):
+        assert group in result.output
+
+
+def test_pi_validate_lvgl_reachable() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["pi", "validate", "lvgl", "--help"])
+    assert result.exit_code == 0
+
+
+def test_pi_power_rtc_reachable() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["pi", "power", "rtc", "status", "--help"])
+    assert result.exit_code == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_pi_tree.py -v`
+Expected: FAIL — `pi` subapp not wired.
+
+- [ ] **Step 3: Update `main.py` to add the `pi` subapp**
+
+Append to `yoyopod_cli/main.py` before `app.add_typer(remote_app, ...)`:
+
+```python
+from yoyopod_cli import pi_network as _pi_network
+from yoyopod_cli import pi_power as _pi_power
+from yoyopod_cli import pi_validate as _pi_validate
+from yoyopod_cli import pi_voip as _pi_voip
+import typer as _typer
+
+pi_app = _typer.Typer(name="pi", help="Commands that run on the Pi.", no_args_is_help=True)
+pi_app.add_typer(_pi_validate.app, name="validate")
+pi_app.add_typer(_pi_voip.app, name="voip")
+pi_app.add_typer(_pi_power.app, name="power")
+pi_app.add_typer(_pi_network.app, name="network")
+
+app.add_typer(pi_app, name="pi")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_pi_tree.py -v`
+Expected: PASS (3 passed)
+
+Run: `uv run yoyopod pi --help`
+Expected: All four subgroups listed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/main.py tests/test_yoyopod_cli_pi_tree.py
+git commit -m "feat(cli): wire pi subapp in main.py"
+```
+
+---
+
+## Task 19: Add top-level shortcuts (`deploy`, `status`, `logs`, `restart`, `validate`)
+
+**Files:**
+- Modify: `yoyopod_cli/main.py`
+- Test: `tests/test_yoyopod_cli_shortcuts.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_shortcuts.py
+"""Test top-level aliases for hot-path commands."""
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from yoyopod_cli.main import app
+
+
+def test_deploy_aliases_remote_sync(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "yoyopod_cli.remote_ops.run_remote",
+        lambda conn, cmd, tty=False: (calls.append(cmd), 0)[1],
+    )
+    monkeypatch.setenv("YOYOPOD_PI_HOST", "rpi-zero")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["deploy"])
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1
+    # verify sync-shaped command
+    assert "git fetch origin" in calls[0]
+
+
+def test_status_alias(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "yoyopod_cli.remote_ops.run_remote",
+        lambda conn, cmd, tty=False: (calls.append(cmd), 0)[1],
+    )
+    monkeypatch.setenv("YOYOPOD_PI_HOST", "rpi-zero")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "git rev-parse HEAD" in calls[0]
+
+
+def test_all_shortcuts_listed_in_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for cmd in ("deploy", "status", "logs", "restart", "validate"):
+        assert cmd in result.output, f"missing top-level shortcut: {cmd}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_shortcuts.py -v`
+Expected: FAIL — shortcuts not wired yet.
+
+- [ ] **Step 3: Add shortcuts to `main.py`**
+
+Append to `yoyopod_cli/main.py` after the `app.add_typer(pi_app, ...)` line:
+
+```python
+# --- top-level shortcuts (thin aliases wrapping the remote handlers)
+# Each alias gets its own Typer.Context → RemoteConnection plumbing because
+# the shared remote_app callback only fires for commands *inside* remote_app.
+# Shortcuts invoke the underlying handler via a small wrapper that mimics
+# the callback.
+from yoyopod_cli.remote_shared import _resolve_remote_connection
+
+
+def _shortcut(handler):
+    """Return a top-level Typer-command wrapper that seeds ctx.obj then calls handler."""
+    def wrapper(
+        host: str = typer.Option("", "--host", envvar="YOYOPOD_PI_HOST"),
+        user: str = typer.Option("", "--user", envvar="YOYOPOD_PI_USER"),
+        project_dir: str = typer.Option("", "--project-dir", envvar="YOYOPOD_PI_PROJECT_DIR"),
+        branch: str = typer.Option("", "--branch", envvar="YOYOPOD_PI_BRANCH"),
+        verbose: bool = typer.Option(False, "--verbose"),
+    ) -> None:
+        conn = _resolve_remote_connection(host, user, project_dir, branch)
+        ctx = typer.Context(typer.Typer())  # minimal context just for ensure_object
+        ctx.obj = conn
+        handler(ctx=ctx, verbose=verbose)
+    wrapper.__name__ = handler.__name__
+    wrapper.__doc__ = handler.__doc__
+    return wrapper
+
+
+app.command(name="deploy")(_shortcut(_remote_ops.sync))
+app.command(name="status")(_shortcut(_remote_ops.status))
+app.command(name="restart")(_shortcut(_remote_ops.restart))
+# logs + validate have extra options — use dedicated wrappers:
+
+@app.command(name="logs")
+def _logs_shortcut(
+    host: str = typer.Option("", "--host", envvar="YOYOPOD_PI_HOST"),
+    user: str = typer.Option("", "--user", envvar="YOYOPOD_PI_USER"),
+    project_dir: str = typer.Option("", "--project-dir", envvar="YOYOPOD_PI_PROJECT_DIR"),
+    branch: str = typer.Option("", "--branch", envvar="YOYOPOD_PI_BRANCH"),
+    lines: int = typer.Option(50, "--lines"),
+    follow: bool = typer.Option(False, "--follow", "-f"),
+    errors: bool = typer.Option(False, "--errors"),
+    filter: str = typer.Option("", "--filter"),
+    verbose: bool = typer.Option(False, "--verbose"),
+) -> None:
+    """Tail yoyopod logs on the Pi (alias for `remote logs`)."""
+    conn = _resolve_remote_connection(host, user, project_dir, branch)
+    ctx = typer.Context(typer.Typer())
+    ctx.obj = conn
+    _remote_ops.logs(ctx=ctx, lines=lines, follow=follow, errors=errors, filter=filter, verbose=verbose)
+
+
+@app.command(name="validate")
+def _validate_shortcut(
+    host: str = typer.Option("", "--host", envvar="YOYOPOD_PI_HOST"),
+    user: str = typer.Option("", "--user", envvar="YOYOPOD_PI_USER"),
+    project_dir: str = typer.Option("", "--project-dir", envvar="YOYOPOD_PI_PROJECT_DIR"),
+    branch: str = typer.Option("", "--branch", envvar="YOYOPOD_PI_BRANCH"),
+    with_music: bool = typer.Option(False, "--with-music"),
+    with_voip: bool = typer.Option(False, "--with-voip"),
+    with_lvgl_soak: bool = typer.Option(False, "--with-lvgl-soak"),
+    with_navigation: bool = typer.Option(False, "--with-navigation"),
+    verbose: bool = typer.Option(False, "--verbose"),
+) -> None:
+    """Run staged Pi validation (alias for `remote validate`)."""
+    conn = _resolve_remote_connection(host, user, project_dir, branch)
+    ctx = typer.Context(typer.Typer())
+    ctx.obj = conn
+    _remote_validate.validate(
+        ctx=ctx,
+        with_music=with_music,
+        with_voip=with_voip,
+        with_lvgl_soak=with_lvgl_soak,
+        with_navigation=with_navigation,
+        verbose=verbose,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_shortcuts.py -v`
+Expected: PASS (3 passed)
+
+Run: `uv run yoyopod --help`
+Expected: Top-level shortcuts visible.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add yoyopod_cli/main.py tests/test_yoyopod_cli_shortcuts.py
+git commit -m "feat(cli): add top-level deploy/status/logs/restart/validate shortcuts"
+```
+
+---
+
+## Task 20: Build `_docgen.py` and generate `COMMANDS.md`
+
+**Files:**
+- Create: `yoyopod_cli/_docgen.py`
+- Create: `yoyopod_cli/COMMANDS.md`
+- Modify: `yoyopod_cli/main.py` (add `dev docs` command)
+- Test: `tests/test_yoyopod_cli_docgen.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_docgen.py
+from __future__ import annotations
+
+from yoyopod_cli._docgen import generate_commands_md
+from yoyopod_cli.main import app
+
+
+def test_docgen_contains_all_shortcut_commands() -> None:
+    md = generate_commands_md(app)
+    for cmd in ("deploy", "status", "logs", "restart", "validate"):
+        assert f"`yoyopod {cmd}`" in md, f"missing shortcut: {cmd}"
+
+
+def test_docgen_contains_remote_commands() -> None:
+    md = generate_commands_md(app)
+    assert "## `yoyopod remote" in md
+    for cmd in ("status", "sync", "logs", "config", "power", "rtc", "service"):
+        assert cmd in md, f"missing remote command: {cmd}"
+
+
+def test_docgen_contains_pi_commands() -> None:
+    md = generate_commands_md(app)
+    assert "## `yoyopod pi" in md
+    for cmd in ("validate", "voip", "power", "network"):
+        assert cmd in md
+
+
+def test_docgen_does_not_contain_cut_commands() -> None:
+    md = generate_commands_md(app)
+    for cut in (
+        "gallery", "tune", "whisplay",
+        "registration-stability", "reconnect-drill", "call-soak",
+        "lvgl probe", "navigation-soak", "lvgl-soak",
+        "rsync", "provision-test-music",
+    ):
+        assert cut not in md, f"cut command still present: {cut}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_yoyopod_cli_docgen.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Create `yoyopod_cli/_docgen.py`**
+
+```python
+# yoyopod_cli/_docgen.py
+"""Walk a Typer app and emit a markdown command-reference table."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import typer
+from click.core import Group
+
+
+def _walk(typer_app: typer.Typer, prefix: str = "yoyopod") -> list[tuple[str, str]]:
+    """Return [(full_path, short_help), ...] for every leaf command."""
+    click_app = typer.main.get_command(typer_app)
+    out: list[tuple[str, str]] = []
+    _walk_click(click_app, prefix, out)
+    return out
+
+
+def _walk_click(click_cmd, prefix: str, out: list[tuple[str, str]]) -> None:
+    if isinstance(click_cmd, Group):
+        for name, sub in (click_cmd.commands or {}).items():
+            _walk_click(sub, f"{prefix} {name}", out)
+    else:
+        help_text = click_cmd.short_help or click_cmd.help or ""
+        out.append((prefix, help_text.strip().split("\n")[0]))
+
+
+def generate_commands_md(typer_app: typer.Typer) -> str:
+    """Emit the full COMMANDS.md string."""
+    entries = _walk(typer_app)
+
+    groups = {
+        "Top-level shortcuts": [],
+        "`yoyopod remote` — dev-machine → Pi via SSH": [],
+        "`yoyopod pi` — on the Pi": [],
+        "`yoyopod build`": [],
+        "`yoyopod setup`": [],
+    }
+
+    for path, help_text in entries:
+        parts = path.split()
+        if len(parts) == 2:
+            groups["Top-level shortcuts"].append((path, help_text))
+        elif parts[1] == "remote":
+            groups["`yoyopod remote` — dev-machine → Pi via SSH"].append((path, help_text))
+        elif parts[1] == "pi":
+            groups["`yoyopod pi` — on the Pi"].append((path, help_text))
+        elif parts[1] == "build":
+            groups["`yoyopod build`"].append((path, help_text))
+        elif parts[1] == "setup":
+            groups["`yoyopod setup`"].append((path, help_text))
+
+    buf = StringIO()
+    buf.write("# YoyoPod CLI — Command Reference\n\n")
+    buf.write("Auto-generated by `_docgen.py`. Run `yoyopod dev docs` to regenerate.\n")
+    buf.write("For live help, use `yoyopod <cmd> --help`.\n\n")
+
+    for title, cmds in groups.items():
+        if not cmds:
+            continue
+        buf.write(f"## {title}\n\n")
+        buf.write("| Command | What it does |\n|---|---|\n")
+        for path, help_text in sorted(cmds):
+            buf.write(f"| `{path}` | {help_text or '—'} |\n")
+        buf.write("\n")
+
+    return buf.getvalue()
+```
+
+- [ ] **Step 4: Generate `COMMANDS.md` once**
+
+Run from the repo root:
+
+```bash
+uv run python -c "from yoyopod_cli._docgen import generate_commands_md; from yoyopod_cli.main import app; open('yoyopod_cli/COMMANDS.md', 'w').write(generate_commands_md(app))"
+```
+
+- [ ] **Step 5: Add `yoyopod dev docs` to `main.py`**
+
+Append to `yoyopod_cli/main.py`:
+
+```python
+dev_app = typer.Typer(name="dev", help="Developer utilities.", no_args_is_help=True)
+app.add_typer(dev_app, name="dev")
+
+
+@dev_app.command()
+def docs() -> None:
+    """Regenerate yoyopod_cli/COMMANDS.md from the live Typer tree."""
+    from yoyopod_cli._docgen import generate_commands_md
+    from yoyopod_cli.paths import HOST
+
+    md = generate_commands_md(app)
+    (HOST.repo_root / "yoyopod_cli" / "COMMANDS.md").write_text(md, encoding="utf-8")
+    typer.echo("yoyopod_cli/COMMANDS.md regenerated.")
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_yoyopod_cli_docgen.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add yoyopod_cli/_docgen.py yoyopod_cli/COMMANDS.md yoyopod_cli/main.py tests/test_yoyopod_cli_docgen.py
+git commit -m "feat(cli): add _docgen and commit initial COMMANDS.md"
+```
+
+---
+
+## Task 21: Wire `COMMANDS.md` drift check into quality gate
+
+**Files:**
+- Modify: `scripts/quality.py`
+- Test: `tests/test_yoyopod_cli_docs_drift.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_yoyopod_cli_docs_drift.py
+"""Verify yoyopod_cli/COMMANDS.md is in sync with the Typer tree."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from yoyopod_cli._docgen import generate_commands_md
+from yoyopod_cli.main import app
+from yoyopod_cli.paths import HOST
+
+
+def test_commands_md_is_up_to_date() -> None:
+    committed = (HOST.repo_root / "yoyopod_cli" / "COMMANDS.md").read_text(encoding="utf-8")
+    regenerated = generate_commands_md(app)
+    assert committed == regenerated, (
+        "yoyopod_cli/COMMANDS.md is out of date. "
+        "Run `uv run yoyopod dev docs` and commit."
+    )
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `uv run pytest tests/test_yoyopod_cli_docs_drift.py -v`
+Expected: PASS (already in sync from Task 20).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_yoyopod_cli_docs_drift.py
+git commit -m "test(cli): enforce COMMANDS.md stays in sync with Typer tree"
+```
+
+---
+
+## Task 22: Update `pyproject.toml` quality-gate paths
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Update the `[tool.yoyopod_quality]` paths**
+
+Edit `pyproject.toml` lines 78–105:
+
+Replace:
+```toml
+gate_format_paths = [
+    "scripts/quality.py",
+    "src/yoyopod/main.py",
+    "src/yoyopod/cli/__init__.py",
+    "src/yoyopod/cli/common.py",
+    "src/yoyopod/cli/build.py",
+    "src/yoyopod/cli/remote",
+]
+```
+with:
+```toml
+gate_format_paths = [
+    "scripts/quality.py",
+    "src/yoyopod/main.py",
+    "yoyopod_cli",
+]
+```
+
+Apply the same replacement pattern to `gate_lint_paths` and `gate_type_paths`.
+
+- [ ] **Step 2: Run the quality gate**
+
+Run: `uv run python scripts/quality.py ci`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "chore(cli): point quality-gate paths at yoyopod_cli"
+```
+
+---
+
+## Task 23: Delete the legacy `src/yoyopod/cli/` tree
+
+**Files:**
+- Delete: `src/yoyopod/cli/` (entire directory)
+
+- [ ] **Step 1: Verify new CLI handles the full surface before deletion**
+
+Run these sanity checks (should all succeed, some may require a Pi):
+
+```bash
+uv run yoyopod --help
+uv run yoyopod remote --help
+uv run yoyopod pi --help
+uv run yoyopod build --help
+uv run yoyopod setup --help
+uv run yoyopod deploy --help
+uv run yoyopod status --help
+uv run yoyopod logs --help
+uv run yoyopod restart --help
+uv run yoyopod validate --help
+uv run yoyopod dev docs --help
+```
+
+- [ ] **Step 2: Delete the old tree**
+
+```bash
+git rm -r src/yoyopod/cli/
+```
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `uv run pytest tests/ -x`
+
+Expected: Some tests still reference the old paths — these are migrated in Task 24. For now, collect the list of failures.
+
+- [ ] **Step 4: Commit the deletion**
+
+```bash
+git commit -m "refactor(cli): delete legacy src/yoyopod/cli/ tree"
+```
+
+---
+
+## Task 24: Migrate existing test files (import path rewrites)
+
+**Files:**
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_cli_bootstrap.py`
+- Modify: `tests/test_pi_remote.py`
+- Modify: `tests/test_setup_cli.py`
+- Modify: `tests/test_voip_cli.py`
+- Modify: `tests/test_navigation_soak.py`
+- Modify: `tests/test_remote_config_helpers.py`
+- Modify: `tests/test_quality_script.py`
+
+- [ ] **Step 1: Rewrite each `from yoyopod.cli.*` to `from yoyopod_cli.*`**
+
+For each file above, replace:
+- `from yoyopod.cli import app` → `from yoyopod_cli.main import app`
+- `from yoyopod.cli.common import ...` → `from yoyopod_cli.common import ...`
+- `from yoyopod.cli.remote.config import ...` → `from yoyopod_cli.paths import load_pi_paths` and `from yoyopod_cli.remote_shared import RemoteConnection`, mapping field names (see Task 24 notes below).
+- `from yoyopod.cli.remote.transport import ...` → `from yoyopod_cli.remote_transport import ...`
+- `from yoyopod.cli.remote.ops import ...` → `from yoyopod_cli.remote_ops import ...` (or `remote_validate`/`remote_infra` as appropriate — see `grep -n "from yoyopod.cli.remote.ops" tests/`)
+- `from yoyopod.cli.pi.voip import ...` → `from yoyopod_cli.pi_voip import ...`
+- `from yoyopod.cli.remote.navigation import ...` → `from yoyopod_cli.remote_validate import ...` (navigation-soak absorbed)
+
+Field renames (`PiDeployConfig` → `RemoteConnection` + `PiPaths`):
+
+- `PiDeployConfig.host/user/project_dir/branch` → `RemoteConnection.host/user/project_dir/branch`
+- `PiDeployConfig.log_file/pid_file/startup_marker/...` → `PiPaths.log_file/pid_file/...`
+
+- [ ] **Step 2: Rewrite monkeypatch targets**
+
+Find all `monkeypatch.setattr("yoyopod.cli.remote.ops.*", ...)`:
+
+Run: `grep -n "yoyopod.cli.remote.ops" tests/`
+
+For each, update to the new module boundary:
+
+| Old target | New target |
+|---|---|
+| `yoyopod.cli.remote.ops.subprocess.run` | `yoyopod_cli.remote_transport.subprocess.run` |
+| `yoyopod.cli.remote.ops.shutil.which` | `yoyopod_cli.remote_transport.shutil.which` (add `import shutil` to transport if missing) |
+| `yoyopod.cli.remote.ops.sys.platform` | (delete — sys.platform usage moved into run_rsync_deploy if still needed; otherwise stub in test) |
+| `yoyopod.cli.remote.ops.run_local_capture` | `yoyopod_cli.remote_transport.run_local_capture` |
+| `yoyopod.cli.remote.ops.run_remote_capture` | `yoyopod_cli.remote_transport.run_remote_capture` |
+| `yoyopod.cli.remote.ops.validation.resolve_local_validation_target` | (function cut — delete the test or replace with direct argument passing) |
+| `yoyopod.cli.remote.ops.validation._resolve_remote_config` | `yoyopod_cli.remote_shared._resolve_remote_connection` |
+| `yoyopod.cli.remote.ops.validation.validate_config` | `yoyopod_cli.remote_transport.validate_config` |
+| `yoyopod.cli.remote.ops.validation.run_remote` | `yoyopod_cli.remote_transport.run_remote` |
+
+- [ ] **Step 3: Run the test suite**
+
+Run: `uv run pytest tests/ -x`
+Expected: PASS — any remaining failure is either a test of a cut command (handled in Task 25) or genuine bug to fix.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/
+git commit -m "test(cli): migrate test imports + monkeypatches to yoyopod_cli"
+```
+
+---
+
+## Task 25: Delete tests for cut commands
+
+**Files:**
+- Delete: `tests/test_pi_gallery.py` (pi gallery cut)
+- Delete: `tests/test_whisplay_tune.py` (pi tune + remote whisplay cut)
+- Modify: `tests/test_navigation_soak.py` (navigation-soak absorbed; convert to test `remote validate --with-navigation`)
+
+- [ ] **Step 1: Delete the tests for cut commands**
+
+```bash
+git rm tests/test_pi_gallery.py tests/test_whisplay_tune.py
+```
+
+- [ ] **Step 2: Rewrite `tests/test_navigation_soak.py`**
+
+Replace its contents with a test that verifies `remote validate --with-navigation` produces the right shell payload:
+
+```python
+# tests/test_navigation_soak.py
+"""Regression test — navigation-soak is now a flag on remote validate."""
+from __future__ import annotations
+
+from yoyopod_cli.remote_validate import _build_validate
+
+
+def test_with_navigation_flag_appends_navigation_stage() -> None:
+    shell = _build_validate(
+        with_music=False,
+        with_voip=False,
+        with_lvgl_soak=False,
+        with_navigation=True,
+    )
+    assert "yoyopod pi validate navigation" in shell
+
+
+def test_without_flag_skips_navigation_stage() -> None:
+    shell = _build_validate(
+        with_music=False,
+        with_voip=False,
+        with_lvgl_soak=False,
+        with_navigation=False,
+    )
+    assert "yoyopod pi validate navigation" not in shell
+```
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `uv run pytest tests/`
+Expected: PASS — whole suite green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/
+git commit -m "test(cli): drop tests for cut commands; convert navigation-soak to flag test"
+```
+
+---
+
+## Task 26: Doc sweep — replace `yoyoctl` with `yoyopod` everywhere
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `docs/DEVELOPMENT_GUIDE.md`
+- Modify: `docs/PI_DEV_WORKFLOW.md`
+- Modify: `docs/RPI_SMOKE_VALIDATION.md`
+- Modify: `docs/SYSTEM_ARCHITECTURE.md`
+- Modify: `rules/*.md`
+- Modify: `skills/yoyopod-*/SKILL.md`
+
+- [ ] **Step 1: Find all occurrences of `yoyoctl`**
+
+Run: `grep -rln "yoyoctl" CLAUDE.md README.md AGENTS.md docs/ rules/ skills/`
+
+Record the list.
+
+- [ ] **Step 2: Find-replace in each file**
+
+For each file in the list, replace `yoyoctl` → `yoyopod`. In most contexts this is a literal replacement; hand-review each doc to catch:
+- Any mention of `yoyoctl` as a separate concept (e.g., "the `yoyoctl` CLI") — reword to "the `yoyopod` CLI" or "the YoyoPod CLI".
+- Any script shown running `uv run yoyoctl` → `uv run yoyopod`.
+
+- [ ] **Step 3: Update skills for removed commands**
+
+For these skills, add a note that the relevant commands have been removed:
+
+- `skills/yoyopod-*/SKILL.md`: refresh command examples to the new names (most are already `yoyoctl pi xxx` or `yoyoctl remote xxx` — just the binary name changes).
+
+If any skill references `pi tune`, `pi gallery`, `remote whisplay`, `remote rsync`, `pi voip registration-stability`, `pi voip reconnect-drill`, `pi voip call-soak`, `pi lvgl probe`, `pi lvgl soak`, `remote navigation-soak`, or `remote lvgl-soak` directly, replace with the surviving equivalent:
+
+| Old | New |
+|---|---|
+| `pi lvgl soak` | `pi validate lvgl` |
+| `remote lvgl-soak` | `remote validate --with-lvgl-soak` |
+| `remote navigation-soak` | `remote validate --with-navigation` |
+| `pi voip registration-stability` | `pi validate voip --soak registration` |
+| `pi voip reconnect-drill` | `pi validate voip --soak reconnect` |
+| `pi voip call-soak` | `pi validate voip --soak call` |
+| `remote rsync` | `remote sync` |
+| `remote smoke` | `remote validate` |
+| `pi smoke` | `pi validate smoke` |
+
+- [ ] **Step 4: Re-run grep to verify**
+
+Run: `grep -rn "yoyoctl" CLAUDE.md README.md AGENTS.md docs/ rules/ skills/`
+Expected: No matches.
+
+- [ ] **Step 5: Run the quality gate**
+
+Run: `uv run python scripts/quality.py ci`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md README.md AGENTS.md docs/ rules/ skills/
+git commit -m "docs: rename yoyoctl → yoyopod across docs/skills/rules"
+```
+
+---
+
+## Task 27: Final verification
+
+**Files:** (none — verification only)
+
+- [ ] **Step 1: Clean install and test from scratch**
+
+Run:
+```bash
+rm -rf .venv
+uv sync --extra dev
+uv run yoyopod --version
+```
+Expected: `yoyopod 0.1.0`
+
+- [ ] **Step 2: Full CI**
+
+Run: `uv run python scripts/quality.py ci`
+Expected: PASS.
+
+Run: `uv run pytest tests/`
+Expected: PASS.
+
+- [ ] **Step 3: Verify `yoyopod dev docs` round-trip**
+
+Run:
+```bash
+uv run yoyopod dev docs
+git diff yoyopod_cli/COMMANDS.md
+```
+Expected: No diff — `COMMANDS.md` is already in sync.
+
+- [ ] **Step 4: Sanity-check help output**
+
+Run:
+```bash
+uv run yoyopod --help
+uv run yoyopod remote --help
+uv run yoyopod pi --help
+uv run yoyopod pi validate --help
+uv run yoyopod pi validate voip --help
+```
+
+Visually confirm:
+- Top-level shortcuts (`deploy`, `status`, `logs`, `restart`, `validate`) are visible.
+- `remote` group lists every KEEP command from the spec and no CUT command.
+- `pi validate` lists `deploy`, `smoke`, `music`, `voip`, `stability`, `navigation`, `lvgl`.
+- `pi validate voip --help` shows the `--soak` flag.
+
+- [ ] **Step 5: Real-hardware validation (optional — ideally on Pi)**
+
+If a Pi is reachable:
+
+```bash
+uv run yoyopod deploy
+uv run yoyopod pi validate deploy
+uv run yoyopod pi validate smoke
+```
+
+Expected: deploy → smoke passes end-to-end.
+
+- [ ] **Step 6: Final commit (if any trailing fixes)**
+
+If any of the steps above required fixes, commit them:
+
+```bash
+git add .
+git commit -m "chore(cli): final fixes from verification"
+```
+
+---
+
+## Self-Review Checklist
+
+### Spec coverage
+- §2 In scope: all 10 bullets covered by Tasks 1–27. ✓
+- §3 Target layout: Tasks 1–17 create the listed files. Tasks 23 deletes the old tree. ✓
+- §4 Command triage: KEEP list covered by Tasks 6–18. CUT list handled by not porting + Task 25. Top-level shortcuts in Task 19. ✓
+- §5 Command pattern: Applied in every port task (6–17). ✓
+- §6 Shared remote options: Task 4. ✓
+- §7 paths.py: Task 2. ✓
+- §8 main.py entry: Tasks 5, 13, 18, 19. ✓
+- §9 COMMANDS.md auto-generation + CI check: Tasks 20, 21. ✓
+- §10 Testing approach: Tasks 24, 25 (migrations + deletions). New tests added throughout. ✓
+- §11 Documentation updates: Task 26. ✓
+- §12 Migration / cutover: Tasks 1–27 map 1:1 against §12's 14 steps (some split for bite-size). ✓
+- pyproject.toml gate paths: Task 22. ✓
+
+### Placeholder scan
+- No `TBD` / `TODO` / `FIXME` in code blocks.
+- No "add error handling" — all error paths in templates are explicit.
+- Code blocks provided wherever a step changes code.
+- Commit messages show exact text.
+
+### Type consistency
+- `RemoteConnection` signature consistent across Tasks 3, 4, 8, 10, 11, 12, 13, 19.
+- `PiPaths` fields consistent across Tasks 2, 8, 10.
+- Helper function names: `_build_*` convention applied uniformly across all port tasks.
+- `pi_conn(ctx)` used consistently in every remote command.
+- `configure_logging(verbose)` used consistently as first line of every handler.
+
+All clear.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-20-cli-polish.md`.**
+
+Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Best for a refactor this size where each task is independently reviewable.
+
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-04-21-phase-a-call.md
+++ b/docs/superpowers/plans/2026-04-21-phase-a-call.md
@@ -1,0 +1,1268 @@
+# Phase A — Plan 6: Call Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the biggest single piece of the spine — `VoIPManager` (618 LOC) + `CallCoordinator` (520 LOC) + `CallFSM` + `CallInterruptionPolicy` — into `integrations/call/`. This is where the 8-hop pseudo-reactive chain collapses to a 5-hop direct-call chain. After this plan lands, the maintainability pain point described in the Phase A spec §1 is gone.
+
+**Architecture:** `LiblinphoneBackend` moves to `src/yoyopod/backends/voip/`. VoIPManager's responsibilities distribute across `integrations/call/{handlers,messaging,voice_notes,history}.py`. Call lifecycle is no longer managed by a FSM object — `call.state` entity is the source of truth, handlers transition it on backend events. Focus integration handles call-interrupts-music (no `CallInterruptionPolicy` needed).
+
+**Tech Stack:** Python 3.12+, pytest, uv, existing Liblinphone shim + cffi binding.
+
+**Spec reference:** spec §3.2, §5 (call entities), §7 (call commands), §9.1 (VoIPManager/CallCoordinator/CallFSM/CallInterruptionPolicy deletion), §9.2.
+
+**Prerequisite:** Plans 1-5 executed; `focus` and `music` integrations working.
+
+---
+
+## File Structure
+
+### Files to create
+
+- `src/yoyopod/backends/voip/__init__.py`
+- `src/yoyopod/backends/voip/liblinphone.py` (moved from `src/yoyopod/communication/calling/backend.py`)
+- `src/yoyopod/backends/voip/binding.py` (moved from `src/yoyopod/communication/integrations/liblinphone_binding/binding.py`)
+- `src/yoyopod/backends/voip/shim_native/` (moved from `src/yoyopod/communication/integrations/liblinphone_binding/native/` — keep structure)
+- `src/yoyopod/integrations/call/__init__.py`
+- `src/yoyopod/integrations/call/commands.py`
+- `src/yoyopod/integrations/call/events.py`
+- `src/yoyopod/integrations/call/handlers.py`
+- `src/yoyopod/integrations/call/messaging.py` (moved from `src/yoyopod/communication/calling/messaging.py`)
+- `src/yoyopod/integrations/call/voice_notes.py` (moved from `src/yoyopod/communication/calling/voice_notes.py`)
+- `src/yoyopod/integrations/call/history.py` (moved from `src/yoyopod/communication/calling/history.py`)
+- `src/yoyopod/integrations/call/models.py` (moved from `src/yoyopod/communication/models.py`)
+- `tests/integrations/test_call.py`
+
+### Files to delete (after migration)
+
+- `src/yoyopod/communication/calling/manager.py` (VoIPManager)
+- `src/yoyopod/communication/calling/backend.py` (moved)
+- `src/yoyopod/communication/calling/messaging.py` (moved)
+- `src/yoyopod/communication/calling/voice_notes.py` (moved)
+- `src/yoyopod/communication/calling/history.py` (moved)
+- `src/yoyopod/communication/models.py` (moved)
+- `src/yoyopod/communication/calling/__init__.py`
+- `src/yoyopod/communication/__init__.py`
+- `src/yoyopod/communication/messaging/store.py` and `__init__.py` (likely stays or moves — check)
+- `src/yoyopod/coordinators/call.py` (CallCoordinator)
+
+---
+
+## Task 1: Branch state verification
+
+- [ ] **Step 1.1**
+
+```bash
+git log --oneline -25
+ls src/yoyopod/integrations/
+uv run pytest tests/ -q
+```
+
+Expected: 10 integrations present; all tests green.
+
+---
+
+## Task 2: Relocate Liblinphone backend
+
+- [ ] **Step 2.1: Move backend files**
+
+```bash
+mkdir -p src/yoyopod/backends/voip
+git mv src/yoyopod/communication/calling/backend.py src/yoyopod/backends/voip/liblinphone.py
+git mv src/yoyopod/communication/integrations/liblinphone_binding/binding.py src/yoyopod/backends/voip/binding.py
+```
+
+The native shim directory may contain C source; move the whole directory:
+
+```bash
+git mv src/yoyopod/communication/integrations/liblinphone_binding/native src/yoyopod/backends/voip/shim_native
+# If there's also an __init__.py at binding level:
+[ -f src/yoyopod/communication/integrations/liblinphone_binding/__init__.py ] && git rm src/yoyopod/communication/integrations/liblinphone_binding/__init__.py
+```
+
+- [ ] **Step 2.2: Move shared communication models**
+
+```bash
+git mv src/yoyopod/communication/models.py src/yoyopod/integrations/call/models.py
+```
+
+- [ ] **Step 2.3: Update imports everywhere**
+
+```bash
+grep -rn "from yoyopod.communication.calling.backend\|from yoyopod.communication.integrations.liblinphone_binding\|from yoyopod.communication.models\|from yoyopod.communication import" src/ tests/
+```
+
+Rewrite to new paths:
+- `yoyopod.communication.calling.backend` → `yoyopod.backends.voip.liblinphone`
+- `yoyopod.communication.integrations.liblinphone_binding.binding` → `yoyopod.backends.voip.binding`
+- `yoyopod.communication.models` → `yoyopod.integrations.call.models`
+- `yoyopod.communication import CallHistoryStore, VoIPManager` → (CallHistoryStore moves later; VoIPManager is about to die — stub temporarily)
+
+- [ ] **Step 2.4: Create `src/yoyopod/backends/voip/__init__.py`**
+
+```python
+"""Liblinphone-based VoIP backend adapter."""
+
+from __future__ import annotations
+
+from yoyopod.backends.voip.liblinphone import LiblinphoneBackend, VoIPBackend
+
+__all__ = ["LiblinphoneBackend", "VoIPBackend"]
+```
+
+- [ ] **Step 2.5: Run the current VoIP tests to confirm imports still resolve**
+
+```bash
+uv run pytest tests/test_voip_backend.py -v
+```
+
+Expected: pass (test exercises the adapter through the new import path).
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(voip): move Liblinphone backend + binding to backends/voip/
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Relocate messaging, voice_notes, history submodules
+
+- [ ] **Step 3.1: Create `integrations/call/` structure and move files**
+
+```bash
+mkdir -p src/yoyopod/integrations/call
+git mv src/yoyopod/communication/calling/messaging.py src/yoyopod/integrations/call/messaging.py
+git mv src/yoyopod/communication/calling/voice_notes.py src/yoyopod/integrations/call/voice_notes.py
+git mv src/yoyopod/communication/calling/history.py src/yoyopod/integrations/call/history.py
+```
+
+- [ ] **Step 3.2: Move the message store**
+
+```bash
+git mv src/yoyopod/communication/messaging/store.py src/yoyopod/integrations/call/message_store.py
+```
+
+- [ ] **Step 3.3: Update internal imports inside moved files**
+
+Grep + rewrite:
+```bash
+grep -rn "from yoyopod.communication" src/yoyopod/integrations/call/
+```
+
+Targets:
+- `from yoyopod.communication.models import …` → `from yoyopod.integrations.call.models import …`
+- `from yoyopod.communication.calling.backend` → `from yoyopod.backends.voip.liblinphone`
+- `from yoyopod.communication.messaging.store` → `from yoyopod.integrations.call.message_store`
+
+- [ ] **Step 3.4: Run CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+Any import errors — fix in place. Tests that asserted exact class locations may need path updates.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(call): relocate messaging, voice_notes, history under integrations/call/
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Write call commands
+
+- [ ] **Step 4.1: Create `src/yoyopod/integrations/call/commands.py`**
+
+```python
+"""Typed commands for the call integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class DialCommand:
+    """Place an outgoing call to the given SIP address."""
+
+    address: str
+    display_name: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class AnswerCommand:
+    """Answer the incoming call."""
+
+
+@dataclass(frozen=True, slots=True)
+class HangupCommand:
+    """End the current call."""
+
+
+@dataclass(frozen=True, slots=True)
+class RejectCommand:
+    """Reject an incoming call."""
+
+
+@dataclass(frozen=True, slots=True)
+class MuteCommand:
+    """Mute the local microphone."""
+
+
+@dataclass(frozen=True, slots=True)
+class UnmuteCommand:
+    """Unmute the local microphone."""
+
+
+@dataclass(frozen=True, slots=True)
+class SendMessageCommand:
+    """Send a text message to the given SIP address."""
+
+    recipient_address: str
+    text: str
+    display_name: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class StartVoiceNoteCommand:
+    """Begin recording a voice note for a recipient."""
+
+    recipient_address: str
+    recipient_name: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class StopVoiceNoteCommand:
+    """Stop recording; prepare the draft for review/send."""
+
+
+@dataclass(frozen=True, slots=True)
+class SendVoiceNoteCommand:
+    """Send the currently active voice-note draft."""
+
+
+@dataclass(frozen=True, slots=True)
+class CancelVoiceNoteCommand:
+    """Discard the in-progress voice-note recording."""
+
+
+@dataclass(frozen=True, slots=True)
+class PlayVoiceNoteCommand:
+    """Play a recorded voice note back through the local speaker."""
+
+    file_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class MarkVoiceNotesSeenCommand:
+    """Clear unread-voice-note markers for the given SIP address."""
+
+    address: str
+```
+
+- [ ] **Step 4.2: Commit**
+
+```bash
+git add src/yoyopod/integrations/call/commands.py
+git commit -m "feat(integrations/call): 13 typed commands
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Write call events
+
+- [ ] **Step 5.1: Create `src/yoyopod/integrations/call/events.py`**
+
+```python
+"""Domain events for the call integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from yoyopod.integrations.call.models import (
+    CallState,
+    RegistrationState,
+    VoIPMessageRecord,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CallBackendStateEvent:
+    """Raw backend-reported call state — internal to the call integration."""
+
+    state: CallState
+    caller_address: str = ""
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class CallIncomingEvent:
+    """An incoming call has arrived and ringing should start."""
+
+    caller_address: str
+    caller_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class MessageReceivedEvent:
+    """An inbound text message or media payload arrived."""
+
+    record: VoIPMessageRecord
+
+
+@dataclass(frozen=True, slots=True)
+class MessageDeliveryChangedEvent:
+    """Outbound message delivery state updated."""
+
+    record: VoIPMessageRecord
+
+
+@dataclass(frozen=True, slots=True)
+class VoiceNoteCompletedEvent:
+    """A voice-note recording finished and is ready for review/send."""
+
+    draft_path: str
+    recipient_address: str
+
+
+@dataclass(frozen=True, slots=True)
+class RegistrationChangedEvent:
+    """SIP registration state updated."""
+
+    state: RegistrationState
+    reason: str = ""
+```
+
+- [ ] **Step 5.2: Commit**
+
+```bash
+git add src/yoyopod/integrations/call/events.py
+git commit -m "feat(integrations/call): domain events
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Write call handlers
+
+This is the meat — the logic that was spread across `VoIPManager._handle_backend_event`, `CallCoordinator.handle_call_state_change`, `handle_call_ended`, and the pause/resume shuttle.
+
+- [ ] **Step 6.1: Create `src/yoyopod/integrations/call/handlers.py`**
+
+```python
+"""Call-lifecycle handlers.
+
+Consumes CallBackendStateEvent from the backend and mutates `call.state` /
+`call.caller` / `call.registration` entities. Requests audio focus on incoming
+or outgoing call start; releases focus when call ends. Auto-resume of music is
+handled by the music integration via its AudioFocusLostEvent subscriber +
+re-request on our release (the focus arbiter fires events naturally).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.integrations.call.events import (
+    CallBackendStateEvent,
+    CallIncomingEvent,
+    RegistrationChangedEvent,
+)
+from yoyopod.integrations.call.models import CallState, RegistrationState
+from yoyopod.integrations.focus.arbiter import release_focus, request_focus
+
+
+def handle_backend_state(app: Any, event: CallBackendStateEvent) -> None:
+    """Main dispatcher for backend-reported call state changes."""
+    state = event.state
+    logger.info("Call backend state: {}", state.value)
+
+    if state == CallState.INCOMING:
+        _enter_incoming(app, event.caller_address)
+        return
+
+    if state in (
+        CallState.OUTGOING,
+        CallState.OUTGOING_PROGRESS,
+        CallState.OUTGOING_RINGING,
+        CallState.OUTGOING_EARLY_MEDIA,
+    ):
+        _enter_outgoing(app, event.caller_address)
+        return
+
+    if state in (CallState.CONNECTED, CallState.STREAMS_RUNNING):
+        _enter_active(app)
+        return
+
+    if state in (CallState.RELEASED, CallState.END, CallState.ERROR):
+        _enter_idle(app, reason=state.value)
+        return
+
+
+def _enter_incoming(app: Any, caller_address: str) -> None:
+    name = _resolve_contact_name(app, caller_address)
+    app.states.set(
+        "call.state",
+        "incoming",
+        attrs={"caller_address": caller_address, "caller_name": name},
+    )
+    app.states.set("call.caller", {"address": caller_address, "display_name": name})
+    request_focus(app, "call")
+    app.bus.publish(CallIncomingEvent(caller_address=caller_address, caller_name=name))
+
+
+def _enter_outgoing(app: Any, callee_address: str) -> None:
+    name = _resolve_contact_name(app, callee_address)
+    app.states.set(
+        "call.state",
+        "outgoing",
+        attrs={"callee_address": callee_address, "callee_name": name},
+    )
+    app.states.set("call.caller", {"address": callee_address, "display_name": name})
+    request_focus(app, "call")
+
+
+def _enter_active(app: Any) -> None:
+    current = app.states.get("call.state")
+    attrs = dict(current.attrs) if current else {}
+    app.states.set("call.state", "active", attrs=attrs)
+
+
+def _enter_idle(app: Any, reason: str = "") -> None:
+    app.states.set("call.state", "idle", attrs={"reason": reason})
+    app.states.set("call.caller", None)
+    app.states.set("call.muted", False)
+    release_focus(app, "call")
+
+
+def handle_registration_changed(app: Any, event: RegistrationChangedEvent) -> None:
+    logger.info("SIP registration: {}", event.state.value)
+    app.states.set(
+        "call.registration",
+        event.state.value,
+        attrs={"reason": event.reason} if event.reason else None,
+    )
+
+
+def _resolve_contact_name(app: Any, address: str) -> str:
+    """Look up a display name for an address via the contacts integration."""
+    try:
+        from yoyopod.integrations.contacts.commands import LookupByAddressCommand
+        contact = app.services.call(
+            "contacts", "lookup_by_address", LookupByAddressCommand(address=address)
+        )
+        if contact is not None:
+            return str(getattr(contact, "display_name", address))
+    except Exception as exc:
+        logger.debug("Contact lookup failed for {}: {}", address, exc)
+    return _extract_username(address)
+
+
+def _extract_username(address: str | None) -> str:
+    if not address:
+        return "Unknown"
+    if "@" in address:
+        username_part = address.split("@", 1)[0]
+        if ":" in username_part:
+            return username_part.split(":")[-1]
+        return username_part
+    return address
+```
+
+- [ ] **Step 6.2: Commit**
+
+```bash
+git add src/yoyopod/integrations/call/handlers.py
+git commit -m "feat(integrations/call): backend-state handlers + registration handler
+
+Implements the call lifecycle state machine as state-entity transitions
+plus focus requests. No more CallFSM, CallCoordinator, or
+CallInterruptionPolicy — the focus arbiter does all the cross-domain
+coordination by publishing AudioFocusLostEvent.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Write call integration `setup()` / `teardown()`
+
+- [ ] **Step 7.1: Create `src/yoyopod/integrations/call/__init__.py`**
+
+```python
+"""Call integration: SIP calls, messages, voice notes, history, registration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.integrations.call.commands import (
+    AnswerCommand,
+    CancelVoiceNoteCommand,
+    DialCommand,
+    HangupCommand,
+    MarkVoiceNotesSeenCommand,
+    MuteCommand,
+    PlayVoiceNoteCommand,
+    RejectCommand,
+    SendMessageCommand,
+    SendVoiceNoteCommand,
+    StartVoiceNoteCommand,
+    StopVoiceNoteCommand,
+    UnmuteCommand,
+)
+from yoyopod.integrations.call.events import (
+    CallBackendStateEvent,
+    MessageDeliveryChangedEvent,
+    MessageReceivedEvent,
+    RegistrationChangedEvent,
+    VoiceNoteCompletedEvent,
+)
+from yoyopod.integrations.call.handlers import (
+    handle_backend_state,
+    handle_registration_changed,
+)
+from yoyopod.integrations.call.models import (
+    CallState,
+    IncomingCallDetected,
+    CallStateChanged,
+    RegistrationStateChanged,
+    MessageReceived,
+    MessageDeliveryChanged,
+    MessageFailed,
+    BackendStopped,
+)
+
+_STATE_KEY = "_call_integration"
+
+
+def setup(
+    app: Any,
+    backend: Any | None = None,
+    message_store: Any | None = None,
+    call_history: Any | None = None,
+) -> None:
+    if backend is None:
+        from yoyopod.backends.voip import LiblinphoneBackend
+        backend = LiblinphoneBackend(app.config.voip)
+
+    if message_store is None:
+        from yoyopod.integrations.call.message_store import VoIPMessageStore
+        from pathlib import Path
+        store_dir = Path(app.config.voip.message_store_dir)
+        store_dir.mkdir(parents=True, exist_ok=True)
+        message_store = VoIPMessageStore(store_dir)
+
+    if call_history is None:
+        from yoyopod.integrations.call.history import CallHistoryStore
+        call_history = CallHistoryStore(app.config.voip)
+        call_history.load()
+
+    # Initial state.
+    app.states.set("call.state", "idle")
+    app.states.set("call.muted", False)
+    app.states.set("call.registration", "none")
+    app.states.set("call.history_unread_count", call_history.missed_count())
+
+    # Route backend events into typed CallBackendStateEvent + others on the bus.
+    def route_backend_event(ev: Any) -> None:
+        if isinstance(ev, CallStateChanged):
+            app.scheduler.run_on_main(
+                lambda: app.bus.publish(
+                    CallBackendStateEvent(state=ev.state, caller_address="")
+                )
+            )
+        elif isinstance(ev, IncomingCallDetected):
+            app.scheduler.run_on_main(
+                lambda: app.bus.publish(
+                    CallBackendStateEvent(state=CallState.INCOMING, caller_address=ev.caller_address)
+                )
+            )
+        elif isinstance(ev, RegistrationStateChanged):
+            app.scheduler.run_on_main(
+                lambda: app.bus.publish(
+                    RegistrationChangedEvent(state=ev.state)
+                )
+            )
+        elif isinstance(ev, MessageReceived):
+            app.scheduler.run_on_main(
+                lambda msg=ev.message: _on_message_received(app, message_store, msg)
+            )
+        elif isinstance(ev, MessageDeliveryChanged):
+            app.scheduler.run_on_main(
+                lambda msg=ev.message: _on_message_delivery_changed(app, message_store, msg)
+            )
+        elif isinstance(ev, MessageFailed):
+            app.scheduler.run_on_main(
+                lambda reason=ev.reason, mid=ev.message_id: logger.error(
+                    "Message {} failed: {}", mid, reason
+                )
+            )
+        elif isinstance(ev, BackendStopped):
+            app.scheduler.run_on_main(
+                lambda reason=ev.reason: logger.warning("Liblinphone backend stopped: {}", reason)
+            )
+
+    backend.on_event(route_backend_event)
+
+    # Subscribe to typed bus events — dispatch to handlers.
+    app.bus.subscribe(
+        CallBackendStateEvent,
+        lambda ev: handle_backend_state(app, ev),
+    )
+    app.bus.subscribe(
+        RegistrationChangedEvent,
+        lambda ev: handle_registration_changed(app, ev),
+    )
+
+    # Commands.
+    def handle_dial(cmd: DialCommand) -> None:
+        backend.make_call(cmd.address, display_name=cmd.display_name)
+
+    def handle_answer(_cmd: AnswerCommand) -> None:
+        backend.answer_call()
+
+    def handle_hangup(_cmd: HangupCommand) -> None:
+        backend.hangup()
+
+    def handle_reject(_cmd: RejectCommand) -> None:
+        backend.reject_call()
+
+    def handle_mute(_cmd: MuteCommand) -> None:
+        if backend.mute():
+            app.states.set("call.muted", True)
+
+    def handle_unmute(_cmd: UnmuteCommand) -> None:
+        if backend.unmute():
+            app.states.set("call.muted", False)
+
+    def handle_send_message(cmd: SendMessageCommand) -> None:
+        from yoyopod.integrations.call.messaging import MessagingService
+        service = MessagingService(
+            config=app.config.voip,
+            backend=backend,
+            message_store=message_store,
+            lookup_contact_name=lambda addr: _lookup(app, addr),
+        )
+        service.send_text_message(cmd.recipient_address, cmd.text, cmd.display_name)
+
+    def handle_start_voice_note(cmd: StartVoiceNoteCommand) -> None:
+        from yoyopod.integrations.call.voice_notes import VoiceNoteService
+        service = VoiceNoteService(
+            config=app.config.voip,
+            backend=backend,
+            message_store=message_store,
+            lookup_contact_name=lambda addr: _lookup(app, addr),
+            notify_message_summary_change=lambda: None,
+        )
+        service.start_voice_note_recording(cmd.recipient_address, cmd.recipient_name)
+        setattr(app, _STATE_KEY + "_voice_note_service", service)
+
+    def handle_stop_voice_note(_cmd: StopVoiceNoteCommand) -> None:
+        service = getattr(app, _STATE_KEY + "_voice_note_service", None)
+        if service is None:
+            return
+        draft = service.stop_voice_note_recording()
+        if draft is not None:
+            app.bus.publish(
+                VoiceNoteCompletedEvent(
+                    draft_path=draft.file_path,
+                    recipient_address=draft.recipient_address,
+                )
+            )
+
+    def handle_send_voice_note(_cmd: SendVoiceNoteCommand) -> None:
+        service = getattr(app, _STATE_KEY + "_voice_note_service", None)
+        if service is not None:
+            service.send_active_voice_note()
+
+    def handle_cancel_voice_note(_cmd: CancelVoiceNoteCommand) -> None:
+        service = getattr(app, _STATE_KEY + "_voice_note_service", None)
+        if service is not None:
+            service.cancel_voice_note_recording()
+
+    def handle_play_voice_note(cmd: PlayVoiceNoteCommand) -> None:
+        service = getattr(app, _STATE_KEY + "_voice_note_service", None)
+        if service is not None:
+            service.play_voice_note(cmd.file_path)
+
+    def handle_mark_seen(cmd: MarkVoiceNotesSeenCommand) -> None:
+        call_history.mark_voice_notes_seen(cmd.address)
+        app.states.set("call.history_unread_count", call_history.missed_count())
+
+    app.services.register("call", "dial", handle_dial)
+    app.services.register("call", "answer", handle_answer)
+    app.services.register("call", "hangup", handle_hangup)
+    app.services.register("call", "reject", handle_reject)
+    app.services.register("call", "mute", handle_mute)
+    app.services.register("call", "unmute", handle_unmute)
+    app.services.register("call", "send_message", handle_send_message)
+    app.services.register("call", "start_voice_note", handle_start_voice_note)
+    app.services.register("call", "stop_voice_note", handle_stop_voice_note)
+    app.services.register("call", "send_voice_note", handle_send_voice_note)
+    app.services.register("call", "cancel_voice_note", handle_cancel_voice_note)
+    app.services.register("call", "play_voice_note", handle_play_voice_note)
+    app.services.register("call", "mark_voice_notes_seen", handle_mark_seen)
+
+    backend.start()
+
+    setattr(app, _STATE_KEY, {
+        "backend": backend,
+        "message_store": message_store,
+        "call_history": call_history,
+    })
+
+
+def teardown(app: Any) -> None:
+    state = getattr(app, _STATE_KEY, None)
+    if state is None:
+        return
+    try:
+        state["backend"].stop()
+    except Exception as exc:
+        logger.error("VoIP backend stop: {}", exc)
+    delattr(app, _STATE_KEY)
+    if hasattr(app, _STATE_KEY + "_voice_note_service"):
+        delattr(app, _STATE_KEY + "_voice_note_service")
+
+
+def _on_message_received(app: Any, message_store: Any, record: Any) -> None:
+    message_store.upsert(record)
+    app.bus.publish(MessageReceivedEvent(record=record))
+
+
+def _on_message_delivery_changed(app: Any, message_store: Any, record: Any) -> None:
+    message_store.upsert(record)
+    app.bus.publish(MessageDeliveryChangedEvent(record=record))
+
+
+def _lookup(app: Any, address: str) -> str:
+    try:
+        from yoyopod.integrations.contacts.commands import LookupByAddressCommand
+        contact = app.services.call(
+            "contacts", "lookup_by_address", LookupByAddressCommand(address=address)
+        )
+        if contact is not None:
+            return str(getattr(contact, "display_name", address))
+    except Exception:
+        pass
+    if "@" in address:
+        return address.split("@", 1)[0]
+    return address
+```
+
+- [ ] **Step 7.2: Create `tests/integrations/test_call.py`**
+
+```python
+from dataclasses import dataclass, field
+from typing import Callable
+
+import pytest
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.call import setup as setup_call, teardown as teardown_call
+from yoyopod.integrations.call.commands import (
+    AnswerCommand,
+    DialCommand,
+    HangupCommand,
+    MuteCommand,
+    UnmuteCommand,
+)
+from yoyopod.integrations.call.events import CallIncomingEvent
+from yoyopod.integrations.call.models import (
+    CallState,
+    CallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged,
+)
+from yoyopod.integrations.focus import setup as setup_focus, teardown as teardown_focus
+
+
+@dataclass
+class _FakeVoipBackend:
+    event_cb: Callable | None = None
+    started: bool = False
+    stopped: bool = False
+    calls_made: list[str] = field(default_factory=list)
+    answered: int = 0
+    hung_up: int = 0
+    rejected: int = 0
+    muted: bool = False
+
+    def on_event(self, cb):
+        self.event_cb = cb
+
+    def start(self):
+        self.started = True
+        return True
+
+    def stop(self):
+        self.stopped = True
+
+    def make_call(self, address, display_name=""):
+        self.calls_made.append(address)
+
+    def answer_call(self):
+        self.answered += 1
+
+    def hangup(self):
+        self.hung_up += 1
+
+    def reject_call(self):
+        self.rejected += 1
+
+    def mute(self):
+        self.muted = True
+        return True
+
+    def unmute(self):
+        self.muted = False
+        return True
+
+    def simulate_incoming(self, caller="sip:bob@x"):
+        if self.event_cb:
+            self.event_cb(IncomingCallDetected(caller_address=caller))
+
+    def simulate_state(self, state: CallState):
+        if self.event_cb:
+            self.event_cb(CallStateChanged(state=state))
+
+    def simulate_registration(self, state: RegistrationState):
+        if self.event_cb:
+            self.event_cb(RegistrationStateChanged(state=state))
+
+
+class _FakeMessageStore:
+    def upsert(self, record):
+        pass
+
+
+class _FakeCallHistory:
+    def __init__(self):
+        self._unread = 0
+
+    def load(self):
+        pass
+
+    def missed_count(self):
+        return self._unread
+
+    def mark_voice_notes_seen(self, address):
+        pass
+
+
+@pytest.fixture
+def app_with_call():
+    app = build_test_app()
+    backend = _FakeVoipBackend()
+    message_store = _FakeMessageStore()
+    call_history = _FakeCallHistory()
+    app.config = type("C", (), {"voip": type("VC", (), {"message_store_dir": "/tmp"})()})()
+
+    app.register_integration("focus", setup=lambda a: setup_focus(a), teardown=lambda a: teardown_focus(a))
+    app.register_integration(
+        "call",
+        setup=lambda a: setup_call(
+            a, backend=backend, message_store=message_store, call_history=call_history
+        ),
+        teardown=lambda a: teardown_call(a),
+    )
+    app.setup()
+    yield app, backend
+    app.stop()
+
+
+def test_setup_initial_state(app_with_call):
+    app, _ = app_with_call
+    assert app.states.get_value("call.state") == "idle"
+    assert app.states.get_value("call.muted") is False
+    assert app.states.get_value("call.registration") == "none"
+
+
+def test_incoming_call_updates_state_and_acquires_focus(app_with_call):
+    app, backend = app_with_call
+    captured: list[CallIncomingEvent] = []
+    app.bus.subscribe(CallIncomingEvent, lambda ev: captured.append(ev))
+
+    backend.simulate_incoming(caller="sip:alice@x")
+    app.drain()
+
+    assert app.states.get_value("call.state") == "incoming"
+    assert app.states.get_value("focus.owner") == "call"
+    assert len(captured) == 1
+    assert captured[0].caller_address == "sip:alice@x"
+
+
+def test_outgoing_call_acquires_focus(app_with_call):
+    app, backend = app_with_call
+    app.services.call("call", "dial", DialCommand(address="sip:bob@x"))
+    backend.simulate_state(CallState.OUTGOING)
+    app.drain()
+
+    assert app.states.get_value("call.state") == "outgoing"
+    assert app.states.get_value("focus.owner") == "call"
+    assert backend.calls_made == ["sip:bob@x"]
+
+
+def test_connected_transitions_to_active(app_with_call):
+    app, backend = app_with_call
+    backend.simulate_incoming()
+    app.drain()
+    backend.simulate_state(CallState.CONNECTED)
+    app.drain()
+
+    assert app.states.get_value("call.state") == "active"
+
+
+def test_released_transitions_to_idle_releases_focus(app_with_call):
+    app, backend = app_with_call
+    backend.simulate_incoming()
+    app.drain()
+    backend.simulate_state(CallState.CONNECTED)
+    app.drain()
+    backend.simulate_state(CallState.RELEASED)
+    app.drain()
+
+    assert app.states.get_value("call.state") == "idle"
+    assert app.states.get_value("focus.owner") is None
+
+
+def test_answer_command_invokes_backend(app_with_call):
+    app, backend = app_with_call
+    app.services.call("call", "answer", AnswerCommand())
+    assert backend.answered == 1
+
+
+def test_hangup_command_invokes_backend(app_with_call):
+    app, backend = app_with_call
+    app.services.call("call", "hangup", HangupCommand())
+    assert backend.hung_up == 1
+
+
+def test_mute_unmute_cycle(app_with_call):
+    app, backend = app_with_call
+    app.services.call("call", "mute", MuteCommand())
+    assert app.states.get_value("call.muted") is True
+    assert backend.muted is True
+
+    app.services.call("call", "unmute", UnmuteCommand())
+    assert app.states.get_value("call.muted") is False
+    assert backend.muted is False
+
+
+def test_registration_change_updates_state(app_with_call):
+    app, backend = app_with_call
+    backend.simulate_registration(RegistrationState.OK)
+    app.drain()
+
+    assert app.states.get_value("call.registration") == "ok"
+```
+
+- [ ] **Step 7.3: Run, commit**
+
+```bash
+uv run pytest tests/integrations/test_call.py -v
+uv run black src/yoyopod/integrations/call/ tests/integrations/test_call.py
+uv run ruff check src/yoyopod/integrations/call/ tests/integrations/test_call.py
+uv run mypy src/yoyopod/integrations/call/
+git add -A
+git commit -m "feat(integrations/call): setup/teardown + 13 commands + event-driven lifecycle
+
+VoIPManager's 618 LOC dissolved. CallCoordinator's 520 LOC gone.
+CallFSM and CallInterruptionPolicy gone. Call state lives in call.state
+entity; focus integration handles call-pre-empts-music.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Delete legacy VoIPManager, CallCoordinator
+
+- [ ] **Step 8.1: Enumerate**
+
+```bash
+grep -rn "VoIPManager\|CallCoordinator\|CallFSM\|CallInterruptionPolicy" src/ tests/
+```
+
+- [ ] **Step 8.2: Delete**
+
+```bash
+git rm src/yoyopod/communication/calling/manager.py
+git rm src/yoyopod/communication/calling/__init__.py
+git rm src/yoyopod/coordinators/call.py
+```
+
+Update `src/yoyopod/coordinators/__init__.py` (remove CallCoordinator re-export).
+
+Stub `src/yoyopod/app.py` references (Plan 8 does the full rewrite).
+
+- [ ] **Step 8.3: CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(call): delete VoIPManager, CallCoordinator, CallFSM, CallInterruptionPolicy
+
+All logic migrated to integrations/call/ and integrations/focus/.
+~1,200 LOC removed from the spine.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Cross-integration test — incoming call auto-pauses music
+
+This is the canonical proof that the rewrite achieves its primary goal.
+
+- [ ] **Step 9.1: Create `tests/e2e/test_call_pauses_music.py`**
+
+```bash
+mkdir -p tests/e2e
+touch tests/e2e/__init__.py
+```
+
+Create `tests/e2e/test_call_pauses_music.py`:
+
+```python
+from dataclasses import dataclass, field
+from typing import Callable
+
+import pytest
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.call import setup as setup_call, teardown as teardown_call
+from yoyopod.integrations.call.commands import HangupCommand
+from yoyopod.integrations.call.models import (
+    CallState,
+    CallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged,
+)
+from yoyopod.integrations.focus import setup as setup_focus, teardown as teardown_focus
+from yoyopod.integrations.music import setup as setup_music, teardown as teardown_music
+from yoyopod.integrations.music.commands import PlayCommand
+
+
+@dataclass
+class _FakeMpv:
+    playback_cb: Callable | None = None
+    track_cb: Callable | None = None
+    avail_cb: Callable | None = None
+    state: str = "idle"
+    play_calls: list[str] = field(default_factory=list)
+    pause_calls: int = 0
+
+    def start(self):
+        return True
+    def stop(self):
+        self.state = "idle"
+        if self.playback_cb: self.playback_cb("idle")
+    def shutdown(self):
+        pass
+    def play(self, uri, start_position=0.0):
+        self.play_calls.append(uri)
+        self.state = "playing"
+        if self.playback_cb: self.playback_cb("playing")
+    def pause(self):
+        self.pause_calls += 1
+        self.state = "paused"
+        if self.playback_cb: self.playback_cb("paused")
+    def resume(self):
+        self.state = "playing"
+        if self.playback_cb: self.playback_cb("playing")
+    def next_track(self): pass
+    def prev_track(self): pass
+    def seek(self, pos): pass
+    def set_volume(self, p): pass
+    def on_playback_state_change(self, cb): self.playback_cb = cb
+    def on_track_change(self, cb): self.track_cb = cb
+    def on_availability_change(self, cb): self.avail_cb = cb
+
+
+@dataclass
+class _FakeVoip:
+    event_cb: Callable | None = None
+    def on_event(self, cb): self.event_cb = cb
+    def start(self): return True
+    def stop(self): pass
+    def make_call(self, address, display_name=""): pass
+    def answer_call(self): pass
+    def hangup(self): pass
+    def reject_call(self): pass
+    def mute(self): return True
+    def unmute(self): return True
+    def simulate_incoming(self, caller="sip:bob@x"):
+        if self.event_cb: self.event_cb(IncomingCallDetected(caller_address=caller))
+    def simulate_state(self, state: CallState):
+        if self.event_cb: self.event_cb(CallStateChanged(state=state))
+
+
+class _FakeLibrary:
+    def record_recent_track(self, t): pass
+
+
+class _FakeMsgStore:
+    def upsert(self, r): pass
+
+
+class _FakeCallHistory:
+    def load(self): pass
+    def missed_count(self): return 0
+    def mark_voice_notes_seen(self, a): pass
+
+
+@pytest.fixture
+def app_full():
+    app = build_test_app()
+    mpv = _FakeMpv()
+    voip = _FakeVoip()
+    app.config = type("C", (), {
+        "audio": type("AC", (), {"default_volume": 70})(),
+        "voip": type("VC", (), {"message_store_dir": "/tmp"})(),
+    })()
+    app.register_integration("focus", setup=lambda a: setup_focus(a), teardown=lambda a: teardown_focus(a))
+    app.register_integration(
+        "music",
+        setup=lambda a: setup_music(a, backend=mpv, library=_FakeLibrary()),
+        teardown=lambda a: teardown_music(a),
+    )
+    app.register_integration(
+        "call",
+        setup=lambda a: setup_call(
+            a, backend=voip, message_store=_FakeMsgStore(), call_history=_FakeCallHistory()
+        ),
+        teardown=lambda a: teardown_call(a),
+    )
+    app.setup()
+    yield app, voip, mpv
+    app.stop()
+
+
+def test_incoming_call_auto_pauses_playing_music(app_full):
+    app, voip, mpv = app_full
+    app.services.call("music", "play", PlayCommand(track_uri="local:track.mp3"))
+    app.drain()
+    assert app.states.get_value("music.state") == "playing"
+    assert app.states.get_value("focus.owner") == "music"
+
+    voip.simulate_incoming(caller="sip:bob@x")
+    app.drain()
+
+    assert app.states.get_value("call.state") == "incoming"
+    assert app.states.get_value("focus.owner") == "call"
+    assert mpv.pause_calls == 1
+    assert app.states.get_value("music.state") == "paused"
+
+
+def test_call_released_leaves_music_paused_until_user_resumes(app_full):
+    app, voip, mpv = app_full
+    app.services.call("music", "play", PlayCommand(track_uri="local:x.mp3"))
+    app.drain()
+
+    voip.simulate_incoming()
+    app.drain()
+    voip.simulate_state(CallState.CONNECTED)
+    app.drain()
+    voip.simulate_state(CallState.RELEASED)
+    app.drain()
+
+    assert app.states.get_value("call.state") == "idle"
+    assert app.states.get_value("focus.owner") is None
+    # Music did NOT auto-resume — the user decides via explicit command.
+    assert app.states.get_value("music.state") == "paused"
+```
+
+- [ ] **Step 9.2: Run**
+
+```bash
+uv run pytest tests/e2e/test_call_pauses_music.py -v
+```
+
+Expected: both passing.
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git add -A
+git commit -m "test(e2e): incoming call auto-pauses music via focus arbiter
+
+Demonstrates the primary goal of the Phase A rewrite: cross-domain
+coordination happens via focus integration with zero direct dependency
+between music and call.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Final verification
+
+- [ ] **Step 10.1: Structure**
+
+```bash
+ls src/yoyopod/integrations/call/
+ls src/yoyopod/backends/voip/
+```
+
+Expected call: `__init__.py`, `commands.py`, `events.py`, `handlers.py`, `messaging.py`, `voice_notes.py`, `history.py`, `message_store.py`, `models.py`.
+Backend: `__init__.py`, `liblinphone.py`, `binding.py`, `shim_native/`.
+
+- [ ] **Step 10.2: No legacy classes linger**
+
+```bash
+git grep -l "VoIPManager\|CallCoordinator\|CallFSM\|CallInterruptionPolicy"
+```
+
+Expected: matches only in docs/ (spec/plan references).
+
+- [ ] **Step 10.3: CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green.
+
+---
+
+## Definition of Done
+
+- `integrations/call/` fully populated with 13 commands, 6 event types, handlers for call-state lifecycle + registration.
+- `backends/voip/` contains relocated Liblinphone adapter + binding + native shim.
+- VoIPManager, CallCoordinator, CallFSM, CallInterruptionPolicy all deleted.
+- End-to-end test demonstrates call-pauses-music via focus integration.
+- All tests green.
+
+---
+
+## What's next (Plan 7)
+
+`recovery` integration (re-home `RecoverySupervisor`), followed by touch-up of all 17 screens to consume `app.states` + `app.services` instead of manager references. This is the UI-side work that makes Phase A feel complete.
+
+---
+
+*End of implementation plan.*

--- a/docs/superpowers/plans/2026-04-21-phase-a-cleanup.md
+++ b/docs/superpowers/plans/2026-04-21-phase-a-cleanup.md
@@ -1,0 +1,540 @@
+# Phase A — Plan 8: Dead-Code Removal + Final Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Final Phase A housekeeping. Delete all remaining legacy files whose functionality has been fully absorbed into `core/` + `integrations/`. Rewrite `src/yoyopod/app.py` as a slim ~150-LOC composition root. Archive or delete stale documentation. Pass the full Pi hardware validation suite. Mark the Phase A spec `Status: Implemented`.
+
+**Architecture:** No new code. Deletions + `app.py` rewrite + docs hygiene.
+
+**Spec reference:** spec §9.1 (deleted outright), §11.2 steps 12-13, §14 Definition of Done.
+
+**Prerequisite:** Plans 1-7 executed. All 12 integrations in `integrations/`. All 17 screens use `app` constructor. `src/yoyopod/runtime/` gone. `src/yoyopod/coordinators/` reduced to `__init__.py` + any stragglers.
+
+---
+
+## File Structure
+
+### Files to rewrite
+
+- `src/yoyopod/app.py` — replace legacy shell with a ~150 LOC composition-root that constructs `YoyoPodApp`, registers integrations, runs.
+
+### Files to delete
+
+- `src/yoyopod/fsm.py` (MusicFSM, CallFSM, CallInterruptionPolicy — already delete-pending since Plan 2, confirm no remaining consumers)
+- `src/yoyopod/event_bus.py` (replaced by `core/bus.py`)
+- `src/yoyopod/events.py` (replaced by `core/events.py` + per-integration events)
+- `src/yoyopod/coordinators/` (entire directory — CoordinatorRuntime, AppRuntimeState, any stragglers)
+- `src/yoyopod/app_context.py` (AppContext)
+- `src/yoyopod/communication/` (whole package — manager.py, calling/, integrations/, messaging/, models.py — all relocated)
+- Any empty legacy packages whose files have been moved away
+
+### Docs to archive or update
+
+- `docs/RUNTIME_EVENT_FLOW.md` — archive (move to `docs/archive/`)
+- `docs/SYSTEM_ARCHITECTURE.md` — update to reflect new architecture
+- `docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md` — mark `Status: Implemented`
+- `CLAUDE.md` — update "Source of Truth" file list
+
+---
+
+## Task 1: Branch state verification
+
+- [ ] **Step 1.1**
+
+```bash
+git log --oneline -40
+ls src/yoyopod/integrations/
+uv run pytest tests/ -q
+```
+
+Expected: Plans 1-7 all landed; all tests green; 12 integrations populated; `src/yoyopod/runtime/` gone.
+
+- [ ] **Step 1.2: Inventory legacy files remaining**
+
+```bash
+ls -la src/yoyopod/fsm.py src/yoyopod/event_bus.py src/yoyopod/events.py 2>/dev/null
+ls -la src/yoyopod/coordinators/ 2>/dev/null
+ls -la src/yoyopod/communication/ 2>/dev/null
+ls -la src/yoyopod/app_context.py 2>/dev/null
+```
+
+Record what's still present. Anything that's already gone, skip in the corresponding delete step.
+
+---
+
+## Task 2: Delete legacy FSMs + event bus + events + app_context
+
+- [ ] **Step 2.1: Confirm no consumers outside already-scheduled-for-rewrite files**
+
+```bash
+grep -rn "from yoyopod.fsm\|from yoyopod.event_bus\|from yoyopod.events\|from yoyopod.app_context" src/ tests/
+```
+
+Consumers: expected only in `src/yoyopod/app.py` (legacy shell, about to be rewritten) and `src/yoyopod/main.py` (entry point, may need update). If a test file still references these, it's slated for deletion per spec §12.1 or needs migration.
+
+- [ ] **Step 2.2: Delete legacy files**
+
+```bash
+git rm src/yoyopod/fsm.py
+git rm src/yoyopod/event_bus.py
+git rm src/yoyopod/events.py
+git rm src/yoyopod/app_context.py
+```
+
+- [ ] **Step 2.3: Delete legacy tests that are no longer applicable**
+
+Per spec §12.1:
+```bash
+git rm tests/test_fsm_runtime.py 2>/dev/null || true
+# tests/test_event_bus.py was rewritten in Plan 1 — keep or delete based on current state
+```
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: delete legacy fsm.py, event_bus.py, events.py, app_context.py
+
+All functionality absorbed into src/yoyopod/core/.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Delete coordinators/ directory
+
+- [ ] **Step 3.1: Confirm no consumers**
+
+```bash
+grep -rn "from yoyopod.coordinators\|CoordinatorRuntime\|AppRuntimeState" src/ tests/
+```
+
+Expected: matches only in docs/ (spec/plans) and possibly `app.py` (to be rewritten).
+
+- [ ] **Step 3.2: Delete**
+
+```bash
+git rm -r src/yoyopod/coordinators/
+```
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: delete src/yoyopod/coordinators/ entirely
+
+CallCoordinator, PlaybackCoordinator, ScreenCoordinator, PowerCoordinator,
+CoordinatorRuntime, AppRuntimeState all obsolete. Replaced by integrations +
+state store + focus arbiter.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Delete communication/ directory
+
+- [ ] **Step 4.1: Confirm all files relocated**
+
+```bash
+ls src/yoyopod/communication/
+```
+
+Expected: `__init__.py`, maybe empty `calling/`, `integrations/`, `messaging/` directories. Anything non-empty here means relocation in Plan 6 missed a file — fix now.
+
+- [ ] **Step 4.2: Delete**
+
+```bash
+git rm -r src/yoyopod/communication/
+```
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: delete src/yoyopod/communication/ (all code relocated)
+
+VoIPManager -> integrations/call/
+LiblinphoneBackend -> backends/voip/
+Models -> integrations/call/models.py
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Rewrite `src/yoyopod/app.py`
+
+Replace the legacy ~685 LOC shell with a slim composition root that constructs `YoyoPodApp`, loads config, registers integrations, and runs.
+
+- [ ] **Step 5.1: Write the new `src/yoyopod/app.py`**
+
+```python
+"""YoyoPod application entry point.
+
+Constructs a YoyoPodApp with config, registers integrations in dependency
+order, runs the main loop. See docs/superpowers/specs/2026-04-21-phase-a-
+spine-rewrite-design.md §3, §11.2 step 13.
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.config import load_config
+from yoyopod.core import YoyoPodApp
+
+
+# Integration registration order matters:
+# 1. diagnostics first so the event log captures later lifecycle events.
+# 2. recovery next so later integrations can register retry handlers.
+# 3. focus before music/call/voice (arbiter must exist first).
+# 4. contacts before call (call looks up names).
+# 5. network -> location (location shares modem serial).
+# 6. cloud, power at any time once bus/states/services exist.
+# 7. screen needs its ui_tick_callback set before run().
+# 8. music before call (call acquires focus which pre-empts music).
+INTEGRATION_MODULES = [
+    "yoyopod.integrations.diagnostics",
+    "yoyopod.integrations.recovery",
+    "yoyopod.integrations.focus",
+    "yoyopod.integrations.contacts",
+    "yoyopod.integrations.network",
+    "yoyopod.integrations.location",
+    "yoyopod.integrations.cloud",
+    "yoyopod.integrations.power",
+    "yoyopod.integrations.screen",
+    "yoyopod.integrations.voice",
+    "yoyopod.integrations.music",
+    "yoyopod.integrations.call",
+]
+
+
+def build_app(config_dir: str = "config", simulate: bool = False) -> YoyoPodApp:
+    """Construct and wire the app. Does not start the main loop."""
+    config = load_config(config_dir=config_dir, simulate=simulate)
+
+    app = YoyoPodApp(log_capacity=500)
+    app.config = config
+
+    for dotted in INTEGRATION_MODULES:
+        module = _import(dotted)
+        name = dotted.rsplit(".", 1)[-1]
+        setup = getattr(module, "setup")
+        teardown = getattr(module, "teardown", None)
+        app.register_integration(name, setup=setup, teardown=teardown)
+
+    return app
+
+
+def run(config_dir: str = "config", simulate: bool = False) -> None:
+    """Construct, setup, and run until SIGINT/SIGTERM."""
+    logger.info("=" * 60)
+    logger.info("YoyoPod starting (simulate={})", simulate)
+    logger.info("=" * 60)
+
+    app = build_app(config_dir=config_dir, simulate=simulate)
+
+    def handle_signal(signum: int, _frame: Any) -> None:
+        logger.info("Signal {} received; stopping", signum)
+        app.stop()
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    try:
+        app.setup()
+        app.run(tick_interval_seconds=0.005)
+    finally:
+        app.stop()
+
+    logger.info("YoyoPod stopped")
+
+
+def _import(dotted: str):
+    import importlib
+    return importlib.import_module(dotted)
+
+
+if __name__ == "__main__":
+    simulate = "--simulate" in sys.argv
+    run(simulate=simulate)
+```
+
+- [ ] **Step 5.2: Verify line count**
+
+```bash
+wc -l src/yoyopod/app.py
+```
+
+Expected: around 80 LOC (slimmer than the target "150 LOC" in the spec — even better).
+
+- [ ] **Step 5.3: Format/lint/type**
+
+```bash
+uv run black src/yoyopod/app.py
+uv run ruff check src/yoyopod/app.py
+uv run mypy src/yoyopod/app.py
+```
+
+- [ ] **Step 5.4: Update `src/yoyopod/main.py`**
+
+```python
+"""Package entry point — delegates to yoyopod.app.run."""
+
+from __future__ import annotations
+
+from yoyopod.app import run
+
+
+def main() -> None:
+    import sys
+    simulate = "--simulate" in sys.argv
+    run(simulate=simulate)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 5.5: CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(app): rewrite app.py as slim composition root
+
+685 LOC -> ~80 LOC. Constructs YoyoPodApp, registers 12 integrations in
+dependency order, handles SIGINT/SIGTERM, runs the main loop.
+All behaviour-specific logic lives in integrations; app.py is pure wiring.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Archive stale documentation
+
+- [ ] **Step 6.1: Move `RUNTIME_EVENT_FLOW.md` to archive**
+
+```bash
+mkdir -p docs/archive
+git mv docs/RUNTIME_EVENT_FLOW.md docs/archive/RUNTIME_EVENT_FLOW.md
+```
+
+- [ ] **Step 6.2: Update `docs/SYSTEM_ARCHITECTURE.md`**
+
+Replace the existing topology section with a new one pointing at the A+3 model:
+
+```markdown
+## Runtime architecture (post-Phase-A)
+
+```
+yoyopod.app:run()
+  -> build_app(config_dir, simulate)
+     -> YoyoPodApp (core/app_shell.py)
+        -> Bus, States, Services, Scheduler, LogBuffer (core/)
+        -> registered integrations (integrations/):
+           diagnostics, recovery, focus, contacts,
+           network, location, cloud, power,
+           screen, voice, music, call
+  -> app.setup()  (calls each integration's setup(app))
+  -> app.run()    (4-line loop: drain scheduler, drain bus, tick UI, sleep)
+```
+
+Integrations consume backends from `src/yoyopod/backends/`. Cross-domain
+coordination is via the focus integration's AudioFocus arbiter and
+typed events on the bus (see docs/superpowers/specs/2026-04-21-phase-a-
+spine-rewrite-design.md §6-7 for the event and command catalog).
+```
+
+- [ ] **Step 6.3: Update `CLAUDE.md` "Source of Truth" section**
+
+Update the list of canonical files:
+- Remove: `src/yoyopod/fsm.py`, `src/yoyopod/event_bus.py`, `src/yoyopod/events.py`, `src/yoyopod/coordinators/`, `src/yoyopod/app_context.py`.
+- Add: `src/yoyopod/core/`, `src/yoyopod/integrations/`, `src/yoyopod/backends/`.
+
+Update the "Runtime Architecture" ASCII diagram to match the new shape.
+
+- [ ] **Step 6.4: Commit doc updates**
+
+```bash
+git add -A
+git commit -m "docs: archive RUNTIME_EVENT_FLOW.md, update SYSTEM_ARCHITECTURE + CLAUDE.md
+
+Post-Phase-A architecture documented. Source-of-truth file list points at
+core/, integrations/, backends/ instead of legacy fsm/event_bus/coordinators.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Mark spec `Status: Implemented`
+
+- [ ] **Step 7.1: Edit the Phase A design spec header**
+
+Open `docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md`. Change:
+
+```markdown
+**Status:** Awaiting review
+```
+
+to:
+
+```markdown
+**Status:** Implemented (2026-04-21 — this is the date the final Phase A PR merged; replace with actual merge date)
+```
+
+- [ ] **Step 7.2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md
+git commit -m "docs: mark Phase A spec as Implemented
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Full CI + Pi hardware validation
+
+This is the pre-merge gate from spec §12.6.
+
+- [ ] **Step 8.1: Full local CI**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green. Any failure is a blocker.
+
+- [ ] **Step 8.2: Pi deploy smoke**
+
+```bash
+yoyopod pi validate deploy
+```
+
+Expected: green. The app starts on the Pi without error.
+
+- [ ] **Step 8.3: Pi validate suite**
+
+```bash
+yoyopod pi validate smoke
+yoyopod pi validate music
+yoyopod pi validate voip
+yoyopod pi validate stability
+```
+
+Expected: each green. Any regression is a blocker — debug before merging.
+
+- [ ] **Step 8.4: Manual on-Pi checklist**
+
+Exercise on real hardware:
+
+1. Place an outgoing call to a test SIP address; verify audio flows both ways; hang up.
+2. Receive an incoming call while music is playing. Verify:
+   - Music auto-pauses (focus arbiter works).
+   - Incoming-call screen appears with caller ID.
+   - Answer → audio flows → hang up.
+3. Receive an incoming call and reject it. Verify call history records it as missed.
+4. Record a voice note, review, send. Verify the recipient receives it (if the SIP peer supports SIMPLE).
+5. Graceful shutdown via power command. Verify clean exit.
+6. Wake from RTC alarm; verify clock sync.
+7. Kill mpv on the Pi (`pkill mpv`) and verify the recovery integration detects it and restarts.
+8. Kill Liblinphone activity and verify SIP re-registers.
+
+- [ ] **Step 8.5: Event-log review**
+
+Tail `~/.yoyopod/logs/events.jsonl` during the manual checklist. Confirm:
+- Every call state transition is logged.
+- Every music state change is logged.
+- Every focus grant/loss is logged.
+- No unexpected errors appear.
+- No `ResponsivenessLagEvent` appears unless intentionally stressing the device.
+
+---
+
+## Task 9: Merge to main
+
+- [ ] **Step 9.1: Rebase if main has moved**
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+Resolve conflicts if any (unlikely — main was frozen for Phase A).
+
+- [ ] **Step 9.2: Push and open PR**
+
+```bash
+git push -u origin arch/phase-a-spine-rewrite
+gh pr create --title "Phase A: spine rewrite (state store + typed bus + service registry)" --body "$(cat <<'EOF'
+## Summary
+
+Rewrites the YoyoPod spine to a Home-Assistant-style state store + typed
+event bus + service registry. Replaces the pseudo-reactive event bus
+(9 of 14 events pub-to-self) with direct-call integrations. Deletes
+FSMs, coordinators, runtime services, AppContext, VoIPManager, old
+event bus. `app.py` shrinks from ~685 to ~80 LOC.
+
+See docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md
+for the full design and docs/superpowers/plans/2026-04-21-phase-a-*.md
+for the 8 implementation plans that produced this branch.
+
+## Test plan
+
+- [ ] `uv run python scripts/quality.py ci` green
+- [ ] `yoyopod pi validate deploy` green on Pi
+- [ ] `yoyopod pi validate smoke` green on Pi
+- [ ] `yoyopod pi validate music` green on Pi
+- [ ] `yoyopod pi validate voip` green on Pi
+- [ ] `yoyopod pi validate stability` green on Pi
+- [ ] Manual on-Pi checklist (place/receive call, music auto-pause, voice note, shutdown, recovery)
+- [ ] Event-log review during manual tests — no unexpected errors, no ResponsivenessLagEvent
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 9.3: Squash-merge when PR is green**
+
+After review and all green checks:
+```bash
+gh pr merge --squash
+```
+
+---
+
+## Definition of Done (Phase A complete)
+
+- `src/yoyopod/core/` (primitives), `src/yoyopod/integrations/` (12 domains), `src/yoyopod/backends/` (adapters) all populated.
+- Legacy files/directories deleted: `fsm.py`, `event_bus.py`, `events.py`, `app_context.py`, `coordinators/`, `runtime/`, `communication/`.
+- `src/yoyopod/app.py` ≤ 150 LOC (actually ~80).
+- Spec marked `Implemented`.
+- Pi validation suite all green.
+- Branch merged to main.
+
+---
+
+## What's next (Phase B)
+
+HAL consolidation — see `docs/superpowers/specs/2026-04-21-phase-b-hal-consolidation-design.md`.
+
+---
+
+*End of implementation plan.*

--- a/docs/superpowers/plans/2026-04-21-phase-a-core-scaffold.md
+++ b/docs/superpowers/plans/2026-04-21-phase-a-core-scaffold.md
@@ -1,0 +1,2829 @@
+# Phase A — CLI Cleanup + Core Scaffold Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the first slice of Phase A on the long-lived `arch/phase-a-spine-rewrite` branch: remove lingering `yoyoctl` references, then build and test the `core/` primitives (`Bus`, `States`, `Services`, `MainThreadScheduler`, core events, log ring buffer, `YoyoPodApp` shell, and test helpers).
+
+**Architecture:** Single long-lived branch off `main`. Two-phase structure: (1) mechanical CLI rename cleanup; (2) TDD-driven construction of the `core/` package. Each primitive is its own module with its own unit-test file. The app shell composes the primitives but does no domain-specific work — that comes in later plans per integration.
+
+**Tech Stack:** Python 3.12+, pytest, uv, Typer (existing), loguru (existing), `dataclasses.dataclass(frozen=True, slots=True)`, stdlib `threading`/`queue`/`collections`. No new runtime dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md` §4 (Core primitives), §11.2 (steps 1-2).
+
+---
+
+## File Structure
+
+### Files to create
+
+- `src/yoyopod/core/__init__.py` — public surface of the core package
+- `src/yoyopod/core/bus.py` — typed event bus
+- `src/yoyopod/core/states.py` — entity state store
+- `src/yoyopod/core/services.py` — command registry
+- `src/yoyopod/core/scheduler.py` — main-thread scheduler
+- `src/yoyopod/core/events.py` — `StateChangedEvent`, `LifecycleEvent`
+- `src/yoyopod/core/logbuffer.py` — ring buffer for recent log entries
+- `src/yoyopod/core/app_shell.py` — `YoyoPodApp`
+- `src/yoyopod/core/testing.py` — `build_test_app`, `assert_events_contain`, `drain_all`
+- `tests/core/__init__.py`
+- `tests/core/test_bus.py`
+- `tests/core/test_states.py`
+- `tests/core/test_services.py`
+- `tests/core/test_scheduler.py`
+- `tests/core/test_events.py`
+- `tests/core/test_logbuffer.py`
+- `tests/core/test_app_shell.py`
+- `tests/core/test_testing_helpers.py`
+
+### Files to modify
+
+~40 files contain live `yoyoctl` references that need replacing with `yoyopod`. Grouped below.
+
+**Targeted edits (non-bulk, because of specific structure):**
+- `pyproject.toml` — drop the second `yoyoctl = "yoyopod.cli:run"` script entry entirely (not a find/replace).
+- `src/yoyopod/cli/__init__.py:14,52` — rename the Typer app and the missing-dep error message.
+
+**Bulk replace across the repo (yoyoctl → yoyopod), everywhere except the preservation list below:**
+- `src/yoyopod/cli/**/*.py` (17 files)
+- `src/yoyopod/ui/display/contracts.py`, `src/yoyopod/ui/display/adapters/whisplay.py`
+- `tests/test_setup_cli.py`, `tests/test_pi_remote.py`, `tests/test_cli.py`
+- `skills/yoyopod-*/SKILL.md` (6 files)
+- `rules/*.md` (4 files: lvgl, project, deploy, design-fidelity)
+- `docs/*.md` (live docs: SETUP_CONTRACT, RPI_SMOKE_VALIDATION, POWER_MODULE, PI_DEV_WORKFLOW, MPV_DEPENDENCIES, DEVELOPMENT_GUIDE, CUBIE_A7Z_PIMORONI_SETUP, CONTRIBUTOR_WORKFLOW)
+- `deploy/pi-deploy.yaml`
+- `CLAUDE.md`, `AGENTS.md`, `README.md`
+
+**Preservation list (DO NOT modify — historical or self-referential):**
+- `docs/superpowers/specs/2026-04-10-yoyoctl-cli-design.md` (the original `yoyoctl` design — must stay historically accurate)
+- `docs/superpowers/specs/2026-04-20-cli-polish-design.md` (describes the rename — `yoyoctl` references are part of the explanation)
+- `docs/superpowers/specs/2026-04-13-4g-connectivity-design.md` (historical spec)
+- `docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md` (our own spec — mentions `yoyoctl` when describing this cleanup)
+- `docs/superpowers/plans/2026-04-10-yoyoctl-cli.md` (original plan — historical)
+- `docs/superpowers/plans/2026-04-20-cli-polish.md` (describes the rename — historical by design)
+- `docs/superpowers/plans/2026-04-13-4g-connectivity.md` (historical)
+- `docs/superpowers/plans/2026-04-13-cubie-pimoroni-driver.md` (historical)
+- `docs/superpowers/plans/2026-04-21-phase-a-core-scaffold.md` (this plan — self-referential)
+- `docs/archive/**` (if any — archive)
+
+### Files to delete
+
+None in this plan.
+
+---
+
+## Task 1: Create the long-lived Phase A branch
+
+**Files:** none (git state only)
+
+- [ ] **Step 1.1: Verify clean working tree and current branch**
+
+Run:
+```bash
+git status
+git branch --show-current
+```
+
+Expected: `git status` shows clean (or only the existing untracked `.claude/settings.local.json`); current branch is `claude/sharp-hermann-6c07d4` (the worktree branch).
+
+- [ ] **Step 1.2: Create and check out the long-lived Phase A branch**
+
+Run:
+```bash
+git checkout -b arch/phase-a-spine-rewrite
+```
+
+Expected: `Switched to a new branch 'arch/phase-a-spine-rewrite'`.
+
+- [ ] **Step 1.3: Confirm branch is off main**
+
+Run:
+```bash
+git log --oneline -5
+```
+
+Expected: top commit is `docs: Phase A spine rewrite design spec (2026-04-21)` (from the brainstorming commit in this worktree).
+
+---
+
+## Task 2: CLI straggler cleanup
+
+**Files:** see "Files to modify" in the File Structure section above. ~40 live files replaced; 10 historical files preserved.
+
+- [ ] **Step 2.1: Enumerate every `yoyoctl` reference**
+
+Run:
+```bash
+grep -rln "yoyoctl" --include="*.py" --include="*.md" --include="*.toml" --include="*.yaml" --include="*.yml" .
+```
+
+Expected: ~51 files listed across `src/`, `tests/`, `skills/`, `rules/`, `docs/`, plus `CLAUDE.md`, `AGENTS.md`, `README.md`, `pyproject.toml`, `deploy/pi-deploy.yaml`. Keep the list — subsequent steps reference it.
+
+- [ ] **Step 2.2: Remove the `yoyoctl` script entry from pyproject.toml**
+
+Edit `pyproject.toml`. Change:
+
+```toml
+[project.scripts]
+yoyopod = "yoyopod.main:main"
+yoyoctl = "yoyopod.cli:run"
+```
+
+to:
+
+```toml
+[project.scripts]
+yoyopod = "yoyopod.main:main"
+```
+
+Rationale: per the CLI polish design, the CLI dispatches through `yoyopod.main:main` which already routes between app-launch and CLI mode. No separate `yoyoctl` entry point is needed.
+
+- [ ] **Step 2.3: Rename the Typer root app in `src/yoyopod/cli/__init__.py`**
+
+Edit `src/yoyopod/cli/__init__.py`. Change line 14 from:
+
+```python
+_MISSING_CLI_DEPENDENCY_MESSAGE = (
+    "yoyoctl requires the contributor CLI dependencies. Bootstrap the repo with:\n"
+    "  uv sync --extra dev"
+)
+```
+
+to:
+
+```python
+_MISSING_CLI_DEPENDENCY_MESSAGE = (
+    "yoyopod CLI requires the contributor dependencies. Bootstrap the repo with:\n"
+    "  uv sync --extra dev"
+)
+```
+
+And change line 52 from:
+
+```python
+    root_app = typer.Typer(
+        name="yoyoctl",
+        help="YoyoPod development and hardware CLI.",
+        no_args_is_help=True,
+    )
+```
+
+to:
+
+```python
+    root_app = typer.Typer(
+        name="yoyopod",
+        help="YoyoPod development and hardware CLI.",
+        no_args_is_help=True,
+    )
+```
+
+- [ ] **Step 2.4: Bulk replace `yoyoctl` → `yoyopod` across the repo, preserving historical docs**
+
+Create `scripts/_phase_a_cli_rename.py` as a one-off helper (to be removed in Step 2.8):
+
+```python
+"""One-off helper: yoyoctl -> yoyopod across the live repo.
+
+Preserves historical design docs and self-referential files. Remove after
+Task 2 of Phase A — no need to keep the helper around.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+PRESERVE = {
+    # Historical design / plan docs
+    "docs/superpowers/specs/2026-04-10-yoyoctl-cli-design.md",
+    "docs/superpowers/specs/2026-04-20-cli-polish-design.md",
+    "docs/superpowers/specs/2026-04-13-4g-connectivity-design.md",
+    "docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md",
+    "docs/superpowers/plans/2026-04-10-yoyoctl-cli.md",
+    "docs/superpowers/plans/2026-04-20-cli-polish.md",
+    "docs/superpowers/plans/2026-04-13-4g-connectivity.md",
+    "docs/superpowers/plans/2026-04-13-cubie-pimoroni-driver.md",
+    "docs/superpowers/plans/2026-04-21-phase-a-core-scaffold.md",
+}
+
+
+def main() -> int:
+    # Use git to enumerate tracked files containing "yoyoctl" — avoids editing
+    # untracked build artefacts, virtualenvs, or the git object database.
+    result = subprocess.run(
+        ["git", "grep", "-l", "yoyoctl"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    candidates = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    edited = 0
+    skipped = 0
+    for relpath in candidates:
+        normalised = relpath.replace("\\", "/")
+        if normalised in PRESERVE or normalised.startswith("docs/archive/"):
+            skipped += 1
+            continue
+
+        path = Path(relpath)
+        if not path.is_file():
+            skipped += 1
+            continue
+
+        text = path.read_text(encoding="utf-8")
+        new_text = text.replace("yoyoctl", "yoyopod")
+        if new_text != text:
+            path.write_text(new_text, encoding="utf-8")
+            edited += 1
+            print(f"edited: {relpath}")
+
+    print(f"\nEdited {edited} files; preserved/skipped {skipped}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Run:
+```bash
+uv run python scripts/_phase_a_cli_rename.py
+```
+
+Expected: ~40 files edited (live code, docs, skills, rules, CLAUDE.md, AGENTS.md, README.md, deploy yaml); 9-10 preserved (all historical design docs + this plan).
+
+- [ ] **Step 2.5: Verify only preservation-list files still contain `yoyoctl`**
+
+Run:
+```bash
+git grep -l "yoyoctl"
+```
+
+Expected output: exactly the 9 files from the PRESERVE list in Step 2.4. If any other file still matches, open it and decide whether it's historical (add to PRESERVE, re-run Step 2.4) or live (update manually).
+
+- [ ] **Step 2.6: Delete the one-off rename helper**
+
+Run:
+```bash
+rm scripts/_phase_a_cli_rename.py
+```
+
+Rationale: keeping the helper around would violate the "no unused code" principle — it has no ongoing purpose.
+
+- [ ] **Step 2.7: Run the CLI + affected test modules**
+
+Run:
+```bash
+uv run pytest tests/test_cli.py tests/test_pi_remote.py tests/test_setup_cli.py -v
+```
+
+Expected: all passing. Some tests assert on the Typer app `name` string (`"yoyoctl"` → `"yoyopod"`) or on help text — Step 2.4's bulk replace already updated the test files, so assertions should match the new names. If a test still fails, open it; either the assertion needs a manual fix (because the bulk replace produced an incorrect string), or the CLI itself has a bug introduced by the rename.
+
+- [ ] **Step 2.8: Run the full CI gate**
+
+Run:
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green. This step honours the user's pre-commit memory (`feedback_verify_ci_locally.md`).
+
+- [ ] **Step 2.9: Commit the CLI cleanup**
+
+Run:
+```bash
+git add -A
+git status  # sanity-check: only expected files appear
+git commit -m "$(cat <<'EOF'
+chore(cli): drop yoyoctl aliases across live code, docs, and rules
+
+Removes the `yoyoctl` console-script entry from pyproject.toml, renames the
+root Typer app from `yoyoctl` to `yoyopod`, and replaces `yoyoctl` with
+`yoyopod` across live source, tests, skills, rules, docs, CLAUDE.md,
+AGENTS.md, README.md, and deploy/pi-deploy.yaml.
+
+Historical design/plan docs under docs/superpowers/{specs,plans}/ that
+describe the pre-rename state or the rename itself are preserved; the
+CLI polish merge (2026-04-20) already unified the dispatcher, and this
+commit clears the last straggling references.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2.10: Confirm clean working tree**
+
+Run:
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean` (ignoring the untracked `.claude/settings.local.json`).
+
+---
+
+## Task 3: Create core/ and tests/core/ scaffold
+
+**Files:**
+- Create: `src/yoyopod/core/__init__.py`
+- Create: `tests/core/__init__.py`
+
+- [ ] **Step 3.1: Create `src/yoyopod/core/` with an empty package marker**
+
+Run:
+```bash
+mkdir -p src/yoyopod/core tests/core
+```
+
+- [ ] **Step 3.2: Populate `src/yoyopod/core/__init__.py`**
+
+Create `src/yoyopod/core/__init__.py` with:
+
+```python
+"""Core primitives for YoyoPod's state-store + typed-bus + service-registry architecture.
+
+See docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md §4.
+"""
+
+from __future__ import annotations
+
+# Explicit re-exports are added as primitives land.
+```
+
+- [ ] **Step 3.3: Populate `tests/core/__init__.py`**
+
+Create `tests/core/__init__.py` with a single blank line (pytest package marker):
+
+```python
+
+```
+
+- [ ] **Step 3.4: Commit the scaffold**
+
+Run:
+```bash
+git add src/yoyopod/core/__init__.py tests/core/__init__.py
+git commit -m "$(cat <<'EOF'
+chore(core): scaffold core package and tests directory
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Build `Bus` with TDD
+
+**Files:**
+- Create: `tests/core/test_bus.py`
+- Create: `src/yoyopod/core/bus.py`
+
+- [ ] **Step 4.1: Write the failing test file `tests/core/test_bus.py`**
+
+Create `tests/core/test_bus.py` with:
+
+```python
+"""Tests for yoyopod.core.bus.Bus."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+import pytest
+
+from yoyopod.core.bus import Bus
+
+
+@dataclass(frozen=True, slots=True)
+class ExampleEvent:
+    payload: str
+
+
+@dataclass(frozen=True, slots=True)
+class ChildEvent(ExampleEvent):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class UnrelatedEvent:
+    count: int
+
+
+def _make_bus(strict: bool = True) -> Bus:
+    return Bus(main_thread_id=threading.get_ident(), strict=strict)
+
+
+def test_subscribe_then_publish_invokes_handler_on_drain() -> None:
+    bus = _make_bus()
+    captured: list[str] = []
+    bus.subscribe(ExampleEvent, lambda ev: captured.append(ev.payload))
+
+    bus.publish(ExampleEvent(payload="hello"))
+    processed = bus.drain()
+
+    assert processed == 1
+    assert captured == ["hello"]
+
+
+def test_publish_before_drain_is_queued_not_dispatched() -> None:
+    bus = _make_bus()
+    captured: list[str] = []
+    bus.subscribe(ExampleEvent, lambda ev: captured.append(ev.payload))
+
+    bus.publish(ExampleEvent(payload="first"))
+    bus.publish(ExampleEvent(payload="second"))
+
+    assert captured == []
+    assert bus.pending_count() == 2
+
+    bus.drain()
+    assert captured == ["first", "second"]
+    assert bus.pending_count() == 0
+
+
+def test_multiple_subscribers_all_invoked() -> None:
+    bus = _make_bus()
+    captured_a: list[str] = []
+    captured_b: list[str] = []
+    bus.subscribe(ExampleEvent, lambda ev: captured_a.append(ev.payload))
+    bus.subscribe(ExampleEvent, lambda ev: captured_b.append(ev.payload))
+
+    bus.publish(ExampleEvent(payload="x"))
+    bus.drain()
+
+    assert captured_a == ["x"]
+    assert captured_b == ["x"]
+
+
+def test_subclass_events_reach_parent_subscribers() -> None:
+    bus = _make_bus()
+    parent_captured: list[str] = []
+    bus.subscribe(ExampleEvent, lambda ev: parent_captured.append(ev.payload))
+
+    bus.publish(ChildEvent(payload="child"))
+    bus.drain()
+
+    assert parent_captured == ["child"]
+
+
+def test_unrelated_events_do_not_reach_subscribers() -> None:
+    bus = _make_bus()
+    captured: list[str] = []
+    bus.subscribe(ExampleEvent, lambda ev: captured.append(ev.payload))
+
+    bus.publish(UnrelatedEvent(count=1))
+    bus.drain()
+
+    assert captured == []
+
+
+def test_drain_limit_respected() -> None:
+    bus = _make_bus()
+    captured: list[str] = []
+    bus.subscribe(ExampleEvent, lambda ev: captured.append(ev.payload))
+
+    for i in range(5):
+        bus.publish(ExampleEvent(payload=str(i)))
+
+    first = bus.drain(limit=2)
+    second = bus.drain()
+
+    assert first == 2
+    assert second == 3
+    assert captured == ["0", "1", "2", "3", "4"]
+
+
+def test_strict_mode_rejects_off_main_publish() -> None:
+    bus = _make_bus(strict=True)
+    error_captured: list[BaseException] = []
+
+    def publish_from_thread() -> None:
+        try:
+            bus.publish(ExampleEvent(payload="bad"))
+        except RuntimeError as exc:
+            error_captured.append(exc)
+
+    t = threading.Thread(target=publish_from_thread)
+    t.start()
+    t.join()
+
+    assert len(error_captured) == 1
+    assert "non-main thread" in str(error_captured[0])
+    assert bus.pending_count() == 0
+
+
+def test_permissive_mode_queues_off_main_publish() -> None:
+    bus = _make_bus(strict=False)
+
+    def publish_from_thread() -> None:
+        bus.publish(ExampleEvent(payload="from-bg"))
+
+    t = threading.Thread(target=publish_from_thread)
+    t.start()
+    t.join()
+
+    assert bus.pending_count() == 1
+
+
+def test_handler_exception_in_strict_mode_raises() -> None:
+    bus = _make_bus(strict=True)
+
+    def bad(_ev: ExampleEvent) -> None:
+        raise ValueError("handler bug")
+
+    bus.subscribe(ExampleEvent, bad)
+    bus.publish(ExampleEvent(payload="x"))
+
+    with pytest.raises(ValueError, match="handler bug"):
+        bus.drain()
+
+
+def test_handler_exception_in_permissive_mode_continues_to_next_handler() -> None:
+    bus = _make_bus(strict=False)
+    captured: list[str] = []
+
+    def bad(_ev: ExampleEvent) -> None:
+        raise ValueError("handler bug")
+
+    bus.subscribe(ExampleEvent, bad)
+    bus.subscribe(ExampleEvent, lambda ev: captured.append(ev.payload))
+
+    bus.publish(ExampleEvent(payload="continues"))
+    bus.drain()
+
+    assert captured == ["continues"]
+```
+
+- [ ] **Step 4.2: Run the tests to confirm they fail (no `bus.py` yet)**
+
+Run:
+```bash
+uv run pytest tests/core/test_bus.py -v
+```
+
+Expected: 10 ERRORS or FAILURES with `ModuleNotFoundError: No module named 'yoyopod.core.bus'`.
+
+- [ ] **Step 4.3: Implement `src/yoyopod/core/bus.py`**
+
+Create `src/yoyopod/core/bus.py` with:
+
+```python
+"""Typed event bus for YoyoPod core primitives.
+
+Design: main-thread-only. Publishing from a non-main thread raises in
+strict mode or logs a warning (and still queues) in permissive mode.
+Backend threads route through the MainThreadScheduler instead of calling
+publish() directly. See docs/superpowers/specs/2026-04-21-phase-a-spine-
+rewrite-design.md §4.1.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import defaultdict, deque
+from typing import Any, Callable, DefaultDict, Deque
+
+from loguru import logger
+
+
+EventHandler = Callable[[Any], None]
+
+
+class Bus:
+    """Typed, main-thread-only event bus."""
+
+    def __init__(self, main_thread_id: int, strict: bool = True) -> None:
+        self._main_thread_id = main_thread_id
+        self._strict = strict
+        self._subscribers: DefaultDict[type, list[EventHandler]] = defaultdict(list)
+        self._queue: Deque[Any] = deque()
+
+    def subscribe(self, event_type: type, handler: EventHandler) -> None:
+        """Register a handler for events of the given type (or subclasses)."""
+        self._subscribers[event_type].append(handler)
+        logger.trace("Bus subscribed to {}", event_type.__name__)
+
+    def publish(self, event: Any) -> None:
+        """Publish an event. Raises in strict mode if called off-main thread."""
+        if threading.get_ident() != self._main_thread_id:
+            if self._strict:
+                raise RuntimeError(
+                    "Bus.publish called from non-main thread "
+                    f"(event: {event.__class__.__name__}). Route through scheduler.run_on_main."
+                )
+            logger.warning(
+                "Bus.publish called from non-main thread: {}",
+                event.__class__.__name__,
+            )
+        self._queue.append(event)
+
+    def drain(self, limit: int | None = None) -> int:
+        """Dispatch queued events to subscribers in FIFO order."""
+        processed = 0
+        while self._queue and (limit is None or processed < limit):
+            event = self._queue.popleft()
+            self._dispatch(event)
+            processed += 1
+        return processed
+
+    def pending_count(self) -> int:
+        """Return the number of events awaiting dispatch."""
+        return len(self._queue)
+
+    def _dispatch(self, event: Any) -> None:
+        handlers: list[EventHandler] = []
+        for event_type, subs in self._subscribers.items():
+            if isinstance(event, event_type):
+                handlers.extend(subs)
+
+        for handler in handlers:
+            try:
+                handler(event)
+            except Exception as exc:
+                if self._strict:
+                    raise
+                logger.error(
+                    "Bus handler {!r} raised {}: {}",
+                    handler,
+                    exc.__class__.__name__,
+                    exc,
+                )
+```
+
+- [ ] **Step 4.4: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/core/test_bus.py -v
+```
+
+Expected: 10 passed.
+
+- [ ] **Step 4.5: Format, lint, and type-check the new files**
+
+Run:
+```bash
+uv run black src/yoyopod/core/bus.py tests/core/test_bus.py
+uv run ruff check src/yoyopod/core/bus.py tests/core/test_bus.py
+uv run mypy src/yoyopod/core/bus.py
+```
+
+Expected: black reports "reformatted" or "unchanged"; ruff reports no issues; mypy passes with no errors.
+
+- [ ] **Step 4.6: Add `Bus` to `core/__init__.py` re-exports**
+
+Edit `src/yoyopod/core/__init__.py` — append:
+
+```python
+from yoyopod.core.bus import Bus
+
+__all__ = ["Bus"]
+```
+
+- [ ] **Step 4.7: Commit**
+
+Run:
+```bash
+git add src/yoyopod/core/__init__.py src/yoyopod/core/bus.py tests/core/test_bus.py
+git commit -m "$(cat <<'EOF'
+feat(core): add typed Bus primitive
+
+Main-thread-only by contract (strict mode raises on off-main publish).
+Subclass events dispatch to parent subscribers via isinstance matching.
+Handler exceptions in permissive mode are logged and dispatch continues;
+strict mode re-raises (used in tests).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Build `States` with TDD
+
+**Files:**
+- Create: `tests/core/test_states.py`
+- Create: `src/yoyopod/core/states.py`
+
+- [ ] **Step 5.1: Write the failing test file `tests/core/test_states.py`**
+
+Create `tests/core/test_states.py`:
+
+```python
+"""Tests for yoyopod.core.states.States."""
+
+from __future__ import annotations
+
+import threading
+
+from yoyopod.core.bus import Bus
+from yoyopod.core.events import StateChangedEvent
+from yoyopod.core.states import States, StateValue
+
+
+def _make_bus_and_states() -> tuple[Bus, States]:
+    bus = Bus(main_thread_id=threading.get_ident(), strict=True)
+    states = States(bus=bus)
+    return bus, states
+
+
+def test_get_missing_entity_returns_none() -> None:
+    _, states = _make_bus_and_states()
+    assert states.get("call.state") is None
+    assert states.has("call.state") is False
+
+
+def test_get_value_missing_returns_default() -> None:
+    _, states = _make_bus_and_states()
+    assert states.get_value("call.state", default="idle") == "idle"
+    assert states.get_value("call.state") is None
+
+
+def test_set_creates_entity_and_fires_state_changed() -> None:
+    bus, states = _make_bus_and_states()
+    captured: list[StateChangedEvent] = []
+    bus.subscribe(StateChangedEvent, lambda ev: captured.append(ev))
+
+    states.set("call.state", "incoming", attrs={"caller": "sip:bob@x"})
+    bus.drain()
+
+    sv = states.get("call.state")
+    assert sv is not None
+    assert sv.value == "incoming"
+    assert sv.attrs == {"caller": "sip:bob@x"}
+    assert sv.last_changed_at > 0.0
+
+    assert len(captured) == 1
+    assert captured[0].entity == "call.state"
+    assert captured[0].old is None
+    assert captured[0].new == sv
+
+
+def test_set_no_op_when_value_and_attrs_unchanged() -> None:
+    bus, states = _make_bus_and_states()
+    captured: list[StateChangedEvent] = []
+    bus.subscribe(StateChangedEvent, lambda ev: captured.append(ev))
+
+    states.set("call.state", "idle", attrs={})
+    bus.drain()
+    captured.clear()
+
+    states.set("call.state", "idle", attrs={})
+    bus.drain()
+
+    assert captured == []
+
+
+def test_set_fires_event_when_attrs_change_but_value_same() -> None:
+    bus, states = _make_bus_and_states()
+    captured: list[StateChangedEvent] = []
+    bus.subscribe(StateChangedEvent, lambda ev: captured.append(ev))
+
+    states.set("call.state", "active", attrs={"caller": "a"})
+    bus.drain()
+    captured.clear()
+
+    states.set("call.state", "active", attrs={"caller": "b"})
+    bus.drain()
+
+    assert len(captured) == 1
+    assert captured[0].entity == "call.state"
+    assert captured[0].old is not None
+    assert captured[0].old.attrs == {"caller": "a"}
+    assert captured[0].new.attrs == {"caller": "b"}
+
+
+def test_set_without_attrs_defaults_to_empty_dict() -> None:
+    _, states = _make_bus_and_states()
+    states.set("music.state", "playing")
+    sv = states.get("music.state")
+    assert sv is not None
+    assert sv.attrs == {}
+
+
+def test_all_returns_snapshot() -> None:
+    _, states = _make_bus_and_states()
+    states.set("call.state", "idle")
+    states.set("music.state", "paused")
+
+    snap = states.all()
+    assert set(snap.keys()) == {"call.state", "music.state"}
+    assert snap["call.state"].value == "idle"
+    assert snap["music.state"].value == "paused"
+
+
+def test_state_changed_event_contains_old_state_value() -> None:
+    bus, states = _make_bus_and_states()
+    captured: list[StateChangedEvent] = []
+    bus.subscribe(StateChangedEvent, lambda ev: captured.append(ev))
+
+    states.set("power.battery_percent", 80)
+    bus.drain()
+    captured.clear()
+
+    states.set("power.battery_percent", 75)
+    bus.drain()
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert ev.old is not None
+    assert ev.old.value == 80
+    assert ev.new.value == 75
+```
+
+- [ ] **Step 5.2: Write the corresponding events stub**
+
+`StateChangedEvent` lives in `core/events.py` which doesn't exist yet — but the tests import it. Create a minimal stub at `src/yoyopod/core/events.py`:
+
+```python
+"""Core event types for YoyoPod's typed event bus.
+
+Expands in Task 8. This minimal version covers only what States needs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from yoyopod.core.states import StateValue
+
+
+@dataclass(frozen=True, slots=True)
+class StateChangedEvent:
+    """Universal state-change notification published by States on every effective set()."""
+
+    entity: str
+    old: "StateValue | None"
+    new: "StateValue"
+```
+
+- [ ] **Step 5.3: Run the test file to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/core/test_states.py -v
+```
+
+Expected: import error on `yoyopod.core.states` (ModuleNotFoundError) or on `States`/`StateValue`.
+
+- [ ] **Step 5.4: Implement `src/yoyopod/core/states.py`**
+
+Create `src/yoyopod/core/states.py`:
+
+```python
+"""Entity state store. Source of truth for domain state across integrations.
+
+Writes fire StateChangedEvent on the bus. Reads return StateValue snapshots.
+See docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md §4.2.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from yoyopod.core.bus import Bus
+from yoyopod.core.events import StateChangedEvent
+
+
+@dataclass(frozen=True, slots=True)
+class StateValue:
+    """Snapshot of an entity's current state."""
+
+    value: Any
+    attrs: dict[str, Any] = field(default_factory=dict)
+    last_changed_at: float = 0.0
+
+
+class States:
+    """Entity state store keyed by `domain.entity_name` strings."""
+
+    def __init__(self, bus: Bus) -> None:
+        self._bus = bus
+        self._store: dict[str, StateValue] = {}
+
+    def set(
+        self,
+        entity: str,
+        value: Any,
+        attrs: dict[str, Any] | None = None,
+    ) -> None:
+        """Set an entity's value. No-op if (value, attrs) unchanged. Fires StateChangedEvent otherwise."""
+        new_attrs = dict(attrs) if attrs is not None else {}
+        current = self._store.get(entity)
+        if current is not None and current.value == value and current.attrs == new_attrs:
+            return
+
+        new_sv = StateValue(value=value, attrs=new_attrs, last_changed_at=time.time())
+        self._store[entity] = new_sv
+        self._bus.publish(StateChangedEvent(entity=entity, old=current, new=new_sv))
+
+    def get(self, entity: str) -> StateValue | None:
+        """Return the StateValue for the given entity, or None if absent."""
+        return self._store.get(entity)
+
+    def get_value(self, entity: str, default: Any = None) -> Any:
+        """Convenience: return the entity's value or default."""
+        sv = self._store.get(entity)
+        return sv.value if sv is not None else default
+
+    def has(self, entity: str) -> bool:
+        """Return True iff the entity has been set at least once."""
+        return entity in self._store
+
+    def all(self) -> dict[str, StateValue]:
+        """Return a shallow snapshot of the full store (used by diagnostics)."""
+        return dict(self._store)
+```
+
+- [ ] **Step 5.5: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/core/test_states.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 5.6: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/core/states.py src/yoyopod/core/events.py tests/core/test_states.py
+uv run ruff check src/yoyopod/core/states.py src/yoyopod/core/events.py tests/core/test_states.py
+uv run mypy src/yoyopod/core/states.py src/yoyopod/core/events.py
+```
+
+Expected: all green.
+
+- [ ] **Step 5.7: Re-export from `core/__init__.py`**
+
+Edit `src/yoyopod/core/__init__.py`:
+
+```python
+"""Core primitives for YoyoPod's state-store + typed-bus + service-registry architecture.
+
+See docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md §4.
+"""
+
+from __future__ import annotations
+
+from yoyopod.core.bus import Bus
+from yoyopod.core.events import StateChangedEvent
+from yoyopod.core.states import States, StateValue
+
+__all__ = ["Bus", "States", "StateValue", "StateChangedEvent"]
+```
+
+- [ ] **Step 5.8: Commit**
+
+Run:
+```bash
+git add src/yoyopod/core/__init__.py src/yoyopod/core/states.py src/yoyopod/core/events.py tests/core/test_states.py
+git commit -m "$(cat <<'EOF'
+feat(core): add States entity store + StateChangedEvent
+
+Writes fire StateChangedEvent on the bus; no-op when (value, attrs) unchanged.
+Attrs-only changes still fire (attrs are carried in StateValue). Reads return
+StateValue snapshots; all() returns a shallow snapshot for diagnostics.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Build `Services` with TDD
+
+**Files:**
+- Create: `tests/core/test_services.py`
+- Create: `src/yoyopod/core/services.py`
+
+- [ ] **Step 6.1: Write `tests/core/test_services.py`**
+
+Create `tests/core/test_services.py`:
+
+```python
+"""Tests for yoyopod.core.services.Services."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+import pytest
+
+from yoyopod.core.bus import Bus
+from yoyopod.core.services import Services, ServiceNotRegisteredError
+
+
+@dataclass(frozen=True, slots=True)
+class PlayCommand:
+    track_uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class VolumeCommand:
+    percent: int
+
+
+def _make() -> tuple[Bus, Services]:
+    bus = Bus(main_thread_id=threading.get_ident(), strict=True)
+    services = Services(bus=bus)
+    return bus, services
+
+
+def test_register_then_call_invokes_handler_with_data() -> None:
+    _, services = _make()
+    captured: list[str] = []
+    services.register("music", "play", lambda cmd: captured.append(cmd.track_uri))
+
+    services.call("music", "play", PlayCommand(track_uri="local:test.mp3"))
+
+    assert captured == ["local:test.mp3"]
+
+
+def test_call_unregistered_raises_service_not_registered() -> None:
+    _, services = _make()
+    with pytest.raises(ServiceNotRegisteredError):
+        services.call("music", "play", PlayCommand(track_uri="x"))
+
+
+def test_register_twice_for_same_service_raises() -> None:
+    _, services = _make()
+    services.register("music", "play", lambda _cmd: None)
+    with pytest.raises(ValueError, match="already registered"):
+        services.register("music", "play", lambda _cmd: None)
+
+
+def test_call_returns_handler_result() -> None:
+    _, services = _make()
+    services.register("contacts", "lookup", lambda _cmd: "Alice")
+
+    result = services.call("contacts", "lookup", None)
+
+    assert result == "Alice"
+
+
+def test_call_propagates_handler_exception() -> None:
+    _, services = _make()
+
+    def bad(_cmd: None) -> None:
+        raise RuntimeError("kaboom")
+
+    services.register("music", "crash", bad)
+
+    with pytest.raises(RuntimeError, match="kaboom"):
+        services.call("music", "crash", None)
+
+
+def test_registered_returns_sorted_list() -> None:
+    _, services = _make()
+    services.register("music", "play", lambda _: None)
+    services.register("call", "dial", lambda _: None)
+    services.register("music", "pause", lambda _: None)
+
+    registered = services.registered()
+
+    assert registered == [("call", "dial"), ("music", "pause"), ("music", "play")]
+
+
+def test_data_can_be_none_for_arg_less_commands() -> None:
+    _, services = _make()
+    called: list[bool] = []
+    services.register("call", "answer", lambda _cmd: called.append(True))
+
+    services.call("call", "answer", None)
+
+    assert called == [True]
+```
+
+- [ ] **Step 6.2: Run tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/core/test_services.py -v
+```
+
+Expected: import error on `yoyopod.core.services`.
+
+- [ ] **Step 6.3: Implement `src/yoyopod/core/services.py`**
+
+Create `src/yoyopod/core/services.py`:
+
+```python
+"""Typed command registry for YoyoPod core primitives.
+
+Services are registered per (domain, service) pair. Callers invoke them via
+`services.call(domain, service, data)` where data is a typed dataclass (or
+None for argless commands). Handlers run synchronously on the main thread.
+See docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md §4.3.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from loguru import logger
+
+from yoyopod.core.bus import Bus
+
+
+Handler = Callable[[Any], Any]
+
+
+class ServiceNotRegisteredError(LookupError):
+    """Raised when Services.call is invoked for an unregistered (domain, service)."""
+
+
+class Services:
+    """Command registry keyed by (domain, service) tuples."""
+
+    def __init__(self, bus: Bus) -> None:
+        self._bus = bus
+        self._handlers: dict[tuple[str, str], Handler] = {}
+
+    def register(self, domain: str, service: str, handler: Handler) -> None:
+        """Register a handler for (domain, service). Raises if already registered."""
+        key = (domain, service)
+        if key in self._handlers:
+            raise ValueError(f"Service {domain}.{service} already registered")
+        self._handlers[key] = handler
+        logger.trace("Services registered {}.{}", domain, service)
+
+    def call(self, domain: str, service: str, data: Any = None) -> Any:
+        """Invoke a registered service synchronously on the main thread."""
+        key = (domain, service)
+        handler = self._handlers.get(key)
+        if handler is None:
+            raise ServiceNotRegisteredError(
+                f"Service {domain}.{service} is not registered"
+            )
+        logger.trace("Services call {}.{} data={!r}", domain, service, data)
+        return handler(data)
+
+    def registered(self) -> list[tuple[str, str]]:
+        """Return all registered (domain, service) pairs, sorted."""
+        return sorted(self._handlers.keys())
+```
+
+- [ ] **Step 6.4: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/core/test_services.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 6.5: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/core/services.py tests/core/test_services.py
+uv run ruff check src/yoyopod/core/services.py tests/core/test_services.py
+uv run mypy src/yoyopod/core/services.py
+```
+
+Expected: all green.
+
+- [ ] **Step 6.6: Re-export from `core/__init__.py`**
+
+Append to `src/yoyopod/core/__init__.py`:
+
+```python
+from yoyopod.core.services import Services, ServiceNotRegisteredError
+```
+
+And extend `__all__`:
+
+```python
+__all__ = [
+    "Bus",
+    "States",
+    "StateValue",
+    "StateChangedEvent",
+    "Services",
+    "ServiceNotRegisteredError",
+]
+```
+
+- [ ] **Step 6.7: Commit**
+
+Run:
+```bash
+git add src/yoyopod/core/__init__.py src/yoyopod/core/services.py tests/core/test_services.py
+git commit -m "$(cat <<'EOF'
+feat(core): add Services command registry
+
+Synchronous (domain, service) handler dispatch. Typed data arg (None allowed).
+Double-registration raises; call on unregistered raises ServiceNotRegisteredError.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Build `MainThreadScheduler` with TDD
+
+**Files:**
+- Create: `tests/core/test_scheduler.py`
+- Create: `src/yoyopod/core/scheduler.py`
+
+- [ ] **Step 7.1: Write `tests/core/test_scheduler.py`**
+
+Create `tests/core/test_scheduler.py`:
+
+```python
+"""Tests for yoyopod.core.scheduler.MainThreadScheduler."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from yoyopod.core.scheduler import MainThreadScheduler
+
+
+def _make() -> MainThreadScheduler:
+    return MainThreadScheduler(main_thread_id=threading.get_ident())
+
+
+def test_run_on_main_same_thread_executes_immediately() -> None:
+    scheduler = _make()
+    captured: list[int] = []
+
+    scheduler.run_on_main(lambda: captured.append(1))
+
+    assert captured == [1]
+    assert scheduler.pending_count() == 0
+
+
+def test_run_on_main_from_background_thread_queues_task() -> None:
+    scheduler = _make()
+    captured: list[str] = []
+
+    def from_bg() -> None:
+        scheduler.run_on_main(lambda: captured.append("from-bg"))
+
+    t = threading.Thread(target=from_bg)
+    t.start()
+    t.join()
+
+    assert captured == []
+    assert scheduler.pending_count() == 1
+
+    processed = scheduler.drain()
+
+    assert processed == 1
+    assert captured == ["from-bg"]
+
+
+def test_drain_runs_tasks_in_fifo_order() -> None:
+    scheduler = _make()
+    captured: list[int] = []
+
+    def from_bg() -> None:
+        for i in range(5):
+            scheduler.run_on_main(lambda n=i: captured.append(n))
+
+    t = threading.Thread(target=from_bg)
+    t.start()
+    t.join()
+
+    scheduler.drain()
+
+    assert captured == [0, 1, 2, 3, 4]
+
+
+def test_drain_limit_respected() -> None:
+    scheduler = _make()
+    captured: list[int] = []
+
+    def from_bg() -> None:
+        for i in range(5):
+            scheduler.run_on_main(lambda n=i: captured.append(n))
+
+    t = threading.Thread(target=from_bg)
+    t.start()
+    t.join()
+
+    first = scheduler.drain(limit=2)
+    rest = scheduler.drain()
+
+    assert first == 2
+    assert rest == 3
+    assert captured == [0, 1, 2, 3, 4]
+
+
+def test_task_exception_is_swallowed_and_remaining_tasks_run() -> None:
+    scheduler = _make()
+    captured: list[str] = []
+
+    def bad() -> None:
+        raise RuntimeError("task bug")
+
+    def from_bg() -> None:
+        scheduler.run_on_main(bad)
+        scheduler.run_on_main(lambda: captured.append("after-bad"))
+
+    t = threading.Thread(target=from_bg)
+    t.start()
+    t.join()
+
+    scheduler.drain()
+
+    assert captured == ["after-bad"]
+
+
+def test_pending_count_reports_queued_depth() -> None:
+    scheduler = _make()
+
+    def from_bg() -> None:
+        for _ in range(3):
+            scheduler.run_on_main(lambda: None)
+
+    t = threading.Thread(target=from_bg)
+    t.start()
+    t.join()
+
+    assert scheduler.pending_count() == 3
+    scheduler.drain()
+    assert scheduler.pending_count() == 0
+```
+
+- [ ] **Step 7.2: Run tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/core/test_scheduler.py -v
+```
+
+Expected: import error on `yoyopod.core.scheduler`.
+
+- [ ] **Step 7.3: Implement `src/yoyopod/core/scheduler.py`**
+
+Create `src/yoyopod/core/scheduler.py`:
+
+```python
+"""Main-thread task scheduler for YoyoPod core primitives.
+
+Backend threads use this to marshal tasks back to the main thread so they
+can safely publish events and mutate state. See docs/superpowers/specs/
+2026-04-21-phase-a-spine-rewrite-design.md §4.4.
+"""
+
+from __future__ import annotations
+
+import threading
+from queue import Empty, Queue
+from typing import Callable
+
+from loguru import logger
+
+
+class MainThreadScheduler:
+    """Thread-safe FIFO queue of tasks drained on the main thread."""
+
+    def __init__(self, main_thread_id: int) -> None:
+        self._main_thread_id = main_thread_id
+        self._queue: "Queue[Callable[[], None]]" = Queue()
+
+    def run_on_main(self, fn: Callable[[], None]) -> None:
+        """Run fn immediately if called on the main thread, else queue it."""
+        if threading.get_ident() == self._main_thread_id:
+            fn()
+            return
+        self._queue.put(fn)
+
+    def drain(self, limit: int | None = None) -> int:
+        """Run queued tasks in FIFO order. Returns number executed."""
+        processed = 0
+        while limit is None or processed < limit:
+            try:
+                fn = self._queue.get_nowait()
+            except Empty:
+                break
+            try:
+                fn()
+            except Exception as exc:
+                logger.error(
+                    "Scheduler task {!r} raised {}: {}",
+                    fn,
+                    exc.__class__.__name__,
+                    exc,
+                )
+            processed += 1
+        return processed
+
+    def pending_count(self) -> int:
+        """Return the queued-task count (best-effort)."""
+        return self._queue.qsize()
+```
+
+- [ ] **Step 7.4: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/core/test_scheduler.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 7.5: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/core/scheduler.py tests/core/test_scheduler.py
+uv run ruff check src/yoyopod/core/scheduler.py tests/core/test_scheduler.py
+uv run mypy src/yoyopod/core/scheduler.py
+```
+
+Expected: all green.
+
+- [ ] **Step 7.6: Re-export from `core/__init__.py`**
+
+Append to `src/yoyopod/core/__init__.py`:
+
+```python
+from yoyopod.core.scheduler import MainThreadScheduler
+```
+
+Extend `__all__`:
+
+```python
+__all__ = [
+    "Bus",
+    "States",
+    "StateValue",
+    "StateChangedEvent",
+    "Services",
+    "ServiceNotRegisteredError",
+    "MainThreadScheduler",
+]
+```
+
+- [ ] **Step 7.7: Commit**
+
+Run:
+```bash
+git add src/yoyopod/core/__init__.py src/yoyopod/core/scheduler.py tests/core/test_scheduler.py
+git commit -m "$(cat <<'EOF'
+feat(core): add MainThreadScheduler
+
+Backend threads call run_on_main(fn) to marshal fn onto the main thread.
+Same-thread calls execute immediately. Task exceptions are logged and do
+not interrupt subsequent tasks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Build core/events.py (cross-cut events beyond StateChangedEvent)
+
+**Files:**
+- Modify: `src/yoyopod/core/events.py`
+- Create: `tests/core/test_events.py`
+
+- [ ] **Step 8.1: Write `tests/core/test_events.py` exercising all core event types**
+
+Create `tests/core/test_events.py`:
+
+```python
+"""Tests for yoyopod.core.events."""
+
+from __future__ import annotations
+
+from yoyopod.core.events import (
+    BackendStoppedEvent,
+    LifecycleEvent,
+    ResponsivenessLagEvent,
+    ShutdownRequestedEvent,
+    StateChangedEvent,
+    UserActivityEvent,
+)
+from yoyopod.core.states import StateValue
+
+
+def test_state_changed_event_is_frozen() -> None:
+    ev = StateChangedEvent(
+        entity="call.state",
+        old=None,
+        new=StateValue(value="idle", attrs={}, last_changed_at=0.0),
+    )
+    try:
+        ev.entity = "other"  # type: ignore[misc]
+    except Exception as exc:
+        assert isinstance(exc, AttributeError) or "frozen" in str(exc).lower()
+
+
+def test_user_activity_event_default_action_name() -> None:
+    ev = UserActivityEvent()
+    assert ev.action_name is None
+
+
+def test_user_activity_event_with_action() -> None:
+    ev = UserActivityEvent(action_name="button_select")
+    assert ev.action_name == "button_select"
+
+
+def test_backend_stopped_event_includes_domain_and_reason() -> None:
+    ev = BackendStoppedEvent(domain="call", reason="register_failed")
+    assert ev.domain == "call"
+    assert ev.reason == "register_failed"
+
+
+def test_shutdown_requested_event_defaults() -> None:
+    ev = ShutdownRequestedEvent(reason="low_battery")
+    assert ev.reason == "low_battery"
+    assert ev.delay_seconds == 0.0
+
+
+def test_lifecycle_event_phases() -> None:
+    ev = LifecycleEvent(integration="call", phase="setup_complete")
+    assert ev.integration == "call"
+    assert ev.phase == "setup_complete"
+
+
+def test_responsiveness_lag_event() -> None:
+    ev = ResponsivenessLagEvent(duration_ms=250.0, context="bus_drain")
+    assert ev.duration_ms == 250.0
+    assert ev.context == "bus_drain"
+```
+
+- [ ] **Step 8.2: Run tests; most should fail on missing imports**
+
+Run:
+```bash
+uv run pytest tests/core/test_events.py -v
+```
+
+Expected: ImportError for events not yet defined.
+
+- [ ] **Step 8.3: Expand `src/yoyopod/core/events.py`**
+
+Replace the contents of `src/yoyopod/core/events.py`:
+
+```python
+"""Core event types for YoyoPod's typed event bus.
+
+Domain-specific events live in each integration's events.py file. This module
+carries only the universal StateChangedEvent and cross-cutting signals that
+any integration may publish or subscribe to. See docs/superpowers/specs/
+2026-04-21-phase-a-spine-rewrite-design.md §6.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from yoyopod.core.states import StateValue
+
+
+@dataclass(frozen=True, slots=True)
+class StateChangedEvent:
+    """Universal state-change notification."""
+
+    entity: str
+    old: "StateValue | None"
+    new: "StateValue"
+
+
+@dataclass(frozen=True, slots=True)
+class UserActivityEvent:
+    """User input activity detected (keep-awake trigger)."""
+
+    action_name: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BackendStoppedEvent:
+    """A backend adapter has stopped (crashed or gracefully exited)."""
+
+    domain: str
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ShutdownRequestedEvent:
+    """Graceful shutdown requested from any integration."""
+
+    reason: str
+    delay_seconds: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleEvent:
+    """Integration setup/teardown boundary marker."""
+
+    integration: str
+    phase: Literal["setup_start", "setup_complete", "teardown_start", "teardown_complete"]
+
+
+@dataclass(frozen=True, slots=True)
+class ResponsivenessLagEvent:
+    """Main-loop tick exceeded threshold."""
+
+    duration_ms: float
+    context: str = ""
+```
+
+- [ ] **Step 8.4: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/core/test_events.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 8.5: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/core/events.py tests/core/test_events.py
+uv run ruff check src/yoyopod/core/events.py tests/core/test_events.py
+uv run mypy src/yoyopod/core/events.py
+```
+
+Expected: all green.
+
+- [ ] **Step 8.6: Re-export new events from `core/__init__.py`**
+
+Append to `src/yoyopod/core/__init__.py`:
+
+```python
+from yoyopod.core.events import (
+    BackendStoppedEvent,
+    LifecycleEvent,
+    ResponsivenessLagEvent,
+    ShutdownRequestedEvent,
+    UserActivityEvent,
+)
+```
+
+Extend `__all__`:
+
+```python
+__all__ = [
+    "Bus",
+    "States",
+    "StateValue",
+    "StateChangedEvent",
+    "Services",
+    "ServiceNotRegisteredError",
+    "MainThreadScheduler",
+    "UserActivityEvent",
+    "BackendStoppedEvent",
+    "ShutdownRequestedEvent",
+    "LifecycleEvent",
+    "ResponsivenessLagEvent",
+]
+```
+
+- [ ] **Step 8.7: Commit**
+
+Run:
+```bash
+git add src/yoyopod/core/__init__.py src/yoyopod/core/events.py tests/core/test_events.py
+git commit -m "$(cat <<'EOF'
+feat(core): expand core events with cross-cut signals
+
+Adds UserActivityEvent, BackendStoppedEvent, ShutdownRequestedEvent,
+LifecycleEvent, and ResponsivenessLagEvent. Domain-specific events stay
+in each integration's own events.py file.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Build log ring buffer with TDD
+
+**Files:**
+- Create: `tests/core/test_logbuffer.py`
+- Create: `src/yoyopod/core/logbuffer.py`
+
+- [ ] **Step 9.1: Write `tests/core/test_logbuffer.py`**
+
+Create `tests/core/test_logbuffer.py`:
+
+```python
+"""Tests for yoyopod.core.logbuffer.LogBuffer."""
+
+from __future__ import annotations
+
+from yoyopod.core.logbuffer import LogBuffer, LogEntry
+
+
+def test_append_and_recent_returns_all_entries_under_capacity() -> None:
+    buf = LogBuffer(capacity=10)
+    buf.append(LogEntry(ts=1.0, kind="event", payload={"a": 1}))
+    buf.append(LogEntry(ts=2.0, kind="command", payload={"b": 2}))
+
+    entries = buf.recent(10)
+
+    assert len(entries) == 2
+    assert entries[0].kind == "event"
+    assert entries[1].kind == "command"
+
+
+def test_recent_count_returns_last_n() -> None:
+    buf = LogBuffer(capacity=10)
+    for i in range(5):
+        buf.append(LogEntry(ts=float(i), kind="event", payload={"i": i}))
+
+    last_two = buf.recent(2)
+
+    assert len(last_two) == 2
+    assert last_two[0].payload == {"i": 3}
+    assert last_two[1].payload == {"i": 4}
+
+
+def test_append_beyond_capacity_drops_oldest() -> None:
+    buf = LogBuffer(capacity=3)
+    for i in range(5):
+        buf.append(LogEntry(ts=float(i), kind="event", payload={"i": i}))
+
+    all_entries = buf.recent(10)
+
+    assert len(all_entries) == 3
+    assert all_entries[0].payload == {"i": 2}
+    assert all_entries[1].payload == {"i": 3}
+    assert all_entries[2].payload == {"i": 4}
+
+
+def test_recent_more_than_available_returns_all() -> None:
+    buf = LogBuffer(capacity=10)
+    buf.append(LogEntry(ts=1.0, kind="event", payload={}))
+
+    assert len(buf.recent(100)) == 1
+
+
+def test_empty_buffer_returns_empty_list() -> None:
+    buf = LogBuffer(capacity=10)
+    assert buf.recent(10) == []
+
+
+def test_entries_are_frozen() -> None:
+    entry = LogEntry(ts=1.0, kind="event", payload={})
+    try:
+        entry.kind = "command"  # type: ignore[misc]
+    except Exception as exc:
+        assert isinstance(exc, AttributeError) or "frozen" in str(exc).lower()
+```
+
+- [ ] **Step 9.2: Run tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/core/test_logbuffer.py -v
+```
+
+Expected: import error on `yoyopod.core.logbuffer`.
+
+- [ ] **Step 9.3: Implement `src/yoyopod/core/logbuffer.py`**
+
+Create `src/yoyopod/core/logbuffer.py`:
+
+```python
+"""In-memory ring buffer for recent log entries.
+
+Used by the diagnostics integration (later plan) to provide `recent_events()`
+access to the app shell. Kept small and dependency-free so it can be used in
+tests without a diagnostics integration present. See docs/superpowers/specs/
+2026-04-21-phase-a-spine-rewrite-design.md §4.5, §8.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Deque, Literal
+
+
+LogKind = Literal["event", "command", "error", "lifecycle"]
+
+
+@dataclass(frozen=True, slots=True)
+class LogEntry:
+    """One entry in the log ring buffer."""
+
+    ts: float
+    kind: LogKind
+    payload: dict[str, Any]
+
+
+class LogBuffer:
+    """Fixed-capacity FIFO ring buffer of LogEntry."""
+
+    def __init__(self, capacity: int = 500) -> None:
+        if capacity <= 0:
+            raise ValueError("LogBuffer capacity must be positive")
+        self._entries: Deque[LogEntry] = deque(maxlen=capacity)
+
+    def append(self, entry: LogEntry) -> None:
+        """Append an entry, dropping oldest if at capacity."""
+        self._entries.append(entry)
+
+    def recent(self, count: int) -> list[LogEntry]:
+        """Return up to `count` most recent entries, in chronological order."""
+        if count <= 0:
+            return []
+        snapshot = list(self._entries)
+        return snapshot[-count:]
+```
+
+- [ ] **Step 9.4: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/core/test_logbuffer.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 9.5: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/core/logbuffer.py tests/core/test_logbuffer.py
+uv run ruff check src/yoyopod/core/logbuffer.py tests/core/test_logbuffer.py
+uv run mypy src/yoyopod/core/logbuffer.py
+```
+
+Expected: all green.
+
+- [ ] **Step 9.6: Re-export**
+
+Append to `src/yoyopod/core/__init__.py`:
+
+```python
+from yoyopod.core.logbuffer import LogBuffer, LogEntry
+```
+
+Extend `__all__`:
+
+```python
+__all__ = [
+    "Bus",
+    "States",
+    "StateValue",
+    "StateChangedEvent",
+    "Services",
+    "ServiceNotRegisteredError",
+    "MainThreadScheduler",
+    "UserActivityEvent",
+    "BackendStoppedEvent",
+    "ShutdownRequestedEvent",
+    "LifecycleEvent",
+    "ResponsivenessLagEvent",
+    "LogBuffer",
+    "LogEntry",
+]
+```
+
+- [ ] **Step 9.7: Commit**
+
+Run:
+```bash
+git add src/yoyopod/core/__init__.py src/yoyopod/core/logbuffer.py tests/core/test_logbuffer.py
+git commit -m "$(cat <<'EOF'
+feat(core): add LogBuffer ring buffer for recent events
+
+Fixed-capacity FIFO deque of LogEntry(ts, kind, payload). Used by the
+diagnostics integration in a later plan; kept dependency-free so tests
+can exercise it without a diagnostics stack.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Build `YoyoPodApp` shell with TDD
+
+**Files:**
+- Create: `tests/core/test_app_shell.py`
+- Create: `src/yoyopod/core/app_shell.py`
+
+- [ ] **Step 10.1: Write `tests/core/test_app_shell.py`**
+
+Create `tests/core/test_app_shell.py`:
+
+```python
+"""Tests for yoyopod.core.app_shell.YoyoPodApp.
+
+These tests construct the app shell with no integrations loaded; they
+exercise the primitive wiring, drain() helper, recent_events() helper, and
+teardown ordering. Config loading is NOT exercised here — that belongs in a
+later plan when integrations actually need config.
+"""
+
+from __future__ import annotations
+
+from yoyopod.core.app_shell import YoyoPodApp
+
+
+def test_app_shell_exposes_core_primitives() -> None:
+    app = YoyoPodApp()
+
+    assert app.bus is not None
+    assert app.states is not None
+    assert app.services is not None
+    assert app.scheduler is not None
+    assert app.log_buffer is not None
+
+
+def test_drain_runs_scheduler_then_bus_to_quiescence() -> None:
+    app = YoyoPodApp()
+    captured: list[str] = []
+
+    def on_state_change(ev):
+        captured.append(f"state:{ev.entity}")
+
+    from yoyopod.core.events import StateChangedEvent
+
+    app.bus.subscribe(StateChangedEvent, on_state_change)
+
+    app.states.set("call.state", "idle")
+
+    app.drain()
+
+    assert captured == ["state:call.state"]
+
+
+def test_recent_events_returns_empty_before_any_log_appends() -> None:
+    app = YoyoPodApp()
+
+    assert app.recent_events() == []
+
+
+def test_recent_events_returns_appended_entries() -> None:
+    app = YoyoPodApp()
+    from yoyopod.core.logbuffer import LogEntry
+
+    app.log_buffer.append(LogEntry(ts=1.0, kind="event", payload={"x": 1}))
+    app.log_buffer.append(LogEntry(ts=2.0, kind="command", payload={"y": 2}))
+
+    entries = app.recent_events(count=10)
+
+    assert len(entries) == 2
+    assert entries[0].payload == {"x": 1}
+
+
+def test_register_integration_tracks_order() -> None:
+    app = YoyoPodApp()
+    order: list[str] = []
+
+    app.register_integration("alpha", setup=lambda _a: order.append("alpha-setup"))
+    app.register_integration("beta", setup=lambda _a: order.append("beta-setup"))
+
+    app.setup()
+
+    assert order == ["alpha-setup", "beta-setup"]
+
+
+def test_teardown_runs_in_reverse_registration_order() -> None:
+    app = YoyoPodApp()
+    order: list[str] = []
+
+    app.register_integration(
+        "alpha",
+        setup=lambda _a: None,
+        teardown=lambda _a: order.append("alpha-teardown"),
+    )
+    app.register_integration(
+        "beta",
+        setup=lambda _a: None,
+        teardown=lambda _a: order.append("beta-teardown"),
+    )
+
+    app.setup()
+    app.stop()
+
+    assert order == ["beta-teardown", "alpha-teardown"]
+
+
+def test_stop_is_idempotent() -> None:
+    app = YoyoPodApp()
+    call_count = {"n": 0}
+
+    app.register_integration(
+        "alpha",
+        setup=lambda _a: None,
+        teardown=lambda _a: call_count.__setitem__("n", call_count["n"] + 1),
+    )
+
+    app.setup()
+    app.stop()
+    app.stop()
+
+    assert call_count["n"] == 1
+
+
+def test_setup_fires_lifecycle_events_on_bus() -> None:
+    app = YoyoPodApp()
+    from yoyopod.core.events import LifecycleEvent
+
+    captured: list[LifecycleEvent] = []
+    app.bus.subscribe(LifecycleEvent, lambda ev: captured.append(ev))
+
+    app.register_integration("alpha", setup=lambda _a: None)
+
+    app.setup()
+    app.drain()
+
+    phases = [(ev.integration, ev.phase) for ev in captured]
+    assert ("alpha", "setup_start") in phases
+    assert ("alpha", "setup_complete") in phases
+```
+
+- [ ] **Step 10.2: Run tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/core/test_app_shell.py -v
+```
+
+Expected: ModuleNotFoundError on `yoyopod.core.app_shell`.
+
+- [ ] **Step 10.3: Implement `src/yoyopod/core/app_shell.py`**
+
+Create `src/yoyopod/core/app_shell.py`:
+
+```python
+"""Main app shell for YoyoPod.
+
+Owns the core primitives (bus, states, services, scheduler, log_buffer) and
+the registration/setup/teardown lifecycle for integrations. Does NOT load
+config or run the main loop in Phase A's initial slice — those are added in
+the next plan when the first integration is migrated.
+See docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md §4.5.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Callable
+
+from loguru import logger
+
+from yoyopod.core.bus import Bus
+from yoyopod.core.events import LifecycleEvent
+from yoyopod.core.logbuffer import LogBuffer, LogEntry
+from yoyopod.core.scheduler import MainThreadScheduler
+from yoyopod.core.services import Services
+from yoyopod.core.states import States
+
+
+SetupFn = Callable[["YoyoPodApp"], None]
+TeardownFn = Callable[["YoyoPodApp"], None]
+
+
+@dataclass(slots=True)
+class _Integration:
+    name: str
+    setup: SetupFn
+    teardown: TeardownFn | None = None
+
+
+class YoyoPodApp:
+    """Composition root for YoyoPod's core primitives + integration registry."""
+
+    bus: Bus
+    states: States
+    services: Services
+    scheduler: MainThreadScheduler
+    log_buffer: LogBuffer
+
+    def __init__(self, log_capacity: int = 500) -> None:
+        main_thread_id = threading.get_ident()
+        self.bus = Bus(main_thread_id=main_thread_id, strict=True)
+        self.scheduler = MainThreadScheduler(main_thread_id=main_thread_id)
+        self.states = States(bus=self.bus)
+        self.services = Services(bus=self.bus)
+        self.log_buffer = LogBuffer(capacity=log_capacity)
+        self._integrations: list[_Integration] = []
+        self._setup_called = False
+        self._stopped = False
+
+    def register_integration(
+        self,
+        name: str,
+        setup: SetupFn,
+        teardown: TeardownFn | None = None,
+    ) -> None:
+        """Record an integration to be initialised in `setup()`."""
+        if self._setup_called:
+            raise RuntimeError(f"Cannot register integration '{name}' after setup()")
+        self._integrations.append(_Integration(name=name, setup=setup, teardown=teardown))
+
+    def setup(self) -> None:
+        """Initialise all registered integrations in registration order."""
+        if self._setup_called:
+            return
+        for integration in self._integrations:
+            logger.debug("Integration {} setup_start", integration.name)
+            self.bus.publish(LifecycleEvent(integration=integration.name, phase="setup_start"))
+            try:
+                integration.setup(self)
+            except Exception:
+                logger.exception("Integration {} setup failed", integration.name)
+                raise
+            self.bus.publish(LifecycleEvent(integration=integration.name, phase="setup_complete"))
+            logger.debug("Integration {} setup_complete", integration.name)
+        self._setup_called = True
+
+    def stop(self) -> None:
+        """Tear down integrations in reverse order. Idempotent."""
+        if self._stopped:
+            return
+        for integration in reversed(self._integrations):
+            if integration.teardown is None:
+                continue
+            logger.debug("Integration {} teardown_start", integration.name)
+            self.bus.publish(LifecycleEvent(integration=integration.name, phase="teardown_start"))
+            try:
+                integration.teardown(self)
+            except Exception:
+                logger.exception("Integration {} teardown failed", integration.name)
+            self.bus.publish(
+                LifecycleEvent(integration=integration.name, phase="teardown_complete")
+            )
+            logger.debug("Integration {} teardown_complete", integration.name)
+        self._stopped = True
+
+    def drain(self) -> None:
+        """Drain scheduler then bus until both are quiescent.
+
+        Test-friendly; production run loop handles drains explicitly per tick.
+        """
+        while self.scheduler.pending_count() > 0 or self.bus.pending_count() > 0:
+            self.scheduler.drain()
+            self.bus.drain()
+
+    def recent_events(self, count: int = 500) -> list[LogEntry]:
+        """Return up to `count` most recent log entries."""
+        return self.log_buffer.recent(count)
+```
+
+- [ ] **Step 10.4: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/core/test_app_shell.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 10.5: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/core/app_shell.py tests/core/test_app_shell.py
+uv run ruff check src/yoyopod/core/app_shell.py tests/core/test_app_shell.py
+uv run mypy src/yoyopod/core/app_shell.py
+```
+
+Expected: all green.
+
+- [ ] **Step 10.6: Re-export `YoyoPodApp`**
+
+Append to `src/yoyopod/core/__init__.py`:
+
+```python
+from yoyopod.core.app_shell import YoyoPodApp
+```
+
+Extend `__all__`:
+
+```python
+__all__ = [
+    "Bus",
+    "States",
+    "StateValue",
+    "StateChangedEvent",
+    "Services",
+    "ServiceNotRegisteredError",
+    "MainThreadScheduler",
+    "UserActivityEvent",
+    "BackendStoppedEvent",
+    "ShutdownRequestedEvent",
+    "LifecycleEvent",
+    "ResponsivenessLagEvent",
+    "LogBuffer",
+    "LogEntry",
+    "YoyoPodApp",
+]
+```
+
+- [ ] **Step 10.7: Commit**
+
+Run:
+```bash
+git add src/yoyopod/core/__init__.py src/yoyopod/core/app_shell.py tests/core/test_app_shell.py
+git commit -m "$(cat <<'EOF'
+feat(core): add YoyoPodApp composition-root shell
+
+Owns bus/states/services/scheduler/log_buffer. Integration registry with
+registration-order setup and reverse-order teardown. Emits LifecycleEvent
+around each setup/teardown. Idempotent stop(). drain() helper for tests.
+Does NOT include run loop or config loading — those land in the next plan
+when the first integration needs them.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Build `core/testing.py` helpers with TDD
+
+**Files:**
+- Create: `tests/core/test_testing_helpers.py`
+- Create: `src/yoyopod/core/testing.py`
+
+- [ ] **Step 11.1: Write `tests/core/test_testing_helpers.py`**
+
+Create `tests/core/test_testing_helpers.py`:
+
+```python
+"""Tests for yoyopod.core.testing helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from yoyopod.core.testing import assert_events_contain, build_test_app, drain_all
+from yoyopod.core.events import StateChangedEvent
+
+
+@dataclass(frozen=True, slots=True)
+class AlphaEvent:
+    value: int
+
+
+@dataclass(frozen=True, slots=True)
+class BetaEvent:
+    name: str
+
+
+def test_build_test_app_returns_app_with_primitives() -> None:
+    app = build_test_app()
+
+    assert app.bus is not None
+    assert app.states is not None
+    assert app.services is not None
+    assert app.scheduler is not None
+
+
+def test_drain_all_drains_both_scheduler_and_bus() -> None:
+    app = build_test_app()
+    captured: list[int] = []
+
+    app.bus.subscribe(AlphaEvent, lambda ev: captured.append(ev.value))
+
+    app.bus.publish(AlphaEvent(value=1))
+    app.bus.publish(AlphaEvent(value=2))
+
+    drain_all(app)
+
+    assert captured == [1, 2]
+
+
+def test_assert_events_contain_passes_when_subsequence_present() -> None:
+    events = [AlphaEvent(1), BetaEvent("b"), AlphaEvent(2)]
+
+    assert_events_contain(events, [AlphaEvent(1), AlphaEvent(2)])
+
+
+def test_assert_events_contain_passes_for_contiguous_match() -> None:
+    events = [AlphaEvent(1), BetaEvent("b"), AlphaEvent(2)]
+
+    assert_events_contain(events, [BetaEvent("b"), AlphaEvent(2)])
+
+
+def test_assert_events_contain_raises_when_missing() -> None:
+    events = [AlphaEvent(1), BetaEvent("b")]
+
+    with pytest.raises(AssertionError, match="not found"):
+        assert_events_contain(events, [AlphaEvent(99)])
+
+
+def test_assert_events_contain_raises_when_order_wrong() -> None:
+    events = [AlphaEvent(1), BetaEvent("b")]
+
+    with pytest.raises(AssertionError):
+        assert_events_contain(events, [BetaEvent("b"), AlphaEvent(1)])
+
+
+def test_build_test_app_supports_drain_of_state_changes() -> None:
+    app = build_test_app()
+    captured: list[str] = []
+    app.bus.subscribe(StateChangedEvent, lambda ev: captured.append(ev.entity))
+
+    app.states.set("call.state", "idle")
+    drain_all(app)
+
+    assert captured == ["call.state"]
+```
+
+- [ ] **Step 11.2: Run tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/core/test_testing_helpers.py -v
+```
+
+Expected: ModuleNotFoundError on `yoyopod.core.testing`.
+
+- [ ] **Step 11.3: Implement `src/yoyopod/core/testing.py`**
+
+Create `src/yoyopod/core/testing.py`:
+
+```python
+"""Test helpers for the YoyoPod core primitives.
+
+Used by unit tests and future integration/e2e tests. Keep this module
+dependency-free so it does not pull in integrations. See docs/superpowers/
+specs/2026-04-21-phase-a-spine-rewrite-design.md §12.4.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from yoyopod.core.app_shell import YoyoPodApp
+
+
+def build_test_app(log_capacity: int = 500) -> YoyoPodApp:
+    """Build a YoyoPodApp with no integrations, suitable for core unit tests.
+
+    Later plans will add an integration-aware variant that preloads the
+    integrations under test.
+    """
+    return YoyoPodApp(log_capacity=log_capacity)
+
+
+def drain_all(app: YoyoPodApp) -> None:
+    """Drain scheduler and bus until both are quiescent."""
+    app.drain()
+
+
+def assert_events_contain(events: list[Any], expected_subsequence: list[Any]) -> None:
+    """Assert the expected events appear in the given order somewhere in events.
+
+    Non-contiguous matches are allowed (events between expected items are OK);
+    order must be preserved. Raises AssertionError with a readable diff on
+    failure.
+    """
+    remaining = list(expected_subsequence)
+    for ev in events:
+        if remaining and ev == remaining[0]:
+            remaining.pop(0)
+    if remaining:
+        raise AssertionError(
+            "Expected event(s) not found in order:\n"
+            f"  first unmatched: {remaining[0]!r}\n"
+            f"  actual stream:   {events!r}\n"
+            f"  expected stream: {expected_subsequence!r}"
+        )
+```
+
+- [ ] **Step 11.4: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/core/test_testing_helpers.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 11.5: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/core/testing.py tests/core/test_testing_helpers.py
+uv run ruff check src/yoyopod/core/testing.py tests/core/test_testing_helpers.py
+uv run mypy src/yoyopod/core/testing.py
+```
+
+Expected: all green.
+
+- [ ] **Step 11.6: Re-export**
+
+Append to `src/yoyopod/core/__init__.py`:
+
+```python
+from yoyopod.core.testing import assert_events_contain, build_test_app, drain_all
+```
+
+Extend `__all__`:
+
+```python
+__all__ = [
+    "Bus",
+    "States",
+    "StateValue",
+    "StateChangedEvent",
+    "Services",
+    "ServiceNotRegisteredError",
+    "MainThreadScheduler",
+    "UserActivityEvent",
+    "BackendStoppedEvent",
+    "ShutdownRequestedEvent",
+    "LifecycleEvent",
+    "ResponsivenessLagEvent",
+    "LogBuffer",
+    "LogEntry",
+    "YoyoPodApp",
+    "build_test_app",
+    "drain_all",
+    "assert_events_contain",
+]
+```
+
+- [ ] **Step 11.7: Commit**
+
+Run:
+```bash
+git add src/yoyopod/core/__init__.py src/yoyopod/core/testing.py tests/core/test_testing_helpers.py
+git commit -m "$(cat <<'EOF'
+feat(core): add core.testing helpers (build_test_app, drain_all, assert_events_contain)
+
+Dependency-free test helpers for core primitives. Integration-aware
+variant will extend these in a later plan.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: End-to-end core integration smoke test
+
+**Files:**
+- Create: `tests/core/test_integration.py`
+
+- [ ] **Step 12.1: Write an end-to-end smoke test exercising every core primitive together**
+
+Create `tests/core/test_integration.py`:
+
+```python
+"""End-to-end smoke test for the core primitives working together."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+from yoyopod.core.events import StateChangedEvent, UserActivityEvent
+from yoyopod.core.testing import (
+    assert_events_contain,
+    build_test_app,
+    drain_all,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SetCallStateCommand:
+    value: str
+
+
+def test_full_round_trip_backend_to_state_to_subscriber() -> None:
+    """Simulates: backend thread schedules a state update, main loop drains it,
+    subscribers observe StateChangedEvent and chain an effect via services."""
+    app = build_test_app()
+
+    captured_state_changes: list[str] = []
+    captured_activities: list[str | None] = []
+
+    app.bus.subscribe(
+        StateChangedEvent,
+        lambda ev: captured_state_changes.append(f"{ev.entity}:{ev.new.value}"),
+    )
+    app.bus.subscribe(
+        UserActivityEvent,
+        lambda ev: captured_activities.append(ev.action_name),
+    )
+
+    def set_call_state(cmd: SetCallStateCommand) -> None:
+        app.states.set("call.state", cmd.value)
+        app.bus.publish(UserActivityEvent(action_name=f"call_{cmd.value}"))
+
+    app.services.register("call", "set_state", set_call_state)
+
+    def from_bg_thread() -> None:
+        app.scheduler.run_on_main(
+            lambda: app.services.call("call", "set_state", SetCallStateCommand(value="incoming"))
+        )
+
+    t = threading.Thread(target=from_bg_thread)
+    t.start()
+    t.join()
+
+    drain_all(app)
+
+    assert captured_state_changes == ["call.state:incoming"]
+    assert captured_activities == ["call_incoming"]
+
+
+def test_integration_lifecycle_events_and_teardown_reverse_order() -> None:
+    """Integrations register, setup fires events in order, teardown reverses."""
+    app = build_test_app()
+    log: list[str] = []
+
+    def setup_a(_app):
+        log.append("setup-a")
+
+    def teardown_a(_app):
+        log.append("teardown-a")
+
+    def setup_b(_app):
+        log.append("setup-b")
+
+    def teardown_b(_app):
+        log.append("teardown-b")
+
+    app.register_integration("a", setup=setup_a, teardown=teardown_a)
+    app.register_integration("b", setup=setup_b, teardown=teardown_b)
+
+    app.setup()
+    app.stop()
+
+    assert log == ["setup-a", "setup-b", "teardown-b", "teardown-a"]
+
+
+def test_off_main_bus_publish_rejected() -> None:
+    """The core bus rejects direct publishes from background threads."""
+    app = build_test_app()
+    errors: list[RuntimeError] = []
+
+    def from_bg() -> None:
+        try:
+            app.bus.publish(UserActivityEvent(action_name="bad"))
+        except RuntimeError as exc:
+            errors.append(exc)
+
+    t = threading.Thread(target=from_bg)
+    t.start()
+    t.join()
+
+    assert len(errors) == 1
+    assert "non-main thread" in str(errors[0])
+
+
+def test_event_trace_assertion_works() -> None:
+    """assert_events_contain composes cleanly with the app primitives."""
+    app = build_test_app()
+    captured_events: list = []
+    app.bus.subscribe(StateChangedEvent, lambda ev: captured_events.append(ev))
+
+    app.states.set("call.state", "idle")
+    app.states.set("music.state", "playing")
+    drain_all(app)
+
+    changed_entities = [ev.entity for ev in captured_events]
+    assert changed_entities == ["call.state", "music.state"]
+    from yoyopod.core.states import StateValue
+    # Direct object equality is feasible since StateValue is a frozen dataclass.
+    # We only assert the entity names are present in order.
+    entity_names_only = [ev.entity for ev in captured_events]
+    assert entity_names_only == ["call.state", "music.state"]
+    # And the assertion helper works on any event list:
+    assert_events_contain(captured_events, [captured_events[0]])
+```
+
+- [ ] **Step 12.2: Run the smoke test**
+
+Run:
+```bash
+uv run pytest tests/core/test_integration.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 12.3: Run the full core test suite to confirm nothing else regressed**
+
+Run:
+```bash
+uv run pytest tests/core/ -v
+```
+
+Expected: all tests across `tests/core/` green.
+
+- [ ] **Step 12.4: Format, lint, type-check**
+
+Run:
+```bash
+uv run black tests/core/test_integration.py
+uv run ruff check tests/core/test_integration.py
+```
+
+Expected: all green.
+
+- [ ] **Step 12.5: Commit**
+
+Run:
+```bash
+git add tests/core/test_integration.py
+git commit -m "$(cat <<'EOF'
+test(core): end-to-end smoke exercising all core primitives together
+
+Covers backend-thread → scheduler → main-thread → state → bus → subscriber
+round trip; integration setup/teardown order; strict off-main rejection;
+event-trace assertion helper.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Update CLAUDE.md with the new core primitives reference
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 13.1: Add a "Core Primitives" section to CLAUDE.md**
+
+Edit `CLAUDE.md`. Insert the following new section directly after the "Current Status" section (before "LVGL Status"):
+
+```markdown
+---
+
+## Core Primitives (Phase A, in-progress)
+
+Phase A of the architectural rewrite has introduced the `src/yoyopod/core/`
+package: a state store + typed event bus + service registry that will host
+every integration as domain-specific logic is migrated.
+
+Primitives (all in `src/yoyopod/core/`):
+
+- `Bus` (`bus.py`) — main-thread-only typed event bus; strict mode raises on off-main publish.
+- `States` (`states.py`) — entity state store keyed by `domain.entity_name`. `set()` fires `StateChangedEvent`.
+- `Services` (`services.py`) — command registry keyed by `(domain, service)`. `call(domain, service, data)` dispatches.
+- `MainThreadScheduler` (`scheduler.py`) — backend threads use `run_on_main(fn)` to marshal tasks onto the main thread.
+- `LogBuffer` / `LogEntry` (`logbuffer.py`) — fixed-capacity ring buffer consumed by the future diagnostics integration.
+- `YoyoPodApp` (`app_shell.py`) — composition root. Integration registry, setup/teardown lifecycle, drain helper.
+- `build_test_app`, `drain_all`, `assert_events_contain` (`testing.py`) — core test helpers.
+
+See `docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md` for
+the full architectural contract. Legacy modules (`src/yoyopod/fsm.py`,
+`src/yoyopod/event_bus.py`, `src/yoyopod/coordinators/`, `src/yoyopod/runtime/`)
+remain in place until each domain is migrated in subsequent Phase A plans.
+```
+
+- [ ] **Step 13.2: Commit**
+
+Run:
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs: document core/ primitives in CLAUDE.md
+
+Added "Core Primitives (Phase A, in-progress)" section pointing
+readers/agents at src/yoyopod/core/ and the Phase A design spec. Legacy
+modules remain documented until their owning domain migrates.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 14.1: Full CI gate**
+
+Run:
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green — format, lint, type, tests. This honours the user's pre-commit memory.
+
+- [ ] **Step 14.2: Confirm all new files are tracked by git**
+
+Run:
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean` (ignoring the untracked `.claude/settings.local.json`).
+
+- [ ] **Step 14.3: Verify branch has the expected commit history**
+
+Run:
+```bash
+git log --oneline arch/phase-a-spine-rewrite ^main
+```
+
+Expected commits (top-to-bottom, newest first):
+```
+docs: document core/ primitives in CLAUDE.md
+test(core): end-to-end smoke exercising all core primitives together
+feat(core): add core.testing helpers (build_test_app, drain_all, assert_events_contain)
+feat(core): add YoyoPodApp composition-root shell
+feat(core): add LogBuffer ring buffer for recent events
+feat(core): expand core events with cross-cut signals
+feat(core): add MainThreadScheduler
+feat(core): add Services command registry
+feat(core): add States entity store + StateChangedEvent
+feat(core): add typed Bus primitive
+chore(core): scaffold core package and tests directory
+chore(cli): drop yoyoctl aliases across live code, docs, and rules
+```
+
+12 commits. If any are missing, find the task they came from and re-run the commit step for that task.
+
+- [ ] **Step 14.4: Verify only preserved historical files still reference `yoyoctl`**
+
+Run:
+```bash
+git grep -l "yoyoctl"
+```
+
+Expected: exactly these files (historical design/plan docs preserved in Task 2):
+- `docs/superpowers/specs/2026-04-10-yoyoctl-cli-design.md`
+- `docs/superpowers/specs/2026-04-20-cli-polish-design.md`
+- `docs/superpowers/specs/2026-04-13-4g-connectivity-design.md`
+- `docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md`
+- `docs/superpowers/plans/2026-04-10-yoyoctl-cli.md`
+- `docs/superpowers/plans/2026-04-20-cli-polish.md`
+- `docs/superpowers/plans/2026-04-13-4g-connectivity.md`
+- `docs/superpowers/plans/2026-04-13-cubie-pimoroni-driver.md`
+- `docs/superpowers/plans/2026-04-21-phase-a-core-scaffold.md`
+
+Any match outside this list is a bug — open the file, confirm whether it's a live reference (fix it) or genuinely historical (add to the PRESERVE list in a follow-up).
+
+- [ ] **Step 14.5: Confirm the app still runs**
+
+Run:
+```bash
+uv run python yoyopod.py --help
+```
+
+Expected: Typer help output — app still starts and the CLI still dispatches. (No integrations migrated yet, so full app run is not expected to do more than before.)
+
+---
+
+## Definition of Done
+
+- Branch `arch/phase-a-spine-rewrite` exists with 12 commits on top of `main`.
+- `src/yoyopod/core/` contains `bus.py`, `states.py`, `services.py`, `scheduler.py`, `events.py`, `logbuffer.py`, `app_shell.py`, `testing.py`, plus `__init__.py` re-exporting the public surface.
+- `tests/core/` contains one test file per primitive plus `test_integration.py` smoke test — all passing.
+- `uv run python scripts/quality.py ci` is green.
+- No `yoyoctl` references outside git history / `docs/archive/` / historical plan docs.
+- CLAUDE.md has a "Core Primitives (Phase A, in-progress)" section pointing to the core package and the design spec.
+- The production Pi runtime (`yoyopod.py`) still starts without error — no integrations have been migrated yet, so behaviour is unchanged beyond the CLI rename cleanup.
+
+---
+
+## What's next (not this plan)
+
+After this plan is executed and reviewed:
+
+1. **Plan 2:** Power pilot integration. Migrate `PowerManager`/`PowerRuntimeService`/`PowerCoordinator` into `integrations/power/` end-to-end. Delete the old classes. Pattern validated.
+2. **Plan 3:** Easy batch (network, location, contacts, cloud).
+3. **Plan 4:** Focus + diagnostics + screen + voice.
+4. **Plan 5:** Music.
+5. **Plan 6:** Call.
+6. **Plan 7:** Recovery + screen touch-up + dead-code removal + final sweep.
+
+Each subsequent plan produces a clean, testable slice of the overall Phase A rewrite, building on the core primitives landed here.
+
+---
+
+*End of implementation plan.*

--- a/docs/superpowers/plans/2026-04-21-phase-a-easy-batch.md
+++ b/docs/superpowers/plans/2026-04-21-phase-a-easy-batch.md
@@ -1,0 +1,1651 @@
+# Phase A — Plan 3: Easy Batch (Network, Location, Contacts, Cloud) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate four data-oriented integrations that share the same shape as the power pilot and don't cross-cut other domains: `network`, `location` (split out of `network/gps.py`), `contacts`, and `cloud`. With the pilot's template now proven, these four fall in sequence using the same backend-move + integration-setup pattern.
+
+**Architecture:** Each integration follows the Plan-2 template — move adapter under `src/yoyopod/backends/<name>/`, create `src/yoyopod/integrations/<name>/` with typed commands, handlers that mirror backend events into `app.states`, `setup(app)`/`teardown(app)` that wires things. Legacy classes (`NetworkManager`, `PeopleDirectory`, `CloudManager`) are deleted at the end.
+
+**Tech Stack:** Python 3.12+, pytest, uv, existing `pyserial` (modem), `paho-mqtt` (cloud), `requests` (cloud HTTPS). No new runtime dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md` §3.2 (layout), §5 (entities), §7 (commands), §9.2 (fate), §11.2 (step 4).
+
+**Prerequisite:** Plan 2 executed — `integrations/power/` working, `core/app_shell.py` has `run()`.
+
+---
+
+## File Structure
+
+### Files to create
+
+**Network:**
+- `src/yoyopod/backends/network/__init__.py`
+- `src/yoyopod/backends/network/modem.py` (moved from `src/yoyopod/network/backend.py`)
+- `src/yoyopod/backends/network/ppp.py` (moved from `src/yoyopod/network/ppp.py`)
+- `src/yoyopod/backends/network/at_commands.py` (moved)
+- `src/yoyopod/backends/network/transport.py` (moved)
+- `src/yoyopod/integrations/network/__init__.py` — setup/teardown
+- `src/yoyopod/integrations/network/commands.py`
+- `src/yoyopod/integrations/network/handlers.py`
+- `src/yoyopod/integrations/network/poller.py`
+- `tests/integrations/test_network_commands.py`
+- `tests/integrations/test_network_handlers.py`
+- `tests/integrations/test_network_integration.py`
+
+**Location:**
+- `src/yoyopod/backends/location/__init__.py`
+- `src/yoyopod/backends/location/gps.py` (moved from `src/yoyopod/network/gps.py`)
+- `src/yoyopod/integrations/location/__init__.py`
+- `src/yoyopod/integrations/location/commands.py`
+- `src/yoyopod/integrations/location/handlers.py`
+- `tests/integrations/test_location_commands.py`
+- `tests/integrations/test_location_integration.py`
+
+**Contacts:**
+- `src/yoyopod/integrations/contacts/__init__.py`
+- `src/yoyopod/integrations/contacts/commands.py`
+- `src/yoyopod/integrations/contacts/handlers.py`
+- `src/yoyopod/integrations/contacts/directory.py` (moved from `src/yoyopod/people/directory.py`)
+- `src/yoyopod/integrations/contacts/models.py` (moved from `src/yoyopod/people/models.py`)
+- `src/yoyopod/integrations/contacts/cloud_sync.py` (moved from `src/yoyopod/people/cloud_sync.py`)
+- `tests/integrations/test_contacts_integration.py`
+
+Contacts is primarily a data service (no external hardware backend), so it lives entirely under `integrations/contacts/` with no corresponding `backends/contacts/` directory.
+
+**Cloud:**
+- `src/yoyopod/backends/cloud/__init__.py`
+- `src/yoyopod/backends/cloud/mqtt.py` (moved from `src/yoyopod/cloud/mqtt_client.py`)
+- `src/yoyopod/backends/cloud/http.py` (moved from `src/yoyopod/cloud/client.py`)
+- `src/yoyopod/integrations/cloud/__init__.py`
+- `src/yoyopod/integrations/cloud/commands.py`
+- `src/yoyopod/integrations/cloud/handlers.py`
+- `src/yoyopod/integrations/cloud/models.py` (moved from `src/yoyopod/cloud/models.py`)
+- `tests/integrations/test_cloud_integration.py`
+
+### Files to delete (after all four migrations land)
+
+- `src/yoyopod/network/__init__.py`, `manager.py`, `models.py` (moved), `gps.py` (moved), `backend.py` (moved), `ppp.py` (moved), `transport.py` (moved), `at_commands.py` (moved) — the whole `src/yoyopod/network/` package dies.
+- `src/yoyopod/people/__init__.py` — the whole package dies.
+- `src/yoyopod/cloud/__init__.py`, `manager.py` (replaced) — the whole package dies.
+
+---
+
+## Task 1: Branch state verification
+
+**Files:** none
+
+- [ ] **Step 1.1: Confirm state after Plan 2**
+
+Run:
+```bash
+git branch --show-current
+git log --oneline -10
+ls src/yoyopod/integrations/power/
+uv run pytest tests/core/ tests/integrations/test_power*.py -q
+```
+
+Expected: on `arch/phase-a-spine-rewrite`; Plan 2 commits visible; `integrations/power/` populated; all power + core tests green.
+
+---
+
+## Task 2: Network integration
+
+The network integration owns cellular modem registration, PPP data session, signal strength, and carrier info. GPS is split into its own integration (Task 3) — do NOT include GPS logic here.
+
+**Entities managed:** `network.cellular_registered` (bool), `network.signal_bars` (int 0–5 or None), `network.ppp_up` (bool), `network.carrier` (str), `network.backend_available` (bool).
+
+**Commands:** `enable_ppp`, `disable_ppp`, `refresh_signal`, `set_apn`.
+
+### Subtask 2.1: Scaffold and relocate backend
+
+- [ ] **Step 2.1.1: Create directories and move backend files (excluding gps)**
+
+Run:
+```bash
+mkdir -p src/yoyopod/backends/network
+git mv src/yoyopod/network/backend.py src/yoyopod/backends/network/modem.py
+git mv src/yoyopod/network/ppp.py src/yoyopod/backends/network/ppp.py
+git mv src/yoyopod/network/at_commands.py src/yoyopod/backends/network/at_commands.py
+git mv src/yoyopod/network/transport.py src/yoyopod/backends/network/transport.py
+```
+
+Create `src/yoyopod/backends/network/__init__.py`:
+
+```python
+"""Cellular modem + PPP adapter (GPS is a separate integration)."""
+
+from __future__ import annotations
+
+from yoyopod.backends.network.modem import ModemBackend
+from yoyopod.backends.network.ppp import PPPBackend
+
+__all__ = ["ModemBackend", "PPPBackend"]
+```
+
+Update imports in the moved files (`from yoyopod.network.X` → `from yoyopod.backends.network.X`). Grep for stragglers: `grep -rn "from yoyopod.network" src/yoyopod/backends/network/`.
+
+### Subtask 2.2: Write network commands
+
+- [ ] **Step 2.2.1: Create `tests/integrations/test_network_commands.py`**
+
+```python
+from yoyopod.integrations.network.commands import (
+    DisablePppCommand,
+    EnablePppCommand,
+    RefreshSignalCommand,
+    SetApnCommand,
+)
+
+
+def test_enable_ppp_command() -> None:
+    cmd = EnablePppCommand()
+    assert cmd is not None
+
+
+def test_disable_ppp_command() -> None:
+    cmd = DisablePppCommand()
+    assert cmd is not None
+
+
+def test_refresh_signal_command() -> None:
+    cmd = RefreshSignalCommand()
+    assert cmd is not None
+
+
+def test_set_apn_command() -> None:
+    cmd = SetApnCommand(apn="internet.provider.com", username="u", password="p")
+    assert cmd.apn == "internet.provider.com"
+    assert cmd.username == "u"
+    assert cmd.password == "p"
+
+
+def test_set_apn_command_defaults_empty() -> None:
+    cmd = SetApnCommand(apn="internet")
+    assert cmd.username == ""
+    assert cmd.password == ""
+```
+
+- [ ] **Step 2.2.2: Implement `src/yoyopod/integrations/network/commands.py`**
+
+```python
+"""Typed commands for the network integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class EnablePppCommand:
+    """Request PPP data-session bring-up."""
+
+
+@dataclass(frozen=True, slots=True)
+class DisablePppCommand:
+    """Request PPP data-session tear-down."""
+
+
+@dataclass(frozen=True, slots=True)
+class RefreshSignalCommand:
+    """One-shot AT query for current signal strength."""
+
+
+@dataclass(frozen=True, slots=True)
+class SetApnCommand:
+    """Configure APN credentials for the cellular connection."""
+
+    apn: str
+    username: str = ""
+    password: str = ""
+```
+
+- [ ] **Step 2.2.3: Run tests, format/lint/type, commit**
+
+```bash
+uv run pytest tests/integrations/test_network_commands.py -v
+uv run black src/yoyopod/integrations/network/commands.py tests/integrations/test_network_commands.py
+uv run ruff check src/yoyopod/integrations/network/commands.py tests/integrations/test_network_commands.py
+uv run mypy src/yoyopod/integrations/network/commands.py
+git add -A
+git commit -m "feat(integrations/network): typed commands + backend relocated under backends/network/
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+### Subtask 2.3: Write network handlers
+
+Handlers translate backend status callbacks into state entity writes.
+
+- [ ] **Step 2.3.1: Create `tests/integrations/test_network_handlers.py`**
+
+```python
+from dataclasses import dataclass
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.network.handlers import (
+    apply_modem_status_to_state,
+    apply_ppp_status_to_state,
+    apply_signal_to_state,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ModemStatus:
+    registered: bool
+    carrier: str
+    network_type: str
+    available: bool = True
+
+
+def test_apply_modem_status_sets_state() -> None:
+    app = build_test_app()
+    apply_modem_status_to_state(
+        app,
+        _ModemStatus(registered=True, carrier="T-Mobile", network_type="4G"),
+    )
+    assert app.states.get_value("network.cellular_registered") is True
+    assert app.states.get_value("network.carrier") == "T-Mobile"
+    assert app.states.get_value("network.network_type") == "4G"
+    assert app.states.get_value("network.backend_available") is True
+
+
+def test_apply_modem_status_unregistered() -> None:
+    app = build_test_app()
+    apply_modem_status_to_state(
+        app,
+        _ModemStatus(registered=False, carrier="", network_type=""),
+    )
+    assert app.states.get_value("network.cellular_registered") is False
+
+
+def test_apply_ppp_status() -> None:
+    app = build_test_app()
+    apply_ppp_status_to_state(app, up=True, reason="session_established")
+    assert app.states.get_value("network.ppp_up") is True
+
+    apply_ppp_status_to_state(app, up=False, reason="link_down")
+    assert app.states.get_value("network.ppp_up") is False
+
+
+def test_apply_signal_maps_csq_to_bars() -> None:
+    app = build_test_app()
+    apply_signal_to_state(app, csq=25, bars=4)
+    assert app.states.get_value("network.signal_bars") == 4
+    assert app.states.get_value("network.signal_csq") == 25
+
+
+def test_apply_signal_none_when_no_service() -> None:
+    app = build_test_app()
+    apply_signal_to_state(app, csq=None, bars=None)
+    assert app.states.get_value("network.signal_bars") is None
+```
+
+- [ ] **Step 2.3.2: Implement `src/yoyopod/integrations/network/handlers.py`**
+
+```python
+"""State-update handlers for the network integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def apply_modem_status_to_state(app: Any, status: Any) -> None:
+    """Mirror a modem-status snapshot into the state store.
+
+    Expected fields: registered (bool), carrier (str), network_type (str),
+    available (bool, defaults True).
+    """
+    app.states.set("network.cellular_registered", bool(status.registered))
+    app.states.set("network.carrier", str(status.carrier))
+    app.states.set("network.network_type", str(status.network_type))
+    app.states.set("network.backend_available", bool(getattr(status, "available", True)))
+
+
+def apply_ppp_status_to_state(app: Any, up: bool, reason: str = "") -> None:
+    """Set network.ppp_up to the given boolean."""
+    app.states.set("network.ppp_up", bool(up), attrs={"reason": reason} if reason else None)
+
+
+def apply_signal_to_state(app: Any, csq: int | None, bars: int | None) -> None:
+    """Set network.signal_bars and network.signal_csq."""
+    app.states.set("network.signal_bars", bars)
+    app.states.set("network.signal_csq", csq)
+```
+
+- [ ] **Step 2.3.3: Run tests, format/lint/type, commit**
+
+```bash
+uv run pytest tests/integrations/test_network_handlers.py -v
+uv run black src/yoyopod/integrations/network/handlers.py tests/integrations/test_network_handlers.py
+uv run ruff check src/yoyopod/integrations/network/handlers.py tests/integrations/test_network_handlers.py
+uv run mypy src/yoyopod/integrations/network/handlers.py
+git add -A
+git commit -m "feat(integrations/network): state-update handlers
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+### Subtask 2.4: Write network poller and integration setup
+
+- [ ] **Step 2.4.1: Create `src/yoyopod/integrations/network/poller.py`**
+
+The network poller queries the modem for registration, signal, and carrier at a fixed cadence. Follow the same structure as the power poller (`src/yoyopod/integrations/power/poller.py`). Thread-based, stop event, `run_on_main` marshalling.
+
+```python
+"""Background poller for modem registration + signal strength."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.integrations.network.handlers import (
+    apply_modem_status_to_state,
+    apply_signal_to_state,
+)
+
+
+class NetworkPoller:
+    def __init__(self, app: Any, backend: Any, interval_seconds: float = 15.0) -> None:
+        self._app = app
+        self._backend = backend
+        self._interval = max(0.01, float(interval_seconds))
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True, name="network-poller")
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+        self._thread = None
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                status = self._backend.get_status()
+                signal = self._backend.get_signal()
+            except Exception as exc:
+                logger.error("NetworkPoller query failed: {}", exc)
+                self._stop.wait(self._interval)
+                continue
+
+            self._app.scheduler.run_on_main(
+                lambda s=status, sig=signal: self._apply(s, sig)
+            )
+            self._stop.wait(self._interval)
+
+    def _apply(self, status: Any, signal: Any) -> None:
+        apply_modem_status_to_state(self._app, status)
+        apply_signal_to_state(
+            self._app,
+            csq=getattr(signal, "csq", None),
+            bars=getattr(signal, "bars", None),
+        )
+```
+
+- [ ] **Step 2.4.2: Create `src/yoyopod/integrations/network/__init__.py`**
+
+```python
+"""Network integration: cellular registration, PPP, signal, carrier.
+
+GPS is a separate integration (yoyopod.integrations.location).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.integrations.network.commands import (
+    DisablePppCommand,
+    EnablePppCommand,
+    RefreshSignalCommand,
+    SetApnCommand,
+)
+from yoyopod.integrations.network.handlers import (
+    apply_ppp_status_to_state,
+    apply_signal_to_state,
+)
+from yoyopod.integrations.network.poller import NetworkPoller
+
+_STATE_KEY = "_network_integration"
+
+
+def setup(app: Any, backend: Any | None = None) -> None:
+    """Wire the network integration."""
+    if backend is None:
+        from yoyopod.backends.network import ModemBackend, PPPBackend
+        modem = ModemBackend(app.config.network)
+        ppp = PPPBackend(app.config.network, modem=modem)
+        backend = _ModemPPPAdapter(modem=modem, ppp=ppp)
+
+    poller = NetworkPoller(
+        app=app,
+        backend=backend,
+        interval_seconds=float(app.config.network.poll_interval_seconds),
+    )
+
+    def handle_enable_ppp(_cmd: EnablePppCommand) -> None:
+        logger.info("Network.enable_ppp")
+        try:
+            backend.enable_ppp()
+            apply_ppp_status_to_state(app, up=True, reason="enabled")
+        except Exception as exc:
+            logger.error("enable_ppp failed: {}", exc)
+            apply_ppp_status_to_state(app, up=False, reason=str(exc))
+
+    def handle_disable_ppp(_cmd: DisablePppCommand) -> None:
+        logger.info("Network.disable_ppp")
+        try:
+            backend.disable_ppp()
+            apply_ppp_status_to_state(app, up=False, reason="disabled")
+        except Exception as exc:
+            logger.error("disable_ppp failed: {}", exc)
+
+    def handle_refresh_signal(_cmd: RefreshSignalCommand) -> None:
+        signal = backend.get_signal()
+        apply_signal_to_state(
+            app,
+            csq=getattr(signal, "csq", None),
+            bars=getattr(signal, "bars", None),
+        )
+
+    def handle_set_apn(cmd: SetApnCommand) -> None:
+        backend.set_apn(apn=cmd.apn, username=cmd.username, password=cmd.password)
+
+    app.services.register("network", "enable_ppp", handle_enable_ppp)
+    app.services.register("network", "disable_ppp", handle_disable_ppp)
+    app.services.register("network", "refresh_signal", handle_refresh_signal)
+    app.services.register("network", "set_apn", handle_set_apn)
+
+    poller.start()
+    setattr(app, _STATE_KEY, {"backend": backend, "poller": poller})
+
+
+def teardown(app: Any) -> None:
+    state = getattr(app, _STATE_KEY, None)
+    if state is None:
+        return
+    try:
+        state["poller"].stop()
+    except Exception as exc:
+        logger.error("NetworkPoller.stop: {}", exc)
+    try:
+        close = getattr(state["backend"], "close", None)
+        if callable(close):
+            close()
+    except Exception as exc:
+        logger.error("Network backend close: {}", exc)
+    delattr(app, _STATE_KEY)
+
+
+class _ModemPPPAdapter:
+    """Adapter that unifies ModemBackend + PPPBackend behind one object."""
+
+    def __init__(self, modem: Any, ppp: Any) -> None:
+        self._modem = modem
+        self._ppp = ppp
+
+    def get_status(self) -> Any:
+        return self._modem.get_status()
+
+    def get_signal(self) -> Any:
+        return self._modem.get_signal()
+
+    def enable_ppp(self) -> None:
+        self._ppp.bring_up()
+
+    def disable_ppp(self) -> None:
+        self._ppp.tear_down()
+
+    def set_apn(self, apn: str, username: str, password: str) -> None:
+        self._modem.set_apn(apn=apn, username=username, password=password)
+
+    def close(self) -> None:
+        try:
+            self._ppp.tear_down()
+        except Exception:
+            pass
+        close = getattr(self._modem, "close", None)
+        if callable(close):
+            close()
+```
+
+- [ ] **Step 2.4.3: Create integration test `tests/integrations/test_network_integration.py`**
+
+```python
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.network import setup as setup_network, teardown as teardown_network
+from yoyopod.integrations.network.commands import (
+    DisablePppCommand,
+    EnablePppCommand,
+    RefreshSignalCommand,
+    SetApnCommand,
+)
+
+
+@dataclass
+class _FakeNetworkBackend:
+    registered: bool = True
+    carrier: str = "TestCarrier"
+    network_type: str = "4G"
+    csq: int = 20
+    bars: int = 3
+    ppp_commands: list[str] = None
+    apn_calls: list[tuple[str, str, str]] = None
+
+    def __post_init__(self):
+        self.ppp_commands = []
+        self.apn_calls = []
+
+    def get_status(self):
+        @dataclass(frozen=True, slots=True)
+        class _S:
+            registered: bool
+            carrier: str
+            network_type: str
+            available: bool = True
+
+        return _S(self.registered, self.carrier, self.network_type)
+
+    def get_signal(self):
+        @dataclass(frozen=True, slots=True)
+        class _Sig:
+            csq: int
+            bars: int
+
+        return _Sig(self.csq, self.bars)
+
+    def enable_ppp(self):
+        self.ppp_commands.append("up")
+
+    def disable_ppp(self):
+        self.ppp_commands.append("down")
+
+    def set_apn(self, apn: str, username: str = "", password: str = ""):
+        self.apn_calls.append((apn, username, password))
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def app_with_network():
+    app = build_test_app()
+    backend = _FakeNetworkBackend()
+    app.config = type("C", (), {"network": type("NC", (), {"poll_interval_seconds": 0.05})()})()
+    app.register_integration(
+        "network",
+        setup=lambda a: setup_network(a, backend=backend),
+        teardown=lambda a: teardown_network(a),
+    )
+    app.setup()
+    yield app, backend
+    app.stop()
+
+
+def test_setup_registers_commands(app_with_network):
+    app, _ = app_with_network
+    pairs = set(app.services.registered())
+    assert ("network", "enable_ppp") in pairs
+    assert ("network", "disable_ppp") in pairs
+    assert ("network", "refresh_signal") in pairs
+    assert ("network", "set_apn") in pairs
+
+
+def test_poller_mirrors_modem_status(app_with_network):
+    app, _ = app_with_network
+    time.sleep(0.2)
+    app.drain()
+    assert app.states.get_value("network.cellular_registered") is True
+    assert app.states.get_value("network.carrier") == "TestCarrier"
+
+
+def test_enable_ppp_command_updates_state(app_with_network):
+    app, backend = app_with_network
+    app.services.call("network", "enable_ppp", EnablePppCommand())
+    assert backend.ppp_commands == ["up"]
+    assert app.states.get_value("network.ppp_up") is True
+
+
+def test_disable_ppp_command(app_with_network):
+    app, backend = app_with_network
+    app.services.call("network", "disable_ppp", DisablePppCommand())
+    assert backend.ppp_commands == ["down"]
+    assert app.states.get_value("network.ppp_up") is False
+
+
+def test_set_apn_command(app_with_network):
+    app, backend = app_with_network
+    app.services.call("network", "set_apn", SetApnCommand(apn="a", username="u", password="p"))
+    assert backend.apn_calls == [("a", "u", "p")]
+
+
+def test_refresh_signal_command(app_with_network):
+    app, _ = app_with_network
+    app.services.call("network", "refresh_signal", RefreshSignalCommand())
+    assert app.states.get_value("network.signal_bars") == 3
+    assert app.states.get_value("network.signal_csq") == 20
+```
+
+- [ ] **Step 2.4.4: Run everything, commit**
+
+```bash
+uv run pytest tests/integrations/test_network_integration.py -v
+uv run black src/yoyopod/integrations/network/ tests/integrations/test_network_integration.py
+uv run ruff check src/yoyopod/integrations/network/ tests/integrations/test_network_integration.py
+uv run mypy src/yoyopod/integrations/network/
+git add -A
+git commit -m "feat(integrations/network): poller, setup/teardown, end-to-end test
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Location integration (GPS split out)
+
+GPS is the sole responsibility of the location integration. Strip it out of the legacy network package and treat it as its own domain.
+
+**Entities:** `location.fix` (LocationFix | None; attrs: lat, lng, altitude, speed_mps, last_fix_at), `location.backend_available` (bool).
+
+**Commands:** `request_fix`, `enable_gps`, `disable_gps`.
+
+### Subtask 3.1: Move GPS backend
+
+- [ ] **Step 3.1.1: Relocate**
+
+```bash
+mkdir -p src/yoyopod/backends/location
+git mv src/yoyopod/network/gps.py src/yoyopod/backends/location/gps.py
+```
+
+Update imports inside `src/yoyopod/backends/location/gps.py` (`from yoyopod.network.*` → `from yoyopod.backends.location.*` / `from yoyopod.backends.network.*` as appropriate — GPS typically shares the modem transport, so it may still need `from yoyopod.backends.network.modem import ModemBackend` or similar).
+
+Create `src/yoyopod/backends/location/__init__.py`:
+
+```python
+"""GPS backend (shares the cellular modem serial transport)."""
+
+from __future__ import annotations
+
+from yoyopod.backends.location.gps import GpsBackend
+
+__all__ = ["GpsBackend"]
+```
+
+### Subtask 3.2: Commands, handlers, integration
+
+- [ ] **Step 3.2.1: Create `tests/integrations/test_location_commands.py`**
+
+```python
+from yoyopod.integrations.location.commands import (
+    DisableGpsCommand,
+    EnableGpsCommand,
+    RequestFixCommand,
+)
+
+
+def test_request_fix_argless():
+    assert RequestFixCommand() is not None
+
+
+def test_enable_gps_argless():
+    assert EnableGpsCommand() is not None
+
+
+def test_disable_gps_argless():
+    assert DisableGpsCommand() is not None
+```
+
+- [ ] **Step 3.2.2: Implement `src/yoyopod/integrations/location/commands.py`**
+
+```python
+"""Typed commands for the location integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RequestFixCommand:
+    """Ask the backend for the latest GPS fix; applies result to state."""
+
+
+@dataclass(frozen=True, slots=True)
+class EnableGpsCommand:
+    """Bring up the GPS receiver."""
+
+
+@dataclass(frozen=True, slots=True)
+class DisableGpsCommand:
+    """Power down the GPS receiver to save battery."""
+```
+
+- [ ] **Step 3.2.3: Implement `src/yoyopod/integrations/location/handlers.py` and `__init__.py`**
+
+Create `src/yoyopod/integrations/location/handlers.py`:
+
+```python
+"""State-update handler for location.fix."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class LocationFix:
+    lat: float
+    lng: float
+    altitude: float
+    speed_mps: float
+    last_fix_at: float
+
+
+def apply_fix_to_state(app: Any, fix: Any | None, reason: str = "") -> None:
+    """Mirror a GPS fix into state. None means 'no current fix'."""
+    if fix is None:
+        app.states.set("location.fix", None, attrs={"no_fix_reason": reason})
+        return
+
+    lf = LocationFix(
+        lat=float(fix.lat),
+        lng=float(fix.lng),
+        altitude=float(getattr(fix, "altitude", 0.0)),
+        speed_mps=float(getattr(fix, "speed", getattr(fix, "speed_mps", 0.0))),
+        last_fix_at=time.time(),
+    )
+    app.states.set("location.fix", lf)
+
+
+def apply_availability_to_state(app: Any, available: bool, reason: str = "") -> None:
+    app.states.set(
+        "location.backend_available",
+        bool(available),
+        attrs={"reason": reason} if reason else None,
+    )
+```
+
+Create `src/yoyopod/integrations/location/__init__.py`:
+
+```python
+"""Location (GPS) integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.integrations.location.commands import (
+    DisableGpsCommand,
+    EnableGpsCommand,
+    RequestFixCommand,
+)
+from yoyopod.integrations.location.handlers import (
+    apply_availability_to_state,
+    apply_fix_to_state,
+)
+
+_STATE_KEY = "_location_integration"
+
+
+def setup(app: Any, backend: Any | None = None) -> None:
+    if backend is None:
+        from yoyopod.backends.location import GpsBackend
+        backend = GpsBackend(app.config.network)  # shares network config (modem serial)
+
+    def handle_request_fix(_cmd: RequestFixCommand) -> None:
+        try:
+            fix = backend.get_fix()
+        except Exception as exc:
+            logger.error("GPS.get_fix failed: {}", exc)
+            apply_fix_to_state(app, None, reason=str(exc))
+            return
+        apply_fix_to_state(app, fix, reason="" if fix else "no_fix")
+
+    def handle_enable_gps(_cmd: EnableGpsCommand) -> None:
+        try:
+            backend.enable()
+            apply_availability_to_state(app, True)
+        except Exception as exc:
+            logger.error("GPS.enable failed: {}", exc)
+            apply_availability_to_state(app, False, reason=str(exc))
+
+    def handle_disable_gps(_cmd: DisableGpsCommand) -> None:
+        try:
+            backend.disable()
+            apply_availability_to_state(app, False, reason="disabled")
+        except Exception as exc:
+            logger.error("GPS.disable failed: {}", exc)
+
+    app.services.register("location", "request_fix", handle_request_fix)
+    app.services.register("location", "enable_gps", handle_enable_gps)
+    app.services.register("location", "disable_gps", handle_disable_gps)
+
+    setattr(app, _STATE_KEY, {"backend": backend})
+
+
+def teardown(app: Any) -> None:
+    state = getattr(app, _STATE_KEY, None)
+    if state is None:
+        return
+    close = getattr(state["backend"], "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception as exc:
+            logger.error("GpsBackend.close: {}", exc)
+    delattr(app, _STATE_KEY)
+```
+
+- [ ] **Step 3.2.4: Create `tests/integrations/test_location_integration.py`**
+
+```python
+from dataclasses import dataclass
+
+import pytest
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.location import setup as setup_location, teardown as teardown_location
+from yoyopod.integrations.location.commands import (
+    DisableGpsCommand,
+    EnableGpsCommand,
+    RequestFixCommand,
+)
+
+
+@dataclass
+class _FakeGpsBackend:
+    fix_lat: float = 48.1
+    fix_lng: float = 11.5
+    return_none: bool = False
+    enabled: bool = False
+
+    def get_fix(self):
+        if self.return_none:
+            return None
+
+        @dataclass(frozen=True, slots=True)
+        class _F:
+            lat: float
+            lng: float
+            altitude: float = 0.0
+            speed: float = 0.0
+
+        return _F(self.fix_lat, self.fix_lng)
+
+    def enable(self):
+        self.enabled = True
+
+    def disable(self):
+        self.enabled = False
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def app_with_location():
+    app = build_test_app()
+    backend = _FakeGpsBackend()
+    app.config = type("C", (), {"network": object()})()
+    app.register_integration(
+        "location",
+        setup=lambda a: setup_location(a, backend=backend),
+        teardown=lambda a: teardown_location(a),
+    )
+    app.setup()
+    yield app, backend
+    app.stop()
+
+
+def test_setup_registers_commands(app_with_location):
+    app, _ = app_with_location
+    pairs = set(app.services.registered())
+    assert ("location", "request_fix") in pairs
+    assert ("location", "enable_gps") in pairs
+    assert ("location", "disable_gps") in pairs
+
+
+def test_request_fix_applies_to_state(app_with_location):
+    app, _ = app_with_location
+    app.services.call("location", "request_fix", RequestFixCommand())
+
+    fix = app.states.get_value("location.fix")
+    assert fix is not None
+    assert fix.lat == 48.1
+    assert fix.lng == 11.5
+
+
+def test_request_fix_none_sets_attr_reason(app_with_location):
+    app, backend = app_with_location
+    backend.return_none = True
+    app.services.call("location", "request_fix", RequestFixCommand())
+    sv = app.states.get("location.fix")
+    assert sv.value is None
+    assert sv.attrs.get("no_fix_reason") == "no_fix"
+
+
+def test_enable_disable(app_with_location):
+    app, backend = app_with_location
+    app.services.call("location", "enable_gps", EnableGpsCommand())
+    assert backend.enabled is True
+    assert app.states.get_value("location.backend_available") is True
+
+    app.services.call("location", "disable_gps", DisableGpsCommand())
+    assert backend.enabled is False
+    assert app.states.get_value("location.backend_available") is False
+```
+
+- [ ] **Step 3.2.5: Run tests, format/lint/type, commit**
+
+```bash
+uv run pytest tests/integrations/test_location_commands.py tests/integrations/test_location_integration.py -v
+uv run black src/yoyopod/integrations/location/ src/yoyopod/backends/location/ tests/integrations/test_location_commands.py tests/integrations/test_location_integration.py
+uv run ruff check src/yoyopod/integrations/location/ src/yoyopod/backends/location/ tests/integrations/test_location_commands.py tests/integrations/test_location_integration.py
+uv run mypy src/yoyopod/integrations/location/ src/yoyopod/backends/location/
+git add -A
+git commit -m "feat(integrations/location): split GPS out of network into its own integration
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Contacts integration (data-only, no backend)
+
+The contacts integration owns the people directory. It has no external backend — all data is local (files + optional cloud sync logic that already lives in `people/cloud_sync.py`).
+
+**Entities:** `contacts.unread_voice_notes` (int; attrs: by_address: dict), `contacts.people_count` (int).
+
+**Commands:** `lookup_by_address` (returns contact or None), `reload`, `mark_voice_notes_seen`.
+
+### Subtask 4.1: Relocate the people directory
+
+- [ ] **Step 4.1.1: Move files**
+
+```bash
+mkdir -p src/yoyopod/integrations/contacts
+git mv src/yoyopod/people/directory.py src/yoyopod/integrations/contacts/directory.py
+git mv src/yoyopod/people/models.py src/yoyopod/integrations/contacts/models.py
+git mv src/yoyopod/people/cloud_sync.py src/yoyopod/integrations/contacts/cloud_sync.py
+```
+
+Update imports inside the moved files (`from yoyopod.people.models` → `from yoyopod.integrations.contacts.models`). Grep for remaining references: `grep -rn "from yoyopod.people" src/yoyopod/integrations/contacts/`.
+
+### Subtask 4.2: Commands + setup
+
+- [ ] **Step 4.2.1: Create `src/yoyopod/integrations/contacts/commands.py`**
+
+```python
+"""Typed commands for the contacts integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class LookupByAddressCommand:
+    """Look up a contact by SIP address; returns Contact | None."""
+
+    address: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReloadCommand:
+    """Re-read the contacts file from disk."""
+
+
+@dataclass(frozen=True, slots=True)
+class MarkVoiceNotesSeenCommand:
+    """Clear unread voice-note marker for the given SIP address."""
+
+    address: str
+```
+
+- [ ] **Step 4.2.2: Create `src/yoyopod/integrations/contacts/__init__.py`**
+
+```python
+"""Contacts integration: people directory + voice-note seen tracking."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.integrations.contacts.commands import (
+    LookupByAddressCommand,
+    MarkVoiceNotesSeenCommand,
+    ReloadCommand,
+)
+from yoyopod.integrations.contacts.directory import PeopleDirectory
+
+_STATE_KEY = "_contacts_integration"
+
+
+def setup(app: Any, directory: PeopleDirectory | None = None) -> None:
+    if directory is None:
+        directory = PeopleDirectory(app.config.people)
+        directory.load()
+
+    def _refresh_counts() -> None:
+        app.states.set("contacts.people_count", directory.count())
+        app.states.set(
+            "contacts.unread_voice_notes",
+            directory.unread_voice_note_count(),
+            attrs={"by_address": dict(directory.unread_voice_notes_by_address())},
+        )
+
+    def handle_lookup(cmd: LookupByAddressCommand):
+        return directory.get_contact_by_address(cmd.address)
+
+    def handle_reload(_cmd: ReloadCommand) -> None:
+        logger.info("Contacts.reload")
+        directory.load()
+        _refresh_counts()
+
+    def handle_mark_seen(cmd: MarkVoiceNotesSeenCommand) -> None:
+        directory.mark_voice_notes_seen(cmd.address)
+        _refresh_counts()
+
+    app.services.register("contacts", "lookup_by_address", handle_lookup)
+    app.services.register("contacts", "reload", handle_reload)
+    app.services.register("contacts", "mark_voice_notes_seen", handle_mark_seen)
+
+    _refresh_counts()
+    setattr(app, _STATE_KEY, {"directory": directory})
+
+
+def teardown(app: Any) -> None:
+    state = getattr(app, _STATE_KEY, None)
+    if state is None:
+        return
+    delattr(app, _STATE_KEY)
+```
+
+- [ ] **Step 4.2.3: Create `tests/integrations/test_contacts_integration.py`**
+
+```python
+from dataclasses import dataclass
+
+import pytest
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.contacts import setup as setup_contacts, teardown as teardown_contacts
+from yoyopod.integrations.contacts.commands import (
+    LookupByAddressCommand,
+    MarkVoiceNotesSeenCommand,
+    ReloadCommand,
+)
+
+
+@dataclass
+class _FakeContact:
+    display_name: str
+    sip_address: str
+
+
+class _FakeDirectory:
+    def __init__(self):
+        self._people = {"sip:alice@x": _FakeContact("Alice", "sip:alice@x")}
+        self._unread = {"sip:alice@x": 2}
+        self.load_calls = 0
+
+    def load(self):
+        self.load_calls += 1
+
+    def count(self):
+        return len(self._people)
+
+    def get_contact_by_address(self, address):
+        return self._people.get(address)
+
+    def unread_voice_note_count(self):
+        return sum(self._unread.values())
+
+    def unread_voice_notes_by_address(self):
+        return dict(self._unread)
+
+    def mark_voice_notes_seen(self, address):
+        self._unread.pop(address, None)
+
+
+@pytest.fixture
+def app_with_contacts():
+    app = build_test_app()
+    directory = _FakeDirectory()
+    app.register_integration(
+        "contacts",
+        setup=lambda a: setup_contacts(a, directory=directory),
+        teardown=lambda a: teardown_contacts(a),
+    )
+    app.setup()
+    yield app, directory
+    app.stop()
+
+
+def test_setup_seeds_state(app_with_contacts):
+    app, _ = app_with_contacts
+    assert app.states.get_value("contacts.people_count") == 1
+    assert app.states.get_value("contacts.unread_voice_notes") == 2
+
+
+def test_lookup_returns_contact(app_with_contacts):
+    app, _ = app_with_contacts
+    contact = app.services.call(
+        "contacts", "lookup_by_address", LookupByAddressCommand(address="sip:alice@x")
+    )
+    assert contact is not None
+    assert contact.display_name == "Alice"
+
+
+def test_lookup_missing_returns_none(app_with_contacts):
+    app, _ = app_with_contacts
+    contact = app.services.call(
+        "contacts", "lookup_by_address", LookupByAddressCommand(address="sip:unknown")
+    )
+    assert contact is None
+
+
+def test_reload(app_with_contacts):
+    app, directory = app_with_contacts
+    app.services.call("contacts", "reload", ReloadCommand())
+    assert directory.load_calls == 1
+
+
+def test_mark_voice_notes_seen_updates_state(app_with_contacts):
+    app, _ = app_with_contacts
+    app.services.call(
+        "contacts",
+        "mark_voice_notes_seen",
+        MarkVoiceNotesSeenCommand(address="sip:alice@x"),
+    )
+    assert app.states.get_value("contacts.unread_voice_notes") == 0
+```
+
+- [ ] **Step 4.2.4: Run tests, format/lint/type, commit**
+
+```bash
+uv run pytest tests/integrations/test_contacts_integration.py -v
+uv run black src/yoyopod/integrations/contacts/ tests/integrations/test_contacts_integration.py
+uv run ruff check src/yoyopod/integrations/contacts/ tests/integrations/test_contacts_integration.py
+uv run mypy src/yoyopod/integrations/contacts/
+git add -A
+git commit -m "feat(integrations/contacts): relocate people directory, add service layer
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Cloud integration
+
+The cloud integration subscribes to `StateChangedEvent` and publishes selected state changes to MQTT — the first concrete demonstration of A+3's "add new observers for free" property. Also owns HTTPS auth/token refresh and config polling.
+
+**Entities:** `cloud.mqtt_connected` (bool; attrs: reason, last_sync_at).
+
+**Commands:** `sync_now`, `publish_telemetry`.
+
+### Subtask 5.1: Relocate cloud backend
+
+- [ ] **Step 5.1.1: Move files**
+
+```bash
+mkdir -p src/yoyopod/backends/cloud
+git mv src/yoyopod/cloud/mqtt_client.py src/yoyopod/backends/cloud/mqtt.py
+git mv src/yoyopod/cloud/client.py src/yoyopod/backends/cloud/http.py
+git mv src/yoyopod/cloud/models.py src/yoyopod/integrations/cloud/models.py
+mkdir -p src/yoyopod/integrations/cloud
+```
+
+Update imports. Create `src/yoyopod/backends/cloud/__init__.py`:
+
+```python
+"""Cloud backends: MQTT (telemetry + remote commands) + HTTPS (auth, config, provisioning)."""
+
+from __future__ import annotations
+
+from yoyopod.backends.cloud.http import CloudHttpClient
+from yoyopod.backends.cloud.mqtt import DeviceMqttClient
+
+__all__ = ["CloudHttpClient", "DeviceMqttClient"]
+```
+
+### Subtask 5.2: Commands + setup
+
+- [ ] **Step 5.2.1: Create `src/yoyopod/integrations/cloud/commands.py`**
+
+```python
+"""Typed commands for the cloud integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class SyncNowCommand:
+    """Trigger an HTTPS config-sync roundtrip on demand."""
+
+
+@dataclass(frozen=True, slots=True)
+class PublishTelemetryCommand:
+    """Publish an explicit telemetry payload to MQTT."""
+
+    topic_suffix: str
+    payload: dict
+```
+
+- [ ] **Step 5.2.2: Create `src/yoyopod/integrations/cloud/handlers.py`**
+
+```python
+"""Cloud integration handlers: MQTT status + state-change forwarding."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.core.events import StateChangedEvent
+
+
+_TELEMETRY_ENTITIES = {
+    "power.battery_percent",
+    "power.charging",
+    "network.cellular_registered",
+    "network.signal_bars",
+    "network.ppp_up",
+    "location.fix",
+    "call.state",
+    "music.state",
+}
+
+
+def apply_mqtt_status_to_state(app: Any, connected: bool, reason: str = "") -> None:
+    attrs = {"reason": reason, "last_sync_at": time.time()} if reason else {"last_sync_at": time.time()}
+    app.states.set("cloud.mqtt_connected", bool(connected), attrs=attrs)
+
+
+def build_forwarder(app: Any, mqtt_client: Any) -> Any:
+    """Build a StateChangedEvent subscriber that forwards interesting entities to MQTT."""
+
+    def on_state_changed(ev: StateChangedEvent) -> None:
+        if ev.entity not in _TELEMETRY_ENTITIES:
+            return
+        if not app.states.get_value("cloud.mqtt_connected"):
+            return
+        try:
+            payload = {
+                "entity": ev.entity,
+                "value": _serialisable(ev.new.value),
+                "attrs": _serialisable_dict(ev.new.attrs),
+                "ts": ev.new.last_changed_at,
+            }
+            mqtt_client.publish(f"yoyopod/telemetry/{ev.entity}", json.dumps(payload), qos=0)
+        except Exception as exc:
+            logger.error("cloud forwarder MQTT publish failed: {}", exc)
+
+    return on_state_changed
+
+
+def _serialisable(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if hasattr(value, "__dict__"):
+        return {k: _serialisable(v) for k, v in vars(value).items()}
+    return str(value)
+
+
+def _serialisable_dict(d: dict) -> dict:
+    return {k: _serialisable(v) for k, v in d.items()}
+```
+
+- [ ] **Step 5.2.3: Create `src/yoyopod/integrations/cloud/__init__.py`**
+
+```python
+"""Cloud integration: MQTT telemetry, HTTPS config sync, remote commands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.core.events import StateChangedEvent
+from yoyopod.integrations.cloud.commands import (
+    PublishTelemetryCommand,
+    SyncNowCommand,
+)
+from yoyopod.integrations.cloud.handlers import (
+    apply_mqtt_status_to_state,
+    build_forwarder,
+)
+
+_STATE_KEY = "_cloud_integration"
+
+
+def setup(
+    app: Any,
+    mqtt_client: Any | None = None,
+    http_client: Any | None = None,
+) -> None:
+    if mqtt_client is None:
+        from yoyopod.backends.cloud import DeviceMqttClient
+        mqtt_client = DeviceMqttClient(app.config.cloud)
+    if http_client is None:
+        from yoyopod.backends.cloud import CloudHttpClient
+        http_client = CloudHttpClient(app.config.cloud)
+
+    def on_mqtt_connect() -> None:
+        app.scheduler.run_on_main(lambda: apply_mqtt_status_to_state(app, True, "connected"))
+
+    def on_mqtt_disconnect(reason: str = "") -> None:
+        app.scheduler.run_on_main(lambda: apply_mqtt_status_to_state(app, False, reason))
+
+    mqtt_client.on_connect(on_mqtt_connect)
+    mqtt_client.on_disconnect(on_mqtt_disconnect)
+
+    forwarder = build_forwarder(app, mqtt_client)
+    app.bus.subscribe(StateChangedEvent, forwarder)
+
+    mqtt_client.start()
+
+    def handle_sync_now(_cmd: SyncNowCommand) -> None:
+        try:
+            config = http_client.sync_config()
+            app.states.set("cloud.last_sync_at", time.time(), attrs={})
+        except Exception as exc:
+            logger.error("cloud sync_now failed: {}", exc)
+
+    def handle_publish_telemetry(cmd: PublishTelemetryCommand) -> None:
+        try:
+            import json
+            mqtt_client.publish(
+                f"yoyopod/telemetry/{cmd.topic_suffix}",
+                json.dumps(cmd.payload),
+                qos=0,
+            )
+        except Exception as exc:
+            logger.error("publish_telemetry failed: {}", exc)
+
+    import time  # avoid circular import in handler closures above
+
+    app.services.register("cloud", "sync_now", handle_sync_now)
+    app.services.register("cloud", "publish_telemetry", handle_publish_telemetry)
+
+    setattr(app, _STATE_KEY, {"mqtt": mqtt_client, "http": http_client})
+
+
+def teardown(app: Any) -> None:
+    state = getattr(app, _STATE_KEY, None)
+    if state is None:
+        return
+    try:
+        state["mqtt"].stop()
+    except Exception as exc:
+        logger.error("mqtt stop: {}", exc)
+    delattr(app, _STATE_KEY)
+```
+
+- [ ] **Step 5.2.4: Create `tests/integrations/test_cloud_integration.py`**
+
+```python
+import json
+from dataclasses import dataclass, field
+from typing import Callable
+
+import pytest
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.cloud import setup as setup_cloud, teardown as teardown_cloud
+from yoyopod.integrations.cloud.commands import (
+    PublishTelemetryCommand,
+    SyncNowCommand,
+)
+
+
+@dataclass
+class _FakeMqtt:
+    _connect_cb: Callable[[], None] | None = None
+    _disconnect_cb: Callable[[str], None] | None = None
+    started: bool = False
+    published: list[tuple[str, str]] = field(default_factory=list)
+
+    def on_connect(self, cb):
+        self._connect_cb = cb
+
+    def on_disconnect(self, cb):
+        self._disconnect_cb = cb
+
+    def start(self):
+        self.started = True
+        if self._connect_cb:
+            self._connect_cb()
+
+    def stop(self):
+        self.started = False
+
+    def publish(self, topic, payload, qos=0):
+        self.published.append((topic, payload))
+
+
+@dataclass
+class _FakeHttp:
+    synced: int = 0
+
+    def sync_config(self):
+        self.synced += 1
+        return {}
+
+
+@pytest.fixture
+def app_with_cloud():
+    app = build_test_app()
+    mqtt = _FakeMqtt()
+    http = _FakeHttp()
+    app.register_integration(
+        "cloud",
+        setup=lambda a: setup_cloud(a, mqtt_client=mqtt, http_client=http),
+        teardown=lambda a: teardown_cloud(a),
+    )
+    app.setup()
+    app.drain()
+    yield app, mqtt, http
+    app.stop()
+
+
+def test_setup_connects_mqtt_and_sets_state(app_with_cloud):
+    app, mqtt, _ = app_with_cloud
+    assert mqtt.started is True
+    assert app.states.get_value("cloud.mqtt_connected") is True
+
+
+def test_state_changes_forward_to_mqtt(app_with_cloud):
+    app, mqtt, _ = app_with_cloud
+    app.states.set("power.battery_percent", 77)
+    app.drain()
+
+    telemetry = [p for p in mqtt.published if "power.battery_percent" in p[0]]
+    assert len(telemetry) == 1
+    payload = json.loads(telemetry[0][1])
+    assert payload["entity"] == "power.battery_percent"
+    assert payload["value"] == 77
+
+
+def test_non_telemetry_entity_not_forwarded(app_with_cloud):
+    app, mqtt, _ = app_with_cloud
+    before = len(mqtt.published)
+    app.states.set("contacts.people_count", 5)
+    app.drain()
+    after = len(mqtt.published)
+    assert after == before  # contacts.people_count is not in _TELEMETRY_ENTITIES
+
+
+def test_sync_now_command(app_with_cloud):
+    app, _, http = app_with_cloud
+    app.services.call("cloud", "sync_now", SyncNowCommand())
+    assert http.synced == 1
+
+
+def test_publish_telemetry_command(app_with_cloud):
+    app, mqtt, _ = app_with_cloud
+    app.services.call(
+        "cloud",
+        "publish_telemetry",
+        PublishTelemetryCommand(topic_suffix="custom", payload={"x": 1}),
+    )
+    custom = [p for p in mqtt.published if "custom" in p[0]]
+    assert len(custom) == 1
+    assert json.loads(custom[0][1]) == {"x": 1}
+```
+
+- [ ] **Step 5.2.5: Run tests, format/lint/type, commit**
+
+```bash
+uv run pytest tests/integrations/test_cloud_integration.py -v
+uv run black src/yoyopod/integrations/cloud/ src/yoyopod/backends/cloud/ tests/integrations/test_cloud_integration.py
+uv run ruff check src/yoyopod/integrations/cloud/ src/yoyopod/backends/cloud/ tests/integrations/test_cloud_integration.py
+uv run mypy src/yoyopod/integrations/cloud/ src/yoyopod/backends/cloud/
+git add -A
+git commit -m "feat(integrations/cloud): MQTT telemetry + HTTPS sync via StateChangedEvent subscriber
+
+First demonstration of A+3's 'add observers for free' pattern — the cloud
+integration subscribes to StateChangedEvent and forwards selected entities
+to MQTT with zero changes to power/network/location integrations.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Retire `NetworkManager`, `PeopleDirectory` (legacy exports), `CloudManager`
+
+- [ ] **Step 6.1: Enumerate remaining consumers**
+
+```bash
+grep -rn "NetworkManager\|PeopleDirectory\|CloudManager" src/ tests/
+grep -rn "from yoyopod.network import\|from yoyopod.people import\|from yoyopod.cloud import" src/ tests/
+```
+
+For each result outside of docs: either the file is still a legacy shell (`src/yoyopod/app.py`, its remaining imports) that will be rewritten in Plan 8 — stub to compile; or the file is a test that's already slated for deletion per the Phase A spec §12.1 — delete it.
+
+- [ ] **Step 6.2: Delete legacy package files**
+
+```bash
+git rm src/yoyopod/network/manager.py
+git rm src/yoyopod/network/models.py
+git rm src/yoyopod/network/__init__.py
+git rm src/yoyopod/people/__init__.py
+git rm src/yoyopod/cloud/manager.py
+git rm src/yoyopod/cloud/__init__.py
+```
+
+Any `__init__.py` reference that no longer exists — skip.
+
+- [ ] **Step 6.3: Update `src/yoyopod/app.py` imports**
+
+Remove `from yoyopod.network import NetworkManager`, `from yoyopod.people import PeopleDirectory`, `from yoyopod.cloud import CloudManager`, and the corresponding instance variables/construction in `app.py`. Leave comments pointing at the new integrations. `app.py` is still the legacy shell and will be rewritten in Plan 8.
+
+- [ ] **Step 6.4: Run CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: delete legacy NetworkManager, PeopleDirectory, CloudManager
+
+All four domains migrated to integrations/. Legacy packages dies. Tests
+updated; app.py still the legacy shell (rewritten in Plan 8).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 7.1: Confirm structure**
+
+```bash
+ls src/yoyopod/integrations/
+ls src/yoyopod/backends/
+```
+
+Expected `integrations/`: `__init__.py`, `power/`, `network/`, `location/`, `contacts/`, `cloud/`.
+Expected `backends/`: `__init__.py`, `power/`, `network/`, `location/`, `cloud/`.
+
+- [ ] **Step 7.2: Full CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green.
+
+- [ ] **Step 7.3: Confirm no legacy references in non-doc paths**
+
+```bash
+git grep -l "from yoyopod.network\|from yoyopod.people\|from yoyopod.cloud"
+```
+
+Expected: matches only in `docs/` (spec/plan references) and archive. Anything else — fix.
+
+- [ ] **Step 7.4: Commit count**
+
+```bash
+git log --oneline arch/phase-a-spine-rewrite ^main
+```
+
+Expected ~12-14 new commits on top of Plan 2 (one per subtask plus cleanup commit).
+
+---
+
+## Definition of Done
+
+- `integrations/network/`, `integrations/location/`, `integrations/contacts/`, `integrations/cloud/` all populated with setup/teardown, commands, handlers, tests.
+- `backends/network/`, `backends/location/`, `backends/cloud/` populated with relocated adapter code.
+- Legacy `src/yoyopod/network/`, `src/yoyopod/people/`, `src/yoyopod/cloud/` packages deleted.
+- Cloud integration demonstrates the "free observability" property: state changes in `power.*`, `network.*`, `location.*`, `call.*`, `music.*` auto-forward to MQTT.
+- All tests green; `uv run python scripts/quality.py ci` green.
+
+---
+
+## What's next (Plan 4)
+
+`focus`, `diagnostics`, `screen`, `voice` — four integrations covering the cross-cutting signals (audio focus arbiter, event log + responsiveness watchdog + snapshot command, screen wake/idle/brightness, STT/TTS/voice-command). Focus must ship before music/call migrations since those depend on it.
+
+---
+
+*End of implementation plan.*

--- a/docs/superpowers/plans/2026-04-21-phase-a-focus-diag-screen-voice.md
+++ b/docs/superpowers/plans/2026-04-21-phase-a-focus-diag-screen-voice.md
@@ -1,0 +1,1504 @@
+# Phase A — Plan 4: Focus + Diagnostics + Screen + Voice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the four cross-cutting integrations that subsequent plans depend on. `focus` is the AudioFocus arbiter (replaces `CallInterruptionPolicy`) — required before music/call migrations in Plans 5 and 6. `diagnostics` owns the structured event log, snapshot command, and responsiveness watchdog. `screen` folds `ScreenPowerService` into integration form. `voice` rehomes `VoiceRuntimeCoordinator` as an integration.
+
+**Architecture:** Same per-integration shape as prior plans. Focus is stateless beyond its arbiter field; diagnostics subscribes to the bus wildly and writes JSONL; screen owns a single `ui.tick()` callback registered into `YoyoPodApp`; voice orchestrates STT engine + TTS engine + command matcher.
+
+**Tech Stack:** Python 3.12+, pytest, uv, existing STT (`vosk`) and TTS backends. No new runtime dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md` §5, §6, §7, §8, §9.1, §9.2, §11.2 (steps 5-7).
+
+**Prerequisite:** Plans 1-3 executed; `integrations/power/`, `network/`, `location/`, `contacts/`, `cloud/` working.
+
+---
+
+## File Structure
+
+**Focus:**
+- `src/yoyopod/integrations/focus/__init__.py`
+- `src/yoyopod/integrations/focus/commands.py`
+- `src/yoyopod/integrations/focus/events.py`
+- `src/yoyopod/integrations/focus/arbiter.py`
+- `tests/integrations/test_focus.py`
+
+**Diagnostics:**
+- `src/yoyopod/integrations/diagnostics/__init__.py`
+- `src/yoyopod/integrations/diagnostics/commands.py`
+- `src/yoyopod/integrations/diagnostics/events.py`
+- `src/yoyopod/integrations/diagnostics/log_writer.py`
+- `src/yoyopod/integrations/diagnostics/snapshot.py`
+- `src/yoyopod/integrations/diagnostics/watchdog.py`
+- `tests/integrations/test_diagnostics.py`
+
+**Screen:**
+- `src/yoyopod/integrations/screen/__init__.py`
+- `src/yoyopod/integrations/screen/commands.py`
+- `src/yoyopod/integrations/screen/handlers.py`
+- `tests/integrations/test_screen.py`
+
+**Voice:**
+- `src/yoyopod/integrations/voice/__init__.py`
+- `src/yoyopod/integrations/voice/commands.py`
+- `src/yoyopod/integrations/voice/events.py`
+- `src/yoyopod/integrations/voice/pipeline.py`
+- `src/yoyopod/backends/voice/__init__.py` (moved)
+- `src/yoyopod/backends/voice/stt.py` (moved from `src/yoyopod/voice/stt*.py`)
+- `src/yoyopod/backends/voice/tts.py` (moved from `src/yoyopod/voice/tts*.py`)
+- `tests/integrations/test_voice.py`
+
+---
+
+## Task 1: Branch state verification
+
+- [ ] **Step 1.1: Confirm Plan 3 is landed**
+
+Run:
+```bash
+git log --oneline -15
+ls src/yoyopod/integrations/
+uv run pytest tests/core/ tests/integrations/ -q
+```
+
+Expected: Plan 3 commits visible; 5 integrations exist (`power`, `network`, `location`, `contacts`, `cloud`); all tests green.
+
+---
+
+## Task 2: Focus integration (AudioFocus arbiter)
+
+The focus integration is the single source of truth for "who owns audio right now." Replaces `CallInterruptionPolicy` and its cross-domain call-interrupts-music logic.
+
+**Entities:** `focus.owner` (`"call" | "music" | "voice" | None`; attrs: `preempted`, `requested_at`).
+
+**Events:** `AudioFocusGrantedEvent(owner, preempted)`, `AudioFocusLostEvent(owner, preempted_by)`.
+
+**Commands:** `request_focus`, `release_focus`.
+
+### Subtask 2.1: Focus events
+
+- [ ] **Step 2.1.1: Create `src/yoyopod/integrations/focus/events.py`**
+
+```python
+"""Audio focus events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class AudioFocusGrantedEvent:
+    """Focus was granted to `owner`. If `preempted` is non-empty, they were kicked."""
+
+    owner: str
+    preempted: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class AudioFocusLostEvent:
+    """`owner` lost focus because `preempted_by` took it."""
+
+    owner: str
+    preempted_by: str
+```
+
+### Subtask 2.2: Focus commands
+
+- [ ] **Step 2.2.1: Create `src/yoyopod/integrations/focus/commands.py`**
+
+```python
+"""Typed commands for the focus integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RequestFocusCommand:
+    """Request audio focus on behalf of `owner`. Grants immediately; pre-empts existing owner."""
+
+    owner: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseFocusCommand:
+    """Release audio focus if `owner` currently holds it. No-op otherwise."""
+
+    owner: str
+```
+
+### Subtask 2.3: Arbiter implementation + test
+
+- [ ] **Step 2.3.1: Create `tests/integrations/test_focus.py`**
+
+```python
+import pytest
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.focus import setup as setup_focus, teardown as teardown_focus
+from yoyopod.integrations.focus.commands import (
+    ReleaseFocusCommand,
+    RequestFocusCommand,
+)
+from yoyopod.integrations.focus.events import (
+    AudioFocusGrantedEvent,
+    AudioFocusLostEvent,
+)
+
+
+@pytest.fixture
+def app_with_focus():
+    app = build_test_app()
+    app.register_integration(
+        "focus",
+        setup=lambda a: setup_focus(a),
+        teardown=lambda a: teardown_focus(a),
+    )
+    app.setup()
+    yield app
+    app.stop()
+
+
+def test_initial_focus_is_none(app_with_focus):
+    assert app_with_focus.states.get_value("focus.owner") is None
+
+
+def test_request_grants_focus_when_none_owned(app_with_focus):
+    app = app_with_focus
+    granted: list[AudioFocusGrantedEvent] = []
+    app.bus.subscribe(AudioFocusGrantedEvent, lambda ev: granted.append(ev))
+
+    app.services.call("focus", "request_focus", RequestFocusCommand(owner="music"))
+    app.drain()
+
+    assert app.states.get_value("focus.owner") == "music"
+    assert len(granted) == 1
+    assert granted[0].owner == "music"
+    assert granted[0].preempted is None
+
+
+def test_request_preempts_current_owner(app_with_focus):
+    app = app_with_focus
+    lost: list[AudioFocusLostEvent] = []
+    granted: list[AudioFocusGrantedEvent] = []
+    app.bus.subscribe(AudioFocusLostEvent, lambda ev: lost.append(ev))
+    app.bus.subscribe(AudioFocusGrantedEvent, lambda ev: granted.append(ev))
+
+    app.services.call("focus", "request_focus", RequestFocusCommand(owner="music"))
+    app.drain()
+    app.services.call("focus", "request_focus", RequestFocusCommand(owner="call"))
+    app.drain()
+
+    assert app.states.get_value("focus.owner") == "call"
+    assert len(lost) == 1
+    assert lost[0].owner == "music"
+    assert lost[0].preempted_by == "call"
+    assert granted[-1].preempted == "music"
+
+
+def test_request_same_owner_is_idempotent(app_with_focus):
+    app = app_with_focus
+    granted: list[AudioFocusGrantedEvent] = []
+    app.bus.subscribe(AudioFocusGrantedEvent, lambda ev: granted.append(ev))
+
+    app.services.call("focus", "request_focus", RequestFocusCommand(owner="call"))
+    app.drain()
+    app.services.call("focus", "request_focus", RequestFocusCommand(owner="call"))
+    app.drain()
+
+    assert len(granted) == 1  # no duplicate grant
+    assert app.states.get_value("focus.owner") == "call"
+
+
+def test_release_clears_focus_for_correct_owner(app_with_focus):
+    app = app_with_focus
+    app.services.call("focus", "request_focus", RequestFocusCommand(owner="music"))
+    app.drain()
+    app.services.call("focus", "release_focus", ReleaseFocusCommand(owner="music"))
+    app.drain()
+
+    assert app.states.get_value("focus.owner") is None
+
+
+def test_release_noop_when_different_owner(app_with_focus):
+    app = app_with_focus
+    app.services.call("focus", "request_focus", RequestFocusCommand(owner="music"))
+    app.drain()
+    app.services.call("focus", "release_focus", ReleaseFocusCommand(owner="call"))
+    app.drain()
+
+    # music still owns; release by call is a no-op
+    assert app.states.get_value("focus.owner") == "music"
+
+
+def test_release_without_owner_is_noop(app_with_focus):
+    app = app_with_focus
+    app.services.call("focus", "release_focus", ReleaseFocusCommand(owner="music"))
+    app.drain()
+
+    assert app.states.get_value("focus.owner") is None
+```
+
+- [ ] **Step 2.3.2: Create `src/yoyopod/integrations/focus/arbiter.py` and `__init__.py`**
+
+`src/yoyopod/integrations/focus/arbiter.py`:
+
+```python
+"""Stateless audio focus arbiter helper."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from yoyopod.integrations.focus.events import (
+    AudioFocusGrantedEvent,
+    AudioFocusLostEvent,
+)
+
+
+def request_focus(app: Any, new_owner: str) -> None:
+    """Grant focus to new_owner. Pre-empts any current owner."""
+    current = app.states.get_value("focus.owner")
+    if current == new_owner:
+        return  # idempotent
+
+    if current is not None and current != new_owner:
+        app.bus.publish(AudioFocusLostEvent(owner=current, preempted_by=new_owner))
+
+    app.states.set(
+        "focus.owner",
+        new_owner,
+        attrs={"preempted": current, "requested_at": time.time()},
+    )
+    app.bus.publish(AudioFocusGrantedEvent(owner=new_owner, preempted=current))
+
+
+def release_focus(app: Any, owner: str) -> None:
+    """Release focus iff owner holds it."""
+    current = app.states.get_value("focus.owner")
+    if current != owner:
+        return
+    app.states.set("focus.owner", None, attrs={"released_by": owner})
+```
+
+`src/yoyopod/integrations/focus/__init__.py`:
+
+```python
+"""Focus integration: audio focus arbiter (replaces CallInterruptionPolicy)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from yoyopod.integrations.focus.arbiter import release_focus, request_focus
+from yoyopod.integrations.focus.commands import (
+    ReleaseFocusCommand,
+    RequestFocusCommand,
+)
+
+
+def setup(app: Any) -> None:
+    def handle_request(cmd: RequestFocusCommand) -> None:
+        request_focus(app, cmd.owner)
+
+    def handle_release(cmd: ReleaseFocusCommand) -> None:
+        release_focus(app, cmd.owner)
+
+    app.services.register("focus", "request_focus", handle_request)
+    app.services.register("focus", "release_focus", handle_release)
+
+
+def teardown(app: Any) -> None:
+    # Focus holds no background resources; nothing to tear down.
+    pass
+```
+
+- [ ] **Step 2.3.3: Run tests, format/lint/type, commit**
+
+```bash
+uv run pytest tests/integrations/test_focus.py -v
+uv run black src/yoyopod/integrations/focus/ tests/integrations/test_focus.py
+uv run ruff check src/yoyopod/integrations/focus/ tests/integrations/test_focus.py
+uv run mypy src/yoyopod/integrations/focus/
+git add -A
+git commit -m "feat(integrations/focus): AudioFocus arbiter (replaces CallInterruptionPolicy)
+
+Stateless arbiter: request_focus pre-empts current owner, emits
+AudioFocusGranted + AudioFocusLost events. release_focus is idempotent.
+focus.owner state entity is the single source of truth.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Diagnostics integration (event log + snapshot + responsiveness watchdog)
+
+The diagnostics integration is the engine for LLM-assisted debugging:
+1. Subscribes to every event on the bus + every state change + every command invocation, and writes structured JSONL.
+2. Exposes `diagnostics.snapshot` command that dumps state + subscriptions + tick stats.
+3. Measures `scheduler.drain() + bus.drain()` duration per tick and emits `ResponsivenessLagEvent` when over threshold.
+
+**Entities:** none directly; diagnostics consumes the bus.
+
+**Events:** `ResponsivenessLagEvent` already defined in `core/events.py`.
+
+**Commands:** `snapshot(SnapshotCommand)`, `mark_user_activity(MarkUserActivityCommand)`.
+
+### Subtask 3.1: Diagnostics commands + events
+
+- [ ] **Step 3.1.1: Create `src/yoyopod/integrations/diagnostics/commands.py`**
+
+```python
+"""Typed commands for the diagnostics integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotCommand:
+    """Write a diagnostic snapshot JSON file to the log directory."""
+
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class MarkUserActivityCommand:
+    """Publish a UserActivityEvent indicating user input (keeps screen awake)."""
+
+    action_name: str | None = None
+```
+
+### Subtask 3.2: Log writer with TDD
+
+The log writer subscribes to the bus and appends each event to a rolling JSONL file.
+
+- [ ] **Step 3.2.1: Create `tests/integrations/test_diagnostics_log_writer.py`**
+
+```python
+import json
+from pathlib import Path
+
+import pytest
+
+from yoyopod.core.events import StateChangedEvent, UserActivityEvent
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.diagnostics.log_writer import LogWriter
+
+
+@pytest.fixture
+def log_path(tmp_path) -> Path:
+    return tmp_path / "events.jsonl"
+
+
+def test_log_writer_appends_state_changed(app_with_log_writer):
+    app, path = app_with_log_writer
+    app.states.set("power.battery_percent", 80)
+    app.drain()
+
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) >= 1
+    last = json.loads(lines[-1])
+    assert last["kind"] == "event"
+    assert last["type"] == "StateChangedEvent"
+    assert last["payload"]["entity"] == "power.battery_percent"
+
+
+def test_log_writer_appends_user_activity(app_with_log_writer):
+    app, path = app_with_log_writer
+    app.bus.publish(UserActivityEvent(action_name="button_select"))
+    app.drain()
+
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert any(json.loads(line)["type"] == "UserActivityEvent" for line in lines)
+
+
+def test_log_writer_tracks_commands(app_with_log_writer):
+    app, path = app_with_log_writer
+    # Commands are logged when services.call is invoked through the diagnostics-wrapped
+    # services proxy; for the test we emulate a command entry directly.
+    app.services.register("demo", "do", lambda _d: None)
+    app.services.call("demo", "do", {"arg": 1})
+
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert any(
+        json.loads(line)["kind"] == "command" and json.loads(line)["domain"] == "demo"
+        for line in lines
+    )
+
+
+def test_log_writer_rotates_on_size(tmp_path, monkeypatch):
+    path = tmp_path / "events.jsonl"
+    writer = LogWriter(path=path, max_bytes=200, max_files=3)
+
+    from yoyopod.integrations.diagnostics.log_writer import LogEntryRecord
+
+    for i in range(100):
+        writer.append(LogEntryRecord(kind="event", type="X", payload={"i": i}))
+
+    # Should have produced at least 1 rotated file alongside current.
+    rotated = list(tmp_path.glob("events.jsonl.*"))
+    assert len(rotated) >= 1
+
+
+@pytest.fixture
+def app_with_log_writer(tmp_path):
+    from yoyopod.integrations.diagnostics import setup as setup_diag, teardown as teardown_diag
+
+    path = tmp_path / "events.jsonl"
+    app = build_test_app()
+    app.config = type("C", (), {
+        "diagnostics": type("DC", (), {
+            "log_path": str(path),
+            "max_bytes": 1_000_000,
+            "max_files": 3,
+            "responsiveness_threshold_ms": 100.0,
+            "responsiveness_watchdog_enabled": False,
+        })(),
+    })()
+    app.register_integration(
+        "diagnostics",
+        setup=lambda a: setup_diag(a),
+        teardown=lambda a: teardown_diag(a),
+    )
+    app.setup()
+    yield app, path
+    app.stop()
+```
+
+- [ ] **Step 3.2.2: Implement `src/yoyopod/integrations/diagnostics/log_writer.py`**
+
+```python
+"""JSONL event log writer.
+
+Subscribes to every event on the bus plus every command invocation; writes
+structured JSONL to a rolling file. See docs/superpowers/specs/2026-04-21-
+phase-a-spine-rewrite-design.md §8.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+
+LogKind = Literal["event", "command", "error", "lifecycle"]
+
+
+@dataclass(frozen=True, slots=True)
+class LogEntryRecord:
+    """Wire format for one log line; not to be confused with core.LogEntry (in-memory buffer)."""
+
+    kind: LogKind
+    type: str = ""
+    payload: dict | None = None
+    domain: str = ""
+    service: str = ""
+    data: dict | None = None
+    handler: str = ""
+    exc: str = ""
+
+
+class LogWriter:
+    """Thread-safe append-only JSONL writer with size-based rotation."""
+
+    def __init__(self, path: Path, max_bytes: int = 5 * 1024 * 1024, max_files: int = 5) -> None:
+        self._path = Path(path)
+        self._max_bytes = int(max_bytes)
+        self._max_files = int(max_files)
+        self._lock = threading.Lock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def append(self, record: LogEntryRecord) -> None:
+        """Append one JSONL line; rotate files when over size."""
+        line = self._to_line(record)
+        with self._lock:
+            if self._path.exists() and self._path.stat().st_size + len(line) > self._max_bytes:
+                self._rotate()
+            with open(self._path, "a", encoding="utf-8") as f:
+                f.write(line)
+
+    def _rotate(self) -> None:
+        """Rotate files: events.jsonl -> events.jsonl.1 -> .2 -> ..., drop beyond max_files."""
+        for i in range(self._max_files - 1, 0, -1):
+            src = self._path.with_suffix(self._path.suffix + f".{i}")
+            dst = self._path.with_suffix(self._path.suffix + f".{i + 1}")
+            if src.exists():
+                if dst.exists():
+                    dst.unlink()
+                src.rename(dst)
+        first_rotated = self._path.with_suffix(self._path.suffix + ".1")
+        if first_rotated.exists():
+            first_rotated.unlink()
+        if self._path.exists():
+            self._path.rename(first_rotated)
+
+    def _to_line(self, record: LogEntryRecord) -> str:
+        obj: dict[str, Any] = {
+            "ts": _iso_now(),
+            "kind": record.kind,
+        }
+        if record.kind == "event":
+            obj["type"] = record.type
+            obj["payload"] = record.payload or {}
+        elif record.kind == "command":
+            obj["domain"] = record.domain
+            obj["service"] = record.service
+            obj["data"] = record.data or {}
+        elif record.kind == "error":
+            obj["handler"] = record.handler
+            obj["exc"] = record.exc
+        elif record.kind == "lifecycle":
+            obj["integration"] = record.payload.get("integration", "") if record.payload else ""
+            obj["phase"] = record.payload.get("phase", "") if record.payload else ""
+        return json.dumps(obj, default=str) + os.linesep
+
+
+def _iso_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + f".{int(time.time() * 1000) % 1000:03d}Z"
+```
+
+### Subtask 3.3: Snapshot implementation
+
+- [ ] **Step 3.3.1: Create `src/yoyopod/integrations/diagnostics/snapshot.py`**
+
+```python
+"""Diagnostic snapshot writer."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+def write_snapshot(app: Any, *, directory: Path, reason: str) -> Path:
+    """Write a JSON snapshot of current app state to `directory`."""
+    directory.mkdir(parents=True, exist_ok=True)
+    ts_compact = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
+    path = directory / f"snapshot-{ts_compact}-{reason}.json"
+
+    states_snapshot = {
+        entity: {
+            "value": _jsonable(sv.value),
+            "attrs": _jsonable_dict(sv.attrs),
+            "last_changed_at": sv.last_changed_at,
+        }
+        for entity, sv in app.states.all().items()
+    }
+
+    snapshot = {
+        "ts": time.time(),
+        "reason": reason,
+        "states": states_snapshot,
+        "services": [f"{d}.{s}" for d, s in app.services.registered()],
+        "recent_events_count": len(app.recent_events(10_000)),
+    }
+
+    path.write_text(json.dumps(snapshot, indent=2, default=str), encoding="utf-8")
+    return path
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if hasattr(value, "__dict__"):
+        return {k: _jsonable(v) for k, v in vars(value).items()}
+    return str(value)
+
+
+def _jsonable_dict(d: dict) -> dict:
+    return {k: _jsonable(v) for k, v in d.items()}
+```
+
+### Subtask 3.4: Responsiveness watchdog
+
+- [ ] **Step 3.4.1: Create `src/yoyopod/integrations/diagnostics/watchdog.py`**
+
+```python
+"""Responsiveness watchdog for the main loop."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from yoyopod.core.events import ResponsivenessLagEvent
+
+
+class ResponsivenessWatchdog:
+    """Measures drain duration per tick; emits ResponsivenessLagEvent when slow."""
+
+    def __init__(self, app: Any, threshold_ms: float = 100.0) -> None:
+        self._app = app
+        self._threshold = float(threshold_ms)
+
+    def tick_start(self) -> float:
+        return time.monotonic()
+
+    def tick_end(self, start_mono: float, context: str = "drain") -> None:
+        elapsed_ms = (time.monotonic() - start_mono) * 1000.0
+        if elapsed_ms > self._threshold:
+            self._app.bus.publish(
+                ResponsivenessLagEvent(duration_ms=elapsed_ms, context=context)
+            )
+```
+
+### Subtask 3.5: Integration setup
+
+- [ ] **Step 3.5.1: Create `src/yoyopod/integrations/diagnostics/__init__.py`**
+
+```python
+"""Diagnostics integration: event log, snapshot, responsiveness watchdog."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.core.events import (
+    LifecycleEvent,
+    ResponsivenessLagEvent,
+    StateChangedEvent,
+    UserActivityEvent,
+)
+from yoyopod.integrations.diagnostics.commands import (
+    MarkUserActivityCommand,
+    SnapshotCommand,
+)
+from yoyopod.integrations.diagnostics.log_writer import (
+    LogEntryRecord,
+    LogWriter,
+)
+from yoyopod.integrations.diagnostics.snapshot import write_snapshot
+from yoyopod.integrations.diagnostics.watchdog import ResponsivenessWatchdog
+
+_STATE_KEY = "_diagnostics_integration"
+
+
+def setup(app: Any) -> None:
+    cfg = app.config.diagnostics
+    log_path = Path(cfg.log_path)
+    writer = LogWriter(
+        path=log_path,
+        max_bytes=int(cfg.max_bytes),
+        max_files=int(cfg.max_files),
+    )
+    watchdog = ResponsivenessWatchdog(app, threshold_ms=float(cfg.responsiveness_threshold_ms))
+
+    # Log every StateChangedEvent.
+    def log_state_changed(ev: StateChangedEvent) -> None:
+        writer.append(
+            LogEntryRecord(
+                kind="event",
+                type="StateChangedEvent",
+                payload={
+                    "entity": ev.entity,
+                    "old": _extract(ev.old) if ev.old else None,
+                    "new": _extract(ev.new),
+                },
+            )
+        )
+
+    # Log every UserActivityEvent.
+    def log_user_activity(ev: UserActivityEvent) -> None:
+        writer.append(
+            LogEntryRecord(
+                kind="event",
+                type="UserActivityEvent",
+                payload={"action_name": ev.action_name},
+            )
+        )
+
+    # Log lifecycle events.
+    def log_lifecycle(ev: LifecycleEvent) -> None:
+        writer.append(
+            LogEntryRecord(
+                kind="lifecycle",
+                payload={"integration": ev.integration, "phase": ev.phase},
+            )
+        )
+
+    # Log responsiveness lags.
+    def log_lag(ev: ResponsivenessLagEvent) -> None:
+        writer.append(
+            LogEntryRecord(
+                kind="error",
+                handler="responsiveness",
+                exc=f"lag {ev.duration_ms:.1f}ms context={ev.context}",
+            )
+        )
+
+    app.bus.subscribe(StateChangedEvent, log_state_changed)
+    app.bus.subscribe(UserActivityEvent, log_user_activity)
+    app.bus.subscribe(LifecycleEvent, log_lifecycle)
+    app.bus.subscribe(ResponsivenessLagEvent, log_lag)
+
+    # Wrap services.call so commands are logged.
+    original_call = app.services.call
+
+    def logged_call(domain: str, service: str, data: Any = None) -> Any:
+        writer.append(
+            LogEntryRecord(
+                kind="command",
+                domain=domain,
+                service=service,
+                data=_extract_data(data),
+            )
+        )
+        try:
+            return original_call(domain, service, data)
+        except Exception as exc:
+            writer.append(
+                LogEntryRecord(
+                    kind="error",
+                    handler=f"{domain}.{service}",
+                    exc=f"{exc.__class__.__name__}: {exc}",
+                )
+            )
+            raise
+
+    app.services.call = logged_call  # type: ignore[assignment]
+
+    # Commands.
+    def handle_snapshot(cmd: SnapshotCommand) -> str:
+        snapshot_path = write_snapshot(
+            app,
+            directory=log_path.parent,
+            reason=cmd.reason,
+        )
+        logger.info("Diagnostics.snapshot written to {}", snapshot_path)
+        return str(snapshot_path)
+
+    def handle_mark_user_activity(cmd: MarkUserActivityCommand) -> None:
+        app.bus.publish(UserActivityEvent(action_name=cmd.action_name))
+
+    app.services.register("diagnostics", "snapshot", handle_snapshot)
+    app.services.register("diagnostics", "mark_user_activity", handle_mark_user_activity)
+
+    setattr(
+        app,
+        _STATE_KEY,
+        {"writer": writer, "watchdog": watchdog, "original_services_call": original_call},
+    )
+
+
+def teardown(app: Any) -> None:
+    state = getattr(app, _STATE_KEY, None)
+    if state is None:
+        return
+    # Restore services.call to avoid surprises in later tests that share a process.
+    try:
+        app.services.call = state["original_services_call"]
+    except Exception:
+        pass
+    delattr(app, _STATE_KEY)
+
+
+def _extract(sv: Any) -> dict:
+    return {
+        "value": _jsonable(sv.value),
+        "attrs": {k: _jsonable(v) for k, v in (sv.attrs or {}).items()},
+    }
+
+
+def _extract_data(data: Any) -> dict:
+    if data is None:
+        return {}
+    if hasattr(data, "__dict__"):
+        return {k: _jsonable(v) for k, v in vars(data).items()}
+    return {"value": _jsonable(data)}
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if hasattr(value, "__dict__"):
+        return {k: _jsonable(v) for k, v in vars(value).items()}
+    return str(value)
+```
+
+### Subtask 3.6: Run tests, commit
+
+- [ ] **Step 3.6.1: Run**
+
+```bash
+uv run pytest tests/integrations/test_diagnostics_log_writer.py -v
+uv run black src/yoyopod/integrations/diagnostics/ tests/integrations/test_diagnostics_log_writer.py
+uv run ruff check src/yoyopod/integrations/diagnostics/ tests/integrations/test_diagnostics_log_writer.py
+uv run mypy src/yoyopod/integrations/diagnostics/
+git add -A
+git commit -m "feat(integrations/diagnostics): event log writer, snapshot, responsiveness watchdog
+
+Subscribes to StateChangedEvent, UserActivityEvent, LifecycleEvent,
+ResponsivenessLagEvent and appends to rolling JSONL. Wraps services.call
+to log every command invocation (and failure). Snapshot command writes
+state + services registry to JSON. Watchdog measures main-loop drain time.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Screen integration
+
+Folds `ScreenPowerService` into an integration. Owns screen wake/sleep state, brightness, idle timeout. Registers a UI tick callback into `YoyoPodApp`.
+
+**Entities:** `screen.awake` (bool), `screen.brightness_percent` (int 0–100), `screen.idle_timeout_seconds` (int).
+
+**Commands:** `wake`, `sleep`, `set_brightness(WakeCommand)`, `set_idle_timeout`.
+
+Wakes the screen on `UserActivityEvent` reception.
+
+### Subtask 4.1: Commands and handlers
+
+- [ ] **Step 4.1.1: Create `src/yoyopod/integrations/screen/commands.py`**
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class WakeCommand:
+    reason: str = "user_activity"
+
+
+@dataclass(frozen=True, slots=True)
+class SleepCommand:
+    reason: str = "idle_timeout"
+
+
+@dataclass(frozen=True, slots=True)
+class SetBrightnessCommand:
+    percent: int
+
+
+@dataclass(frozen=True, slots=True)
+class SetIdleTimeoutCommand:
+    seconds: int
+```
+
+- [ ] **Step 4.1.2: Create `src/yoyopod/integrations/screen/handlers.py`**
+
+```python
+"""Screen integration state handlers."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+
+def wake(app: Any, reason: str = "user_activity") -> None:
+    app.states.set("screen.awake", True, attrs={"reason": reason, "woke_at": time.time()})
+
+
+def sleep(app: Any, reason: str = "idle_timeout") -> None:
+    app.states.set("screen.awake", False, attrs={"reason": reason, "slept_at": time.time()})
+
+
+def set_brightness(app: Any, percent: int) -> None:
+    clamped = max(0, min(100, int(percent)))
+    app.states.set("screen.brightness_percent", clamped)
+
+
+def set_idle_timeout(app: Any, seconds: int) -> None:
+    app.states.set("screen.idle_timeout_seconds", max(0, int(seconds)))
+
+
+def check_idle_timeout(app: Any, now: float | None = None) -> None:
+    if not app.states.get_value("screen.awake"):
+        return
+    timeout = app.states.get_value("screen.idle_timeout_seconds", 0)
+    if timeout <= 0:
+        return
+    sv = app.states.get("screen.last_activity_at")
+    if sv is None:
+        return
+    last = float(sv.value or 0.0)
+    current = now if now is not None else time.time()
+    if current - last >= timeout:
+        sleep(app, reason="idle_timeout")
+```
+
+- [ ] **Step 4.1.3: Create `src/yoyopod/integrations/screen/__init__.py`**
+
+```python
+"""Screen integration: wake/sleep, brightness, idle timeout."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from yoyopod.core.events import UserActivityEvent
+from yoyopod.integrations.screen.commands import (
+    SetBrightnessCommand,
+    SetIdleTimeoutCommand,
+    SleepCommand,
+    WakeCommand,
+)
+from yoyopod.integrations.screen.handlers import (
+    check_idle_timeout,
+    set_brightness,
+    set_idle_timeout,
+    sleep,
+    wake,
+)
+
+
+_STATE_KEY = "_screen_integration"
+
+
+def setup(app: Any) -> None:
+    cfg = app.config.screen
+
+    app.states.set("screen.brightness_percent", int(cfg.default_brightness_percent))
+    app.states.set("screen.idle_timeout_seconds", int(cfg.idle_timeout_seconds))
+    app.states.set("screen.awake", True, attrs={"reason": "boot"})
+    app.states.set("screen.last_activity_at", time.time())
+
+    def on_user_activity(_ev: UserActivityEvent) -> None:
+        app.states.set("screen.last_activity_at", time.time())
+        if not app.states.get_value("screen.awake"):
+            wake(app, reason="user_activity")
+
+    app.bus.subscribe(UserActivityEvent, on_user_activity)
+
+    def handle_wake(cmd: WakeCommand) -> None:
+        wake(app, reason=cmd.reason)
+
+    def handle_sleep(cmd: SleepCommand) -> None:
+        sleep(app, reason=cmd.reason)
+
+    def handle_set_brightness(cmd: SetBrightnessCommand) -> None:
+        set_brightness(app, cmd.percent)
+
+    def handle_set_idle_timeout(cmd: SetIdleTimeoutCommand) -> None:
+        set_idle_timeout(app, cmd.seconds)
+
+    app.services.register("screen", "wake", handle_wake)
+    app.services.register("screen", "sleep", handle_sleep)
+    app.services.register("screen", "set_brightness", handle_set_brightness)
+    app.services.register("screen", "set_idle_timeout", handle_set_idle_timeout)
+
+    # UI tick: idle-timeout check + optional display driver pump.
+    def ui_tick() -> None:
+        check_idle_timeout(app)
+
+    app._ui_tick_callback = ui_tick
+
+    setattr(app, _STATE_KEY, {})
+
+
+def teardown(app: Any) -> None:
+    if hasattr(app, "_ui_tick_callback"):
+        delattr(app, "_ui_tick_callback")
+    if hasattr(app, _STATE_KEY):
+        delattr(app, _STATE_KEY)
+```
+
+- [ ] **Step 4.1.4: Create `tests/integrations/test_screen.py`**
+
+```python
+import time
+
+import pytest
+
+from yoyopod.core.events import UserActivityEvent
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.screen import setup as setup_screen, teardown as teardown_screen
+from yoyopod.integrations.screen.commands import (
+    SetBrightnessCommand,
+    SetIdleTimeoutCommand,
+    SleepCommand,
+    WakeCommand,
+)
+
+
+@pytest.fixture
+def app_with_screen():
+    app = build_test_app()
+    app.config = type("C", (), {
+        "screen": type("SC", (), {
+            "default_brightness_percent": 75,
+            "idle_timeout_seconds": 30,
+        })(),
+    })()
+    app.register_integration(
+        "screen",
+        setup=lambda a: setup_screen(a),
+        teardown=lambda a: teardown_screen(a),
+    )
+    app.setup()
+    yield app
+    app.stop()
+
+
+def test_initial_state(app_with_screen):
+    app = app_with_screen
+    assert app.states.get_value("screen.awake") is True
+    assert app.states.get_value("screen.brightness_percent") == 75
+    assert app.states.get_value("screen.idle_timeout_seconds") == 30
+
+
+def test_sleep_and_wake_via_commands(app_with_screen):
+    app = app_with_screen
+    app.services.call("screen", "sleep", SleepCommand(reason="test"))
+    assert app.states.get_value("screen.awake") is False
+
+    app.services.call("screen", "wake", WakeCommand(reason="test"))
+    assert app.states.get_value("screen.awake") is True
+
+
+def test_user_activity_wakes_screen(app_with_screen):
+    app = app_with_screen
+    app.services.call("screen", "sleep", SleepCommand())
+    assert app.states.get_value("screen.awake") is False
+
+    app.bus.publish(UserActivityEvent(action_name="button"))
+    app.drain()
+
+    assert app.states.get_value("screen.awake") is True
+
+
+def test_set_brightness_clamps_to_0_100(app_with_screen):
+    app = app_with_screen
+    app.services.call("screen", "set_brightness", SetBrightnessCommand(percent=150))
+    assert app.states.get_value("screen.brightness_percent") == 100
+    app.services.call("screen", "set_brightness", SetBrightnessCommand(percent=-10))
+    assert app.states.get_value("screen.brightness_percent") == 0
+
+
+def test_set_idle_timeout(app_with_screen):
+    app = app_with_screen
+    app.services.call("screen", "set_idle_timeout", SetIdleTimeoutCommand(seconds=60))
+    assert app.states.get_value("screen.idle_timeout_seconds") == 60
+
+
+def test_idle_timeout_sleeps_screen_via_ui_tick(app_with_screen, monkeypatch):
+    app = app_with_screen
+    # simulate that no activity for a long time
+    app.states.set("screen.last_activity_at", time.time() - 1000.0)
+    app._ui_tick_callback()
+    assert app.states.get_value("screen.awake") is False
+```
+
+- [ ] **Step 4.1.5: Run, commit**
+
+```bash
+uv run pytest tests/integrations/test_screen.py -v
+uv run black src/yoyopod/integrations/screen/ tests/integrations/test_screen.py
+uv run ruff check src/yoyopod/integrations/screen/ tests/integrations/test_screen.py
+uv run mypy src/yoyopod/integrations/screen/
+git add -A
+git commit -m "feat(integrations/screen): wake/sleep/brightness/idle-timeout + UI tick callback
+
+Subscribes to UserActivityEvent to wake; registers a ui_tick callback
+that the main loop invokes for idle-timeout checks. Folds the old
+ScreenPowerService responsibilities into the new integration shape.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Voice integration
+
+Rehomes `VoiceRuntimeCoordinator` + STT/TTS backends. Models the voice pipeline as idle → listening → thinking → responding state machine expressed as `voice.state`.
+
+**Entities:** `voice.state` (`"idle" | "listening" | "thinking" | "responding"`; attrs: `transcript`, `response`).
+
+**Events:** `VoiceTranscriptReadyEvent(transcript)`, `VoiceResponseCompletedEvent(text)`.
+
+**Commands:** `start_listening`, `stop_listening`, `say`.
+
+### Subtask 5.1: Relocate voice backends
+
+- [ ] **Step 5.1.1: Move STT/TTS engines under `backends/voice/`**
+
+```bash
+mkdir -p src/yoyopod/backends/voice
+```
+
+Examine `src/yoyopod/voice/` and relocate STT/TTS engine files (the names depend on the current structure; examples: `stt_vosk.py`, `tts_*.py`):
+
+```bash
+git mv src/yoyopod/voice/<stt_file>.py src/yoyopod/backends/voice/stt.py
+git mv src/yoyopod/voice/<tts_file>.py src/yoyopod/backends/voice/tts.py
+```
+
+Update imports inside moved files. Create `src/yoyopod/backends/voice/__init__.py`:
+
+```python
+"""STT and TTS backend adapters."""
+
+from __future__ import annotations
+
+from yoyopod.backends.voice.stt import SttBackend
+from yoyopod.backends.voice.tts import TtsBackend
+
+__all__ = ["SttBackend", "TtsBackend"]
+```
+
+### Subtask 5.2: Voice events + commands
+
+- [ ] **Step 5.2.1: Create `src/yoyopod/integrations/voice/events.py`**
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class VoiceTranscriptReadyEvent:
+    transcript: str
+
+
+@dataclass(frozen=True, slots=True)
+class VoiceResponseCompletedEvent:
+    text: str
+```
+
+- [ ] **Step 5.2.2: Create `src/yoyopod/integrations/voice/commands.py`**
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class StartListeningCommand:
+    """Begin STT capture; transitions voice.state to 'listening'."""
+
+
+@dataclass(frozen=True, slots=True)
+class StopListeningCommand:
+    """End STT capture; transitions voice.state to 'thinking'."""
+
+
+@dataclass(frozen=True, slots=True)
+class SayCommand:
+    """Speak the given text via TTS; transitions voice.state to 'responding' then 'idle'."""
+
+    text: str
+```
+
+### Subtask 5.3: Voice pipeline
+
+- [ ] **Step 5.3.1: Create `src/yoyopod/integrations/voice/pipeline.py`**
+
+```python
+"""Voice pipeline state transitions driven by STT/TTS callbacks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from yoyopod.integrations.focus.arbiter import release_focus, request_focus
+from yoyopod.integrations.voice.events import (
+    VoiceResponseCompletedEvent,
+    VoiceTranscriptReadyEvent,
+)
+
+
+def begin_listening(app: Any, stt: Any) -> None:
+    request_focus(app, "voice")
+    app.states.set("voice.state", "listening")
+    stt.start()
+
+
+def end_listening(app: Any, stt: Any) -> None:
+    app.states.set("voice.state", "thinking")
+
+    def on_transcript(text: str) -> None:
+        app.scheduler.run_on_main(
+            lambda t=text: _on_transcript_ready(app, t)
+        )
+
+    stt.stop(callback=on_transcript)
+
+
+def _on_transcript_ready(app: Any, transcript: str) -> None:
+    app.states.set("voice.state", "thinking", attrs={"transcript": transcript})
+    app.bus.publish(VoiceTranscriptReadyEvent(transcript=transcript))
+
+
+def say(app: Any, tts: Any, text: str) -> None:
+    app.states.set("voice.state", "responding", attrs={"response": text})
+
+    def on_finished() -> None:
+        app.scheduler.run_on_main(lambda: _on_response_finished(app, text))
+
+    tts.speak(text, on_done=on_finished)
+
+
+def _on_response_finished(app: Any, text: str) -> None:
+    app.bus.publish(VoiceResponseCompletedEvent(text=text))
+    app.states.set("voice.state", "idle")
+    release_focus(app, "voice")
+```
+
+### Subtask 5.4: Voice integration setup
+
+- [ ] **Step 5.4.1: Create `src/yoyopod/integrations/voice/__init__.py`**
+
+```python
+"""Voice integration: STT, TTS, pipeline state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from yoyopod.integrations.voice.commands import (
+    SayCommand,
+    StartListeningCommand,
+    StopListeningCommand,
+)
+from yoyopod.integrations.voice.pipeline import (
+    begin_listening,
+    end_listening,
+    say,
+)
+
+_STATE_KEY = "_voice_integration"
+
+
+def setup(app: Any, stt: Any | None = None, tts: Any | None = None) -> None:
+    if stt is None or tts is None:
+        from yoyopod.backends.voice import SttBackend, TtsBackend
+        if stt is None:
+            stt = SttBackend(app.config.voice)
+        if tts is None:
+            tts = TtsBackend(app.config.voice)
+
+    app.states.set("voice.state", "idle")
+
+    def handle_start(_cmd: StartListeningCommand) -> None:
+        begin_listening(app, stt)
+
+    def handle_stop(_cmd: StopListeningCommand) -> None:
+        end_listening(app, stt)
+
+    def handle_say(cmd: SayCommand) -> None:
+        say(app, tts, cmd.text)
+
+    app.services.register("voice", "start_listening", handle_start)
+    app.services.register("voice", "stop_listening", handle_stop)
+    app.services.register("voice", "say", handle_say)
+
+    setattr(app, _STATE_KEY, {"stt": stt, "tts": tts})
+
+
+def teardown(app: Any) -> None:
+    state = getattr(app, _STATE_KEY, None)
+    if state is None:
+        return
+    try:
+        close = getattr(state["stt"], "close", None)
+        if callable(close):
+            close()
+    except Exception:
+        pass
+    try:
+        close = getattr(state["tts"], "close", None)
+        if callable(close):
+            close()
+    except Exception:
+        pass
+    delattr(app, _STATE_KEY)
+```
+
+- [ ] **Step 5.4.2: Create `tests/integrations/test_voice.py`**
+
+```python
+from dataclasses import dataclass, field
+from typing import Callable
+
+import pytest
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.focus import setup as setup_focus, teardown as teardown_focus
+from yoyopod.integrations.voice import setup as setup_voice, teardown as teardown_voice
+from yoyopod.integrations.voice.commands import (
+    SayCommand,
+    StartListeningCommand,
+    StopListeningCommand,
+)
+from yoyopod.integrations.voice.events import (
+    VoiceResponseCompletedEvent,
+    VoiceTranscriptReadyEvent,
+)
+
+
+@dataclass
+class _FakeStt:
+    started: bool = False
+    stopped_with_callback: Callable[[str], None] | None = None
+
+    def start(self):
+        self.started = True
+
+    def stop(self, callback):
+        self.started = False
+        self.stopped_with_callback = callback
+
+
+@dataclass
+class _FakeTts:
+    spoken: list[str] = field(default_factory=list)
+    on_done_cb: Callable[[], None] | None = None
+
+    def speak(self, text, on_done):
+        self.spoken.append(text)
+        self.on_done_cb = on_done
+
+
+@pytest.fixture
+def app_with_voice():
+    app = build_test_app()
+    stt = _FakeStt()
+    tts = _FakeTts()
+    app.register_integration("focus", setup=lambda a: setup_focus(a), teardown=lambda a: teardown_focus(a))
+    app.register_integration(
+        "voice",
+        setup=lambda a: setup_voice(a, stt=stt, tts=tts),
+        teardown=lambda a: teardown_voice(a),
+    )
+    app.setup()
+    yield app, stt, tts
+    app.stop()
+
+
+def test_start_listening_requests_focus(app_with_voice):
+    app, stt, _ = app_with_voice
+    app.services.call("voice", "start_listening", StartListeningCommand())
+    app.drain()
+
+    assert stt.started is True
+    assert app.states.get_value("voice.state") == "listening"
+    assert app.states.get_value("focus.owner") == "voice"
+
+
+def test_stop_listening_transitions_to_thinking_and_publishes_transcript(app_with_voice):
+    app, stt, _ = app_with_voice
+    captured: list[VoiceTranscriptReadyEvent] = []
+    app.bus.subscribe(VoiceTranscriptReadyEvent, lambda ev: captured.append(ev))
+
+    app.services.call("voice", "start_listening", StartListeningCommand())
+    app.drain()
+
+    app.services.call("voice", "stop_listening", StopListeningCommand())
+    app.drain()
+
+    assert app.states.get_value("voice.state") == "thinking"
+    assert stt.stopped_with_callback is not None
+
+    # Simulate STT completing with a transcript.
+    stt.stopped_with_callback("hello world")
+    app.drain()
+
+    assert any(ev.transcript == "hello world" for ev in captured)
+
+
+def test_say_plays_tts_and_releases_focus(app_with_voice):
+    app, _, tts = app_with_voice
+    completed: list[VoiceResponseCompletedEvent] = []
+    app.bus.subscribe(VoiceResponseCompletedEvent, lambda ev: completed.append(ev))
+
+    # Acquire voice focus first.
+    from yoyopod.integrations.focus.arbiter import request_focus
+    request_focus(app, "voice")
+
+    app.services.call("voice", "say", SayCommand(text="Hi there"))
+    app.drain()
+
+    assert tts.spoken == ["Hi there"]
+    assert app.states.get_value("voice.state") == "responding"
+
+    # Simulate TTS completion.
+    tts.on_done_cb()
+    app.drain()
+
+    assert app.states.get_value("voice.state") == "idle"
+    assert app.states.get_value("focus.owner") is None
+    assert any(ev.text == "Hi there" for ev in completed)
+```
+
+- [ ] **Step 5.4.3: Run, commit**
+
+```bash
+uv run pytest tests/integrations/test_voice.py -v
+uv run black src/yoyopod/integrations/voice/ src/yoyopod/backends/voice/ tests/integrations/test_voice.py
+uv run ruff check src/yoyopod/integrations/voice/ src/yoyopod/backends/voice/ tests/integrations/test_voice.py
+uv run mypy src/yoyopod/integrations/voice/ src/yoyopod/backends/voice/
+git add -A
+git commit -m "feat(integrations/voice): STT/TTS pipeline with focus integration
+
+Voice integration drives STT begin/end + TTS say via a small pipeline that
+transitions voice.state (idle -> listening -> thinking -> responding).
+Acquires focus.owner='voice' during listening; releases on response done.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 6.1: Confirm structure**
+
+```bash
+ls src/yoyopod/integrations/
+# expected: __init__.py, power/, network/, location/, contacts/, cloud/, focus/, diagnostics/, screen/, voice/
+```
+
+- [ ] **Step 6.2: CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green.
+
+- [ ] **Step 6.3: Commit count**
+
+Expect ~10 new commits on top of Plan 3 (one per subtask).
+
+---
+
+## Definition of Done
+
+- `focus`, `diagnostics`, `screen`, `voice` integrations populated.
+- Event log writes JSONL to configured path.
+- Snapshot command writes state + services dump.
+- Screen idle-timeout works via ui_tick callback.
+- Voice pipeline transitions state through listening → thinking → responding → idle, coordinating with focus integration.
+- Full CI gate green.
+
+---
+
+## What's next (Plan 5)
+
+`music` — local mpv playback, library, playlists, recent tracks. First integration to actually use `focus.request_focus("music")`.
+
+---
+
+*End of implementation plan.*

--- a/docs/superpowers/plans/2026-04-21-phase-a-music.md
+++ b/docs/superpowers/plans/2026-04-21-phase-a-music.md
@@ -1,0 +1,697 @@
+# Phase A — Plan 5: Music Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate local music playback (mpv-backed) into the new integration architecture. First integration to exercise the `focus` arbiter — `music.play` acquires focus, `AudioFocusLostEvent` auto-pauses playback.
+
+**Architecture:** `MpvBackend` (+ `process.py`, `ipc.py`) moves to `src/yoyopod/backends/music/`. `LocalMusicService` becomes `src/yoyopod/integrations/music/library.py`. `PlaybackCoordinator` deleted. State entities mirror backend status; focus-loss subscriber handles auto-pause.
+
+**Tech Stack:** Python 3.12+, pytest, uv, existing mpv IPC.
+
+**Spec reference:** spec §3.2, §5 (music entities), §7 (music commands), §9.1/§9.2 (fate of MpvBackend + LocalMusicService + PlaybackCoordinator + MusicFSM).
+
+**Prerequisite:** Plans 1-4 executed; `focus` integration available.
+
+---
+
+## File Structure
+
+### Files to create
+
+- `src/yoyopod/backends/music/__init__.py`
+- `src/yoyopod/backends/music/mpv.py` (moved from `src/yoyopod/audio/music/backend.py`)
+- `src/yoyopod/backends/music/process.py` (moved)
+- `src/yoyopod/backends/music/ipc.py` (moved)
+- `src/yoyopod/backends/music/models.py` (moved from `src/yoyopod/audio/music/models.py`)
+- `src/yoyopod/integrations/music/__init__.py`
+- `src/yoyopod/integrations/music/commands.py`
+- `src/yoyopod/integrations/music/events.py`
+- `src/yoyopod/integrations/music/handlers.py`
+- `src/yoyopod/integrations/music/library.py` (moved from `src/yoyopod/audio/local_service.py`)
+- `src/yoyopod/integrations/music/history.py` (moved from `src/yoyopod/audio/history.py`)
+- `tests/integrations/test_music.py`
+
+### Files to delete
+
+- `src/yoyopod/audio/music/` (the whole subpackage — all files moved)
+- `src/yoyopod/audio/manager.py` (if exists and is a thin shim)
+- `src/yoyopod/audio/local_service.py` (moved)
+- `src/yoyopod/audio/history.py` (moved)
+- `src/yoyopod/coordinators/playback.py`
+- Legacy `MusicFSM` lives in `src/yoyopod/fsm.py` — that file is deleted in Plan 8's final sweep, not here.
+
+### Files that stay
+
+- `src/yoyopod/audio/volume.py`, `src/yoyopod/audio/volume_controller.py` — shared ALSA volume control — stay under `audio/` for now (used by both music and call ring tone). They may be re-homed later.
+
+---
+
+## Task 1: Branch state verification
+
+- [ ] **Step 1.1: Confirm Plans 1-4 complete**
+
+```bash
+git log --oneline -20
+ls src/yoyopod/integrations/
+uv run pytest tests/ -q
+```
+
+Expected: 9 integrations exist (power, network, location, contacts, cloud, focus, diagnostics, screen, voice); all tests green.
+
+---
+
+## Task 2: Relocate mpv backend
+
+- [ ] **Step 2.1: Move files under `backends/music/`**
+
+```bash
+mkdir -p src/yoyopod/backends/music
+git mv src/yoyopod/audio/music/backend.py src/yoyopod/backends/music/mpv.py
+git mv src/yoyopod/audio/music/process.py src/yoyopod/backends/music/process.py
+git mv src/yoyopod/audio/music/ipc.py src/yoyopod/backends/music/ipc.py
+git mv src/yoyopod/audio/music/models.py src/yoyopod/backends/music/models.py
+```
+
+- [ ] **Step 2.2: Update internal imports**
+
+Grep:
+```bash
+grep -rn "from yoyopod.audio.music" src/yoyopod/backends/music/
+```
+
+Rewrite each occurrence to `from yoyopod.backends.music.<name>`.
+
+- [ ] **Step 2.3: Create `src/yoyopod/backends/music/__init__.py`**
+
+```python
+"""MpvBackend and media models."""
+
+from __future__ import annotations
+
+from yoyopod.backends.music.mpv import MpvBackend, MusicBackend
+from yoyopod.backends.music.models import MusicConfig, Playlist, Track
+
+__all__ = ["MpvBackend", "MusicBackend", "Track", "Playlist", "MusicConfig"]
+```
+
+- [ ] **Step 2.4: Delete `src/yoyopod/audio/music/__init__.py`**
+
+```bash
+git rm src/yoyopod/audio/music/__init__.py
+```
+
+- [ ] **Step 2.5: Update external imports of `yoyopod.audio.music.*`**
+
+```bash
+grep -rn "from yoyopod.audio.music" src/ tests/
+```
+
+Rewrite each to `from yoyopod.backends.music`. Some tests like `tests/test_music_backend.py` will need updating.
+
+- [ ] **Step 2.6: Run affected tests**
+
+```bash
+uv run pytest tests/test_music_backend.py -v
+```
+
+Expected: pass (adapter still works; just new import paths).
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(music): move MpvBackend + mpv adapters to src/yoyopod/backends/music/
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Move `LocalMusicService` under `integrations/music/library.py`
+
+- [ ] **Step 3.1: Relocate**
+
+```bash
+mkdir -p src/yoyopod/integrations/music
+git mv src/yoyopod/audio/local_service.py src/yoyopod/integrations/music/library.py
+git mv src/yoyopod/audio/history.py src/yoyopod/integrations/music/history.py
+```
+
+- [ ] **Step 3.2: Update imports**
+
+Grep + rewrite:
+```bash
+grep -rn "from yoyopod.audio.local_service\|from yoyopod.audio.history\|from yoyopod.audio import.*LocalMusicService\|from yoyopod.audio import.*RecentTrackHistoryStore" src/ tests/
+```
+
+Rewrite to `from yoyopod.integrations.music.library import LocalMusicService` and `from yoyopod.integrations.music.history import RecentTrackHistoryStore`.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(music): LocalMusicService + RecentTrackHistoryStore into integrations/music/
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Write music commands + events
+
+- [ ] **Step 4.1: Create `src/yoyopod/integrations/music/commands.py`**
+
+```python
+"""Typed commands for the music integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class PlayCommand:
+    """Start playback of the given URI; acquires audio focus."""
+
+    track_uri: str
+    start_position_seconds: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class PauseCommand:
+    """Pause playback without releasing focus."""
+
+
+@dataclass(frozen=True, slots=True)
+class ResumeCommand:
+    """Resume paused playback (re-acquires focus if lost)."""
+
+
+@dataclass(frozen=True, slots=True)
+class StopCommand:
+    """Stop playback and release focus."""
+
+
+@dataclass(frozen=True, slots=True)
+class NextCommand:
+    """Skip to next track in current playlist."""
+
+
+@dataclass(frozen=True, slots=True)
+class PrevCommand:
+    """Skip to previous track."""
+
+
+@dataclass(frozen=True, slots=True)
+class SeekCommand:
+    """Seek to absolute position in seconds."""
+
+    position_seconds: float
+
+
+@dataclass(frozen=True, slots=True)
+class SetVolumeCommand:
+    """Set playback volume percent (0-100)."""
+
+    percent: int
+```
+
+- [ ] **Step 4.2: Create `src/yoyopod/integrations/music/events.py`**
+
+```python
+"""Music-specific domain events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from yoyopod.backends.music.models import Track
+
+
+@dataclass(frozen=True, slots=True)
+class TrackPlaybackCompletedEvent:
+    """Published when a track finishes playing (end-of-file)."""
+
+    track: Track | None
+```
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add src/yoyopod/integrations/music/commands.py src/yoyopod/integrations/music/events.py
+git commit -m "feat(integrations/music): typed commands + domain events
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Write music handlers + setup
+
+- [ ] **Step 5.1: Create `src/yoyopod/integrations/music/handlers.py`**
+
+```python
+"""State-update handlers for the music integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def apply_playback_state_to_state(app: Any, state: str, reason: str = "") -> None:
+    """state is one of 'idle', 'playing', 'paused'."""
+    app.states.set(
+        "music.state",
+        state,
+        attrs={"reason": reason} if reason else None,
+    )
+
+
+def apply_track_to_state(app: Any, track: Any | None) -> None:
+    """Mirror the current track into state."""
+    if track is None:
+        app.states.set("music.track", None)
+        return
+    app.states.set(
+        "music.track",
+        track,
+        attrs={
+            "title": getattr(track, "name", "") or getattr(track, "title", ""),
+            "artist": getattr(track, "artist", ""),
+            "duration_seconds": float(getattr(track, "duration_seconds", 0.0) or 0.0),
+            "path": getattr(track, "path", ""),
+        },
+    )
+
+
+def apply_backend_availability_to_state(app: Any, available: bool, reason: str = "") -> None:
+    app.states.set("music.backend_available", bool(available), attrs={"reason": reason} if reason else None)
+
+
+def apply_volume_to_state(app: Any, percent: int) -> None:
+    app.states.set("music.volume_percent", max(0, min(100, int(percent))))
+```
+
+- [ ] **Step 5.2: Create `src/yoyopod/integrations/music/__init__.py`**
+
+```python
+"""Music integration: mpv playback, library, playlists, focus-coordinated pause/resume."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.integrations.focus.arbiter import release_focus, request_focus
+from yoyopod.integrations.focus.events import AudioFocusLostEvent
+from yoyopod.integrations.music.commands import (
+    NextCommand,
+    PauseCommand,
+    PlayCommand,
+    PrevCommand,
+    ResumeCommand,
+    SeekCommand,
+    SetVolumeCommand,
+    StopCommand,
+)
+from yoyopod.integrations.music.handlers import (
+    apply_backend_availability_to_state,
+    apply_playback_state_to_state,
+    apply_track_to_state,
+    apply_volume_to_state,
+)
+
+_STATE_KEY = "_music_integration"
+
+
+def setup(app: Any, backend: Any | None = None, library: Any | None = None) -> None:
+    if backend is None:
+        from yoyopod.backends.music import MpvBackend
+        backend = MpvBackend(app.config.audio)
+
+    if library is None:
+        from yoyopod.integrations.music.library import LocalMusicService
+        from yoyopod.integrations.music.history import RecentTrackHistoryStore
+        recent_store = RecentTrackHistoryStore(app.config.audio)
+        library = LocalMusicService(app.config.audio, recent_store=recent_store)
+
+    # Start the backend.
+    started = backend.start()
+    apply_backend_availability_to_state(app, started, reason="start" if started else "start_failed")
+    if started:
+        apply_playback_state_to_state(app, "idle")
+        apply_volume_to_state(app, int(getattr(app.config.audio, "default_volume", 70)))
+
+    # Backend callback: playback state.
+    def on_backend_playback_state(state: str) -> None:
+        app.scheduler.run_on_main(
+            lambda s=state: apply_playback_state_to_state(app, s)
+        )
+
+    # Backend callback: track change.
+    def on_backend_track_change(track: Any | None) -> None:
+        app.scheduler.run_on_main(lambda t=track: apply_track_to_state(app, t))
+        if track is not None:
+            app.scheduler.run_on_main(lambda t=track: library.record_recent_track(t))
+
+    # Backend callback: connectivity/availability.
+    def on_backend_availability(available: bool, reason: str = "") -> None:
+        app.scheduler.run_on_main(
+            lambda a=available, r=reason: apply_backend_availability_to_state(app, a, r)
+        )
+
+    # Register callbacks with the backend.
+    backend.on_playback_state_change(on_backend_playback_state)
+    backend.on_track_change(on_backend_track_change)
+    backend.on_availability_change(on_backend_availability)
+
+    # Subscribe to focus loss → auto-pause playback.
+    def on_focus_lost(ev: AudioFocusLostEvent) -> None:
+        if ev.owner != "music":
+            return
+        if app.states.get_value("music.state") == "playing":
+            logger.info("Music auto-pausing due to focus loss to {}", ev.preempted_by)
+            backend.pause()
+
+    app.bus.subscribe(AudioFocusLostEvent, on_focus_lost)
+
+    # Commands.
+    def handle_play(cmd: PlayCommand) -> None:
+        request_focus(app, "music")
+        backend.play(cmd.track_uri, start_position=cmd.start_position_seconds)
+
+    def handle_pause(_cmd: PauseCommand) -> None:
+        backend.pause()
+
+    def handle_resume(_cmd: ResumeCommand) -> None:
+        request_focus(app, "music")
+        backend.resume()
+
+    def handle_stop(_cmd: StopCommand) -> None:
+        backend.stop()
+        release_focus(app, "music")
+
+    def handle_next(_cmd: NextCommand) -> None:
+        backend.next_track()
+
+    def handle_prev(_cmd: PrevCommand) -> None:
+        backend.prev_track()
+
+    def handle_seek(cmd: SeekCommand) -> None:
+        backend.seek(cmd.position_seconds)
+
+    def handle_set_volume(cmd: SetVolumeCommand) -> None:
+        backend.set_volume(cmd.percent)
+        apply_volume_to_state(app, cmd.percent)
+
+    app.services.register("music", "play", handle_play)
+    app.services.register("music", "pause", handle_pause)
+    app.services.register("music", "resume", handle_resume)
+    app.services.register("music", "stop", handle_stop)
+    app.services.register("music", "next", handle_next)
+    app.services.register("music", "prev", handle_prev)
+    app.services.register("music", "seek", handle_seek)
+    app.services.register("music", "set_volume", handle_set_volume)
+
+    setattr(app, _STATE_KEY, {"backend": backend, "library": library})
+
+
+def teardown(app: Any) -> None:
+    state = getattr(app, _STATE_KEY, None)
+    if state is None:
+        return
+    try:
+        state["backend"].stop()
+        state["backend"].shutdown()
+    except Exception as exc:
+        logger.error("MpvBackend shutdown: {}", exc)
+    delattr(app, _STATE_KEY)
+```
+
+- [ ] **Step 5.3: Create `tests/integrations/test_music.py`**
+
+```python
+from dataclasses import dataclass, field
+
+import pytest
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.focus import setup as setup_focus, teardown as teardown_focus
+from yoyopod.integrations.focus.arbiter import request_focus
+from yoyopod.integrations.focus.events import AudioFocusLostEvent
+from yoyopod.integrations.music import setup as setup_music, teardown as teardown_music
+from yoyopod.integrations.music.commands import (
+    PauseCommand,
+    PlayCommand,
+    ResumeCommand,
+    SetVolumeCommand,
+    StopCommand,
+)
+
+
+@dataclass
+class _FakeMpvBackend:
+    playback_state_cb: callable = None
+    track_cb: callable = None
+    availability_cb: callable = None
+    play_calls: list[str] = field(default_factory=list)
+    pause_calls: int = 0
+    stop_calls: int = 0
+    resume_calls: int = 0
+
+    def start(self):
+        return True
+
+    def stop(self):
+        self.stop_calls += 1
+        if self.playback_state_cb:
+            self.playback_state_cb("idle")
+
+    def shutdown(self):
+        pass
+
+    def pause(self):
+        self.pause_calls += 1
+        if self.playback_state_cb:
+            self.playback_state_cb("paused")
+
+    def resume(self):
+        self.resume_calls += 1
+        if self.playback_state_cb:
+            self.playback_state_cb("playing")
+
+    def play(self, uri, start_position=0.0):
+        self.play_calls.append(uri)
+        if self.playback_state_cb:
+            self.playback_state_cb("playing")
+
+    def next_track(self):
+        pass
+
+    def prev_track(self):
+        pass
+
+    def seek(self, pos):
+        pass
+
+    def set_volume(self, percent):
+        pass
+
+    def on_playback_state_change(self, cb):
+        self.playback_state_cb = cb
+
+    def on_track_change(self, cb):
+        self.track_cb = cb
+
+    def on_availability_change(self, cb):
+        self.availability_cb = cb
+
+
+@dataclass
+class _FakeLibrary:
+    recent: list = field(default_factory=list)
+
+    def record_recent_track(self, track):
+        self.recent.append(track)
+
+
+@pytest.fixture
+def app_with_music():
+    app = build_test_app()
+    backend = _FakeMpvBackend()
+    library = _FakeLibrary()
+    app.config = type("C", (), {"audio": type("AC", (), {"default_volume": 70})()})()
+    app.register_integration("focus", setup=lambda a: setup_focus(a), teardown=lambda a: teardown_focus(a))
+    app.register_integration(
+        "music",
+        setup=lambda a: setup_music(a, backend=backend, library=library),
+        teardown=lambda a: teardown_music(a),
+    )
+    app.setup()
+    yield app, backend, library
+    app.stop()
+
+
+def test_setup_initial_state(app_with_music):
+    app, _, _ = app_with_music
+    assert app.states.get_value("music.state") == "idle"
+    assert app.states.get_value("music.backend_available") is True
+    assert app.states.get_value("music.volume_percent") == 70
+
+
+def test_play_acquires_focus_and_updates_state(app_with_music):
+    app, backend, _ = app_with_music
+    app.services.call("music", "play", PlayCommand(track_uri="local:t.mp3"))
+    app.drain()
+
+    assert backend.play_calls == ["local:t.mp3"]
+    assert app.states.get_value("music.state") == "playing"
+    assert app.states.get_value("focus.owner") == "music"
+
+
+def test_pause_does_not_release_focus(app_with_music):
+    app, _, _ = app_with_music
+    app.services.call("music", "play", PlayCommand(track_uri="local:t.mp3"))
+    app.drain()
+    app.services.call("music", "pause", PauseCommand())
+    app.drain()
+
+    assert app.states.get_value("music.state") == "paused"
+    assert app.states.get_value("focus.owner") == "music"  # still held
+
+
+def test_resume_reacquires_focus(app_with_music):
+    app, _, _ = app_with_music
+    app.services.call("music", "play", PlayCommand(track_uri="local:t.mp3"))
+    app.drain()
+    app.services.call("music", "pause", PauseCommand())
+    app.drain()
+    # Simulate some other owner taking focus.
+    request_focus(app, "call")
+    app.drain()
+    app.services.call("music", "resume", ResumeCommand())
+    app.drain()
+
+    assert app.states.get_value("focus.owner") == "music"
+
+
+def test_stop_releases_focus(app_with_music):
+    app, _, _ = app_with_music
+    app.services.call("music", "play", PlayCommand(track_uri="local:t.mp3"))
+    app.drain()
+    app.services.call("music", "stop", StopCommand())
+    app.drain()
+
+    assert app.states.get_value("music.state") == "idle"
+    assert app.states.get_value("focus.owner") is None
+
+
+def test_focus_loss_auto_pauses_playback(app_with_music):
+    app, backend, _ = app_with_music
+    app.services.call("music", "play", PlayCommand(track_uri="local:t.mp3"))
+    app.drain()
+
+    app.bus.publish(AudioFocusLostEvent(owner="music", preempted_by="call"))
+    app.drain()
+
+    assert backend.pause_calls == 1
+    assert app.states.get_value("music.state") == "paused"
+
+
+def test_set_volume_updates_state(app_with_music):
+    app, _, _ = app_with_music
+    app.services.call("music", "set_volume", SetVolumeCommand(percent=50))
+    assert app.states.get_value("music.volume_percent") == 50
+```
+
+- [ ] **Step 5.4: Run, commit**
+
+```bash
+uv run pytest tests/integrations/test_music.py -v
+uv run black src/yoyopod/integrations/music/ tests/integrations/test_music.py
+uv run ruff check src/yoyopod/integrations/music/ tests/integrations/test_music.py
+uv run mypy src/yoyopod/integrations/music/
+git add -A
+git commit -m "feat(integrations/music): playback + library + focus-coordinated pause/resume
+
+Acquires focus on play/resume; pause leaves focus held; stop releases.
+AudioFocusLostEvent subscriber auto-pauses when another owner takes focus.
+First integration to exercise the cross-domain focus pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Delete `PlaybackCoordinator`
+
+- [ ] **Step 6.1: Enumerate and delete**
+
+```bash
+grep -rn "PlaybackCoordinator" src/ tests/
+git rm src/yoyopod/coordinators/playback.py
+```
+
+Update `src/yoyopod/coordinators/__init__.py` if it re-exports `PlaybackCoordinator`; remove that line.
+
+Stub `src/yoyopod/app.py` references (they'll be removed in Plan 8).
+
+- [ ] **Step 6.2: Run CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(music): delete PlaybackCoordinator
+
+Replaced by integrations/music/ setup + handlers.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 7.1: Structure**
+
+```bash
+ls src/yoyopod/integrations/music/
+ls src/yoyopod/backends/music/
+```
+
+Expected music integration: `__init__.py`, `commands.py`, `events.py`, `handlers.py`, `library.py`, `history.py`.
+Backend: `__init__.py`, `mpv.py`, `process.py`, `ipc.py`, `models.py`.
+
+- [ ] **Step 7.2: CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green.
+
+---
+
+## Definition of Done
+
+- `integrations/music/` complete.
+- `backends/music/` populated with relocated mpv code.
+- Music commands exercise focus correctly (play/resume acquire; stop releases; focus loss auto-pauses).
+- `PlaybackCoordinator` deleted.
+- All tests green.
+
+---
+
+## What's next (Plan 6)
+
+`call` — the biggest single migration. VoIPManager's 618 LOC split into `integrations/call/` with `handlers.py`, `messaging.py`, `voice_notes.py`, `history.py`. Uses focus (call pre-empts music).
+
+---
+
+*End of implementation plan.*

--- a/docs/superpowers/plans/2026-04-21-phase-a-power-pilot.md
+++ b/docs/superpowers/plans/2026-04-21-phase-a-power-pilot.md
@@ -1,0 +1,1605 @@
+# Phase A — Plan 2: Power Pilot Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the power subsystem to the new `core/` architecture as the pilot integration. Validate the A+3 pattern end-to-end on an isolated, well-understood domain before extending it to the other 10 integrations.
+
+**Architecture:** Backend adapter (PiSugar) moves to `src/yoyopod/backends/power/`. The domain integration lives under `src/yoyopod/integrations/power/` with `setup(app)`, typed commands, and handlers that mirror backend events into the state store. Old `PowerManager`, `PowerRuntimeService`, `PowerCoordinator` classes are deleted at the end of this plan. A new main-loop integration point in `YoyoPodApp.run()` replaces the previous ad-hoc polling — `app.run()` now drains the scheduler, drains the bus, and ticks UI.
+
+**Tech Stack:** Python 3.12+, pytest, uv, existing PiSugar socket/TCP backend + watchdog. No new runtime dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md` §3.2 (directory layout), §5 (power entities), §7 (power commands), §9.2 (fate of PowerManager), §11.2 (step 3 — power pilot).
+
+**Prerequisite:** Plan 1 (core scaffold) is executed — `src/yoyopod/core/` exists with tested primitives; branch `arch/phase-a-spine-rewrite` has the 12 Plan-1 commits.
+
+---
+
+## File Structure
+
+### Files to create
+
+- `src/yoyopod/backends/__init__.py` — backends package marker
+- `src/yoyopod/backends/power/__init__.py` — power backend package marker + public surface
+- `src/yoyopod/backends/power/pisugar.py` — moved from `src/yoyopod/power/backend.py`
+- `src/yoyopod/backends/power/watchdog.py` — moved from `src/yoyopod/power/watchdog.py`
+- `src/yoyopod/integrations/__init__.py` — integrations package marker
+- `src/yoyopod/integrations/power/__init__.py` — `setup(app)` + `teardown(app)`
+- `src/yoyopod/integrations/power/commands.py` — `ShutdownCommand`, `RebootCommand`, etc.
+- `src/yoyopod/integrations/power/handlers.py` — state-update logic, low-battery policy
+- `src/yoyopod/integrations/power/poller.py` — background thread that polls the backend
+- `tests/integrations/__init__.py`
+- `tests/integrations/test_power.py`
+
+### Files to modify
+
+- `src/yoyopod/core/app_shell.py` — add `run()` main loop; add `config` attribute
+- `src/yoyopod/app.py` — stub — will be rewritten in Plan 8; for now point `main` at `YoyoPodApp`
+
+### Files to move (git mv)
+
+- `src/yoyopod/power/backend.py` → `src/yoyopod/backends/power/pisugar.py`
+- `src/yoyopod/power/watchdog.py` → `src/yoyopod/backends/power/watchdog.py`
+
+### Files to delete
+
+- `src/yoyopod/power/manager.py` (PowerManager — replaced by `integrations/power/`)
+- `src/yoyopod/power/policies.py` (logic folds into `handlers.py`)
+- `src/yoyopod/power/events.py` (power-specific events become domain events under `integrations/power/`)
+- `src/yoyopod/power/__init__.py` (package itself dies)
+- `src/yoyopod/runtime/power.py` (PowerRuntimeService — delete class, runtime/ stays because other services still live there)
+- `src/yoyopod/coordinators/power.py` (PowerCoordinator)
+
+---
+
+## Task 1: Branch state verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1.1: Confirm you're on the Phase A branch with Plan 1 committed**
+
+Run:
+```bash
+git branch --show-current
+git log --oneline -15
+```
+
+Expected: branch is `arch/phase-a-spine-rewrite`; the top commits include `docs: renumber Phase C -> Phase B in Phase A spec`, `docs: Phase A core scaffold implementation plan (14 tasks)`, and the 12 Plan-1 commits (`feat(core): …`, `test(core): …`, `chore(core): …`, `chore(cli): …`).
+
+- [ ] **Step 1.2: Verify `core/` primitives are in place**
+
+Run:
+```bash
+ls src/yoyopod/core/
+uv run pytest tests/core/ -q
+```
+
+Expected: all 8 core modules present (`__init__.py`, `app_shell.py`, `bus.py`, `events.py`, `logbuffer.py`, `scheduler.py`, `services.py`, `states.py`, `testing.py`); all core tests green.
+
+- [ ] **Step 1.3: Read the existing power implementation for context**
+
+Read these files and skim to understand the shape (DO NOT edit them yet):
+```
+src/yoyopod/power/backend.py
+src/yoyopod/power/watchdog.py
+src/yoyopod/power/manager.py
+src/yoyopod/power/policies.py
+src/yoyopod/power/events.py
+src/yoyopod/runtime/power.py
+src/yoyopod/coordinators/power.py
+```
+
+Goal: understand the current `PiSugarBackend` interface (connection, poll, get_snapshot, shutdown, set_rtc_alarm, etc.) and the responsibilities that are about to be re-homed (polling cadence, low-battery policy, watchdog feeding).
+
+---
+
+## Task 2: Scaffold `backends/` and move the PiSugar backend
+
+**Files:**
+- Create: `src/yoyopod/backends/__init__.py`
+- Create: `src/yoyopod/backends/power/__init__.py`
+- Move: `src/yoyopod/power/backend.py` → `src/yoyopod/backends/power/pisugar.py`
+- Move: `src/yoyopod/power/watchdog.py` → `src/yoyopod/backends/power/watchdog.py`
+
+- [ ] **Step 2.1: Create `src/yoyopod/backends/` and `src/yoyopod/backends/power/`**
+
+Run:
+```bash
+mkdir -p src/yoyopod/backends/power
+```
+
+Create `src/yoyopod/backends/__init__.py` with:
+
+```python
+"""Adapter layer for external systems (SIP, media, power, network, location, voice).
+
+See docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md §3.2.
+Integrations under src/yoyopod/integrations/ construct these adapters during
+setup() and wire their events through the main-thread scheduler onto the bus.
+"""
+```
+
+Create `src/yoyopod/backends/power/__init__.py` with:
+
+```python
+"""PiSugar power + watchdog backend adapters."""
+
+from __future__ import annotations
+
+from yoyopod.backends.power.pisugar import PiSugarBackend, PowerSnapshot
+from yoyopod.backends.power.watchdog import PiSugarWatchdog
+
+__all__ = ["PiSugarBackend", "PowerSnapshot", "PiSugarWatchdog"]
+```
+
+- [ ] **Step 2.2: Move the two backend files with `git mv`**
+
+Run:
+```bash
+git mv src/yoyopod/power/backend.py src/yoyopod/backends/power/pisugar.py
+git mv src/yoyopod/power/watchdog.py src/yoyopod/backends/power/watchdog.py
+```
+
+- [ ] **Step 2.3: Update imports inside the moved files**
+
+Open `src/yoyopod/backends/power/pisugar.py`. Any imports of the form `from yoyopod.power...` referencing other files in the old package must be fixed. Most likely the backend is self-contained, but check for cross-references like `from yoyopod.power.events import PowerSnapshotUpdated` (if such imports exist) — those need to be rewritten to not depend on the legacy `power/` package (move the referenced types inline or into `backends/power/pisugar.py` if they belong there).
+
+Open `src/yoyopod/backends/power/watchdog.py` — same check.
+
+Verify there are no `yoyopod.power.` imports lingering in the moved files:
+```bash
+grep -rn "from yoyopod.power" src/yoyopod/backends/power/
+```
+
+Expected: no output (all internal references have been resolved).
+
+- [ ] **Step 2.4: Update the one in-tree import of the watchdog class, if any, to the new location**
+
+Run:
+```bash
+grep -rn "from yoyopod.power.watchdog" src/ tests/
+grep -rn "from yoyopod.power.backend" src/ tests/
+```
+
+For each result, rewrite the import to `from yoyopod.backends.power import PiSugarBackend, PowerSnapshot, PiSugarWatchdog`. (At this stage the old `src/yoyopod/power/__init__.py` may still be re-exporting these; leave it intact for now — Task 10 deletes the old package entirely once everything is migrated.)
+
+- [ ] **Step 2.5: Run the existing test suite to confirm the move didn't break anything**
+
+Run:
+```bash
+uv run pytest tests/ -q --ignore=tests/core
+```
+
+Expected: same pass/fail set as before the move. If a test fails because of an import it previously resolved through `src/yoyopod/power/backend.py`, update its import to the new path.
+
+- [ ] **Step 2.6: Commit the backend move**
+
+Run:
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+refactor(power): move PiSugar backend and watchdog under src/yoyopod/backends/power/
+
+Relocates the adapter layer per the Phase A target directory layout.
+integrations/power/ in the next task will consume these from the new path.
+No logic changes; imports updated in place.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Scaffold `integrations/` and `integrations/power/`
+
+**Files:**
+- Create: `src/yoyopod/integrations/__init__.py`
+- Create: `src/yoyopod/integrations/power/__init__.py` (empty for now)
+- Create: `tests/integrations/__init__.py`
+- Create: `tests/integrations/test_power.py` (empty for now)
+
+- [ ] **Step 3.1: Create the directory structure**
+
+Run:
+```bash
+mkdir -p src/yoyopod/integrations/power tests/integrations
+```
+
+- [ ] **Step 3.2: Populate `src/yoyopod/integrations/__init__.py`**
+
+Create `src/yoyopod/integrations/__init__.py`:
+
+```python
+"""Domain integrations for YoyoPod.
+
+Each subpackage is a self-contained integration with a setup(app) function
+that wires backends, registers commands, and subscribes to events. Integrations
+read and write the state store (app.states) and publish/subscribe to the bus.
+
+See docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md §3.2.
+"""
+```
+
+- [ ] **Step 3.3: Populate placeholder `src/yoyopod/integrations/power/__init__.py`**
+
+Create a minimal placeholder that will grow through Tasks 4–8:
+
+```python
+"""Power integration: battery, charging, RTC, watchdog, shutdown policy.
+
+See docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md §5
+(entities), §7 (commands), §9.2 (fate of PowerManager).
+"""
+
+from __future__ import annotations
+
+# Extended in Task 7 with setup() and teardown().
+```
+
+- [ ] **Step 3.4: Populate `tests/integrations/__init__.py`**
+
+Create `tests/integrations/__init__.py` as a one-line marker:
+
+```python
+
+```
+
+- [ ] **Step 3.5: Commit the scaffold**
+
+Run:
+```bash
+git add src/yoyopod/integrations/ tests/integrations/__init__.py
+git commit -m "$(cat <<'EOF'
+chore(integrations): scaffold integrations package + power placeholder
+
+Empty skeleton; populated in subsequent tasks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Write power commands (typed dataclasses) with TDD
+
+**Files:**
+- Create: `tests/integrations/test_power_commands.py`
+- Create: `src/yoyopod/integrations/power/commands.py`
+
+- [ ] **Step 4.1: Write the failing test**
+
+Create `tests/integrations/test_power_commands.py`:
+
+```python
+"""Tests for yoyopod.integrations.power.commands."""
+
+from __future__ import annotations
+
+from yoyopod.integrations.power.commands import (
+    DisableRtcAlarmCommand,
+    RebootCommand,
+    SetRtcAlarmCommand,
+    SetWatchdogCommand,
+    ShutdownCommand,
+    SyncRtcFromSystemCommand,
+    SyncRtcToSystemCommand,
+)
+
+
+def test_shutdown_command_default_delay() -> None:
+    cmd = ShutdownCommand(reason="test")
+    assert cmd.reason == "test"
+    assert cmd.delay_seconds == 0.0
+
+
+def test_shutdown_command_with_delay() -> None:
+    cmd = ShutdownCommand(reason="low_battery", delay_seconds=30.0)
+    assert cmd.delay_seconds == 30.0
+
+
+def test_reboot_command_defaults() -> None:
+    cmd = RebootCommand(reason="settings")
+    assert cmd.reason == "settings"
+
+
+def test_set_watchdog_command() -> None:
+    cmd = SetWatchdogCommand(enabled=True, timeout_seconds=60.0)
+    assert cmd.enabled is True
+    assert cmd.timeout_seconds == 60.0
+
+
+def test_set_rtc_alarm_command_accepts_seconds_from_now() -> None:
+    cmd = SetRtcAlarmCommand(seconds_from_now=300)
+    assert cmd.seconds_from_now == 300
+
+
+def test_disable_rtc_alarm_is_argless() -> None:
+    cmd = DisableRtcAlarmCommand()
+    assert cmd is not None  # frozen dataclass with no fields is valid
+
+
+def test_sync_rtc_to_system_is_argless() -> None:
+    cmd = SyncRtcToSystemCommand()
+    assert cmd is not None
+
+
+def test_sync_rtc_from_system_is_argless() -> None:
+    cmd = SyncRtcFromSystemCommand()
+    assert cmd is not None
+
+
+def test_commands_are_frozen() -> None:
+    cmd = ShutdownCommand(reason="x")
+    try:
+        cmd.reason = "y"  # type: ignore[misc]
+    except Exception as exc:
+        assert isinstance(exc, AttributeError) or "frozen" in str(exc).lower()
+```
+
+- [ ] **Step 4.2: Run the test to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/integrations/test_power_commands.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'yoyopod.integrations.power.commands'`.
+
+- [ ] **Step 4.3: Implement `src/yoyopod/integrations/power/commands.py`**
+
+Create:
+
+```python
+"""Typed command dataclasses for the power integration.
+
+See docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md §7.3.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ShutdownCommand:
+    """Graceful shutdown request."""
+
+    reason: str
+    delay_seconds: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class RebootCommand:
+    """Reboot request."""
+
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class SetWatchdogCommand:
+    """Enable/disable the PiSugar hardware watchdog; set the feed timeout."""
+
+    enabled: bool
+    timeout_seconds: float = 60.0
+
+
+@dataclass(frozen=True, slots=True)
+class SetRtcAlarmCommand:
+    """Arm the PiSugar RTC wake-up alarm."""
+
+    seconds_from_now: int
+
+
+@dataclass(frozen=True, slots=True)
+class DisableRtcAlarmCommand:
+    """Clear any pending PiSugar RTC wake-up alarm."""
+
+
+@dataclass(frozen=True, slots=True)
+class SyncRtcToSystemCommand:
+    """Copy system time into the PiSugar RTC."""
+
+
+@dataclass(frozen=True, slots=True)
+class SyncRtcFromSystemCommand:
+    """Copy PiSugar RTC time into the system clock."""
+```
+
+- [ ] **Step 4.4: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/integrations/test_power_commands.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 4.5: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/integrations/power/commands.py tests/integrations/test_power_commands.py
+uv run ruff check src/yoyopod/integrations/power/commands.py tests/integrations/test_power_commands.py
+uv run mypy src/yoyopod/integrations/power/commands.py
+```
+
+Expected: all green.
+
+- [ ] **Step 4.6: Commit**
+
+Run:
+```bash
+git add src/yoyopod/integrations/power/commands.py tests/integrations/test_power_commands.py
+git commit -m "$(cat <<'EOF'
+feat(integrations/power): add typed command dataclasses
+
+7 frozen dataclasses: Shutdown, Reboot, SetWatchdog, SetRtcAlarm,
+DisableRtcAlarm, SyncRtcToSystem, SyncRtcFromSystem.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Write power handlers (state-update logic + low-battery policy) with TDD
+
+**Files:**
+- Create: `tests/integrations/test_power_handlers.py`
+- Create: `src/yoyopod/integrations/power/handlers.py`
+
+- [ ] **Step 5.1: Write the failing test**
+
+Create `tests/integrations/test_power_handlers.py`:
+
+```python
+"""Tests for yoyopod.integrations.power.handlers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from yoyopod.core.events import ShutdownRequestedEvent
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.power.handlers import (
+    PowerPolicy,
+    apply_snapshot_to_state,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _BatteryStub:
+    percent: int | None
+    voltage_volts: float
+    temperature_celsius: float
+    charging: bool
+    external_power: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _DeviceStub:
+    model: str
+
+
+@dataclass(frozen=True, slots=True)
+class _RtcStub:
+    time: str | None = None
+    alarm_enabled: bool = False
+    alarm_time: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _SnapshotStub:
+    available: bool
+    battery: _BatteryStub
+    device: _DeviceStub = _DeviceStub(model="pisugar3")
+    rtc: _RtcStub = _RtcStub()
+    error: str | None = None
+
+
+def _mk_snapshot(
+    *,
+    available: bool = True,
+    percent: int | None = 80,
+    charging: bool = False,
+    external_power: bool = False,
+) -> _SnapshotStub:
+    return _SnapshotStub(
+        available=available,
+        battery=_BatteryStub(
+            percent=percent,
+            voltage_volts=3.7,
+            temperature_celsius=25.0,
+            charging=charging,
+            external_power=external_power,
+        ),
+    )
+
+
+def test_apply_snapshot_populates_state_entities() -> None:
+    app = build_test_app()
+
+    apply_snapshot_to_state(app, _mk_snapshot(percent=72, charging=True))
+
+    assert app.states.get_value("power.battery_percent") == 72
+    assert app.states.get_value("power.charging") is True
+    assert app.states.get_value("power.external_power") is False
+    assert app.states.get_value("power.backend_available") is True
+    assert app.states.get_value("power.voltage_volts") == 3.7
+    assert app.states.get_value("power.temperature_celsius") == 25.0
+
+
+def test_apply_snapshot_handles_unavailable_backend() -> None:
+    app = build_test_app()
+
+    apply_snapshot_to_state(app, _mk_snapshot(available=False, percent=None))
+
+    assert app.states.get_value("power.backend_available") is False
+    assert app.states.get_value("power.battery_percent") is None
+
+
+def test_low_battery_policy_below_warning_threshold_noops() -> None:
+    app = build_test_app()
+    policy = PowerPolicy(
+        warning_percent=20,
+        critical_percent=5,
+        shutdown_delay_seconds=30.0,
+    )
+    apply_snapshot_to_state(app, _mk_snapshot(percent=15, charging=False))
+    app.drain()
+
+    captured: list[ShutdownRequestedEvent] = []
+    app.bus.subscribe(ShutdownRequestedEvent, lambda ev: captured.append(ev))
+
+    policy.observe(app)
+    app.drain()
+
+    # 15% > 5% critical threshold, so no shutdown request — just a warning state.
+    assert captured == []
+    assert app.states.get_value("power.low_battery_warned") is True
+
+
+def test_low_battery_policy_critical_threshold_emits_shutdown() -> None:
+    app = build_test_app()
+    policy = PowerPolicy(
+        warning_percent=20,
+        critical_percent=5,
+        shutdown_delay_seconds=30.0,
+    )
+    apply_snapshot_to_state(app, _mk_snapshot(percent=3, charging=False))
+    app.drain()
+
+    captured: list[ShutdownRequestedEvent] = []
+    app.bus.subscribe(ShutdownRequestedEvent, lambda ev: captured.append(ev))
+
+    policy.observe(app)
+    app.drain()
+
+    assert len(captured) == 1
+    assert captured[0].reason == "battery_critical"
+    assert captured[0].delay_seconds == 30.0
+
+
+def test_low_battery_policy_skips_when_charging() -> None:
+    app = build_test_app()
+    policy = PowerPolicy(warning_percent=20, critical_percent=5, shutdown_delay_seconds=30.0)
+    apply_snapshot_to_state(app, _mk_snapshot(percent=3, charging=True))
+    app.drain()
+
+    captured: list[ShutdownRequestedEvent] = []
+    app.bus.subscribe(ShutdownRequestedEvent, lambda ev: captured.append(ev))
+
+    policy.observe(app)
+    app.drain()
+
+    assert captured == []
+
+
+def test_low_battery_policy_fires_only_once_per_descent() -> None:
+    app = build_test_app()
+    policy = PowerPolicy(warning_percent=20, critical_percent=5, shutdown_delay_seconds=30.0)
+
+    captured: list[ShutdownRequestedEvent] = []
+    app.bus.subscribe(ShutdownRequestedEvent, lambda ev: captured.append(ev))
+
+    apply_snapshot_to_state(app, _mk_snapshot(percent=3, charging=False))
+    policy.observe(app)
+    app.drain()
+    policy.observe(app)  # called again with same snapshot
+    app.drain()
+
+    assert len(captured) == 1  # not duplicated
+
+
+def test_low_battery_policy_rearms_after_recovery() -> None:
+    app = build_test_app()
+    policy = PowerPolicy(warning_percent=20, critical_percent=5, shutdown_delay_seconds=30.0)
+
+    captured: list[ShutdownRequestedEvent] = []
+    app.bus.subscribe(ShutdownRequestedEvent, lambda ev: captured.append(ev))
+
+    apply_snapshot_to_state(app, _mk_snapshot(percent=3, charging=False))
+    policy.observe(app)
+    app.drain()
+    assert len(captured) == 1
+
+    # battery recovers (plug in charger)
+    apply_snapshot_to_state(app, _mk_snapshot(percent=50, charging=True))
+    policy.observe(app)
+    app.drain()
+
+    # drops again
+    apply_snapshot_to_state(app, _mk_snapshot(percent=3, charging=False))
+    policy.observe(app)
+    app.drain()
+
+    assert len(captured) == 2
+```
+
+- [ ] **Step 5.2: Run the test to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/integrations/test_power_handlers.py -v
+```
+
+Expected: `ModuleNotFoundError` on `yoyopod.integrations.power.handlers`.
+
+- [ ] **Step 5.3: Implement `src/yoyopod/integrations/power/handlers.py`**
+
+Create:
+
+```python
+"""State-update and policy logic for the power integration.
+
+Converts backend snapshots into app.states entries. Emits ShutdownRequestedEvent
+when battery crosses the critical threshold while not charging. See
+docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md §5, §9.2.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from yoyopod.core.events import ShutdownRequestedEvent
+
+
+def apply_snapshot_to_state(app: Any, snapshot: Any) -> None:
+    """Mirror a PowerSnapshot into the state store.
+
+    `snapshot` must expose `.available`, `.battery.percent`, `.battery.voltage_volts`,
+    `.battery.temperature_celsius`, `.battery.charging`, `.battery.external_power`.
+    Duck-typed to allow the real PiSugar snapshot and test stubs.
+    """
+    battery = snapshot.battery
+    app.states.set("power.backend_available", bool(snapshot.available))
+    app.states.set("power.battery_percent", battery.percent)
+    app.states.set("power.charging", bool(battery.charging))
+    app.states.set("power.external_power", bool(battery.external_power))
+    app.states.set("power.voltage_volts", float(battery.voltage_volts))
+    app.states.set("power.temperature_celsius", float(battery.temperature_celsius))
+
+
+@dataclass(slots=True)
+class PowerPolicy:
+    """Low-battery policy. Emits ShutdownRequestedEvent when battery is critical."""
+
+    warning_percent: int
+    critical_percent: int
+    shutdown_delay_seconds: float
+
+    _warning_latched: bool = False
+    _critical_latched: bool = False
+
+    def observe(self, app: Any) -> None:
+        """Observe current power state. May publish ShutdownRequestedEvent."""
+        percent = app.states.get_value("power.battery_percent")
+        charging = app.states.get_value("power.charging") is True
+        available = app.states.get_value("power.backend_available") is True
+
+        if not available or percent is None:
+            return
+
+        # Re-arm the latches once charging resumes OR battery climbs back above threshold.
+        if charging or percent > self.warning_percent:
+            self._warning_latched = False
+            self._critical_latched = False
+
+        if charging:
+            return
+
+        if percent <= self.critical_percent and not self._critical_latched:
+            self._critical_latched = True
+            app.bus.publish(
+                ShutdownRequestedEvent(
+                    reason="battery_critical",
+                    delay_seconds=self.shutdown_delay_seconds,
+                )
+            )
+            return
+
+        if percent <= self.warning_percent and not self._warning_latched:
+            self._warning_latched = True
+            app.states.set("power.low_battery_warned", True)
+```
+
+- [ ] **Step 5.4: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/integrations/test_power_handlers.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 5.5: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/integrations/power/handlers.py tests/integrations/test_power_handlers.py
+uv run ruff check src/yoyopod/integrations/power/handlers.py tests/integrations/test_power_handlers.py
+uv run mypy src/yoyopod/integrations/power/handlers.py
+```
+
+Expected: all green.
+
+- [ ] **Step 5.6: Commit**
+
+Run:
+```bash
+git add src/yoyopod/integrations/power/handlers.py tests/integrations/test_power_handlers.py
+git commit -m "$(cat <<'EOF'
+feat(integrations/power): add snapshot-to-state handler + low-battery policy
+
+apply_snapshot_to_state writes 6 power.* entities from a snapshot.
+PowerPolicy latches warning/critical thresholds and emits
+ShutdownRequestedEvent at critical while not charging; re-arms on recovery.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Write the background poller with TDD
+
+**Files:**
+- Create: `tests/integrations/test_power_poller.py`
+- Create: `src/yoyopod/integrations/power/poller.py`
+
+- [ ] **Step 6.1: Write the failing test**
+
+Create `tests/integrations/test_power_poller.py`:
+
+```python
+"""Tests for yoyopod.integrations.power.poller."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.power.poller import PowerPoller
+
+
+@dataclass
+class _FakeBackend:
+    snapshots_yielded: int = 0
+
+    def get_snapshot(self):
+        self.snapshots_yielded += 1
+
+        @dataclass(frozen=True, slots=True)
+        class _B:
+            percent: int = 80
+            voltage_volts: float = 3.7
+            temperature_celsius: float = 25.0
+            charging: bool = False
+            external_power: bool = False
+
+        @dataclass(frozen=True, slots=True)
+        class _D:
+            model: str = "pisugar3"
+
+        @dataclass(frozen=True, slots=True)
+        class _R:
+            time: str | None = None
+            alarm_enabled: bool = False
+            alarm_time: str | None = None
+
+        @dataclass(frozen=True, slots=True)
+        class _S:
+            available: bool = True
+            battery: _B = _B()
+            device: _D = _D()
+            rtc: _R = _R()
+            error: str | None = None
+
+        return _S()
+
+
+def test_poller_schedules_state_update_on_main_thread_each_tick() -> None:
+    app = build_test_app()
+    backend = _FakeBackend()
+    poller = PowerPoller(app=app, backend=backend, interval_seconds=0.05)
+
+    poller.start()
+    time.sleep(0.2)
+    poller.stop()
+
+    app.drain()
+
+    assert backend.snapshots_yielded >= 2
+    assert app.states.get_value("power.battery_percent") == 80
+
+
+def test_poller_is_idempotent() -> None:
+    app = build_test_app()
+    backend = _FakeBackend()
+    poller = PowerPoller(app=app, backend=backend, interval_seconds=0.05)
+
+    poller.start()
+    poller.start()  # second start is a no-op
+    time.sleep(0.1)
+    poller.stop()
+    poller.stop()  # second stop is a no-op
+
+
+def test_poller_thread_exits_promptly_on_stop() -> None:
+    app = build_test_app()
+    backend = _FakeBackend()
+    poller = PowerPoller(app=app, backend=backend, interval_seconds=1.0)
+
+    poller.start()
+    start = time.monotonic()
+    poller.stop()
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.5  # stop() signals, thread exits near-immediately
+```
+
+- [ ] **Step 6.2: Run the test to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/integrations/test_power_poller.py -v
+```
+
+Expected: `ModuleNotFoundError` on `yoyopod.integrations.power.poller`.
+
+- [ ] **Step 6.3: Implement `src/yoyopod/integrations/power/poller.py`**
+
+Create:
+
+```python
+"""Background poller: reads the PiSugar backend and schedules state updates on main.
+
+Owned by the power integration. See docs/superpowers/specs/
+2026-04-21-phase-a-spine-rewrite-design.md §4.4 (scheduler), §5 (entities).
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.integrations.power.handlers import apply_snapshot_to_state
+
+
+class PowerPoller:
+    """Dedicated worker thread that polls the power backend at a fixed interval."""
+
+    def __init__(self, app: Any, backend: Any, interval_seconds: float = 10.0) -> None:
+        self._app = app
+        self._backend = backend
+        self._interval = max(0.01, float(interval_seconds))
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        """Start the poller thread (idempotent)."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name="power-poller",
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Signal the poller to stop and wait briefly for the thread to exit."""
+        self._stop.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+        self._thread = None
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                snapshot = self._backend.get_snapshot()
+            except Exception as exc:
+                logger.error("PowerPoller.get_snapshot failed: {}", exc)
+                self._stop.wait(self._interval)
+                continue
+
+            self._app.scheduler.run_on_main(
+                lambda s=snapshot: apply_snapshot_to_state(self._app, s)
+            )
+            self._stop.wait(self._interval)
+```
+
+- [ ] **Step 6.4: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/integrations/test_power_poller.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 6.5: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/integrations/power/poller.py tests/integrations/test_power_poller.py
+uv run ruff check src/yoyopod/integrations/power/poller.py tests/integrations/test_power_poller.py
+uv run mypy src/yoyopod/integrations/power/poller.py
+```
+
+Expected: all green.
+
+- [ ] **Step 6.6: Commit**
+
+Run:
+```bash
+git add src/yoyopod/integrations/power/poller.py tests/integrations/test_power_poller.py
+git commit -m "$(cat <<'EOF'
+feat(integrations/power): add background poller
+
+Dedicated worker thread reads backend.get_snapshot() at fixed interval
+and marshals apply_snapshot_to_state onto the main thread via the
+scheduler. Idempotent start/stop; exits within 500 ms of stop().
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Write the power integration `setup()` / `teardown()` with TDD
+
+**Files:**
+- Create: `tests/integrations/test_power_integration.py`
+- Modify: `src/yoyopod/integrations/power/__init__.py`
+
+- [ ] **Step 7.1: Write the integration test**
+
+Create `tests/integrations/test_power_integration.py`:
+
+```python
+"""End-to-end test for the power integration using a mock backend."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from yoyopod.core.events import ShutdownRequestedEvent
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.power import setup as setup_power, teardown as teardown_power
+from yoyopod.integrations.power.commands import (
+    RebootCommand,
+    ShutdownCommand,
+)
+
+
+@dataclass
+class _FakePiSugarBackend:
+    percent: int = 80
+    charging: bool = False
+    shutdown_called: list[str] = None
+    reboot_called: list[str] = None
+
+    def __post_init__(self):
+        self.shutdown_called = []
+        self.reboot_called = []
+
+    def get_snapshot(self):
+        @dataclass(frozen=True, slots=True)
+        class _B:
+            percent: int
+            voltage_volts: float = 3.7
+            temperature_celsius: float = 25.0
+            charging: bool = False
+            external_power: bool = False
+
+        @dataclass(frozen=True, slots=True)
+        class _D:
+            model: str = "pisugar3"
+
+        @dataclass(frozen=True, slots=True)
+        class _R:
+            time: str | None = None
+            alarm_enabled: bool = False
+            alarm_time: str | None = None
+
+        @dataclass(frozen=True, slots=True)
+        class _S:
+            available: bool
+            battery: _B
+            device: _D = _D()
+            rtc: _R = _R()
+            error: str | None = None
+
+        return _S(
+            available=True,
+            battery=_B(percent=self.percent, charging=self.charging),
+        )
+
+    def shutdown(self, reason: str = "") -> None:
+        self.shutdown_called.append(reason)
+
+    def reboot(self, reason: str = "") -> None:
+        self.reboot_called.append(reason)
+
+    def close(self) -> None:
+        pass
+
+
+@pytest.fixture
+def app_with_power():
+    app = build_test_app()
+    backend = _FakePiSugarBackend()
+    app.config = type("Config", (), {
+        "power": type("PC", (), {
+            "poll_interval_seconds": 0.05,
+            "low_battery_warning_percent": 20,
+            "critical_shutdown_percent": 5,
+            "shutdown_delay_seconds": 30.0,
+        })(),
+    })()
+    app.register_integration(
+        "power",
+        setup=lambda a: setup_power(a, backend=backend),
+        teardown=lambda a: teardown_power(a),
+    )
+    app.setup()
+    yield app, backend
+    app.stop()
+
+
+def test_power_setup_registers_all_commands(app_with_power) -> None:
+    app, _ = app_with_power
+    pairs = set(app.services.registered())
+    for expected in [
+        ("power", "shutdown"),
+        ("power", "reboot"),
+        ("power", "set_watchdog"),
+        ("power", "set_rtc_alarm"),
+        ("power", "disable_rtc_alarm"),
+        ("power", "sync_rtc_to_system"),
+        ("power", "sync_rtc_from_system"),
+    ]:
+        assert expected in pairs
+
+
+def test_power_poller_eventually_sets_state(app_with_power) -> None:
+    app, backend = app_with_power
+    time.sleep(0.2)
+    app.drain()
+    assert app.states.get_value("power.battery_percent") == 80
+
+
+def test_shutdown_command_invokes_backend(app_with_power) -> None:
+    app, backend = app_with_power
+    app.services.call("power", "shutdown", ShutdownCommand(reason="manual"))
+    assert backend.shutdown_called == ["manual"]
+
+
+def test_reboot_command_invokes_backend(app_with_power) -> None:
+    app, backend = app_with_power
+    app.services.call("power", "reboot", RebootCommand(reason="update"))
+    assert backend.reboot_called == ["update"]
+
+
+def test_low_battery_policy_triggers_shutdown_request(app_with_power) -> None:
+    app, backend = app_with_power
+    captured: list[ShutdownRequestedEvent] = []
+    app.bus.subscribe(ShutdownRequestedEvent, lambda ev: captured.append(ev))
+
+    backend.percent = 2
+    backend.charging = False
+    time.sleep(0.2)  # let poller tick + policy observe
+    app.drain()
+
+    assert any(ev.reason == "battery_critical" for ev in captured)
+```
+
+- [ ] **Step 7.2: Run the test to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/integrations/test_power_integration.py -v
+```
+
+Expected: ImportError on `setup`/`teardown` from `yoyopod.integrations.power`.
+
+- [ ] **Step 7.3: Implement `src/yoyopod/integrations/power/__init__.py`**
+
+Replace the placeholder contents with:
+
+```python
+"""Power integration: battery, charging, RTC, watchdog, shutdown policy.
+
+See docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md §5, §7, §9.2.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.integrations.power.commands import (
+    DisableRtcAlarmCommand,
+    RebootCommand,
+    SetRtcAlarmCommand,
+    SetWatchdogCommand,
+    ShutdownCommand,
+    SyncRtcFromSystemCommand,
+    SyncRtcToSystemCommand,
+)
+from yoyopod.integrations.power.handlers import PowerPolicy
+from yoyopod.integrations.power.poller import PowerPoller
+
+
+_STATE_KEY = "_power_integration"
+
+
+def setup(app: Any, backend: Any | None = None) -> None:
+    """Wire the power integration: construct backend, register commands, start poller."""
+    if backend is None:
+        from yoyopod.backends.power import PiSugarBackend
+        backend = PiSugarBackend(app.config.power)
+
+    power_cfg = app.config.power
+    policy = PowerPolicy(
+        warning_percent=int(power_cfg.low_battery_warning_percent),
+        critical_percent=int(power_cfg.critical_shutdown_percent),
+        shutdown_delay_seconds=float(power_cfg.shutdown_delay_seconds),
+    )
+    poller = PowerPoller(
+        app=app,
+        backend=backend,
+        interval_seconds=float(power_cfg.poll_interval_seconds),
+    )
+
+    # Re-evaluate policy on every state change touching power entities.
+    from yoyopod.core.events import StateChangedEvent
+
+    def on_state_changed(ev: StateChangedEvent) -> None:
+        if ev.entity.startswith("power."):
+            policy.observe(app)
+
+    app.bus.subscribe(StateChangedEvent, on_state_changed)
+
+    # Commands.
+    def handle_shutdown(cmd: ShutdownCommand) -> None:
+        logger.info("Power.shutdown(reason={}, delay={}s)", cmd.reason, cmd.delay_seconds)
+        backend.shutdown(reason=cmd.reason)
+
+    def handle_reboot(cmd: RebootCommand) -> None:
+        logger.info("Power.reboot(reason={})", cmd.reason)
+        backend.reboot(reason=cmd.reason)
+
+    def handle_set_watchdog(cmd: SetWatchdogCommand) -> None:
+        logger.info("Power.set_watchdog(enabled={}, timeout={})", cmd.enabled, cmd.timeout_seconds)
+        backend.set_watchdog(cmd.enabled, cmd.timeout_seconds)
+
+    def handle_set_rtc_alarm(cmd: SetRtcAlarmCommand) -> None:
+        backend.set_rtc_alarm(cmd.seconds_from_now)
+
+    def handle_disable_rtc_alarm(_cmd: DisableRtcAlarmCommand) -> None:
+        backend.disable_rtc_alarm()
+
+    def handle_sync_rtc_to_system(_cmd: SyncRtcToSystemCommand) -> None:
+        backend.sync_rtc_to_system()
+
+    def handle_sync_rtc_from_system(_cmd: SyncRtcFromSystemCommand) -> None:
+        backend.sync_rtc_from_system()
+
+    app.services.register("power", "shutdown", handle_shutdown)
+    app.services.register("power", "reboot", handle_reboot)
+    app.services.register("power", "set_watchdog", handle_set_watchdog)
+    app.services.register("power", "set_rtc_alarm", handle_set_rtc_alarm)
+    app.services.register("power", "disable_rtc_alarm", handle_disable_rtc_alarm)
+    app.services.register("power", "sync_rtc_to_system", handle_sync_rtc_to_system)
+    app.services.register("power", "sync_rtc_from_system", handle_sync_rtc_from_system)
+
+    # Start polling.
+    poller.start()
+
+    # Stash state for teardown.
+    setattr(app, _STATE_KEY, {"backend": backend, "poller": poller, "policy": policy})
+
+
+def teardown(app: Any) -> None:
+    """Stop the poller and close the backend."""
+    state = getattr(app, _STATE_KEY, None)
+    if state is None:
+        return
+    try:
+        state["poller"].stop()
+    except Exception as exc:
+        logger.error("PowerPoller.stop failed: {}", exc)
+    try:
+        state["backend"].close()
+    except Exception as exc:
+        logger.error("PiSugarBackend.close failed: {}", exc)
+    delattr(app, _STATE_KEY)
+```
+
+- [ ] **Step 7.4: Run tests; all should pass**
+
+Run:
+```bash
+uv run pytest tests/integrations/test_power_integration.py -v
+```
+
+Expected: all passing.
+
+- [ ] **Step 7.5: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/integrations/power/__init__.py tests/integrations/test_power_integration.py
+uv run ruff check src/yoyopod/integrations/power/__init__.py tests/integrations/test_power_integration.py
+uv run mypy src/yoyopod/integrations/power/__init__.py
+```
+
+Expected: all green.
+
+- [ ] **Step 7.6: Commit**
+
+Run:
+```bash
+git add src/yoyopod/integrations/power/__init__.py tests/integrations/test_power_integration.py
+git commit -m "$(cat <<'EOF'
+feat(integrations/power): setup/teardown wiring, commands, policy loop
+
+setup() constructs backend (or accepts an injected one for tests),
+registers 7 typed commands, subscribes PowerPolicy to power.* state
+changes, starts the background poller. teardown() stops the poller and
+closes the backend.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Add `run()` loop to `YoyoPodApp` with TDD
+
+**Files:**
+- Modify: `src/yoyopod/core/app_shell.py`
+- Modify: `tests/core/test_app_shell.py`
+
+- [ ] **Step 8.1: Extend `test_app_shell.py` with run-loop tests**
+
+Append the following to `tests/core/test_app_shell.py`:
+
+```python
+
+
+def test_run_loop_drains_scheduler_and_bus_per_tick() -> None:
+    """run() iterates until stop() is called, draining scheduler+bus each tick."""
+    import threading
+    import time
+
+    app = YoyoPodApp()
+    tick_counts = {"count": 0}
+
+    from yoyopod.core.events import LifecycleEvent
+
+    def on_lifecycle(_ev):
+        tick_counts["count"] += 1
+
+    app.bus.subscribe(LifecycleEvent, on_lifecycle)
+
+    def stop_soon():
+        time.sleep(0.1)
+        app.stop()
+
+    t = threading.Thread(target=stop_soon, daemon=True)
+    t.start()
+
+    app.register_integration("dummy", setup=lambda _a: None)
+    app.setup()
+    app.run(tick_interval_seconds=0.01)
+
+    # Setup fired 2 lifecycle events (start + complete) — at least those dispatched.
+    assert tick_counts["count"] >= 2
+
+
+def test_run_exits_cleanly_after_stop() -> None:
+    """stop() called before run() exits immediately."""
+    app = YoyoPodApp()
+    app.stop()
+    app.run(tick_interval_seconds=0.01)  # no-op; returns immediately
+```
+
+- [ ] **Step 8.2: Run the tests; both should fail**
+
+Run:
+```bash
+uv run pytest tests/core/test_app_shell.py::test_run_loop_drains_scheduler_and_bus_per_tick tests/core/test_app_shell.py::test_run_exits_cleanly_after_stop -v
+```
+
+Expected: `AttributeError: 'YoyoPodApp' object has no attribute 'run'`.
+
+- [ ] **Step 8.3: Implement `run()` in `src/yoyopod/core/app_shell.py`**
+
+Edit `src/yoyopod/core/app_shell.py`. Add this method inside `YoyoPodApp`:
+
+```python
+    def run(self, tick_interval_seconds: float = 0.005) -> None:
+        """Main loop: drain scheduler, drain bus, tick UI, sleep, repeat.
+
+        UI tick is a placeholder in Phase A; the screen integration will
+        register a callback that this loop invokes once per tick.
+        """
+        import time
+
+        while not self._stopped:
+            self.scheduler.drain()
+            self.bus.drain()
+            self._tick_ui()
+            time.sleep(tick_interval_seconds)
+
+    def _tick_ui(self) -> None:
+        """Call the UI tick callback if one has been registered.
+
+        The screen integration in a later plan sets app._ui_tick_callback to a
+        function. Until then, _tick_ui is a no-op.
+        """
+        callback = getattr(self, "_ui_tick_callback", None)
+        if callback is not None:
+            try:
+                callback()
+            except Exception as exc:
+                from loguru import logger
+
+                logger.error("UI tick callback raised: {}", exc)
+```
+
+- [ ] **Step 8.4: Run the tests; both should pass**
+
+Run:
+```bash
+uv run pytest tests/core/test_app_shell.py -v
+```
+
+Expected: all passing (including the two new run-loop tests).
+
+- [ ] **Step 8.5: Format, lint, type-check**
+
+Run:
+```bash
+uv run black src/yoyopod/core/app_shell.py tests/core/test_app_shell.py
+uv run ruff check src/yoyopod/core/app_shell.py tests/core/test_app_shell.py
+uv run mypy src/yoyopod/core/app_shell.py
+```
+
+Expected: all green.
+
+- [ ] **Step 8.6: Commit**
+
+Run:
+```bash
+git add src/yoyopod/core/app_shell.py tests/core/test_app_shell.py
+git commit -m "$(cat <<'EOF'
+feat(core): add YoyoPodApp.run() main loop
+
+4-line loop: drain scheduler, drain bus, tick UI, sleep. Exits when
+stop() is called. UI tick is a placeholder callback that the screen
+integration will set in a later plan.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Retire the legacy `PowerManager`, `PowerRuntimeService`, `PowerCoordinator`
+
+**Files:**
+- Delete: `src/yoyopod/power/manager.py`
+- Delete: `src/yoyopod/power/policies.py`
+- Delete: `src/yoyopod/power/events.py`
+- Delete: `src/yoyopod/power/__init__.py`
+- Delete: `src/yoyopod/runtime/power.py` (PowerRuntimeService)
+- Delete: `src/yoyopod/coordinators/power.py`
+
+- [ ] **Step 9.1: Enumerate remaining consumers of the old power classes**
+
+Run:
+```bash
+grep -rn "from yoyopod.power" src/ tests/
+grep -rn "PowerManager\|PowerRuntimeService\|PowerCoordinator" src/ tests/
+```
+
+Expected: some hits inside `src/yoyopod/app.py`, `src/yoyopod/runtime/`, maybe `src/yoyopod/cli/`, and in tests (`test_app_orchestration.py`, `test_fsm_runtime.py` if they haven't been deleted yet).
+
+Triage:
+- Consumers inside `src/yoyopod/app.py` — that file is being rewritten in Plan 8, but for this plan it needs to compile. Stub out the power references with a comment `# TODO: removed in Phase A plan 2; wired via integrations/power/` and either delete the import or leave a minimal no-op shim.
+- Consumers inside `src/yoyopod/runtime/power.py` — delete the file. If the `runtime/__init__.py` re-exports `PowerRuntimeService`, remove that re-export too.
+- Tests that reference `PowerManager` or `PowerRuntimeService` and are already marked for deletion in the Phase A spec (e.g., `test_fsm_runtime.py`, `test_app_orchestration.py`): delete them if they exist.
+
+- [ ] **Step 9.2: Delete the files**
+
+Run:
+```bash
+git rm src/yoyopod/power/manager.py
+git rm src/yoyopod/power/policies.py
+git rm src/yoyopod/power/events.py
+git rm src/yoyopod/power/__init__.py
+git rm src/yoyopod/runtime/power.py
+git rm src/yoyopod/coordinators/power.py
+```
+
+If any of these files no longer exist (already moved/removed), the `git rm` will error; skip those and continue.
+
+- [ ] **Step 9.3: Remove power-related imports and instance variables from `src/yoyopod/app.py`**
+
+Open `src/yoyopod/app.py`. Remove:
+- `from yoyopod.power import (PowerManager, PowerRuntimeService)` (or similar)
+- `self.power_manager: Optional[PowerManager] = None`
+- `self.power_runtime = PowerRuntimeService(self)`
+- Any `self.power_manager.*` calls — replace with comments `# power is now an integration; see integrations/power/`
+- Any `self._poll_power_status(...)` compatibility wrappers — remove
+
+Do not try to make `app.py` pretty — it is being fully rewritten in Plan 8.
+
+- [ ] **Step 9.4: Remove power re-exports from `src/yoyopod/runtime/__init__.py`**
+
+Open `src/yoyopod/runtime/__init__.py`. Remove any line that imports or re-exports `PowerRuntimeService`.
+
+- [ ] **Step 9.5: Run the full test suite**
+
+Run:
+```bash
+uv run pytest tests/ -q
+```
+
+Expected: all tests green. Tests that used to reference `PowerManager` or `PowerRuntimeService` must already be migrated (new power-integration tests under `tests/integrations/test_power*.py`) or deleted.
+
+- [ ] **Step 9.6: Run the full CI gate**
+
+Run:
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green.
+
+- [ ] **Step 9.7: Commit**
+
+Run:
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+refactor(power): delete PowerManager, PowerRuntimeService, PowerCoordinator
+
+Power is now a pure integration under src/yoyopod/integrations/power/.
+The legacy manager/runtime/coordinator triple is gone; app.py is stubbed
+to compile (will be rewritten in Plan 8's final sweep).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 10.1: Verify no legacy `PowerManager` references remain**
+
+Run:
+```bash
+git grep -l "PowerManager\|PowerRuntimeService\|PowerCoordinator"
+```
+
+Expected: matches only in the Phase A spec and plan files under `docs/superpowers/` (they legitimately reference the old names to explain what was removed). Any match outside those paths is a bug to fix.
+
+- [ ] **Step 10.2: Verify the integration shape**
+
+Run:
+```bash
+ls src/yoyopod/integrations/power/
+ls src/yoyopod/backends/power/
+```
+
+Expected:
+- `integrations/power/`: `__init__.py`, `commands.py`, `handlers.py`, `poller.py` (no `events.py` yet; later plans add domain events when needed).
+- `backends/power/`: `__init__.py`, `pisugar.py`, `watchdog.py`.
+
+- [ ] **Step 10.3: Run the full CI gate**
+
+Run:
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green.
+
+- [ ] **Step 10.4: Confirm branch history**
+
+Run:
+```bash
+git log --oneline arch/phase-a-spine-rewrite ^main
+```
+
+Expected (newest first), appended to the 12 Plan-1 commits:
+```
+refactor(power): delete PowerManager, PowerRuntimeService, PowerCoordinator
+feat(core): add YoyoPodApp.run() main loop
+feat(integrations/power): setup/teardown wiring, commands, policy loop
+feat(integrations/power): add background poller
+feat(integrations/power): add snapshot-to-state handler + low-battery policy
+feat(integrations/power): add typed command dataclasses
+chore(integrations): scaffold integrations package + power placeholder
+refactor(power): move PiSugar backend and watchdog under src/yoyopod/backends/power/
+docs: renumber Phase C -> Phase B in Phase A spec
+```
+
+9 commits on top of Plan 1. The overall branch now has 21 commits.
+
+- [ ] **Step 10.5: Confirm the power integration is registered in some wiring**
+
+For Phase A Plan 2 the integration is registered by the test fixture only — the main `src/yoyopod/app.py` is still the legacy shell. This is expected; subsequent integrations join a real wiring point in `app.py` which is rewritten in Plan 8.
+
+---
+
+## Definition of Done
+
+- `src/yoyopod/backends/power/` contains `pisugar.py` and `watchdog.py`, both moved from the legacy `src/yoyopod/power/` package.
+- `src/yoyopod/integrations/power/` contains `__init__.py` (setup/teardown), `commands.py`, `handlers.py`, `poller.py`.
+- `tests/integrations/test_power_commands.py`, `test_power_handlers.py`, `test_power_poller.py`, `test_power_integration.py` all passing.
+- `core/app_shell.py` has `run()` and `_tick_ui()` methods.
+- `PowerManager`, `PowerRuntimeService`, `PowerCoordinator` deleted; no references outside docs/.
+- `uv run python scripts/quality.py ci` green.
+
+---
+
+## What's next (Plan 3)
+
+The "easy batch" — four integrations that share patterns and don't cross-cut:
+1. `network` — cellular registration, PPP, signal (no GPS)
+2. `location` — GPS fix (split out of the legacy `network/gps.py`)
+3. `contacts` — people directory, SIP→name lookup
+4. `cloud` — MQTT telemetry, HTTPS sync, remote commands
+
+Each follows the same template as the power pilot: backend under `backends/<name>/`, integration under `integrations/<name>/` with `setup(app)`, typed commands, state-mirroring handlers.
+
+---
+
+*End of implementation plan.*

--- a/docs/superpowers/plans/2026-04-21-phase-a-recovery-and-screens.md
+++ b/docs/superpowers/plans/2026-04-21-phase-a-recovery-and-screens.md
@@ -1,0 +1,757 @@
+# Phase A — Plan 7: Recovery Integration + 17-Screen Touch-Up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-home `RecoverySupervisor` as an integration and migrate all 17 screens to consume `app.states` and `app.services` instead of direct manager references. This is the UI-side work that makes Phase A feel coherent end-to-end.
+
+**Architecture:** Recovery subscribes to `BackendStoppedEvent`, retries the owning integration's backend on a backoff, publishes `RecoveryAttemptedEvent`. Screens change constructor signature from `(manager1, manager2, ...)` to `(app: YoyoPodApp)`. Read paths become `app.states.get_value(...)`; action paths become `app.services.call(...)`. Screens that need periodic refresh subscribe to `StateChangedEvent` with an entity prefix filter.
+
+**Tech Stack:** Python 3.12+, pytest, uv, existing PIL/LVGL rendering (unchanged — only the data-access seam changes).
+
+**Spec reference:** spec §10 (screen touch-up), §11.2 step 10-11.
+
+**Prerequisite:** Plans 1-6 executed. All 10 integrations working; `VoIPManager`/`CallCoordinator` deleted.
+
+---
+
+## File Structure
+
+### Files to create
+
+- `src/yoyopod/integrations/recovery/__init__.py`
+- `src/yoyopod/integrations/recovery/commands.py`
+- `src/yoyopod/integrations/recovery/events.py` (optional — `RecoveryAttemptedEvent`)
+- `src/yoyopod/integrations/recovery/supervisor.py` (logic relocated from `src/yoyopod/runtime/recovery.py`)
+- `tests/integrations/test_recovery.py`
+
+### Files to modify (17 screen files + ScreenManager)
+
+Under `src/yoyopod/ui/screens/`:
+- `home.py`
+- `hub.py`
+- `menu.py`
+- `navigation/listen.py`
+- `navigation/ask.py`
+- `system/power.py`
+- `music/now_playing.py`
+- `music/playlist.py`
+- `music/recent.py`
+- `voip/call.py`
+- `voip/talk_contact.py`
+- `voip/call_history.py`
+- `voip/contact_list.py`
+- `voip/voice_note.py`
+- `voip/quick_call.py`
+- `voip/incoming_call.py` (or wherever the incoming-call screen lives)
+- `voip/outgoing_call.py`
+- `voip/in_call.py`
+- `manager.py` (ScreenManager — takes `app` in constructor, uses it for screen-instance resolution)
+- `router.py` (if it needs `app`)
+
+### Files to delete
+
+- `src/yoyopod/runtime/recovery.py` (relocated to `integrations/recovery/supervisor.py`)
+- `src/yoyopod/runtime/event_wiring.py` (replaced by integrations' own setup())
+- `src/yoyopod/runtime/loop.py` / similar (run() now on YoyoPodApp — per Plan 2)
+- `src/yoyopod/runtime/screen_power.py` (folded into integrations/screen/ in Plan 4)
+- `src/yoyopod/runtime/shutdown.py` (teardown() handled by app_shell)
+- `src/yoyopod/runtime/voice.py` (folded into integrations/voice/ in Plan 4)
+
+---
+
+## Task 1: Branch state verification
+
+- [ ] **Step 1.1**
+
+```bash
+git log --oneline -30
+uv run pytest tests/ -q
+```
+
+Expected: Plans 1-6 all landed; tests green.
+
+---
+
+## Task 2: Recovery integration
+
+**Events:** `RecoveryAttemptedEvent(domain, success, reason)`.
+
+**Commands:** `request_recovery(RequestRecoveryCommand(domain))` — manual trigger.
+
+Recovery subscribes to `BackendStoppedEvent` and retries the named integration's backend on an exponential backoff.
+
+### Subtask 2.1: Events + commands
+
+- [ ] **Step 2.1.1: Create `src/yoyopod/integrations/recovery/events.py`**
+
+```python
+"""Recovery integration events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryAttemptedEvent:
+    """Published after a backend-recovery attempt completes."""
+
+    domain: str
+    success: bool
+    reason: str = ""
+```
+
+- [ ] **Step 2.1.2: Create `src/yoyopod/integrations/recovery/commands.py`**
+
+```python
+"""Recovery integration commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RequestRecoveryCommand:
+    """Manually trigger a recovery attempt for the given domain."""
+
+    domain: str
+```
+
+### Subtask 2.2: Supervisor implementation
+
+- [ ] **Step 2.2.1: Create `src/yoyopod/integrations/recovery/supervisor.py`**
+
+```python
+"""Recovery supervisor.
+
+Subscribes to BackendStoppedEvent and schedules retry attempts via the
+main-thread scheduler (with exponential backoff per domain). Publishes
+RecoveryAttemptedEvent after each attempt.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from loguru import logger
+
+from yoyopod.core.events import BackendStoppedEvent
+from yoyopod.integrations.recovery.events import RecoveryAttemptedEvent
+
+
+@dataclass
+class _DomainState:
+    attempt_count: int = 0
+    next_delay_seconds: float = 1.0
+    scheduled: bool = False
+
+
+MAX_DELAY_SECONDS = 30.0
+
+
+class RecoverySupervisor:
+    def __init__(
+        self,
+        app: Any,
+        retry_handlers: dict[str, Callable[[], bool]] | None = None,
+    ) -> None:
+        self._app = app
+        self._retry_handlers: dict[str, Callable[[], bool]] = retry_handlers or {}
+        self._domains: dict[str, _DomainState] = {}
+        self._lock = threading.Lock()
+
+    def register_retry_handler(self, domain: str, handler: Callable[[], bool]) -> None:
+        """Integrations call this in their setup() to opt in to recovery."""
+        self._retry_handlers[domain] = handler
+
+    def on_backend_stopped(self, event: BackendStoppedEvent) -> None:
+        """Schedule a retry for the domain whose backend stopped."""
+        self._schedule_retry(event.domain, reason=event.reason)
+
+    def request_recovery(self, domain: str) -> None:
+        """Manual retry request (from command)."""
+        self._schedule_retry(domain, reason="manual")
+
+    def _schedule_retry(self, domain: str, reason: str) -> None:
+        with self._lock:
+            state = self._domains.setdefault(domain, _DomainState())
+            if state.scheduled:
+                return
+            state.scheduled = True
+            delay = state.next_delay_seconds
+
+        def run_retry() -> None:
+            time.sleep(delay)
+            self._app.scheduler.run_on_main(lambda: self._attempt(domain, reason))
+
+        threading.Thread(target=run_retry, daemon=True, name=f"recovery-{domain}").start()
+
+    def _attempt(self, domain: str, reason: str) -> None:
+        handler = self._retry_handlers.get(domain)
+        with self._lock:
+            state = self._domains.setdefault(domain, _DomainState())
+            state.scheduled = False
+            state.attempt_count += 1
+
+        success = False
+        if handler is None:
+            logger.warning("No recovery handler for domain {}", domain)
+        else:
+            try:
+                success = bool(handler())
+            except Exception as exc:
+                logger.error("Recovery handler {} raised: {}", domain, exc)
+
+        self._app.bus.publish(
+            RecoveryAttemptedEvent(domain=domain, success=success, reason=reason)
+        )
+
+        with self._lock:
+            if success:
+                state.attempt_count = 0
+                state.next_delay_seconds = 1.0
+            else:
+                state.next_delay_seconds = min(state.next_delay_seconds * 2, MAX_DELAY_SECONDS)
+
+        if not success:
+            # Schedule another retry.
+            self._schedule_retry(domain, reason=f"retry_{state.attempt_count}")
+```
+
+### Subtask 2.3: Integration setup
+
+- [ ] **Step 2.3.1: Create `src/yoyopod/integrations/recovery/__init__.py`**
+
+```python
+"""Recovery integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from yoyopod.core.events import BackendStoppedEvent
+from yoyopod.integrations.recovery.commands import RequestRecoveryCommand
+from yoyopod.integrations.recovery.supervisor import RecoverySupervisor
+
+
+_STATE_KEY = "_recovery_integration"
+
+
+def setup(app: Any) -> None:
+    supervisor = RecoverySupervisor(app=app)
+
+    app.bus.subscribe(
+        BackendStoppedEvent,
+        lambda ev: supervisor.on_backend_stopped(ev),
+    )
+
+    def handle_request_recovery(cmd: RequestRecoveryCommand) -> None:
+        supervisor.request_recovery(cmd.domain)
+
+    app.services.register("recovery", "request_recovery", handle_request_recovery)
+
+    # Expose supervisor so other integrations can register their retry handlers.
+    setattr(app, "recovery_supervisor", supervisor)
+    setattr(app, _STATE_KEY, {"supervisor": supervisor})
+
+
+def teardown(app: Any) -> None:
+    if hasattr(app, _STATE_KEY):
+        delattr(app, _STATE_KEY)
+    if hasattr(app, "recovery_supervisor"):
+        delattr(app, "recovery_supervisor")
+```
+
+### Subtask 2.4: Tests
+
+- [ ] **Step 2.4.1: Create `tests/integrations/test_recovery.py`**
+
+```python
+import time
+
+import pytest
+
+from yoyopod.core.events import BackendStoppedEvent
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.recovery import setup as setup_recovery, teardown as teardown_recovery
+from yoyopod.integrations.recovery.commands import RequestRecoveryCommand
+from yoyopod.integrations.recovery.events import RecoveryAttemptedEvent
+
+
+@pytest.fixture
+def app_with_recovery():
+    app = build_test_app()
+    app.register_integration(
+        "recovery",
+        setup=lambda a: setup_recovery(a),
+        teardown=lambda a: teardown_recovery(a),
+    )
+    app.setup()
+    yield app
+    app.stop()
+
+
+def test_backend_stopped_schedules_retry_handler(app_with_recovery):
+    app = app_with_recovery
+    attempts = []
+    def handler():
+        attempts.append("call")
+        return True
+
+    app.recovery_supervisor.register_retry_handler("call", handler)
+
+    captured: list[RecoveryAttemptedEvent] = []
+    app.bus.subscribe(RecoveryAttemptedEvent, lambda ev: captured.append(ev))
+
+    app.bus.publish(BackendStoppedEvent(domain="call", reason="test"))
+    app.drain()
+
+    # Backoff in tests is 1s + scheduling overhead; poll briefly.
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline and not attempts:
+        time.sleep(0.1)
+        app.drain()
+
+    assert attempts == ["call"]
+    assert captured, "RecoveryAttemptedEvent not published"
+    assert captured[-1].success is True
+
+
+def test_request_recovery_command_triggers_handler(app_with_recovery):
+    app = app_with_recovery
+    attempts = []
+    app.recovery_supervisor.register_retry_handler("music", lambda: (attempts.append("music"), True)[1])
+
+    app.services.call("recovery", "request_recovery", RequestRecoveryCommand(domain="music"))
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline and not attempts:
+        time.sleep(0.1)
+        app.drain()
+
+    assert attempts == ["music"]
+
+
+def test_failing_handler_schedules_retry(app_with_recovery):
+    app = app_with_recovery
+    count = {"n": 0}
+
+    def fail_twice_then_succeed():
+        count["n"] += 1
+        return count["n"] >= 3
+
+    app.recovery_supervisor.register_retry_handler("net", fail_twice_then_succeed)
+
+    app.services.call("recovery", "request_recovery", RequestRecoveryCommand(domain="net"))
+
+    deadline = time.monotonic() + 10.0  # backoff 1+2+4 = 7s max
+    while time.monotonic() < deadline and count["n"] < 3:
+        time.sleep(0.2)
+        app.drain()
+
+    assert count["n"] >= 3
+```
+
+- [ ] **Step 2.4.2: Run, commit**
+
+```bash
+uv run pytest tests/integrations/test_recovery.py -v
+uv run black src/yoyopod/integrations/recovery/ tests/integrations/test_recovery.py
+uv run ruff check src/yoyopod/integrations/recovery/ tests/integrations/test_recovery.py
+uv run mypy src/yoyopod/integrations/recovery/
+git add -A
+git commit -m "feat(integrations/recovery): relocate RecoverySupervisor under integrations
+
+Subscribes to BackendStoppedEvent; per-domain exponential-backoff retries;
+publishes RecoveryAttemptedEvent. Integrations register retry handlers in
+their own setup().
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+### Subtask 2.5: Delete legacy recovery module
+
+- [ ] **Step 2.5.1: Delete + CI + commit**
+
+```bash
+git rm src/yoyopod/runtime/recovery.py
+uv run python scripts/quality.py ci
+git add -A
+git commit -m "refactor: delete legacy src/yoyopod/runtime/recovery.py
+
+Replaced by integrations/recovery/.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Screen touch-up — the migration pattern
+
+Every screen currently takes multiple manager references in its constructor. After migration, every screen takes exactly one dependency: `app: YoyoPodApp`. Reads of domain data go through `app.states.get_value(...)` or `app.states.get(...)`. Actions go through `app.services.call(...)`.
+
+**Canonical migration pattern (apply to every screen):**
+
+1. Change the constructor: replace all manager/coordinator arguments with a single `app: YoyoPodApp`.
+2. Subscribe to `StateChangedEvent` (filtered by the entity prefix the screen cares about) to set `self.dirty = True` or similar render trigger. If the screen does not re-render on state change (static screen), skip subscription.
+3. Rewrite every data read:
+   - `self.voip_manager.is_registered()` → `app.states.get_value("call.registration") == "ok"`
+   - `self.power_manager.get_snapshot().battery.percent` → `app.states.get_value("power.battery_percent")`
+   - etc.
+4. Rewrite every action:
+   - `self.voip_manager.make_call(addr)` → `app.services.call("call", "dial", DialCommand(address=addr))`
+   - `self.music_backend.play(uri)` → `app.services.call("music", "play", PlayCommand(track_uri=uri))`
+   - etc.
+5. Update or add tests that construct the screen with a test app built via `build_test_app()` and exercise interaction through state + services.
+
+The following subtasks apply this pattern to each screen.
+
+---
+
+## Task 4: Migrate home, hub, menu, navigation screens (simple cases)
+
+These screens are mostly passive (show info, no commands) or make limited service calls. Handle them in one task since the pattern is uniform.
+
+- [ ] **Step 4.1: Migrate `home.py`**
+
+Open `src/yoyopod/ui/screens/home.py`. Change constructor to `def __init__(self, app): self.app = app`. Replace reads of manager attributes with `app.states.get_value(...)`. If the home screen shows the current track or call status, use entity reads. If the home screen triggers navigation only, no service calls are needed.
+
+Update corresponding test file (`tests/test_home_screen.py` if it exists) to build the app via `build_test_app()` and set relevant states.
+
+- [ ] **Step 4.2: Migrate `hub.py`, `menu.py`, `navigation/listen.py`, `navigation/ask.py`, `system/power.py`**
+
+Same mechanical migration. For `system/power.py`, the screen reads `app.states.get_value("power.battery_percent")`, `power.charging`, `power.external_power` etc. For `navigation/ask.py`, it issues `voice.start_listening`/`voice.stop_listening` via `app.services.call`.
+
+- [ ] **Step 4.3: Run affected screen tests**
+
+```bash
+uv run pytest tests/ -k "home_screen or hub_screen or menu_screen or listen_screen or ask_screen or power_screen" -v
+```
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(ui): migrate home/hub/menu/navigation/power screens to app-based constructor
+
+Screens now take a single app argument; reads use app.states, actions use
+app.services. No behaviour change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Migrate music screens
+
+- [ ] **Step 5.1: Migrate `music/now_playing.py`, `music/playlist.py`, `music/recent.py`**
+
+Critical reads:
+- `app.states.get_value("music.state")` — "idle" | "playing" | "paused"
+- `app.states.get("music.track")` — returns `StateValue` with `.attrs["title"]`, `.attrs["artist"]`, etc.
+- `app.states.get_value("music.volume_percent")`
+
+Actions:
+- `app.services.call("music", "play", PlayCommand(track_uri=uri))`
+- `app.services.call("music", "pause", PauseCommand())`
+- `app.services.call("music", "resume", ResumeCommand())`
+- `app.services.call("music", "next", NextCommand())`
+- `app.services.call("music", "prev", PrevCommand())`
+- `app.services.call("music", "seek", SeekCommand(position_seconds=pos))`
+- `app.services.call("music", "set_volume", SetVolumeCommand(percent=p))`
+
+For position/progress display on now_playing — position is NOT in the state store (ephemeral, polls too fast). Keep the existing direct `backend.get_position()` via `app.states.get_value("_music_integration")["backend"]` — or expose a small getter on the app: `app.music_position_seconds()`. Simpler: add a helper to the music integration exported as `app.get_music_position()`:
+
+In `src/yoyopod/integrations/music/__init__.py` `setup()` append:
+
+```python
+def get_music_position() -> float:
+    try:
+        return float(backend.get_position())
+    except Exception:
+        return 0.0
+
+app.get_music_position = get_music_position
+```
+
+In `teardown()` append `if hasattr(app, "get_music_position"): delattr(app, "get_music_position")`.
+
+Now `now_playing.py` reads the live position via `app.get_music_position()`.
+
+Subscribe to `StateChangedEvent` filtered on `music.*` to mark dirty. On each `render()`, fetch position.
+
+- [ ] **Step 5.2: Run music screen tests**
+
+```bash
+uv run pytest tests/ -k "music_screen or now_playing or playlist_screen or recent" -v
+```
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(ui): migrate music screens to app-based constructor
+
+Now-playing uses app.get_music_position() for ephemeral position reads
+that shouldn't live in the state store.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Migrate call screens
+
+These are the most complex screens — they subscribe to multiple state changes and issue many commands.
+
+- [ ] **Step 6.1: Migrate `voip/call.py` (status screen)**
+
+Reads:
+- `app.states.get_value("call.registration")` → show registration status
+- `app.states.get_value("call.state")` → show current call state
+
+Actions: none (display only).
+
+- [ ] **Step 6.2: Migrate `voip/quick_call.py`, `voip/talk_contact.py`, `voip/contact_list.py`**
+
+Actions:
+- `app.services.call("call", "dial", DialCommand(address=...))`
+- `app.services.call("call", "send_message", SendMessageCommand(...))` (if applicable)
+- `app.services.call("call", "start_voice_note", StartVoiceNoteCommand(...))`
+- `app.services.call("contacts", "lookup_by_address", LookupByAddressCommand(...))`
+
+- [ ] **Step 6.3: Migrate `voip/call_history.py`**
+
+Read the call history via the call integration's store. Expose a helper:
+
+In `src/yoyopod/integrations/call/__init__.py` `setup()` append:
+
+```python
+app.get_call_history = call_history
+```
+
+In `teardown` — `delattr(app, "get_call_history")`.
+
+Then the history screen reads entries via `app.get_call_history.recent_preview()` or similar existing API.
+
+- [ ] **Step 6.4: Migrate `voip/voice_note.py`**
+
+Actions:
+- `app.services.call("call", "start_voice_note", StartVoiceNoteCommand(...))`
+- `app.services.call("call", "stop_voice_note", StopVoiceNoteCommand())`
+- `app.services.call("call", "send_voice_note", SendVoiceNoteCommand())`
+- `app.services.call("call", "cancel_voice_note", CancelVoiceNoteCommand())`
+- `app.services.call("call", "play_voice_note", PlayVoiceNoteCommand(file_path=...))`
+
+Subscribes to `VoiceNoteCompletedEvent` to refresh the review screen.
+
+- [ ] **Step 6.5: Migrate `voip/incoming_call.py`, `voip/outgoing_call.py`, `voip/in_call.py`**
+
+Incoming:
+- Read `app.states.get("call.caller")` for address + name.
+- Action: `app.services.call("call", "answer", AnswerCommand())` or `"reject"`.
+- Subscribe to `StateChangedEvent` filtered on `call.state` — pop screen when state leaves `"incoming"`.
+
+Outgoing:
+- Read `app.states.get("call.caller")` for callee info.
+- Action: `app.services.call("call", "hangup", HangupCommand())`.
+
+In-call:
+- Reads: `app.states.get("call.caller")`, `app.states.get_value("call.muted")`.
+- Actions: `mute`/`unmute`/`hangup`.
+- Duration read: expose helper on app:
+
+In `src/yoyopod/integrations/call/__init__.py` setup() append:
+```python
+def get_call_duration_seconds() -> int:
+    return int(backend.get_call_duration())
+app.get_call_duration_seconds = get_call_duration_seconds
+```
+
+- [ ] **Step 6.6: Run all voip-screen tests**
+
+```bash
+uv run pytest tests/ -k "call_screen or talk or voice_note or contact_list or incoming_call or outgoing_call or in_call" -v
+```
+
+- [ ] **Step 6.7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(ui): migrate all VoIP screens to app-based constructor
+
+Call/Quick-Call/Talk/Contact-List/Call-History/Voice-Note/Incoming/
+Outgoing/In-Call all take a single app arg. Helpers get_call_history,
+get_call_duration_seconds exposed on app during call setup().
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Migrate ScreenManager + router
+
+- [ ] **Step 7.1: Update `src/yoyopod/ui/screens/manager.py`**
+
+`ScreenManager` constructs screen instances. Change construction to pass `app` only.
+
+Replace:
+```python
+screen = CallScreen(voip_manager=vm, config_manager=cm, ...)
+```
+
+with:
+```python
+screen = CallScreen(app=app)
+```
+
+`ScreenManager.__init__` itself takes `app` and uses it to resolve integrations' helpers (`app.get_call_history`, etc.).
+
+- [ ] **Step 7.2: Update `src/yoyopod/ui/screens/router.py`**
+
+If router decorates or dispatches screen creation, update its hook points to accept `app`.
+
+- [ ] **Step 7.3: Run screen manager + routing tests**
+
+```bash
+uv run pytest tests/test_screen_routing.py tests/test_call_screen.py -v
+```
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(ui): ScreenManager constructs screens with app only
+
+Router and manager take app; individual screens no longer need manager
+references. AppContext dependency removed from constructor chains.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Exhaustive grep for stragglers
+
+- [ ] **Step 8.1: Verify no screen references removed classes**
+
+```bash
+grep -rn "voip_manager\|music_backend\|power_manager\|network_manager\|people_directory\|cloud_manager\|local_music_service" src/yoyopod/ui/
+```
+
+Expected: no matches (or only matches in legacy-named helpers that the touch-up already replaced).
+
+- [ ] **Step 8.2: CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: all green.
+
+- [ ] **Step 8.3: Commit any last-mile cleanup**
+
+If the grep finds leftover references, fix them in place and commit.
+
+```bash
+git add -A
+git commit -m "refactor(ui): last-mile screen touch-up stragglers
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Delete legacy runtime files
+
+With every runtime responsibility absorbed into the core app shell + integrations, the `src/yoyopod/runtime/` package can be emptied.
+
+- [ ] **Step 9.1: Delete leftover runtime files**
+
+```bash
+git rm -r src/yoyopod/runtime/
+```
+
+Update any `__init__.py` re-exports that referenced the deleted runtime files.
+
+- [ ] **Step 9.2: CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: delete src/yoyopod/runtime/ (all services folded into integrations)
+
+RuntimeBootService, RuntimeLoopService, ShutdownLifecycleService,
+RuntimeEventWiring, PowerRuntimeService, ScreenPowerService, and
+VoiceRuntimeCoordinator have all been absorbed into YoyoPodApp.run()
+(Plan 2) + the appropriate integrations.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Final verification
+
+- [ ] **Step 10.1: Structure**
+
+```bash
+ls src/yoyopod/integrations/
+# expected: __init__.py, call/, cloud/, contacts/, diagnostics/, focus/, location/, music/, network/, power/, recovery/, screen/, voice/
+
+ls src/yoyopod/
+# expected: app.py (legacy shell, rewritten in Plan 8), main.py, __init__.py, app_context.py (deleted in Plan 8), core/, backends/, integrations/, ui/, cli/, config/, audio/, device/
+```
+
+- [ ] **Step 10.2: All 11 integrations + recovery present**
+
+```bash
+ls src/yoyopod/integrations/ | wc -l
+```
+
+Expected: 12 entries (`__init__.py` + 11 integration directories). Counting: call, cloud, contacts, diagnostics, focus, location, music, network, power, recovery, screen, voice = 12 directories + `__init__.py`.
+
+- [ ] **Step 10.3: CI + Pi validate (if hardware available)**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+If hardware available, run:
+```bash
+yoyopod pi validate deploy
+yoyopod pi validate smoke
+```
+
+- [ ] **Step 10.4: Branch history**
+
+Expected ~15 new commits on top of Plan 6.
+
+---
+
+## Definition of Done
+
+- `integrations/recovery/` populated and tested.
+- All 17 screens (home, hub, menu, navigation/*, system/power, music/*, voip/*) migrated to single-`app` constructor.
+- `ScreenManager` constructs screens with `app` only.
+- `src/yoyopod/runtime/` deleted entirely.
+- `uv run python scripts/quality.py ci` green.
+
+---
+
+## What's next (Plan 8)
+
+Dead-code removal + final sweep — delete `fsm.py`, `app_context.py`, old `event_bus.py`, old `events.py`, `coordinators/` entirely, shrink `app.py` to a ~150 LOC composition-root shim, archive `docs/RUNTIME_EVENT_FLOW.md`, mark spec `Status: Implemented`, run full Pi validate.
+
+---
+
+*End of implementation plan.*

--- a/docs/superpowers/plans/2026-04-21-phase-b-display.md
+++ b/docs/superpowers/plans/2026-04-21-phase-b-display.md
@@ -1,0 +1,597 @@
+# Phase B — Plan B1: Display HAL Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move display adapters and LVGL binding under `src/yoyopod/backends/display/`; create `src/yoyopod/integrations/display/` to own adapter selection and the UI tick callback. Delete `src/yoyopod/ui/display/` and `src/yoyopod/ui/lvgl_binding/`.
+
+**Architecture:** Display integration's `setup(app)` constructs the correct backend from env/config, binds it as `app.display`, and sets `app._ui_tick_callback` so the main loop pumps it. Screens stay unchanged on the consumer side — they already took `app` in Phase A Plan 7 and called `app.display.render(...)`.
+
+**Tech Stack:** Python 3.12+, pytest, uv, existing cffi + LVGL C shim. No new runtime dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-21-phase-b-hal-consolidation-design.md` §4.1, §5, §6.
+
+**Prerequisite:** Phase A complete and merged to main. Branch `arch/phase-b-hal-consolidation` off main.
+
+---
+
+## File Structure
+
+### Files to create
+
+- `src/yoyopod/backends/display/__init__.py`
+- `src/yoyopod/backends/display/api.py` — common display API (`DisplayBackend` protocol)
+- `src/yoyopod/backends/display/pimoroni.py` (moved)
+- `src/yoyopod/backends/display/whisplay.py` (moved, simplified)
+- `src/yoyopod/backends/display/simulation.py` (moved)
+- `src/yoyopod/backends/display/lvgl/__init__.py`
+- `src/yoyopod/backends/display/lvgl/binding.py` (moved from `ui/lvgl_binding/binding.py`)
+- `src/yoyopod/backends/display/lvgl/backend.py` (moved from `ui/lvgl_binding/backend.py`)
+- `src/yoyopod/backends/display/lvgl/native_shim/` (moved)
+- `src/yoyopod/integrations/display/__init__.py`
+- `src/yoyopod/integrations/display/commands.py`
+- `tests/backends/test_display_api.py`
+- `tests/integrations/test_display.py`
+
+### Files to delete
+
+- `src/yoyopod/ui/display/` (entire directory)
+- `src/yoyopod/ui/lvgl_binding/` (entire directory)
+
+---
+
+## Task 1: Branch setup and build validation
+
+- [ ] **Step 1.1: Create Phase B branch**
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b arch/phase-b-hal-consolidation
+```
+
+- [ ] **Step 1.2: Validate current LVGL build**
+
+```bash
+yoyopod build lvgl
+```
+
+Expected: succeeds, producing the native shim `.so` in its current location. We need this baseline so we can detect if moving the source breaks the build.
+
+---
+
+## Task 2: Move LVGL binding and native shim
+
+- [ ] **Step 2.1: Move files**
+
+```bash
+mkdir -p src/yoyopod/backends/display/lvgl
+git mv src/yoyopod/ui/lvgl_binding/binding.py src/yoyopod/backends/display/lvgl/binding.py
+git mv src/yoyopod/ui/lvgl_binding/backend.py src/yoyopod/backends/display/lvgl/backend.py 2>/dev/null || true
+
+# Move native shim directory (name may be 'native' or 'native_shim' — check)
+git mv src/yoyopod/ui/lvgl_binding/native src/yoyopod/backends/display/lvgl/native_shim
+```
+
+- [ ] **Step 2.2: Create `src/yoyopod/backends/display/lvgl/__init__.py`**
+
+```python
+"""LVGL native binding (confined to this package)."""
+
+from __future__ import annotations
+
+from yoyopod.backends.display.lvgl.binding import LvglBinding
+from yoyopod.backends.display.lvgl.backend import LvglDisplayBackend
+
+__all__ = ["LvglBinding", "LvglDisplayBackend"]
+```
+
+- [ ] **Step 2.3: Update the LVGL build script**
+
+Open `src/yoyopod/cli/build.py` (or wherever `yoyopod build lvgl` is defined). Update the path it expects the native source at — from `src/yoyopod/ui/lvgl_binding/native/` to `src/yoyopod/backends/display/lvgl/native_shim/`.
+
+- [ ] **Step 2.4: Re-run the LVGL build**
+
+```bash
+yoyopod build lvgl
+```
+
+Expected: succeeds at the new path.
+
+- [ ] **Step 2.5: Update imports inside the moved files**
+
+```bash
+grep -rn "from yoyopod.ui.lvgl_binding" src/yoyopod/backends/display/lvgl/
+```
+
+Rewrite to `from yoyopod.backends.display.lvgl`. Also check for relative imports inside the binding that reference the native shim path.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(display): relocate LVGL binding + native shim under backends/display/lvgl/
+
+Build script updated to the new native-source path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Move display adapters under `backends/display/`
+
+- [ ] **Step 3.1: Move facade into a common API module**
+
+```bash
+git mv src/yoyopod/ui/display/facade.py src/yoyopod/backends/display/api.py
+# If contracts.py exists separately, fold it into api.py manually; then:
+[ -f src/yoyopod/ui/display/contracts.py ] && git rm src/yoyopod/ui/display/contracts.py
+```
+
+Open `src/yoyopod/backends/display/api.py` and verify it defines a clean `DisplayBackend` abstract class (using `abc.ABC` or `typing.Protocol`) with the methods screens actually call:
+
+```python
+class DisplayBackend(Protocol):
+    """Common API every display backend implements."""
+
+    backend_kind: str
+
+    def initialize(self) -> None: ...
+    def shutdown(self) -> None: ...
+    def render(self, canvas: Any) -> None: ...
+    def capture_screenshot(self, path: str) -> None: ...
+    def tick(self) -> None: ...
+    def set_brightness(self, percent: int) -> None: ...
+```
+
+Add any helpers the current code needs. Remove any adapter-specific quirks that leaked into the facade — those belong in the adapter.
+
+- [ ] **Step 3.2: Move adapters**
+
+```bash
+git mv src/yoyopod/ui/display/adapters/pimoroni.py src/yoyopod/backends/display/pimoroni.py
+git mv src/yoyopod/ui/display/adapters/whisplay.py src/yoyopod/backends/display/whisplay.py
+git mv src/yoyopod/ui/display/adapters/simulation.py src/yoyopod/backends/display/simulation.py
+```
+
+- [ ] **Step 3.3: Create `src/yoyopod/backends/display/__init__.py`**
+
+```python
+"""Display backend adapters."""
+
+from __future__ import annotations
+
+from yoyopod.backends.display.api import DisplayBackend
+from yoyopod.backends.display.pimoroni import PimoroniDisplayBackend
+from yoyopod.backends.display.simulation import SimulationDisplayBackend
+from yoyopod.backends.display.whisplay import WhisplayDisplayBackend
+
+__all__ = [
+    "DisplayBackend",
+    "PimoroniDisplayBackend",
+    "SimulationDisplayBackend",
+    "WhisplayDisplayBackend",
+]
+```
+
+- [ ] **Step 3.4: Update imports in moved adapters**
+
+```bash
+grep -rn "from yoyopod.ui.display\|from yoyopod.ui.lvgl_binding" src/yoyopod/backends/display/
+```
+
+Rewrite to `yoyopod.backends.display` / `yoyopod.backends.display.lvgl`.
+
+- [ ] **Step 3.5: Rename adapter classes if appropriate**
+
+Current class names may be `PimoroniAdapter`, `WhisplayAdapter`, `SimulationAdapter`. Rename to `PimoroniDisplayBackend` / `WhisplayDisplayBackend` / `SimulationDisplayBackend` to match the new pattern. Update all references.
+
+```bash
+grep -rn "PimoroniAdapter\|WhisplayAdapter\|SimulationAdapter" src/ tests/
+```
+
+Rewrite each match.
+
+- [ ] **Step 3.6: Delete `src/yoyopod/ui/display/factory.py`**
+
+```bash
+git rm src/yoyopod/ui/display/factory.py
+```
+
+Any existing consumers of `get_display_adapter()` / similar factory function will be updated in Task 4 (integration takes over adapter selection).
+
+- [ ] **Step 3.7: Delete remaining `ui/display/` shell**
+
+```bash
+ls src/yoyopod/ui/display/
+```
+
+Whatever remains (empty `__init__.py`, residual files) — delete:
+
+```bash
+git rm -r src/yoyopod/ui/display/
+```
+
+- [ ] **Step 3.8: CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+Expected: any remaining `from yoyopod.ui.display` imports in `src/yoyopod/app.py`, `src/yoyopod/cli/*`, etc., fail type-check or import. Fix inline.
+
+- [ ] **Step 3.9: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(display): move adapters under backends/display/; delete ui/display/
+
+Pimoroni, Whisplay, Simulation adapters now in backends/display/.
+ui/display/factory.py deleted — adapter selection moves into the
+display integration in the next task. Common API defined in
+backends/display/api.py as a Protocol.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Create `integrations/display/`
+
+- [ ] **Step 4.1: Create `src/yoyopod/integrations/display/commands.py`**
+
+```python
+"""Typed commands for the display integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureScreenshotCommand:
+    """Write a PNG screenshot of the current display to `path`."""
+
+    path: str
+
+
+@dataclass(frozen=True, slots=True)
+class RefreshCommand:
+    """Force a re-render of the current screen."""
+
+
+@dataclass(frozen=True, slots=True)
+class SetBrightnessOverrideCommand:
+    """Override display brightness (overrides the screen integration's value)."""
+
+    percent: int
+```
+
+- [ ] **Step 4.2: Create `src/yoyopod/integrations/display/__init__.py`**
+
+```python
+"""Display integration: chooses the right backend, wires ui_tick pump."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.integrations.display.commands import (
+    CaptureScreenshotCommand,
+    RefreshCommand,
+    SetBrightnessOverrideCommand,
+)
+
+
+_STATE_KEY = "_display_integration"
+
+
+def _select_backend_class():
+    backend_env = os.environ.get("YOYOPOD_DISPLAY", "").lower()
+    whisplay_driver = os.environ.get("YOYOPOD_WHISPLAY_DRIVER", "lvgl").lower()
+
+    if backend_env == "simulation":
+        from yoyopod.backends.display import SimulationDisplayBackend
+        return SimulationDisplayBackend
+
+    if backend_env == "pimoroni":
+        from yoyopod.backends.display import PimoroniDisplayBackend
+        return PimoroniDisplayBackend
+
+    if backend_env == "whisplay":
+        from yoyopod.backends.display import WhisplayDisplayBackend
+        return WhisplayDisplayBackend
+
+    # No override: fall back to the per-hardware default from config.
+    return None
+
+
+def setup(app: Any, backend: Any | None = None) -> None:
+    if backend is None:
+        cls = _select_backend_class()
+        if cls is None:
+            # Use config fallback — hardware config names which class to use.
+            hardware = getattr(app.config, "device", None) or getattr(app.config, "hardware", None)
+            name = getattr(hardware, "display", "simulation") if hardware else "simulation"
+            from yoyopod.backends.display import (
+                PimoroniDisplayBackend,
+                SimulationDisplayBackend,
+                WhisplayDisplayBackend,
+            )
+            cls = {
+                "pimoroni": PimoroniDisplayBackend,
+                "whisplay": WhisplayDisplayBackend,
+                "simulation": SimulationDisplayBackend,
+            }.get(name, SimulationDisplayBackend)
+        backend = cls(app.config)
+
+    backend.initialize()
+    app.display = backend
+
+    # Pump the display on each UI tick. If another integration (e.g. screen) has
+    # already registered a ui_tick_callback, chain them.
+    previous_tick = getattr(app, "_ui_tick_callback", None)
+
+    def ui_tick() -> None:
+        try:
+            backend.tick()
+        except Exception as exc:
+            logger.error("Display.tick failed: {}", exc)
+        if previous_tick is not None:
+            previous_tick()
+
+    app._ui_tick_callback = ui_tick
+
+    # Commands.
+    def handle_capture_screenshot(cmd: CaptureScreenshotCommand) -> None:
+        backend.capture_screenshot(cmd.path)
+
+    def handle_refresh(_cmd: RefreshCommand) -> None:
+        # The screen manager will know to re-render on next tick; we publish a
+        # hint so screens can invalidate manually if they want.
+        pass
+
+    def handle_set_brightness_override(cmd: SetBrightnessOverrideCommand) -> None:
+        backend.set_brightness(cmd.percent)
+
+    app.services.register("display", "capture_screenshot", handle_capture_screenshot)
+    app.services.register("display", "refresh", handle_refresh)
+    app.services.register("display", "set_brightness_override", handle_set_brightness_override)
+
+    setattr(app, _STATE_KEY, {"backend": backend})
+
+
+def teardown(app: Any) -> None:
+    state = getattr(app, _STATE_KEY, None)
+    if state is None:
+        return
+    try:
+        state["backend"].shutdown()
+    except Exception as exc:
+        logger.error("Display.shutdown: {}", exc)
+    if hasattr(app, "display"):
+        delattr(app, "display")
+    delattr(app, _STATE_KEY)
+```
+
+- [ ] **Step 4.3: Register the display integration in `src/yoyopod/app.py`**
+
+Insert `"yoyopod.integrations.display"` in `INTEGRATION_MODULES`. Put it **before** `screen` so `app._ui_tick_callback` chain order is correct (display tick runs first, then screen's idle-timeout check).
+
+- [ ] **Step 4.4: Create `tests/integrations/test_display.py`**
+
+```python
+from dataclasses import dataclass
+
+import pytest
+
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.display import setup as setup_display, teardown as teardown_display
+from yoyopod.integrations.display.commands import (
+    CaptureScreenshotCommand,
+    SetBrightnessOverrideCommand,
+)
+
+
+@dataclass
+class _FakeDisplayBackend:
+    backend_kind: str = "fake"
+    initialized: bool = False
+    shutdown_count: int = 0
+    ticks: int = 0
+    renders: int = 0
+    screenshots: list[str] = None
+    brightness_calls: list[int] = None
+
+    def __post_init__(self):
+        self.screenshots = []
+        self.brightness_calls = []
+
+    def initialize(self):
+        self.initialized = True
+
+    def shutdown(self):
+        self.shutdown_count += 1
+
+    def tick(self):
+        self.ticks += 1
+
+    def render(self, canvas):
+        self.renders += 1
+
+    def capture_screenshot(self, path):
+        self.screenshots.append(path)
+
+    def set_brightness(self, percent):
+        self.brightness_calls.append(percent)
+
+
+@pytest.fixture
+def app_with_display():
+    app = build_test_app()
+    backend = _FakeDisplayBackend()
+    app.register_integration(
+        "display",
+        setup=lambda a: setup_display(a, backend=backend),
+        teardown=lambda a: teardown_display(a),
+    )
+    app.setup()
+    yield app, backend
+    app.stop()
+
+
+def test_setup_binds_app_display(app_with_display):
+    app, backend = app_with_display
+    assert app.display is backend
+    assert backend.initialized is True
+
+
+def test_ui_tick_callback_pumps_backend(app_with_display):
+    app, backend = app_with_display
+    app._ui_tick_callback()
+    app._ui_tick_callback()
+    assert backend.ticks == 2
+
+
+def test_capture_screenshot_command(app_with_display):
+    app, backend = app_with_display
+    app.services.call("display", "capture_screenshot", CaptureScreenshotCommand(path="/tmp/x.png"))
+    assert backend.screenshots == ["/tmp/x.png"]
+
+
+def test_set_brightness_override_command(app_with_display):
+    app, backend = app_with_display
+    app.services.call("display", "set_brightness_override", SetBrightnessOverrideCommand(percent=50))
+    assert backend.brightness_calls == [50]
+
+
+def test_teardown_shuts_down_backend(app_with_display):
+    app, backend = app_with_display
+    app.stop()
+    assert backend.shutdown_count == 1
+    assert not hasattr(app, "display")
+```
+
+- [ ] **Step 4.5: Run, format, commit**
+
+```bash
+uv run pytest tests/integrations/test_display.py -v
+uv run black src/yoyopod/integrations/display/ tests/integrations/test_display.py
+uv run ruff check src/yoyopod/integrations/display/ tests/integrations/test_display.py
+uv run mypy src/yoyopod/integrations/display/
+git add -A
+git commit -m "feat(integrations/display): adapter selection + ui_tick wiring + commands
+
+setup() picks Pimoroni/Whisplay/Simulation backend from env/config,
+binds as app.display, registers ui_tick callback that pumps the
+backend. Commands: capture_screenshot, refresh, set_brightness_override.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Update screens to use the new `app.display`
+
+Most screens were migrated in Phase A Plan 7 to take `app` and use `app.display`. Any lingering `ui/display` imports in screens need to be fixed.
+
+- [ ] **Step 5.1: Search for stragglers**
+
+```bash
+grep -rn "from yoyopod.ui.display\|from yoyopod.ui.lvgl_binding" src/yoyopod/ui/screens/ src/yoyopod/app.py
+```
+
+Rewrite to `from yoyopod.backends.display` / `from yoyopod.backends.display.lvgl` as needed.
+
+- [ ] **Step 5.2: Full CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+- [ ] **Step 5.3: Commit fixups**
+
+```bash
+git add -A
+git commit -m "refactor(ui): update screen imports to yoyopod.backends.display
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: On-hardware validation
+
+- [ ] **Step 6.1: Simulation smoke**
+
+```bash
+python yoyopod.py --simulate
+```
+
+Navigate to home screen; confirm it renders. Exit cleanly.
+
+- [ ] **Step 6.2: Pi on-hardware**
+
+```bash
+yoyopod pi validate deploy
+yoyopod pi validate smoke
+yoyopod pi validate lvgl-soak
+```
+
+Expected: green on both Pimoroni and Whisplay.
+
+- [ ] **Step 6.3: Screenshot check**
+
+```bash
+yoyopod pi screenshot --readback --output /tmp/home.png
+```
+
+Inspect `/tmp/home.png` — should match pre-Phase-B baseline visually (pixel-perfect comparison not required; structural/visual parity is the goal).
+
+---
+
+## Task 7: Final sweep
+
+- [ ] **Step 7.1: Confirm no `ui/display` or `ui/lvgl_binding` references linger**
+
+```bash
+git grep -l "yoyopod.ui.display\|yoyopod.ui.lvgl_binding"
+```
+
+Expected: matches only in docs/ (spec/plan history).
+
+- [ ] **Step 7.2: CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+- [ ] **Step 7.3: Commit any final fixup**
+
+```bash
+git add -A
+git commit -m "refactor(display): final sweep for yoyopod.ui.display stragglers" 2>/dev/null || true
+```
+
+---
+
+## Definition of Done
+
+- `src/yoyopod/backends/display/` and `src/yoyopod/backends/display/lvgl/` populated.
+- `src/yoyopod/integrations/display/` registered in `app.py`.
+- `src/yoyopod/ui/display/` and `src/yoyopod/ui/lvgl_binding/` deleted.
+- All three adapters (Pimoroni, Whisplay, Simulation) pass their tests + Pi validate.
+- No raw LVGL imports outside `backends/display/lvgl/` and `backends/display/whisplay.py`.
+
+---
+
+## What's next (Plan B2)
+
+Input HAL consolidation — same pattern for buttons and PTT.
+
+---
+
+*End of implementation plan.*

--- a/docs/superpowers/plans/2026-04-21-phase-b-input.md
+++ b/docs/superpowers/plans/2026-04-21-phase-b-input.md
@@ -1,0 +1,546 @@
+# Phase B — Plan B2: Input HAL Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move input adapters under `src/yoyopod/backends/input/`; create `src/yoyopod/integrations/input/` to own adapter selection, reader-thread lifecycle, and event publishing. Delete `src/yoyopod/ui/input/`.
+
+**Architecture:** Input integration's `setup(app)` constructs the right adapter, starts its reader thread, maps low-level button events to typed domain events published via `scheduler.run_on_main(lambda: app.bus.publish(...))`. Also publishes `UserActivityEvent` for every input to drive screen wake.
+
+**Tech Stack:** Python 3.12+, pytest, uv, existing GPIO reading (`gpiod` on Pi), `pynput` (dev keyboard).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-21-phase-b-hal-consolidation-design.md` §4.2, §5.
+
+**Prerequisite:** Plan B1 executed.
+
+---
+
+## File Structure
+
+### Files to create
+
+- `src/yoyopod/backends/input/__init__.py`
+- `src/yoyopod/backends/input/api.py` — `InputBackend` protocol
+- `src/yoyopod/backends/input/four_button.py` (moved)
+- `src/yoyopod/backends/input/ptt.py` (moved)
+- `src/yoyopod/backends/input/keyboard.py` (moved)
+- `src/yoyopod/integrations/input/__init__.py`
+- `src/yoyopod/integrations/input/events.py`
+- `src/yoyopod/integrations/input/commands.py`
+- `tests/integrations/test_input.py`
+
+### Files to delete
+
+- `src/yoyopod/ui/input/` (entire directory)
+
+---
+
+## Task 1: Branch state verification
+
+- [ ] **Step 1.1**
+
+```bash
+git log --oneline -10
+ls src/yoyopod/backends/
+ls src/yoyopod/integrations/
+```
+
+Expected: Plan B1 commits present; `backends/display/` populated; `integrations/display/` populated. On branch `arch/phase-b-hal-consolidation`.
+
+---
+
+## Task 2: Move input adapters
+
+- [ ] **Step 2.1: Create directory and move adapters**
+
+```bash
+mkdir -p src/yoyopod/backends/input
+git mv src/yoyopod/ui/input/adapters/four_button.py src/yoyopod/backends/input/four_button.py
+git mv src/yoyopod/ui/input/adapters/ptt.py src/yoyopod/backends/input/ptt.py
+git mv src/yoyopod/ui/input/adapters/keyboard.py src/yoyopod/backends/input/keyboard.py
+```
+
+- [ ] **Step 2.2: Move or fold the common interface**
+
+If `src/yoyopod/ui/input/contracts.py` exists, move it:
+
+```bash
+git mv src/yoyopod/ui/input/contracts.py src/yoyopod/backends/input/api.py
+```
+
+Inspect `api.py` — it should define an `InputBackend` protocol:
+
+```python
+class InputBackend(Protocol):
+    """Common API for every input backend."""
+
+    def start(self) -> None: ...
+    def stop(self) -> None: ...
+    def set_event_callback(self, callback: Callable[[str], None]) -> None: ...
+```
+
+Where `callback` receives event names like `"select"`, `"up"`, `"down"`, `"back"`, `"ptt_held"`, `"ptt_released"`, etc. The exact vocabulary depends on the existing adapters — preserve it to avoid downstream churn.
+
+- [ ] **Step 2.3: Create `src/yoyopod/backends/input/__init__.py`**
+
+```python
+"""Input backend adapters."""
+
+from __future__ import annotations
+
+from yoyopod.backends.input.api import InputBackend
+from yoyopod.backends.input.four_button import FourButtonInputBackend
+from yoyopod.backends.input.keyboard import KeyboardInputBackend
+from yoyopod.backends.input.ptt import PttInputBackend
+
+__all__ = [
+    "InputBackend",
+    "FourButtonInputBackend",
+    "KeyboardInputBackend",
+    "PttInputBackend",
+]
+```
+
+- [ ] **Step 2.4: Rename classes to `*InputBackend`**
+
+If existing classes are named `FourButtonAdapter` etc., rename to `FourButtonInputBackend` in place. Grep and rewrite:
+
+```bash
+grep -rn "FourButtonAdapter\|PttAdapter\|KeyboardAdapter" src/ tests/
+```
+
+- [ ] **Step 2.5: Delete `src/yoyopod/ui/input/factory.py` and `manager.py`**
+
+```bash
+git rm src/yoyopod/ui/input/factory.py
+git rm src/yoyopod/ui/input/manager.py
+```
+
+Inspect and remove the `src/yoyopod/ui/input/` directory entirely:
+
+```bash
+git rm -r src/yoyopod/ui/input/
+```
+
+- [ ] **Step 2.6: Update imports everywhere**
+
+```bash
+grep -rn "from yoyopod.ui.input" src/ tests/
+```
+
+Rewrite to `from yoyopod.backends.input`.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(input): relocate adapters under backends/input/; delete ui/input/
+
+FourButton, PTT, Keyboard backends now in backends/input/.
+ui/input/factory.py and ui/input/manager.py deleted — selection
+and reader-thread lifecycle move into the input integration.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Input integration events + commands
+
+- [ ] **Step 3.1: Create `src/yoyopod/integrations/input/events.py`**
+
+```python
+"""Input domain events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ButtonPressedEvent:
+    """A button was pressed (short press)."""
+
+    button: str  # "select", "up", "down", "back", etc.
+
+
+@dataclass(frozen=True, slots=True)
+class ButtonLongPressEvent:
+    """A button was held for the long-press duration."""
+
+    button: str
+
+
+@dataclass(frozen=True, slots=True)
+class PttHeldEvent:
+    """Push-to-talk button is now held down."""
+
+
+@dataclass(frozen=True, slots=True)
+class PttReleasedEvent:
+    """Push-to-talk button was released."""
+```
+
+- [ ] **Step 3.2: Create `src/yoyopod/integrations/input/commands.py`**
+
+```python
+"""Input integration commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class SimulateButtonCommand:
+    """Injects a synthetic button event — test-only helper."""
+
+    button: str
+```
+
+---
+
+## Task 4: Input integration setup
+
+- [ ] **Step 4.1: Create `src/yoyopod/integrations/input/__init__.py`**
+
+```python
+"""Input integration: reader-thread lifecycle, event publishing."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.core.events import UserActivityEvent
+from yoyopod.integrations.input.commands import SimulateButtonCommand
+from yoyopod.integrations.input.events import (
+    ButtonLongPressEvent,
+    ButtonPressedEvent,
+    PttHeldEvent,
+    PttReleasedEvent,
+)
+
+
+_STATE_KEY = "_input_integration"
+
+
+def _select_backend_class():
+    override = os.environ.get("YOYOPOD_INPUT", "").lower()
+    if override == "four_button":
+        from yoyopod.backends.input import FourButtonInputBackend
+        return FourButtonInputBackend
+    if override == "ptt":
+        from yoyopod.backends.input import PttInputBackend
+        return PttInputBackend
+    if override == "keyboard":
+        from yoyopod.backends.input import KeyboardInputBackend
+        return KeyboardInputBackend
+    return None
+
+
+def setup(app: Any, backend: Any | None = None) -> None:
+    if backend is None:
+        cls = _select_backend_class()
+        if cls is None:
+            hardware = getattr(app.config, "device", None) or getattr(app.config, "hardware", None)
+            name = getattr(hardware, "input", "keyboard") if hardware else "keyboard"
+            from yoyopod.backends.input import (
+                FourButtonInputBackend,
+                KeyboardInputBackend,
+                PttInputBackend,
+            )
+            cls = {
+                "four_button": FourButtonInputBackend,
+                "ptt": PttInputBackend,
+                "keyboard": KeyboardInputBackend,
+            }.get(name, KeyboardInputBackend)
+        backend = cls(app.config)
+
+    # Map low-level events to typed domain events.
+    def on_event(event_name: str) -> None:
+        def publish() -> None:
+            if event_name == "ptt_held":
+                app.bus.publish(PttHeldEvent())
+            elif event_name == "ptt_released":
+                app.bus.publish(PttReleasedEvent())
+            elif event_name.endswith("_long"):
+                app.bus.publish(ButtonLongPressEvent(button=event_name[:-5]))
+            else:
+                app.bus.publish(ButtonPressedEvent(button=event_name))
+            app.bus.publish(UserActivityEvent(action_name=event_name))
+
+        app.scheduler.run_on_main(publish)
+
+    backend.set_event_callback(on_event)
+    backend.start()
+
+    # Command — test-only helper.
+    def handle_simulate(cmd: SimulateButtonCommand) -> None:
+        on_event(cmd.button)
+
+    app.services.register("input", "simulate", handle_simulate)
+
+    setattr(app, _STATE_KEY, {"backend": backend})
+
+
+def teardown(app: Any) -> None:
+    state = getattr(app, _STATE_KEY, None)
+    if state is None:
+        return
+    try:
+        state["backend"].stop()
+    except Exception as exc:
+        logger.error("Input.stop: {}", exc)
+    delattr(app, _STATE_KEY)
+```
+
+- [ ] **Step 4.2: Register in `src/yoyopod/app.py` integration list**
+
+Add `"yoyopod.integrations.input"` to `INTEGRATION_MODULES`, positioned before `screen` so `UserActivityEvent` reaches screen's subscription.
+
+- [ ] **Step 4.3: Create `tests/integrations/test_input.py`**
+
+```python
+from dataclasses import dataclass, field
+from typing import Callable
+
+import pytest
+
+from yoyopod.core.events import UserActivityEvent
+from yoyopod.core.testing import build_test_app
+from yoyopod.integrations.input import setup as setup_input, teardown as teardown_input
+from yoyopod.integrations.input.commands import SimulateButtonCommand
+from yoyopod.integrations.input.events import (
+    ButtonLongPressEvent,
+    ButtonPressedEvent,
+    PttHeldEvent,
+    PttReleasedEvent,
+)
+
+
+@dataclass
+class _FakeInputBackend:
+    callback: Callable[[str], None] | None = None
+    started: bool = False
+    stopped: bool = False
+
+    def set_event_callback(self, cb):
+        self.callback = cb
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+
+@pytest.fixture
+def app_with_input():
+    app = build_test_app()
+    backend = _FakeInputBackend()
+    app.register_integration(
+        "input",
+        setup=lambda a: setup_input(a, backend=backend),
+        teardown=lambda a: teardown_input(a),
+    )
+    app.setup()
+    yield app, backend
+    app.stop()
+
+
+def test_setup_starts_backend(app_with_input):
+    _, backend = app_with_input
+    assert backend.started is True
+
+
+def test_button_event_publishes_button_pressed_and_user_activity(app_with_input):
+    app, backend = app_with_input
+    pressed: list[ButtonPressedEvent] = []
+    activity: list[UserActivityEvent] = []
+    app.bus.subscribe(ButtonPressedEvent, lambda ev: pressed.append(ev))
+    app.bus.subscribe(UserActivityEvent, lambda ev: activity.append(ev))
+
+    backend.callback("select")
+    app.drain()
+
+    assert pressed == [ButtonPressedEvent(button="select")]
+    assert len(activity) == 1
+    assert activity[0].action_name == "select"
+
+
+def test_long_press_publishes_button_long_press(app_with_input):
+    app, backend = app_with_input
+    long_events: list[ButtonLongPressEvent] = []
+    app.bus.subscribe(ButtonLongPressEvent, lambda ev: long_events.append(ev))
+
+    backend.callback("select_long")
+    app.drain()
+
+    assert long_events == [ButtonLongPressEvent(button="select")]
+
+
+def test_ptt_events(app_with_input):
+    app, backend = app_with_input
+    held: list[PttHeldEvent] = []
+    released: list[PttReleasedEvent] = []
+    app.bus.subscribe(PttHeldEvent, lambda ev: held.append(ev))
+    app.bus.subscribe(PttReleasedEvent, lambda ev: released.append(ev))
+
+    backend.callback("ptt_held")
+    backend.callback("ptt_released")
+    app.drain()
+
+    assert len(held) == 1
+    assert len(released) == 1
+
+
+def test_simulate_command(app_with_input):
+    app, _ = app_with_input
+    pressed: list[ButtonPressedEvent] = []
+    app.bus.subscribe(ButtonPressedEvent, lambda ev: pressed.append(ev))
+
+    app.services.call("input", "simulate", SimulateButtonCommand(button="up"))
+    app.drain()
+
+    assert pressed == [ButtonPressedEvent(button="up")]
+
+
+def test_teardown_stops_backend(app_with_input):
+    app, backend = app_with_input
+    app.stop()
+    assert backend.stopped is True
+```
+
+- [ ] **Step 4.4: Run, commit**
+
+```bash
+uv run pytest tests/integrations/test_input.py -v
+uv run black src/yoyopod/integrations/input/ tests/integrations/test_input.py
+uv run ruff check src/yoyopod/integrations/input/ tests/integrations/test_input.py
+uv run mypy src/yoyopod/integrations/input/
+git add -A
+git commit -m "feat(integrations/input): adapter selection + event publishing
+
+setup() picks FourButton/PTT/Keyboard backend from env/config, starts
+reader thread, maps events to ButtonPressed/ButtonLongPress/PttHeld/
+PttReleased + publishes UserActivityEvent. Includes input.simulate
+command for tests.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Update screens to subscribe to input events
+
+Most screens in Phase A Plan 7 already subscribe through `self.app.bus.subscribe(...)` in their constructor. If any screen still references `self.input_manager.on_button(...)` or similar, update.
+
+- [ ] **Step 5.1: Search for stragglers**
+
+```bash
+grep -rn "input_manager\|from yoyopod.ui.input" src/yoyopod/
+```
+
+Rewrite: screens subscribe to `ButtonPressedEvent` / `ButtonLongPressEvent` etc. from `yoyopod.integrations.input.events`.
+
+- [ ] **Step 5.2: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(ui): screens subscribe to input events from integrations/input
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Validation
+
+- [ ] **Step 6.1: CI gate**
+
+```bash
+uv run python scripts/quality.py ci
+```
+
+- [ ] **Step 6.2: Simulation smoke**
+
+```bash
+python yoyopod.py --simulate
+```
+
+Press keys; verify navigation works.
+
+- [ ] **Step 6.3: Pi on-hardware**
+
+```bash
+yoyopod pi validate smoke
+```
+
+Press the real buttons / PTT. Verify events flow through to screens.
+
+- [ ] **Step 6.4: No `ui/input` stragglers**
+
+```bash
+git grep -l "yoyopod.ui.input"
+```
+
+Expected: docs/ only.
+
+---
+
+## Task 7: Merge Phase B
+
+- [ ] **Step 7.1: Rebase onto main**
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+- [ ] **Step 7.2: Push + PR**
+
+```bash
+git push -u origin arch/phase-b-hal-consolidation
+gh pr create --title "Phase B: HAL consolidation (display + input backends+integrations)" --body "$(cat <<'EOF'
+## Summary
+
+Moves display and input HALs under the Phase A backends+integrations
+pattern. LVGL binding relocated to backends/display/lvgl/, confined to
+the Whisplay adapter. ui/display/ and ui/input/ deleted. Explicitly
+skips the OVOS PHAL consolidation after evaluation (see spec §4.4).
+
+## Test plan
+
+- [ ] `uv run python scripts/quality.py ci` green
+- [ ] `yoyopod pi validate smoke` green on Pimoroni + Whisplay
+- [ ] `yoyopod pi validate lvgl-soak` green on Whisplay
+- [ ] `python yoyopod.py --simulate` runs; home screen renders; keyboard nav works
+- [ ] No raw LVGL imports outside backends/display/lvgl/ and backends/display/whisplay.py
+- [ ] No yoyopod.ui.display or yoyopod.ui.input imports outside docs/
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7.3: Merge when green**
+
+```bash
+gh pr merge --squash
+```
+
+---
+
+## Definition of Done
+
+- `src/yoyopod/backends/input/` and `src/yoyopod/integrations/input/` populated.
+- `src/yoyopod/ui/input/` deleted.
+- All adapters pass their tests; Pi validate smoke green on real hardware.
+- Phase B spec marked `Status: Implemented`.
+- Branch merged to main.
+
+---
+
+*End of implementation plan.*

--- a/docs/superpowers/specs/2026-04-20-cli-polish-design.md
+++ b/docs/superpowers/specs/2026-04-20-cli-polish-design.md
@@ -1,0 +1,561 @@
+# CLI Polish — Design
+
+**Date:** 2026-04-20
+**Owner:** Moustafa
+**Status:** Approved for implementation planning
+**Supersedes:** `docs/superpowers/plans/2026-04-10-yoyoctl-cli.md` (the original `yoyoctl` CLI scaffold plan)
+
+---
+
+## 1. Goals
+
+The current CLI (`src/yoyopod/cli/`, ~8,800 lines across ~30 files) has grown organically and now exhibits three kinds of friction:
+
+1. **Too many layers per command.** A typical remote command passes through a Typer handler → an `argparse.Namespace` shim → a `build_X_command()` builder → `run_remote()`. Readers trace three files to understand one command.
+2. **Boilerplate duplication.** Every remote command re-declares the same four Pi-connection options (`--host / --user / --project-dir / --branch`) with identical help text — 20+ copies.
+3. **Scattered path and process constants.** Log paths, PID files, screenshot paths, process names, and rsync excludes are defined in 10+ places, making "where do I edit if this path changes?" a non-trivial question.
+
+Plus a pile of commands that are no longer part of any real workflow (duplicates, one-shot bring-up helpers, specialist soak drills).
+
+**Success criteria:**
+
+- One flat package at the repo root, one file per command subgroup, no nested directories.
+- Every CLI command follows the same template (signature → shared state pull → inline shell → exit).
+- All path and process constants live in a single `paths.py`.
+- Every surviving command is one you run often enough to justify keeping.
+- `yoyoctl` is gone; `yoyopod` is both the app launcher and the CLI dispatcher.
+- An auto-generated `COMMANDS.md` at the CLI root lists every command.
+
+---
+
+## 2. Scope
+
+**In scope:**
+- Move CLI from `src/yoyopod/cli/` to a new top-level `yoyopod_cli/` package.
+- Prune ~15 rarely-used or duplicate commands.
+- Fold the three VoIP soak commands into `pi validate voip --soak {kind}`.
+- Add five top-level shortcut commands (`deploy`, `status`, `logs`, `restart`, `validate`).
+- Consolidate all path and process constants into `yoyopod_cli/paths.py`.
+- Introduce a single shared-options callback for the remote Pi connection.
+- Remove the `cli/remote/ops/__init__.py` 152-line re-export shim.
+- Remove the `argparse.Namespace` bridge in every remote handler.
+- Rename the console script `yoyoctl` → `yoyopod` (cold cutover, no alias).
+- Regenerate and commit `yoyopod_cli/COMMANDS.md` from Typer introspection.
+- Update all documentation, skills, CLAUDE.md, and tests.
+
+**Out of scope:**
+- Changing the behavior of any surviving command (same flags, same outputs).
+- Rewriting off-CLI code such as `YoyoPodApp`, coordinators, runtime services, or config models.
+- Changing `config/**/*.yaml` layouts (app config stays where it is).
+- Migrating away from Typer, argparse, or any framework.
+
+---
+
+## 3. Target layout
+
+```
+<repo root>/
+├── yoyopod_cli/                          ← new flat package
+│   ├── __init__.py                       ← __version__, run(), lazy build_app()
+│   ├── main.py                           ← single entry + usage docstring + root callback
+│   ├── paths.py                          ← all path/process constants
+│   ├── common.py                         ← configure_logging, REPO_ROOT re-export
+│   ├── remote_shared.py                  ← build_remote_app(), pi_conn(), RemoteConnection
+│   ├── remote_transport.py               ← run_remote, run_local, ssh/rsync helpers
+│   ├── remote_config.py                  ← yoyopod remote config {show,edit}
+│   ├── remote_ops.py                     ← status, sync, restart, logs, screenshot
+│   ├── remote_validate.py                ← validate (with --with-music/--with-voip/--with-lvgl-soak/--with-navigation), preflight
+│   ├── remote_infra.py                   ← power, rtc, service
+│   ├── remote_setup.py                   ← setup, verify-setup
+│   ├── pi_validate.py                    ← deploy, smoke, music, voip (with --soak), stability, navigation
+│   ├── pi_voip.py                        ← check, debug
+│   ├── pi_power.py                       ← battery, rtc {status,sync-to,sync-from,set-alarm,disable-alarm}
+│   ├── pi_network.py                     ← probe, status
+│   ├── build.py                          ← lvgl, liblinphone
+│   ├── setup.py                          ← host, pi, verify-host, verify-pi
+│   ├── _docgen.py                        ← introspection helper for COMMANDS.md
+│   └── COMMANDS.md                       ← auto-generated command reference
+└── src/yoyopod/                          ← app code only; cli/ subdir deleted
+```
+
+**~17 Python files flat.** Each 100–1100 lines. No subdirs, no re-export shims, no compat layer.
+
+`pi_gallery.py`, `pi_tune.py`, `pi_lvgl.py`, `pi_music.py`, `remote_lvgl.py`, `remote_navigation.py` do **not** appear — their commands are cut (see §4).
+
+---
+
+## 4. Command triage (the definitive cut list)
+
+### KEEP — the surviving command set (~25 commands)
+
+**`yoyopod` top-level shortcuts (new; thin aliases to `remote`):**
+- `yoyopod` — bare invocation launches the app (via `main:run` → `YoyoPodApp`)
+- `yoyopod deploy` — alias for `remote sync`
+- `yoyopod status` — alias for `remote status`
+- `yoyopod logs` — alias for `remote logs`
+- `yoyopod restart` — alias for `remote restart`
+- `yoyopod validate` — alias for `remote validate`
+
+**`yoyopod remote …` (dev machine → Pi via SSH):**
+- `remote status`, `remote sync`, `remote validate [--with-music --with-voip --with-lvgl-soak --with-navigation]`, `remote preflight`, `remote restart`, `remote logs`, `remote screenshot`, `remote config {show,edit}`, `remote service {install,uninstall,status,start,stop}`, `remote setup`, `remote verify-setup`, `remote power`, `remote rtc {status,sync-to,sync-from,set-alarm,disable-alarm}`
+
+**`yoyopod pi …` (on the Pi):**
+- `pi validate {deploy, smoke, music, voip, stability, navigation, lvgl}` — `lvgl` is new, absorbs the cut `pi lvgl soak`
+- `pi validate voip [--soak {registration,reconnect,call}]` — absorbs the three cut soak commands
+- `pi voip {check, debug}`
+- `pi power battery`, `pi power rtc {status,sync-to,sync-from,set-alarm,disable-alarm}`
+- `pi network {probe, status}`
+
+**`yoyopod build …`:**
+- `build lvgl`, `build liblinphone`
+
+**`yoyopod setup …`:**
+- `setup host`, `setup pi`, `setup verify-host`, `setup verify-pi`
+
+### CUT — removed commands (~15 commands)
+
+| Command | Reason |
+|---|---|
+| `pi smoke` | Duplicate of `pi validate smoke` |
+| `remote smoke` | Duplicate of `remote validate` |
+| `remote rsync` | Legacy direct-mode alternative to `remote sync` |
+| `remote provision-test-music` | Dead — covered by `pi validate music` |
+| `pi music provision-test-library` | Dead — covered by `pi validate music` |
+| `pi network gps` | One-shot modem bring-up, effectively never run |
+| `pi lvgl probe` | Superseded by `pi lvgl soak`, and lvgl-soak itself gets folded |
+| `pi lvgl soak` | Folded into `pi validate lvgl` (used on-Pi) and surfaced as `remote validate --with-lvgl-soak` from the dev machine |
+| `pi voip registration-stability` | Folded into `pi validate voip --soak registration` |
+| `pi voip reconnect-drill` | Folded into `pi validate voip --soak reconnect` |
+| `pi voip call-soak` | Folded into `pi validate voip --soak call` |
+| `pi tune` | Whisplay bring-up tooling, effectively frozen |
+| `pi gallery` | Whisplay bring-up tooling, effectively frozen |
+| `remote whisplay` | Cut with `pi tune` |
+| `remote navigation-soak` | Folded into `remote validate --with-navigation` |
+| `remote lvgl-soak` | Folded into `remote validate --with-lvgl-soak` |
+
+Net effect: ~40 commands → ~25 commands (38% reduction), with every survivor on a real workflow.
+
+---
+
+## 5. The command pattern (applied to every file)
+
+Every command in every file conforms to this template. Consistency across files is the core readability win.
+
+### Template
+
+```python
+# yoyopod_cli/remote_ops.py
+import shlex
+import typer
+
+from yoyopod_cli.common import configure_logging
+from yoyopod_cli.paths import load_pi_paths
+from yoyopod_cli.remote_shared import build_remote_app, pi_conn
+from yoyopod_cli.remote_transport import run_remote
+
+app = build_remote_app("ops", "Runtime ops on the Pi via SSH.")
+
+
+@app.command()
+def logs(
+    ctx: typer.Context,
+    lines: int = 50,
+    follow: bool = typer.Option(False, "--follow", "-f"),
+    errors: bool = False,
+    filter: str = "",
+    verbose: bool = False,
+) -> None:
+    """Tail yoyopod logs on the Pi."""
+    configure_logging(verbose)
+    conn = pi_conn(ctx)
+    pi = load_pi_paths()
+
+    log_path = pi.error_log_file if errors else pi.log_file
+    cmd = f"tail -n {lines}{' -f' if follow else ''} {log_path}"
+    if filter:
+        cmd += f" | grep {shlex.quote(filter)}"
+
+    raise typer.Exit(run_remote(conn, cmd, tty=follow))
+```
+
+### Rules (applied uniformly to every CLI file)
+
+1. **One file per command subgroup.** No split between handlers and builders.
+2. **One function = one command.** Typer parameters are typed Python parameters; no `argparse.Namespace` anywhere.
+3. **Shared remote options are declared once** in `build_remote_app()` inside `remote_shared.py`. Every remote command pulls the typed `RemoteConnection` via `pi_conn(ctx)`.
+4. **Shell commands are inline f-strings** using paths from `load_pi_paths()`. No `build_X_command()` layer.
+5. **Exit codes propagate via `raise typer.Exit(run_remote(...))`.** No manual `if rc != 0` ladders.
+6. **Module-level `app = typer.Typer(...)` or `build_remote_app(...)`**, registered into the root app by `main.py`. Every file exposes its `app` under the same name.
+
+### Reader's locality promise
+
+To understand any command, the reader needs to hold in their head:
+- The command's own function body (≤30 lines typical).
+- One accessor call (`pi_conn(ctx)`, `load_pi_paths()`).
+- The shell string it builds.
+
+To go deeper, the reader follows exactly one of these paths:
+- `paths.py` — where the path came from.
+- `remote_transport.py` — what `run_remote` does.
+- `remote_shared.py` — what `pi_conn` returns.
+
+Each is a single ≤120-line file with no cross-references between them. Flat dependency graph. No circular imports. No cycles.
+
+---
+
+## 6. Shared remote options (kill the 4× duplication)
+
+```python
+# yoyopod_cli/remote_shared.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import typer
+
+
+@dataclass(frozen=True)
+class RemoteConnection:
+    host: str
+    user: str
+    project_dir: str
+    branch: str
+
+    @property
+    def ssh_target(self) -> str:
+        return f"{self.user}@{self.host}" if self.user else self.host
+
+
+def build_remote_app(name: str, help: str) -> typer.Typer:
+    """Build a Typer sub-app that captures the shared Pi-connection options once."""
+    app = typer.Typer(name=name, help=help, no_args_is_help=True)
+
+    @app.callback()
+    def _capture_connection(
+        ctx: typer.Context,
+        host: str = typer.Option("", "--host", envvar="YOYOPOD_PI_HOST"),
+        user: str = typer.Option("", "--user", envvar="YOYOPOD_PI_USER"),
+        project_dir: str = typer.Option("", "--project-dir", envvar="YOYOPOD_PI_PROJECT_DIR"),
+        branch: str = typer.Option("", "--branch", envvar="YOYOPOD_PI_BRANCH"),
+    ) -> None:
+        ctx.obj = _resolve_remote_connection(host, user, project_dir, branch)
+
+    return app
+
+
+def pi_conn(ctx: typer.Context) -> RemoteConnection:
+    """Typed accessor — returns a RemoteConnection, not a vague ctx.obj."""
+    return ctx.ensure_object(RemoteConnection)
+
+
+def _resolve_remote_connection(host: str, user: str, project_dir: str, branch: str) -> RemoteConnection:
+    """Merge CLI flags over env vars over pi-deploy.yaml defaults."""
+    # ...loads yaml, applies defaults, returns RemoteConnection
+```
+
+**Resolution precedence** (highest wins): CLI flag → env var → `deploy/pi-deploy.local.yaml` → `deploy/pi-deploy.yaml` → hardcoded defaults in `paths.py`. Matches current behavior exactly.
+
+Every remote command signature becomes **just its own flags** — `host/user/project_dir/branch` are present at the group level but invisible to individual command handlers.
+
+---
+
+## 7. `paths.py` — the single config file
+
+All path and process constants live in `yoyopod_cli/paths.py`. When anything path-shaped changes, it's the one file to edit.
+
+### Structure
+
+```python
+# yoyopod_cli/paths.py
+"""All CLI paths and process constants — single source of truth."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class HostPaths:
+    repo_root: Path = REPO_ROOT
+    deploy_config: Path = REPO_ROOT / "deploy" / "pi-deploy.yaml"
+    deploy_config_local: Path = REPO_ROOT / "deploy" / "pi-deploy.local.yaml"
+    systemd_unit_template: Path = REPO_ROOT / "deploy" / "systemd" / "yoyopod@.service"
+
+
+@dataclass(frozen=True)
+class PiPaths:
+    project_dir: str = "~/YoyoPod_Core"
+    venv: str = ".venv"
+    start_cmd: str = "python yoyopod.py"
+    log_file: str = "logs/yoyopod.log"
+    error_log_file: str = "logs/yoyopod_errors.log"
+    pid_file: str = "/tmp/yoyopod.pid"
+    screenshot_path: str = "/tmp/yoyopod_screenshot.png"
+    test_music_target_dir: str = "logs/test-music"
+    startup_marker: str = "YoyoPod starting"
+    kill_processes: tuple[str, ...] = ("python", "linphonec")
+    rsync_exclude: tuple[str, ...] = (
+        ".git/", ".cache/", "__pycache__/", "*.pyc",
+        ".venv/", "build/", "logs/", "models/",
+        "node_modules/", "*.egg-info/",
+    )
+
+
+@dataclass(frozen=True)
+class ConfigFiles:
+    core: Path = REPO_ROOT / "config" / "app" / "core.yaml"
+    music: Path = REPO_ROOT / "config" / "audio" / "music.yaml"
+    hardware: Path = REPO_ROOT / "config" / "device" / "hardware.yaml"
+    cellular: Path = REPO_ROOT / "config" / "network" / "cellular.yaml"
+    voice: Path = REPO_ROOT / "config" / "voice" / "assistant.yaml"
+    calling: Path = REPO_ROOT / "config" / "communication" / "calling.yaml"
+    messaging: Path = REPO_ROOT / "config" / "communication" / "messaging.yaml"
+    people: Path = REPO_ROOT / "config" / "people" / "directory.yaml"
+    cloud_backend: Path = REPO_ROOT / "config" / "cloud" / "backend.yaml"
+
+
+@dataclass(frozen=True)
+class ProcessNames:
+    app: str = "python yoyopod.py"
+    mpv: str = "mpv"
+    linphonec: str = "linphonec"
+
+
+HOST = HostPaths()
+PI_DEFAULTS = PiPaths()
+CONFIGS = ConfigFiles()
+PROCS = ProcessNames()
+
+
+def load_pi_paths() -> PiPaths:
+    """Return PiPaths with overrides from deploy/pi-deploy.{,.local}.yaml applied.
+
+    Reads fresh on every call — commands are short-lived processes.
+    """
+    # reads HOST.deploy_config + HOST.deploy_config_local, merges, returns overridden PiPaths
+```
+
+### What this consolidates
+
+Replaces path constants currently scattered across:
+- `cli/remote/config.py` (`PiDeployConfig`, `DEPLOY_CONFIG_PATH`, `LOCAL_DEPLOY_CONFIG_PATH`, `DEFAULT_PI_PROJECT_DIR`, defaults inside `parse_pi_deploy_config`)
+- `cli/common.py` (`REPO_ROOT`)
+- `cli/setup.py` (`TRACKED_CONFIG_PATHS`, `NATIVE_ARTIFACTS`)
+- Inline string literals in 10+ handler files
+
+Non-path constants such as the host apt package lists (`CORE_PI_PACKAGES`, etc.) stay in `setup.py` — `paths.py` is for paths and process names only.
+
+### Override model (unchanged)
+
+`deploy/pi-deploy.yaml` + `deploy/pi-deploy.local.yaml` continue to override any `PiPaths` field per host. The YAML layer's merge logic moves from `cli/remote/config.py` into `paths.load_pi_paths()` without behavior change.
+
+---
+
+## 8. `main.py` — the entry point
+
+```python
+# yoyopod_cli/main.py
+"""
+yoyopod — app launcher and CLI dispatcher.
+
+Usage:
+    yoyopod                      # Launch the YoyoPod app
+    yoyopod deploy               # Sync code to Pi and restart
+    yoyopod status               # Pi health dashboard
+    yoyopod logs [-f --errors]   # Tail logs from the Pi
+    yoyopod restart              # Restart app on the Pi
+    yoyopod validate             # Run validation suite on the Pi
+    yoyopod remote <cmd>         # Dev-machine → Pi commands (full list: yoyopod remote --help)
+    yoyopod pi <cmd>             # On-device commands (yoyopod pi --help)
+    yoyopod build <cmd>          # Native extension builds
+    yoyopod setup <cmd>          # Host and Pi setup
+"""
+from __future__ import annotations
+
+import typer
+
+from yoyopod_cli import remote_ops, remote_validate, pi_validate, pi_voip, pi_power, pi_network
+from yoyopod_cli import remote_config, remote_infra, remote_setup, build, setup
+
+app = typer.Typer(name="yoyopod", help="YoyoPod app launcher and CLI.", no_args_is_help=False)
+
+
+@app.callback(invoke_without_command=True)
+def _root(ctx: typer.Context) -> None:
+    """Launch the app when invoked with no subcommand."""
+    if ctx.invoked_subcommand is None:
+        from yoyopod.main import main as launch_app
+        launch_app()
+
+
+# --- sub-apps
+remote_app = typer.Typer(name="remote", help="Dev-machine → Pi via SSH.", no_args_is_help=True)
+# ... merge remote_ops/remote_validate/remote_config/remote_infra/remote_setup into remote_app
+app.add_typer(remote_app)
+
+pi_app = typer.Typer(name="pi", help="Commands that run on the Pi.", no_args_is_help=True)
+# ... merge pi_validate/pi_voip/pi_power/pi_network into pi_app
+app.add_typer(pi_app)
+
+app.add_typer(build.app, name="build")
+app.add_typer(setup.app, name="setup")
+
+
+# --- top-level shortcuts (thin aliases)
+app.command("deploy")(remote_ops.sync)
+app.command("status")(remote_ops.status)
+app.command("logs")(remote_ops.logs)
+app.command("restart")(remote_ops.restart)
+app.command("validate")(remote_validate.validate)
+
+
+def run() -> None:
+    app()
+```
+
+### Entry-point rewiring
+
+**`pyproject.toml`:**
+```toml
+[project.scripts]
+yoyopod = "yoyopod_cli.main:run"
+# yoyoctl removed entirely
+```
+
+The bare-`yoyopod`-launches-the-app behavior uses Typer's `@app.callback(invoke_without_command=True)` — no custom sys.argv parsing.
+
+---
+
+## 9. `COMMANDS.md` — auto-generated reference
+
+One markdown file at `yoyopod_cli/COMMANDS.md`, generated from the live Typer tree.
+
+### Generator
+
+- `yoyopod_cli/_docgen.py` walks the app tree, collects `(command_path, help_text, parameters)` triples, and emits the markdown.
+- Invoked via a new dev command: `yoyopod dev docs`.
+- Run as part of CI (quality gate) to catch drift between code and `COMMANDS.md`.
+
+### Output shape
+
+Grouped sections for top-level shortcuts, `remote`, `pi`, `build`, `setup`. Each section is a table: Command | What it does. Sub-variants listed inline (e.g., `remote validate [--with-music --with-voip --with-lvgl-soak --with-navigation]`).
+
+### Why auto-generated
+
+With 25 commands and expected churn, a hand-written table drifts. CI regenerates the file on every run and fails if the regenerated output does not match the committed `COMMANDS.md` — so `yoyopod --help` and the committed reference table cannot disagree.
+
+---
+
+## 10. Testing approach
+
+### Files to migrate (import-path rewrites, no behavior changes)
+
+- `tests/test_cli.py`
+- `tests/test_cli_bootstrap.py`
+- `tests/test_pi_remote.py`
+- `tests/test_setup_cli.py`
+- `tests/test_voip_cli.py`
+- `tests/test_navigation_soak.py`
+- `tests/test_remote_config_helpers.py`
+- `tests/test_quality_script.py`
+
+### Files to delete (test cut commands)
+
+- `tests/test_pi_gallery.py` — `pi gallery` removed
+- `tests/test_whisplay_tune.py` — `pi tune` / `remote whisplay` removed
+
+### Monkeypatch targets
+
+Tests that patch `yoyopod.cli.remote.ops.subprocess.run`, `yoyopod.cli.remote.ops.run_local_capture`, `yoyopod.cli.remote.ops.validation.run_remote`, etc. must be rewritten to patch the new module boundaries:
+
+- `yoyopod_cli.remote_transport.subprocess.run`
+- `yoyopod_cli.remote_transport.run_remote`
+- `yoyopod_cli.remote_transport.run_local_capture`
+
+Every monkeypatch target in `tests/test_pi_remote.py` (~15 lines) gets a one-line path rewrite. No test logic changes.
+
+### New tests (minimal)
+
+- `test_paths.py` — verify `load_pi_paths()` merges defaults + yaml + local override correctly.
+- `test_remote_shared.py` — verify `build_remote_app` callback captures flags / env / defaults and produces a valid `RemoteConnection`.
+- `test_main_shortcuts.py` — verify `yoyopod status` invokes the same handler as `yoyopod remote status`.
+
+---
+
+## 11. Documentation updates
+
+### Files requiring find-and-replace of `yoyoctl` → `yoyopod`
+
+- `CLAUDE.md` (project instructions)
+- `README.md`
+- `AGENTS.md`
+- `docs/DEVELOPMENT_GUIDE.md`
+- `docs/PI_DEV_WORKFLOW.md`
+- `docs/RPI_SMOKE_VALIDATION.md`
+- `docs/SYSTEM_ARCHITECTURE.md` (anywhere it mentions CLI)
+- `skills/yoyopod-deploy/SKILL.md`
+- `skills/yoyopod-sync/SKILL.md`
+- `skills/yoyopod-logs/SKILL.md`
+- `skills/yoyopod-restart/SKILL.md`
+- `skills/yoyopod-status/SKILL.md`
+- `skills/yoyopod-screenshot/SKILL.md`
+- Any `rules/*.md` referencing `yoyoctl`
+
+Global `grep -rn yoyoctl` + find-replace pass, followed by human review.
+
+### Updates covering removed commands
+
+- Skills that specifically invoke `pi gallery`, `pi tune`, `remote whisplay`, `remote rsync`, `pi voip registration-stability/reconnect-drill/call-soak`, `pi lvgl probe/soak`, `remote navigation-soak`, `remote lvgl-soak` get their instructions rewritten to use the surviving equivalents or are noted as "removed in 2026-04-20 CLI polish; use `remote validate --with-lvgl-soak`" where applicable.
+
+### `pyproject.toml` gate paths
+
+The `[tool.yoyopod_quality]` `gate_format_paths`, `gate_lint_paths`, `gate_type_paths` entries pointing at `src/yoyopod/cli/*` become `yoyopod_cli/` so the new CLI package stays under strict quality enforcement.
+
+---
+
+## 12. Migration / cutover plan
+
+Low-risk because scope is well-contained to one package plus its tests and docs.
+
+### Step sequence
+
+1. **Scaffold** `yoyopod_cli/` with `paths.py`, `common.py`, `remote_shared.py`, `remote_transport.py`, empty `main.py` skeleton, `__init__.py`. No commands yet. Verify `python -c "import yoyopod_cli"` works.
+2. **Rewire entry point.** `pyproject.toml`: `yoyopod = "yoyopod_cli.main:run"`. Remove `yoyoctl` line. Verify `yoyopod --help` shows the skeleton.
+3. **Port `build` + `setup` groups** (smallest, least cross-referenced — warm-up).
+4. **Port `remote_ops`** (status, sync, restart, logs, screenshot) — proves the shared-options pattern on the hot path.
+5. **Port `remote_config`, `remote_infra`, `remote_setup`** — rest of remote except validate.
+6. **Port `remote_validate`** — fold `lvgl-soak` and `navigation-soak` in as `--with-*` flags.
+7. **Port `pi_voip`, `pi_power`, `pi_network`** — small on-device groups.
+8. **Port `pi_validate`** with the new `--soak {registration,reconnect,call}` flag absorbing the three soak commands.
+9. **Add top-level shortcuts** (`deploy`, `status`, `logs`, `restart`, `validate`).
+10. **Build `_docgen.py`** and generate `COMMANDS.md`.
+11. **Delete `src/yoyopod/cli/`** in one commit. Update `pyproject.toml` quality-gate paths.
+12. **Migrate tests** — import-path rewrites, monkeypatch target updates, delete tests for cut commands. Run `uv run python scripts/quality.py ci` to green.
+13. **Doc sweep** — find-replace `yoyoctl` → `yoyopod` across docs/skills/CLAUDE.md/rules. Note removed commands in relevant skills.
+14. **Final verification** — full CI pass, `yoyopod pi validate deploy` + `yoyopod pi validate smoke` on real hardware.
+
+### Risk notes
+
+- **Tests that monkeypatch legacy paths are the biggest nuisance.** The current `cli/remote/ops/__init__.py` shim exists specifically for legacy test paths. New tests monkeypatch at the new module boundaries. ~15 lines to rewrite; no test logic changes.
+- **Cold cutover means one painful day for anyone with `yoyoctl` in muscle memory or personal scripts.** That's the user (and accepted).
+- **Doc drift risk.** ~50 mentions of `yoyoctl` across docs/skills. A single grep + find-replace catches most; human review catches the rest.
+- **Steps 1–11 are pre-deletion.** You can run the new CLI end-to-end and exercise every command before anything gets deleted. Rollback is `git checkout` of steps 2–11.
+
+---
+
+## 13. Open questions
+
+None at design time. All architectural decisions above are locked after the brainstorming round.
+
+Implementation-level decisions (file-by-file call choices, exact helper signatures, minor YAML-merge details) are intentionally deferred to the writing-plans step.
+
+---
+
+## 14. References
+
+- Current implementation: `src/yoyopod/cli/` (~8,800 lines, ~30 files)
+- Reference layout: Hermes Agent `hermes_cli/` — flat package at repo root, bare-`hermes` launches app
+- Superseded plan: `docs/superpowers/plans/2026-04-10-yoyoctl-cli.md` (original scaffold plan)
+- Related docs: `rules/project.md`, `rules/architecture.md`, `rules/deploy.md`

--- a/docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md
+++ b/docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md
@@ -3,7 +3,7 @@
 **Date:** 2026-04-21
 **Owner:** Moustafa
 **Status:** Awaiting review
-**Precedes:** Phase B (runtime services cleanup), Phase C (HAL consolidation)
+**Precedes:** Phase B (HAL consolidation, formerly Phase C — renumbered when the original Phase B was absorbed into Phase A)
 **Supersedes:** `docs/RUNTIME_EVENT_FLOW.md` (the old coordinator/FSM event flow becomes historical)
 
 ---

--- a/docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md
+++ b/docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md
@@ -1,0 +1,837 @@
+# Phase A — Spine Rewrite (State Store + Typed Bus + Service Registry) — Design
+
+**Date:** 2026-04-21
+**Owner:** Moustafa
+**Status:** Awaiting review
+**Precedes:** Phase B (runtime services cleanup), Phase C (HAL consolidation)
+**Supersedes:** `docs/RUNTIME_EVENT_FLOW.md` (the old coordinator/FSM event flow becomes historical)
+
+---
+
+## 1. Goals
+
+The current YoyoPod spine exhibits a pseudo-reactive anti-pattern: 9 of 14 event-bus events are published and subscribed by the **same coordinator class**, so the bus is functioning as a thread-marshaller pretending to be pub/sub. One incoming-call event traverses 7–8 hops (`LiblinphoneBackend → VoIPManager → event_scheduler → callback list → CallCoordinator.publish → EventBus → CallCoordinator.handle`) before any real work runs. Call state lives in 5 places simultaneously — Liblinphone native, `VoIPManager`, `CallFSM`, `CoordinatorRuntime`, and screens — with manual sync bookkeeping in between.
+
+Against Moustafa's maintainability rule ((1) reduce the layers a reader traces, (2) reduce the state a reader holds in their head), both axes are over budget.
+
+Phase A rewrites the spine to a single consistent model inspired by Home Assistant's architecture (typed event bus + entity state store + typed service registry), adapted in-process for a Pi Zero 2W.
+
+**Success criteria:**
+
+- One place to answer "where is X's state?" — the state store (`app.states`).
+- One mechanism to trigger an action — the service registry (`app.services.call`).
+- One mechanism to react to signals — the event bus (`app.bus.subscribe`).
+- Every event on the bus has a real reason to be there (never pub-to-self).
+- `CallState` change path: ≤5 hops, top-down readable.
+- All state transitions recorded to `events.jsonl` as structured JSON for LLM-driven debugging.
+- `app.py` shrinks from ~685 LOC to ~150 LOC.
+- The entire "coordinator" concept (CallCoordinator, PlaybackCoordinator, ScreenCoordinator, PowerCoordinator, CoordinatorRuntime, AppRuntimeState) deleted.
+- MusicFSM, CallFSM, CallInterruptionPolicy deleted.
+- VoIPManager's 4 private callback lists deleted.
+- Adding a new cross-cutting observer (LED status, cloud telemetry, metrics) = one new file, zero changes to existing integrations.
+
+---
+
+## 2. Scope
+
+**In scope:**
+
+- Build new `core/` primitives: `Bus`, `States`, `Services`, `Scheduler`, and `App` shell.
+- Rewrite the spine under `integrations/` in HA-style: 11 integration folders, each with a `setup(app)` function that subscribes to events, registers commands, and mirrors backend state into the store.
+- Delete all FSMs, coordinators, derived-state enums, runtime services (boot/loop/shutdown/eventwiring), AppContext.
+- Split VoIPManager into `integrations/call/` (handlers, messaging, voice notes, history).
+- Fold PowerManager, NetworkManager, CloudManager, PeopleDirectory, LocalMusicService, VoiceRuntimeCoordinator, ScreenPowerService into their respective integrations.
+- Separate GPS from network into a new `location` integration.
+- Add an `audio focus` integration (replaces CallInterruptionPolicy; arbiter pattern borrowed from Android's AudioFocus).
+- Add a `diagnostics` integration that owns the structured event log, responsiveness watchdog, and snapshot command.
+- Touch up `ScreenManager` + all 17 screens to read state via `app.states.get(...)` and trigger actions via `app.services.call(...)` instead of holding direct manager references.
+- Clean up straggling `yoyoctl` references to `yoyopod` (pyproject.toml script, cli `__init__.py` Typer name, skills/yoyopod-*/SKILL.md, CLAUDE.md, docs).
+- Rewrite tests for new primitives and integrations; rewrite orchestration tests as state-store + event-trace assertions.
+
+**Out of scope (deferred to later phases):**
+
+- Display/input HAL consolidation and LVGL binding changes (Phase C).
+- Runtime service rethink beyond what Phase A already collapses (Phase B finishes the job if anything remains).
+- Screen rendering changes beyond the read-paths/action-paths touch-up.
+- Config model changes (`src/yoyopod/config/models.py` untouched).
+- Backend adapter reshaping beyond the new observer-via-scheduler contract (Liblinphone binding, mpv IPC, PiSugar socket, modem serial all keep their current internal structure).
+- Moving to asyncio.
+- Process-based architecture (Mycroft-style separate services).
+
+---
+
+## 3. Target architecture
+
+### 3.1 Three primitives
+
+```
+app.bus                 ← observations: "X happened"
+app.states              ← state of record: "X is currently Y"
+app.services            ← commands: "please do X"
+```
+
+Plus `app.scheduler` as a main-thread task queue for background-to-main marshalling.
+
+### 3.2 Directory layout
+
+```
+src/yoyopod/
+├── app.py                         # ~150 LOC — constructs core, loads integrations, runs main loop
+├── main.py                        # entry point
+├── core/
+│   ├── __init__.py
+│   ├── app_shell.py               # YoyoPodApp class
+│   ├── bus.py                     # Bus (main-thread-only, strict)
+│   ├── states.py                  # States (entity store)
+│   ├── services.py                # Services (command registry)
+│   ├── scheduler.py               # MainThreadScheduler
+│   ├── events.py                  # StateChangedEvent + cross-cut event types
+│   └── testing.py                 # build_test_app, assert_events_contain, drain_all
+├── integrations/
+│   ├── call/
+│   │   ├── __init__.py            # setup(app)
+│   │   ├── events.py              # CallIncomingEvent, MessageReceivedEvent, ...
+│   │   ├── commands.py            # DialCommand, AnswerCommand, HangupCommand, ...
+│   │   ├── handlers.py            # _handle_backend_state, etc.
+│   │   ├── messaging.py           # text message handling
+│   │   ├── voice_notes.py         # voice-note record/play
+│   │   └── history.py             # call history store
+│   ├── music/
+│   │   ├── __init__.py
+│   │   ├── events.py
+│   │   ├── commands.py            # PlayCommand, PauseCommand, SeekCommand, ...
+│   │   ├── handlers.py
+│   │   └── library.py             # playlists, recent tracks
+│   ├── power/                     # battery, charging, RTC, watchdog, shutdown
+│   ├── network/                   # cellular, PPP, signal
+│   ├── location/                  # GPS (split out of network)
+│   ├── focus/                     # AudioFocus arbiter
+│   ├── cloud/                     # MQTT telemetry, HTTPS sync, remote commands
+│   ├── contacts/                  # people directory, SIP→name lookup
+│   ├── voice/                     # STT, TTS, voice commands, Ask screen backend
+│   ├── screen/                    # display on/off, brightness, idle timeout
+│   ├── diagnostics/               # event log, responsiveness watchdog, snapshots
+│   └── recovery/                  # backend recovery supervision
+├── backends/                      # adapters to external systems (adapter layer only)
+│   ├── voip/                      # LiblinphoneBackend + binding
+│   ├── music/                     # MpvBackend + process + ipc
+│   ├── power/                     # PiSugarBackend + watchdog
+│   ├── network/                   # modem AT, PPP, transport
+│   ├── location/                  # GPS backend
+│   └── voice/                     # STT engines, TTS engines
+└── ui/                            # screens + display/input (unchanged structurally for Phase A)
+```
+
+### 3.3 Threading model
+
+One main thread runs the app loop:
+
+```python
+while running:
+    scheduler.drain()     # run queued main-thread tasks (backends → handlers)
+    bus.drain()           # dispatch events published during scheduler tasks
+    ui.tick()             # render / input poll
+    time.sleep(SLEEP_SECONDS)
+```
+
+Rule: **the bus is main-thread-only.** `bus.publish()` from any other thread raises in strict mode. Backend callbacks schedule main-thread tasks via `scheduler.run_on_main(fn)`; those tasks then safely publish events and mutate state.
+
+This eliminates the bus's current dual semantics (sync-from-main, queued-from-other) and the re-entrancy edge case where a handler publishing during dispatch recursively re-enters `_dispatch`.
+
+### 3.4 Canonical flow (incoming call pauses music)
+
+```
+Liblinphone native callback (bg thread)
+  → LiblinphoneBackend.on_native_event(ev)       [bg thread]
+  → scheduler.run_on_main(lambda: app.bus.publish(CallBackendStateEvent("connected", caller)))
+  → [main loop drains scheduler]
+  → bus.publish(CallBackendStateEvent(...))      [main thread]
+  → [bus drains]
+  → handlers.handle_backend_state(app, ev)       [main thread]
+       ├─ app.states.set("call.state", "active", attrs={"caller": ...})
+       │    └─ auto-fires StateChangedEvent (bus drains before tick ends)
+       ├─ app.services.call("focus", "request", RequestFocusCommand(owner="call"))
+       │    └─ focus integration publishes AudioFocusLostEvent(owner="music", preempted_by="call")
+       │    └─ music integration subscriber: backend.pause()
+       │    └─ mpv fires "paused" → scheduler → bus → states.set("music.state", "paused")
+       └─ (done)
+UI screens subscribed to StateChangedEvent redraw as relevant state keys change.
+```
+
+Hops from native callback to final state: 5. Every hop a direct call or a single queue. No pub-to-self. No bidirectional callback web.
+
+---
+
+## 4. Core primitives
+
+### 4.1 Bus (`core/bus.py`)
+
+```python
+class Bus:
+    """Typed, main-thread-only, strict event bus."""
+
+    def __init__(self, main_thread_id: int) -> None: ...
+
+    def subscribe(self, event_type: type[E], handler: Callable[[E], None]) -> None: ...
+
+    def publish(self, event: Any) -> None:
+        """Publish an event. Raises if called from a non-main thread."""
+
+    def drain(self, limit: int | None = None) -> int:
+        """Dispatch queued events to subscribers. Returns count dispatched."""
+
+    def pending_count(self) -> int: ...
+```
+
+- `publish()` queues the event on an internal deque; `drain()` dispatches.
+- Dispatch iterates subscribers registered for the exact event type or any base class (isinstance-based).
+- Exceptions in a handler are logged (loguru error) and recorded as an error event in the structured log; dispatch continues to remaining handlers. Strict mode can be enabled to re-raise (used in tests).
+
+### 4.2 States (`core/states.py`)
+
+```python
+@dataclass(frozen=True, slots=True)
+class StateValue:
+    value: Any
+    attrs: dict[str, Any]
+    last_changed_at: float
+
+class States:
+    def __init__(self, bus: Bus) -> None: ...
+
+    def set(self, entity: str, value: Any, attrs: dict[str, Any] | None = None) -> None:
+        """Set an entity's value. No-op if unchanged. Fires StateChangedEvent on change."""
+
+    def get(self, entity: str) -> StateValue | None: ...
+
+    def get_value(self, entity: str, default: Any = None) -> Any:
+        """Convenience: return .value or default."""
+
+    def all(self) -> dict[str, StateValue]:
+        """Snapshot of the full state store (used by diagnostics)."""
+
+    def has(self, entity: str) -> bool: ...
+```
+
+Rules:
+- Entity keys are `domain.entity_name` (snake_case). See §5 for the catalog.
+- `set()` is a no-op when the new `(value, attrs)` equals the current `(value, attrs)` — prevents no-op `StateChangedEvent` spam.
+- `set()` auto-publishes `StateChangedEvent(entity, old, new, attrs, last_changed_at)`.
+- State is in-memory only. Persistence (call history, contacts, etc.) is the owning integration's job via its own store.
+- High-frequency ephemeral values (e.g., music position, call duration-in-progress) do **not** live in the state store. They are direct reads on the owning integration's backend.
+
+### 4.3 Services (`core/services.py`)
+
+```python
+Handler = Callable[[Any], Any]
+
+class Services:
+    def __init__(self, bus: Bus, diagnostics_log: DiagnosticsLog | None = None) -> None: ...
+
+    def register(self, domain: str, service: str, handler: Handler) -> None: ...
+
+    def call(self, domain: str, service: str, data: Any = None) -> Any:
+        """Invoke a registered service synchronously on the main thread.
+        Logs the invocation to the event log. Raises if unregistered."""
+
+    def registered(self) -> list[tuple[str, str]]:
+        """List (domain, service) pairs (for diagnostics)."""
+```
+
+Rules:
+- `data` is a typed frozen dataclass per command, defined in the owning integration's `commands.py`.
+- Handlers run synchronously on the main thread. Slow work (e.g., file I/O during voice-note save) is offloaded by the handler itself (a background thread or a scheduler task) — the service call returns quickly.
+- Return is typically `None`. Query-style services (e.g., `contacts.get_by_address`) may return typed data.
+- Errors raise to the caller; the event log records both the call and the exception.
+
+### 4.4 Scheduler (`core/scheduler.py`)
+
+```python
+class MainThreadScheduler:
+    def __init__(self, main_thread_id: int) -> None: ...
+
+    def run_on_main(self, fn: Callable[[], None]) -> None:
+        """Schedule fn to run on the main thread. Runs immediately if called on main."""
+
+    def drain(self, limit: int | None = None) -> int:
+        """Run queued tasks in FIFO order."""
+
+    def pending_count(self) -> int: ...
+```
+
+Rules:
+- Thread-safe queue (`queue.Queue`).
+- Called from backend threads with a closure: `scheduler.run_on_main(lambda: handle(...))`.
+- Drained once per main-loop tick.
+- Exceptions in a scheduled task are logged; drain continues to remaining tasks.
+
+### 4.5 App shell (`core/app_shell.py`)
+
+```python
+class YoyoPodApp:
+    bus: Bus
+    states: States
+    services: Services
+    scheduler: MainThreadScheduler
+    config: YoyoPodConfig
+
+    def __init__(self, config_dir: str = "config", simulate: bool = False) -> None: ...
+
+    def setup(self) -> None:
+        """Load config, init core primitives, call setup(self) on every integration."""
+
+    def run(self) -> None:
+        """Main loop: drain scheduler, drain bus, tick UI, sleep, repeat."""
+
+    def stop(self) -> None:
+        """Call teardown() on each integration in reverse registration order. Idempotent."""
+
+    def drain(self) -> None:
+        """Test-friendly composite: drain scheduler then bus until both quiescent.
+        Called by unit/e2e tests between stimulus and assertion; not used in production run loop."""
+
+    def recent_events(self, count: int = 500) -> list[LogEntry]:
+        """Return the last N entries from the diagnostics ring buffer.
+        Convenience accessor; delegates to the diagnostics integration."""
+```
+
+Integrations register their `setup(app)` in a known order (see §11.2). The app shell does nothing domain-specific; all behavior lives in integrations.
+
+**Dependency injection pattern.** Every integration's `setup(app)` receives the `app` instance as its only argument. Integrations pull their dependencies (`bus`, `states`, `services`, `scheduler`, `config`, plus any other integration's state via `app.states.get(...)`) from `app`. No separate DI container, no constructor-graph wiring, no service locator. The `app` object is the single ambient dependency. This matches HA's `hass` pattern one-to-one.
+
+---
+
+## 5. Entity catalog
+
+~22 entities total. Values are authoritative; screens and other observers read these.
+
+| Entity | Value domain | Attrs | Owner |
+|---|---|---|---|
+| `call.state` | `idle | incoming | outgoing | active` | `caller`, `call_id` | call |
+| `call.caller` | `CallerInfo | None` | (embedded in `call.state.attrs`; may split if redundant) | call |
+| `call.muted` | `bool` | — | call |
+| `call.registration` | `none | progress | ok | failed` | `reason` | call |
+| `call.history_unread_count` | `int` | `recent_preview` | call |
+| `music.state` | `idle | playing | paused` | `reason` | music |
+| `music.track` | `Track | None` | `title`, `artist`, `duration_seconds`, `path` | music |
+| `music.volume_percent` | `int 0..100` | — | music |
+| `music.backend_available` | `bool` | `reason` | music |
+| `power.battery_percent` | `int 0..100 | None` | `voltage_volts`, `temperature_celsius` | power |
+| `power.charging` | `bool` | — | power |
+| `power.external_power` | `bool` | — | power |
+| `power.backend_available` | `bool` | `reason` | power |
+| `network.cellular_registered` | `bool` | `carrier`, `network_type` | network |
+| `network.signal_bars` | `int 0..5 | None` | `csq` | network |
+| `network.ppp_up` | `bool` | `reason` | network |
+| `location.fix` | `LocationFix | None` | `lat`, `lng`, `altitude`, `speed_mps`, `last_fix_at` | location |
+| `focus.owner` | `call | music | voice | None` | `preempted_by` | focus |
+| `cloud.mqtt_connected` | `bool` | `reason`, `last_sync_at` | cloud |
+| `screen.awake` | `bool` | — | screen |
+| `screen.brightness_percent` | `int 0..100` | — | screen |
+| `voice.state` | `idle | listening | thinking | responding` | `transcript`, `response` | voice |
+| `contacts.unread_voice_notes` | `int` | `by_address` | contacts |
+
+**Not in the state store** (direct reads on the owning integration):
+- `music.position_seconds` — changes 1×/sec during playback; would flood the event log.
+- `call.duration_seconds` — same reason.
+- Signal polling deltas before they cross a "bars" threshold.
+
+Naming conventions:
+- `domain.entity_name` snake_case.
+- Booleans: adjective / past-tense (`charging`, `muted`, `ppp_up`).
+- Percentages: `_percent` suffix.
+- Durations: `_seconds` suffix.
+- Timestamps: `_at` suffix (unix-time float or ISO string as documented per-entity).
+- Counts: `_count` suffix.
+
+---
+
+## 6. Event catalog rules
+
+### 6.1 Universal: `StateChangedEvent`
+
+```python
+@dataclass(frozen=True, slots=True)
+class StateChangedEvent:
+    entity: str
+    old: StateValue | None
+    new: StateValue
+```
+
+Auto-published on every effective `states.set(...)`. Subscribers filter by entity prefix:
+
+```python
+def on_state_changed(ev):
+    if ev.entity.startswith("call."):
+        ...
+```
+
+This single event type covers ~80% of "refresh UI when X changes" subscriptions.
+
+### 6.2 One-off domain events (per-type, frozen dataclasses)
+
+Per-domain `events.py` files define events that are **not** state changes — they carry a distinct payload shape.
+
+| Event | Origin | Purpose |
+|---|---|---|
+| `CallIncomingEvent(caller_address, caller_name)` | call | New incoming call arrived |
+| `CallBackendStateEvent(state, caller_address, reason)` | call | Raw Liblinphone state (internal, used by handler) |
+| `MessageReceivedEvent(sender, text, timestamp, message_id)` | call | Inbound text message |
+| `MessageDeliveryChangedEvent(message_id, state)` | call | Delivery receipt |
+| `VoiceNoteCompletedEvent(draft)` | call | Recorded voice note ready to send |
+| `MusicTrackChangedEvent(track)` | music | (Alternative to state change; may be collapsed into state) |
+| `UserActivityEvent(action_name)` | screen | User input detected (keep-awake trigger) |
+| `BackendStoppedEvent(domain, reason)` | any | Backend crashed or shut down |
+| `RecoveryAttemptedEvent(domain, success)` | recovery | Recovery attempt result |
+| `AudioFocusGrantedEvent(owner, preempted)` | focus | Focus awarded |
+| `AudioFocusLostEvent(owner, preempted_by)` | focus | Focus lost |
+| `ShutdownRequestedEvent(reason, delay_seconds)` | power/cloud | Graceful shutdown requested |
+| `ResponsivenessLagEvent(duration_ms, context)` | diagnostics | Main loop tick exceeded threshold |
+| `LifecycleEvent(integration, phase)` | core | Integration setup/teardown boundaries |
+
+Estimated total: ~15 event types plus the universal `StateChangedEvent`.
+
+### 6.3 Rules
+
+- **Prefer state.** If something can be modeled as a state change, don't create a per-type event.
+- **Frozen dataclasses** with `slots=True` for every event — immutable, typed, cheap.
+- **No commands via events.** If the intent is "please do X," register it as a service and call it. Events are observations, not requests.
+- **No event-to-event forwarding.** A subscriber that only publishes another event should be collapsed.
+
+---
+
+## 7. Command API (services)
+
+### 7.1 Command dataclasses
+
+Each integration defines its commands in `commands.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class PlayCommand:
+    track_uri: str
+    start_position_seconds: float = 0.0
+```
+
+### 7.2 Registration and invocation
+
+```python
+# during integrations/music/__init__.py :: setup(app)
+app.services.register("music", "play", lambda cmd: _handle_play(app, cmd))
+
+# during another integration's handler
+app.services.call("music", "play", PlayCommand(track_uri="local:file:song.mp3"))
+```
+
+### 7.3 Command catalog (approximate; final set emerges per integration)
+
+**call:** `dial`, `answer`, `hangup`, `reject`, `mute`, `unmute`, `send_message`, `start_voice_note`, `stop_voice_note`, `send_voice_note`, `cancel_voice_note`, `play_voice_note`, `mark_voice_notes_seen`
+**music:** `play`, `pause`, `resume`, `stop`, `next`, `prev`, `seek`, `set_volume`
+**power:** `shutdown`, `reboot`, `set_watchdog`, `set_rtc_alarm`, `disable_rtc_alarm`, `sync_rtc_to_system`, `sync_rtc_from_system`
+**focus:** `request`, `release`
+**screen:** `wake`, `sleep`, `set_brightness`, `set_idle_timeout`
+**voice:** `start_listening`, `stop_listening`, `say`
+**cloud:** `sync_now`, `publish_telemetry`
+**contacts:** `lookup_by_address`, `reload`
+**diagnostics:** `snapshot`, `mark_user_activity`
+
+Total ≈ 40 commands. Exact set finalised per integration during implementation.
+
+---
+
+## 8. Observability
+
+### 8.1 Structured event log
+
+- File: `~/.yoyopod/logs/events.jsonl`.
+- Rolling: 5 files × 5 MB = 25 MB total ceiling.
+- One JSON object per line.
+- Four `kind` values: `event`, `command`, `error`, `lifecycle`.
+
+Sample:
+```json
+{"ts":"2026-04-21T10:15:32.123Z","kind":"event","type":"StateChangedEvent","payload":{"entity":"call.state","old":"idle","new":"incoming","attrs":{"caller":"sip:bob@..."}}}
+{"ts":"2026-04-21T10:15:32.125Z","kind":"command","domain":"focus","service":"request","data":{"owner":"call"}}
+{"ts":"2026-04-21T10:15:32.140Z","kind":"error","handler":"music.on_focus_lost","exc":"RuntimeError: mpv not connected"}
+{"ts":"2026-04-21T10:15:32.160Z","kind":"lifecycle","integration":"call","phase":"setup_complete"}
+```
+
+### 8.2 Responsibility
+
+The `diagnostics` integration:
+- Subscribes to `StateChangedEvent` and every one-off event type.
+- Is wired into `services.call()` to log every command invocation.
+- Catches handler exceptions from `bus.drain()` and `scheduler.drain()` and records them.
+- Owns event-log file rotation.
+- Measures `scheduler.drain() + bus.drain()` duration per tick; emits `ResponsivenessLagEvent` when over threshold (default 100 ms, configurable).
+- Exposes the `diagnostics.snapshot` service (see below).
+
+### 8.3 Snapshot command
+
+```python
+@dataclass(frozen=True, slots=True)
+class SnapshotCommand:
+    reason: str
+```
+
+`app.services.call("diagnostics", "snapshot", SnapshotCommand(reason="bug_report"))` writes `~/.yoyopod/logs/snapshot-{ts}-{reason}.json`:
+
+```json
+{
+  "ts": "2026-04-21T10:15:32Z",
+  "reason": "bug_report",
+  "states": { "call.state": {"value": "active", "attrs": {...}, "last_changed_at": 1234.56}, ... },
+  "subscriptions": { "StateChangedEvent": 6, "CallIncomingEvent": 2, ... },
+  "services": ["call.dial", "call.answer", "music.play", ...],
+  "tick_stats_last_100": {
+    "drain_ms_p50": 2.1,
+    "drain_ms_p99": 18.4,
+    "queue_depth_max": 12
+  },
+  "recent_events_tail_path": "events.jsonl",
+  "recent_events_tail_lines": 500
+}
+```
+
+### 8.4 Cloud observability
+
+The `cloud` integration subscribes to `StateChangedEvent` (filtered by what the cloud cares about) and publishes to MQTT. This requires zero changes to other integrations — the whole point of A+3.
+
+### 8.5 loguru
+
+Retained for human-readable `info`/`warn`/`error` lines. Complementary to the structured event log, not replaced. Rule: loguru for human context ("registering with SIP server..."), event log for machine-consumable state transitions.
+
+---
+
+## 9. Fate of existing classes
+
+### 9.1 Deleted outright
+
+| Class / module | File(s) | Why |
+|---|---|---|
+| `MusicFSM` | `src/yoyopod/fsm.py` | 3 states, 3 triggers; replaced by `app.states.get("music.state")` |
+| `CallFSM` | `src/yoyopod/fsm.py` | Replaced by `app.states.get("call.state")` |
+| `CallInterruptionPolicy` | `src/yoyopod/fsm.py` | Replaced by `focus` integration's AudioFocus arbiter |
+| `AppRuntimeState` enum | `src/yoyopod/coordinators/runtime.py` | 18 cross-product values become direct state reads per entity |
+| `CoordinatorRuntime` | `src/yoyopod/coordinators/runtime.py` | Aggregate view replaced by `app.states.all()` + direct reads |
+| `CallCoordinator` | `src/yoyopod/coordinators/call.py` | Logic into `integrations/call/handlers.py` |
+| `PlaybackCoordinator` | `src/yoyopod/coordinators/playback.py` | Logic into `integrations/music/handlers.py` |
+| `ScreenCoordinator` | `src/yoyopod/coordinators/screen.py` | Push/pop into `ScreenManager`; refresh-if-visible becomes subscription |
+| `PowerCoordinator` | `src/yoyopod/coordinators/power.py` | Into `integrations/power/handlers.py` |
+| `RuntimeBootService` | `src/yoyopod/runtime/` | Replaced by `YoyoPodApp.setup()` calling each integration's `setup(app)` |
+| `RuntimeLoopService` | `src/yoyopod/runtime/` | Replaced by 4-line loop in `YoyoPodApp.run()` |
+| `ShutdownLifecycleService` | `src/yoyopod/runtime/` | Replaced by `YoyoPodApp.stop()` calling integration `teardown(app)` |
+| `RuntimeEventWiring` | `src/yoyopod/runtime/event_wiring.py` | Each integration wires itself in its own `setup()` |
+| `AppContext` | `src/yoyopod/app_context.py` | Screens read via `app.states.get(...)`; config via `app.config` |
+
+All of `src/yoyopod/coordinators/` and `src/yoyopod/runtime/` end up empty and are removed.
+
+### 9.2 Split
+
+**VoIPManager** (`src/yoyopod/communication/calling/manager.py`, 618 LOC) dissolves into `integrations/call/`:
+- `__init__.py` — `setup(app)`: constructs `LiblinphoneBackend`, wires callbacks through scheduler, registers commands, subscribes to `AudioFocusLostEvent`.
+- `handlers.py` — call-state handler, registration-state handler, availability handler, post-call history finalization.
+- `messaging.py` — text message handling (from existing `MessagingService`).
+- `voice_notes.py` — voice-note record/playback/send (from existing `VoiceNoteService`).
+- `history.py` — persistent call history store (from existing `CallHistoryStore`).
+- `commands.py` — `DialCommand`, `AnswerCommand`, `HangupCommand`, `RejectCommand`, `MuteCommand`, `UnmuteCommand`, `SendMessageCommand`, ...
+- `events.py` — `CallIncomingEvent`, `CallBackendStateEvent`, `MessageReceivedEvent`, ...
+
+Killed inside VoIPManager:
+- All 4 private callback lists.
+- `_dispatch_backend_event` / `_handle_backend_event` / `event_scheduler` chain.
+- Private state mirrors (`call_state`, `registration_state`, `caller_address`, `caller_name`, `is_muted`, `registered`, `current_call_id`) — moved to `app.states`.
+- Background iterate worker thread — kept but re-homed as an integration-owned helper, not a class method.
+
+Analogous splits for:
+- **PowerManager** + **PowerRuntimeService** → `integrations/power/`
+- **NetworkManager** → `integrations/network/` and `integrations/location/` (GPS split out)
+- **CloudManager** → `integrations/cloud/`
+- **PeopleDirectory** → `integrations/contacts/`
+- **LocalMusicService** → `integrations/music/library.py` (substantial logic kept as submodule)
+- **VoiceRuntimeCoordinator** → `integrations/voice/`
+- **ScreenPowerService** → `integrations/screen/`
+- **RecoverySupervisor** → `integrations/recovery/`
+
+### 9.3 Kept as adapters
+
+Adapters retain their current file layout under `src/yoyopod/backends/`:
+- `LiblinphoneBackend` (+ binding + shim)
+- `MpvBackend` (+ process + ipc)
+- `PiSugarBackend` (+ watchdog)
+- Network modem/PPP/GPS backends
+- Voice STT/TTS backends
+
+Each gets a lightly trimmed interface: events are fired via `scheduler.run_on_main(lambda: app.bus.publish(...))` callbacks set by the owning integration's `setup()`. No more observer classes or callback lists on the adapter side.
+
+### 9.4 Kept, slimmed
+
+| Class | New LOC (approx) | Notes |
+|---|---|---|
+| `YoyoPodApp` | ~150 | Owns `bus`, `states`, `services`, `scheduler`, `config`. Calls `setup()` per integration. Runs main loop. Nothing else. |
+| `Bus` (new) | ~50 | Main-thread-only, strict, no conditional branches in `publish()` |
+| `ScreenManager` + screens | ≈ current | Constructors take `app` instead of specific managers; read via `states`, act via `services` |
+
+Current spine LOC (app.py + fsm.py + event_bus.py + events.py + coordinators/ + VoIPManager + runtime/) ≈ **2,800 LOC**.
+Target spine LOC (app_shell + bus + states + services + scheduler + core events + integrations' handler/command files) ≈ **1,400 LOC**.
+
+---
+
+## 10. Screen touch-up
+
+Screens (`src/yoyopod/ui/screens/`) currently hold references to specific managers (e.g., `voip_manager`, `local_music_service`, `power_manager`). These become a single `app` reference.
+
+### 10.1 Target pattern
+
+```python
+class NowPlayingScreen:
+    def __init__(self, app: YoyoPodApp) -> None:
+        self.app = app
+        app.bus.subscribe(StateChangedEvent, self._on_state_changed)
+
+    def _on_state_changed(self, ev: StateChangedEvent) -> None:
+        if ev.entity in ("music.state", "music.track", "music.volume_percent"):
+            self.dirty = True
+
+    def render(self, canvas) -> None:
+        state = self.app.states.get_value("music.state")
+        track = self.app.states.get_value("music.track")
+        # ... draw
+
+    def on_button_play(self) -> None:
+        if self.app.states.get_value("music.state") == "paused":
+            self.app.services.call("music", "resume", ResumeCommand())
+        else:
+            current = self.app.states.get_value("music.track")
+            self.app.services.call("music", "play", PlayCommand(track_uri=current.uri))
+```
+
+### 10.2 Screens affected
+
+All 17 screens in `src/yoyopod/ui/screens/`:
+- `home`, `hub`, `menu`, `listen`, `ask`, `power`
+- `now_playing`, `playlist`, `recent_tracks`
+- `call`, `talk_contact`, `call_history`, `contact_list`, `voice_note`, `incoming_call`, `outgoing_call`, `in_call`
+
+Per-screen work is mechanical: replace manager references with `app`; rewrite reads to `app.states.get_value(...)`; rewrite writes to `app.services.call(...)`; add `StateChangedEvent` subscription for redraw triggers.
+
+### 10.3 ScreenManager changes
+
+- Constructor takes `app` (to resolve screen instances).
+- `show_incoming_call(address, name)` / `show_in_call()` / `show_outgoing_call(...)` absorb the push/pop logic previously in `ScreenCoordinator`.
+- `refresh_current_screen()` called once per tick by `ui.tick()`; screens mark themselves dirty via `StateChangedEvent` subscriptions.
+
+---
+
+## 11. Migration strategy: M-BigBang on a long-lived branch
+
+Chosen explicitly by Moustafa over M-Incremental. Main branch frozen for the duration of Phase A (emergency hotfixes cherry-picked if unavoidable). Single merge when CI + Pi validation both green.
+
+### 11.1 Branch plan
+
+- Branch: `arch/phase-a-spine-rewrite` off `main` at SHA-of-record.
+- Target merge commit is a single squash or a clean rebased history — reviewer's choice.
+- No intermediate merges to main. No alias/compat code kept alive after each step.
+
+### 11.2 Internal implementation order (commits on the branch, small and reviewable)
+
+1. **CLI straggler cleanup.** Remove lingering `yoyoctl` references. Drop second `yoyoctl` script from `pyproject.toml`. Rename Typer app. Update `skills/yoyopod-*/SKILL.md` and `CLAUDE.md`. Trivial find/replace.
+
+2. **Build `core/` scaffold.** `Bus`, `States`, `Services`, `MainThreadScheduler`, `YoyoPodApp` shell, core `events.py`, `core/testing.py`. Unit tests for each primitive. No integrations yet. Old app still runs.
+
+3. **Migrate `power`.** Pilot. Isolated, well-understood. Delete `PowerManager`, `PowerRuntimeService`, `PowerCoordinator`. Pattern validated end-to-end.
+
+4. **Easy batch: `network`, `location`, `contacts`, `cloud`.** Mostly data-flow, minimal cross-cutting.
+
+5. **`focus` + `diagnostics`.** The arbiter and the event-log writer. Required before music/call migrations touch focus.
+
+6. **`screen`.** Fold `ScreenPowerService`. Establishes the "integration owns the UI-adjacent side" pattern.
+
+7. **`voice`.** Medium complexity. Uses `screen` (wake/sleep).
+
+8. **`music`.** Uses `focus`. First hard integration.
+
+9. **`call`.** Most complex. Uses `focus`; interacts with `music` via focus; messaging and voice-notes submodules.
+
+10. **`recovery`.** Pulls in the last runtime service.
+
+11. **Screen touch-up.** All 17 screens migrated to new pattern.
+
+12. **Dead-code removal.** Delete FSMs, CoordinatorRuntime, AppRuntimeState, all coordinators, RuntimeBootService, RuntimeLoopService, ShutdownLifecycleService, RuntimeEventWiring, AppContext. `app.py` shrinks.
+
+13. **Final sweep.** Double-check no `yoyoctl` references, no lingering managers outside integrations/, tests clean, docs updated. `docs/RUNTIME_EVENT_FLOW.md` archived or rewritten.
+
+### 11.3 Acceptance bar per commit
+
+- All commits on the branch pass `uv run python scripts/quality.py ci`.
+- After step 2, `core/` has ≥90% test coverage.
+- After each integration migration, its tests pass.
+- The branch may leave the app unrunnable for some commits mid-rewrite (acceptable under M-BigBang), but tests must pass.
+
+---
+
+## 12. Testing strategy
+
+### 12.1 Existing test suite — case by case
+
+| File | Fate | Reason |
+|---|---|---|
+| `tests/test_fsm_runtime.py` | Delete | FSMs gone |
+| `tests/test_event_bus.py` | Rewrite | New bus primitive |
+| `tests/test_app_orchestration.py` | Rewrite | Orchestration is now integrations; tests go against `states`/`services`/`bus` |
+| `tests/test_screen_routing.py` | Adapt | Screens still exist; touchpoints changed |
+| `tests/test_call_screen.py` | Adapt | Screen now reads `states`, calls `services` |
+| `tests/test_music_backend.py` | Keep | Backend adapter interface stays |
+| `tests/test_voip_backend.py` | Keep | Same |
+| `tests/test_config_models.py` | Keep | Config untouched |
+| `tests/test_pi_remote.py` | Keep | CLI layer untouched (beyond rename) |
+| `tests/test_cli.py` | Keep | Same |
+| `tests/test_setup_cli.py` | Keep | Same |
+
+### 12.2 New test structure
+
+```
+tests/
+├── core/
+│   ├── test_bus.py
+│   ├── test_states.py
+│   ├── test_services.py
+│   └── test_scheduler.py
+├── integrations/
+│   ├── test_power.py
+│   ├── test_music.py
+│   ├── test_call.py
+│   ├── test_focus.py
+│   ├── test_network.py
+│   ├── test_location.py
+│   ├── test_cloud.py
+│   ├── test_contacts.py
+│   ├── test_voice.py
+│   ├── test_screen.py
+│   ├── test_diagnostics.py
+│   └── test_recovery.py
+├── e2e/
+│   ├── test_call_pauses_music.py
+│   ├── test_missed_call_logged.py
+│   ├── test_voice_note_round_trip.py
+│   ├── test_shutdown_flow.py
+│   └── test_recovery_after_backend_stop.py
+├── fixtures/
+│   └── mock_backends.py
+└── (kept) test_music_backend.py, test_voip_backend.py, test_config_models.py, test_pi_remote.py, test_cli.py, test_setup_cli.py
+```
+
+### 12.3 Test style
+
+State-store + event-trace assertions, no method-mocking:
+
+```python
+def test_incoming_call_pauses_music(app):
+    app.services.call("music", "play", PlayCommand(track_uri="local:test.mp3"))
+    app.drain()
+    assert app.states.get_value("music.state") == "playing"
+
+    app.voip_backend.simulate_call("connected", caller="sip:bob@example")
+    app.drain()
+
+    assert app.states.get_value("call.state") == "active"
+    assert app.states.get_value("music.state") == "paused"
+    assert app.states.get_value("focus.owner") == "call"
+
+    assert_events_contain(app.recent_events(), [
+        CallBackendStateEvent(state="connected", caller_address="sip:bob@example"),
+        StateChangedEvent(entity="call.state", old=("idle", {}), new=("active", {...})),
+        AudioFocusLostEvent(owner="music", preempted_by="call"),
+        StateChangedEvent(entity="music.state", old=("playing", ...), new=("paused", ...)),
+    ])
+```
+
+### 12.4 Backend mocking
+
+Mock backends live in `tests/fixtures/mock_backends.py`. Same interface as real backends; expose a test API to inject events:
+
+```python
+class MockVoIPBackend(VoIPBackend):
+    def simulate_call(self, state: str, caller: str = "test@sip.example") -> None:
+        self._publish_event(CallBackendStateEvent(state=state, caller_address=caller))
+```
+
+`build_test_app()` in `core/testing.py` wires mocks in place of real backends.
+
+### 12.5 Development cadence: TDD
+
+For each new primitive and integration:
+1. Write failing unit / integration / e2e test.
+2. Implement until green.
+3. Refactor.
+
+LLM-driven work benefits materially from concrete failing tests as specs. No legacy-test backward-compat pressure because rewriting tests is scope.
+
+### 12.6 Pre-merge gate
+
+Before the big-bang merge to main, all of:
+- `uv run python scripts/quality.py ci` — full CI suite green (this is also the pre-commit gate per Moustafa's memory).
+- `yoyopod pi validate deploy` — Pi deploy smoke green on actual hardware.
+- `yoyopod pi validate smoke` — basic app-starts-and-responds green.
+- `yoyopod pi validate music` — music flows green on hardware.
+- `yoyopod pi validate voip` — VoIP flows green on hardware.
+- `yoyopod pi validate stability` — no regressions under soak.
+- Manual on-Pi checklist: place outgoing call, receive incoming call during music playback (verify auto-pause + auto-resume), missed call recording, voice note round-trip, graceful shutdown, wake from sleep after RTC alarm, recovery after killing mpv backend, recovery after killing Liblinphone backend.
+- Event log review: tail `events.jsonl` during the manual checklist; verify no unexpected errors, no unexpected state transitions, no responsiveness-lag events.
+
+---
+
+## 13. Risks and known unknowns
+
+1. **LVGL backend pump cadence.** The LVGL display backend needs its pump driven at a fixed cadence from the main loop. Under the new loop, this sits alongside `scheduler.drain()` and `bus.drain()`. Verify `ui.tick()` pumps LVGL at the current rate (current `_pump_lvgl_backend` fires every 5–10 ms). Mitigation: keep tick interval tunable; add `lvgl_pump_interval_seconds` to config; assert in `test_screen_integration` that the pump rate is maintained under event-storm conditions.
+
+2. **VoIP iterate worker thread.** Liblinphone's native iterate runs on a dedicated worker (`voip-iterate` thread). Under the new model, this stays a worker thread owned by the `call` integration; events flow back to main via `scheduler.run_on_main()`. Mitigation: keep the worker's lifecycle simple (start in setup, stop in teardown). Validate the `_current_iterate_interval_seconds()` timing snapshot feeds `diagnostics` without cross-integration coupling.
+
+3. **Event-log I/O on Pi Zero 2W.** SD-card write latency could spike during bursts. Mitigation: diagnostics writes via a background thread fed from the main-thread's event subscription; back-pressure drops oldest buffered entries rather than blocking the main loop. Add a test that asserts the log writer never blocks the main loop >5 ms.
+
+4. **State-store fan-out on busy entities.** If a subscriber mis-uses `StateChangedEvent` without filtering, every state change wakes it. Mitigation: provide `bus.subscribe_to_entity(prefix, handler)` as a filtered helper; document the filter-by-prefix pattern; add a warning log if any handler exceeds a tick budget.
+
+5. **Screen touch-up scope creep.** Screens are thick; changing them touches render logic. Mitigation: touch-up is strictly about read/write seams (manager references → `app.*`), not rendering. Any rendering change is out of scope for Phase A.
+
+6. **Discovery that the pattern needs adjustment mid-rewrite.** Under M-BigBang this is the main risk: if `core/` primitives need a tweak after 3 integrations migrated, we retrofit in-branch. Mitigation: `core/` is small (~500 LOC) and has unit tests; changes there are localized; integration migrations are templateable, so retrofits propagate quickly.
+
+7. **CLI rename collateral damage.** If the Phase A branch diverges from main for weeks and another CLI change lands on main, merge conflicts multiply. Mitigation: rebase the branch onto main after any significant main update; keep the CLI cleanup as the first commit so later conflicts are purely spine-related.
+
+8. **Screens referencing deleted `AppContext`.** Many screens likely destructure `AppContext` for `battery_percent`, `missed_calls`, `recent_calls`, etc. Mitigation: the screen touch-up (step 11 of 11.2) explicitly replaces these reads with `app.states.get_value(...)`; exhaustive grep `context\.` in `ui/screens/` before merge.
+
+---
+
+## 14. Definition of done
+
+- `src/yoyopod/coordinators/` deleted.
+- `src/yoyopod/runtime/` deleted.
+- `src/yoyopod/fsm.py` deleted.
+- `src/yoyopod/app_context.py` deleted.
+- `src/yoyopod/communication/calling/manager.py` deleted (logic split into `integrations/call/`).
+- `src/yoyopod/app.py` ≤ 200 LOC.
+- All 11 integrations present under `src/yoyopod/integrations/`.
+- `core/` present with tested `Bus`, `States`, `Services`, `MainThreadScheduler`, `YoyoPodApp`.
+- All 17 screens updated to take `app` and use `states`/`services`.
+- Event log writing to `~/.yoyopod/logs/events.jsonl` with rotation.
+- `diagnostics.snapshot` command produces a complete state + subscription + tick-stat dump.
+- No `yoyoctl` references anywhere in the repo outside historical git history.
+- Pre-merge gate (§12.6) all green.
+- Design doc marked `Status: Implemented`.
+
+---
+
+## 15. Open questions for review
+
+1. **`call.caller` entity shape.** Currently proposed as a separate entity alongside `call.state` with redundant data in attrs. Alternative: collapse caller into `call.state.attrs` only. Consequence: subscribers interested in just-caller-change need to filter on `call.state`'s attrs changing. Recommend: collapse (simpler catalog).
+
+2. **Recovery integration location.** Originally a `RecoverySupervisor` runtime service. Now proposed as its own integration. Alternative: fold into `diagnostics` (recovery is arguably diagnostic). Recommend: keep separate — recovery is active behavior, diagnostics is passive observation.
+
+3. **Voice integration scope.** Should STT engine lifecycle (model load/unload) be in `voice`, or split into a `voice_stt` integration? Recommend: keep together for Phase A; re-evaluate if `voice/` grows too large.
+
+4. **`focus` integration state.** Proposed entity `focus.owner`. Alternative: expose `focus.active_mode` with value `none|call|music|voice`. Functionally equivalent. Recommend: keep `focus.owner`.
+
+5. **Backwards-compat for Pi production deployment.** Production Pi runs `yoyopod@raouf.service`. During the frozen-main window, production Pi stays on pre-rewrite main. After merge, one coordinated deploy flips to new spine. Acceptable.
+
+---
+
+*End of design spec.*

--- a/docs/superpowers/specs/2026-04-21-phase-b-hal-consolidation-design.md
+++ b/docs/superpowers/specs/2026-04-21-phase-b-hal-consolidation-design.md
@@ -1,0 +1,219 @@
+# Phase B — HAL Consolidation — Design
+
+**Date:** 2026-04-21
+**Owner:** Moustafa
+**Status:** Awaiting review
+**Follows:** Phase A (`docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md`)
+**Note:** Renumbered from Phase C; the original Phase B (runtime services cleanup) was absorbed into Phase A.
+
+---
+
+## 1. Goals
+
+After Phase A, the `src/yoyopod/core/` + `integrations/` + `backends/` architecture is in place. Display and input hardware is still reached through the pre-Phase-A HAL:
+
+- `src/yoyopod/ui/display/` — facade + factory + adapters (Pimoroni, Whisplay/LVGL, Simulation)
+- `src/yoyopod/ui/input/` — manager + factory + adapters (FourButton, PTT, Keyboard)
+- `src/yoyopod/ui/lvgl_binding/` — native LVGL C shim + cffi binding + backend bridge + input bridge
+
+These HALs predate the Phase A pattern and exhibit three maintainability smells:
+
+1. **Four-to-five-level abstraction stack per HAL.** Display: facade → factory → adapter → (optional LVGL bridge → LVGL backend → C shim). Reading "how does a pixel end up on screen" requires tracing five files. Same magnitude for input.
+2. **Abstraction mismatch.** The facade interface is tuned for Pimoroni-style PIL rendering; the Whisplay adapter is forced to translate PIL calls into LVGL which is designed around its own retained-mode widget tree. The translation happens inside the adapter and leaks across the abstraction.
+3. **Hardware-adjacent services are scattered.** Display, input, power (Phase A kept it as an integration), network (same), audio-device routing live in separate packages with their own patterns. No single consistent "this is how hardware is wired" story.
+
+Phase B reshapes display and input HALs to the Phase A pattern — backends under `src/yoyopod/backends/`, thin integrations under `src/yoyopod/integrations/` — and evaluates whether the OVOS-style PHAL consolidation (all hardware behind one `hardware` service) is worth adopting.
+
+**Success criteria:**
+
+- Display pipeline traceable top-to-bottom in ≤3 hops on both PIL and LVGL paths.
+- Input pipeline traceable top-to-bottom in ≤3 hops.
+- LVGL binding confined to one adapter — other code never `import`s raw LVGL types.
+- Display + input backend swap still controlled by the same `YOYOPOD_DISPLAY` / `YOYOPOD_WHISPLAY_DRIVER` env vars as today (no user-visible regression).
+- No `ui/display/factory.py` or `ui/input/factory.py` indirection — backends constructed inside each integration's `setup()`.
+- Consolidation decision made: either adopt a single `hardware` integration (OVOS PHAL-style) or keep per-device integrations (display + input as separate integrations).
+
+---
+
+## 2. Scope
+
+**In scope:**
+
+- Restructure `src/yoyopod/ui/display/` into:
+  - `src/yoyopod/backends/display/` — adapter implementations (Pimoroni, Whisplay/LVGL, Simulation).
+  - `src/yoyopod/integrations/display/` — `setup(app)` that picks the right adapter based on config/env, exposes display primitives to screens via `app.display` handle.
+- Restructure `src/yoyopod/ui/input/` into:
+  - `src/yoyopod/backends/input/` — adapter implementations (FourButton, PTT, Keyboard).
+  - `src/yoyopod/integrations/input/` — `setup(app)` that constructs the right adapter, publishes `UserActivityEvent` + typed domain events for each input.
+- Evaluate and implement (or explicitly skip) the OVOS PHAL-style `hardware` integration that consolidates display + input (+ optionally some backends from Phase A integrations) behind a single unified API.
+- Decide whether `src/yoyopod/ui/lvgl_binding/` should stay as-is, be relocated, or be absorbed into `backends/display/whisplay/`. Target: LVGL raw types appear in only one file.
+- Rewrite the display facade interface to match how LVGL actually wants to be used (retained widget tree + dirty-region invalidation), with the PIL adapters implementing the same API via an internal PIL→widget-tree translator.
+- Update all 17 screens to consume the new display API in one sweep (or confirm compatibility if the API stays similar).
+- Delete stale code: `ui/display/factory.py`, `ui/input/factory.py`, and any facade/factory/adapter boilerplate that no longer pays for itself.
+
+**Out of scope:**
+
+- Changing the rendering output (screens look the same on both Pimoroni and Whisplay).
+- New display adapters or new input modes.
+- Rewriting Phase A integrations beyond wiring adjustments.
+
+---
+
+## 3. Current state analysis
+
+(Brief — full detail in the audit that led to Phase A spec §1.)
+
+**Display HAL layers:**
+1. `src/yoyopod/ui/display/__init__.py` — public surface
+2. `src/yoyopod/ui/display/facade.py` — `Display` class that screens hold
+3. `src/yoyopod/ui/display/factory.py` — selects adapter based on env/config
+4. `src/yoyopod/ui/display/contracts.py` — abstract interface
+5. `src/yoyopod/ui/display/adapters/pimoroni.py` / `whisplay.py` / `simulation.py`
+6. (For Whisplay) `src/yoyopod/ui/lvgl_binding/backend.py` + `binding.py` + native shim
+
+**Input HAL layers:**
+1. `src/yoyopod/ui/input/manager.py` — InputManager
+2. `src/yoyopod/ui/input/factory.py` — selects adapter
+3. `src/yoyopod/ui/input/contracts.py` — abstract interface
+4. `src/yoyopod/ui/input/adapters/four_button.py` / `ptt.py` / `keyboard.py`
+
+**Smells captured in §1.** Most egregious is the LVGL cross-cutting: `ui/lvgl_binding/` holds LVGL types, but `ui/display/adapters/whisplay.py` calls into it, and `app.py` historically also poked at the LVGL backend directly (`_pump_lvgl_backend`). In the Phase A rewrite, that pump logic moves into the display integration's ui_tick callback.
+
+---
+
+## 4. Target architecture
+
+### 4.1 Display integration + backends
+
+```
+src/yoyopod/
+├── backends/display/
+│   ├── __init__.py
+│   ├── pimoroni.py       # Display-HAT-Mini adapter (PIL rendering)
+│   ├── whisplay.py       # Whisplay adapter (LVGL retained-mode widget tree)
+│   ├── simulation.py     # pygame-backed preview for dev
+│   └── lvgl/
+│       ├── __init__.py
+│       ├── binding.py    # cffi binding to the native shim (moved from ui/lvgl_binding/)
+│       └── native_shim/  # C source (moved)
+└── integrations/display/
+    ├── __init__.py       # setup(app): pick adapter by env, bind app.display, register ui_tick
+    ├── commands.py       # RefreshCommand, CaptureScreenshotCommand, SetBrightnessOverrideCommand
+    └── api.py            # Common display API all screens use (DrawContext-like)
+```
+
+- Screens hold `self.app` and call into `app.display.render(canvas)` / `app.display.capture_screenshot()` / `app.display.invalidate_region(rect)`.
+- `app.display` is an object with the canonical API — its implementation is the backend adapter.
+- The display integration's `ui_tick_callback` (registered in `core/app_shell.YoyoPodApp._ui_tick_callback`) calls the backend's `tick()` — PIL adapters do nothing here; LVGL adapter pumps the native LVGL loop.
+
+### 4.2 Input integration + backends
+
+```
+src/yoyopod/
+├── backends/input/
+│   ├── __init__.py
+│   ├── four_button.py    # Pimoroni 4-button GPIO reader
+│   ├── ptt.py            # Whisplay push-to-talk single button
+│   └── keyboard.py       # Dev-mode keyboard input
+└── integrations/input/
+    ├── __init__.py       # setup(app): pick adapter by env, register reader thread, bind
+    ├── events.py         # ButtonPressedEvent, ButtonLongPressEvent, PttHeldEvent, PttReleasedEvent
+    └── commands.py       # (few — maybe SimulateButtonCommand for tests)
+```
+
+- Input adapter runs a reader thread; on events, `scheduler.run_on_main(lambda: app.bus.publish(…))`.
+- Every input also triggers `app.bus.publish(UserActivityEvent(action_name=…))` for the screen integration.
+
+### 4.3 LVGL isolation
+
+LVGL types (from cffi binding) appear only inside `backends/display/lvgl/` and `backends/display/whisplay.py`. No other file imports LVGL directly. Screens never know LVGL exists.
+
+### 4.4 OVOS PHAL-style `hardware` integration — DECIDED: DO NOT ADOPT
+
+Evaluated during this plan's brainstorming. Conclusion: consolidating display + input + (possibly) power + network behind a single `hardware` service adds a layer without removing any. OVOS's PHAL wins come from their message-bus transport between processes; YoyoPod is single-process so the benefit evaporates.
+
+Keep display and input as separate integrations. The consistency comes from using the Phase A pattern (backend + integration + setup), not from jamming everything behind one API.
+
+---
+
+## 5. Fate of existing classes
+
+| Class / module | Fate |
+|---|---|
+| `src/yoyopod/ui/display/facade.py` `Display` class | Rewritten as the adapter-common API (in `backends/display/api.py` or similar) |
+| `src/yoyopod/ui/display/factory.py` | **Delete.** Adapter selection moves into `integrations/display/__init__.py`'s `setup()` |
+| `src/yoyopod/ui/display/contracts.py` | Fold into the common API definition |
+| `src/yoyopod/ui/display/adapters/pimoroni.py` | Move to `backends/display/pimoroni.py` |
+| `src/yoyopod/ui/display/adapters/whisplay.py` | Move to `backends/display/whisplay.py`, simplified now that LVGL imports are local |
+| `src/yoyopod/ui/display/adapters/simulation.py` | Move to `backends/display/simulation.py` |
+| `src/yoyopod/ui/lvgl_binding/*` | Move under `backends/display/lvgl/` |
+| `src/yoyopod/ui/input/manager.py` `InputManager` | Logic absorbed into `integrations/input/__init__.py` |
+| `src/yoyopod/ui/input/factory.py` | **Delete.** Adapter selection in `integrations/input/__init__.py` |
+| `src/yoyopod/ui/input/contracts.py` | Fold into the common API definition |
+| `src/yoyopod/ui/input/adapters/*` | Move to `backends/input/*` |
+| `app._pump_lvgl_backend` / `app._tick_ui` hook | Wired via the display integration's `setup()` that sets `app._ui_tick_callback` |
+
+Net result: `src/yoyopod/ui/` holds only `screens/` — the rendering/input HAL moves entirely to `backends/` + `integrations/`.
+
+---
+
+## 6. Migration strategy
+
+Two or three plans — M-BigBang on `arch/phase-b-hal-consolidation` branch.
+
+1. **Plan B1: Display migration.** Move adapters + LVGL binding. Create `integrations/display/`. Update screens to consume `app.display`. Delete old `ui/display/`.
+2. **Plan B2: Input migration.** Move adapters. Create `integrations/input/`. Update screen event wiring. Delete old `ui/input/`.
+3. **Plan B3 (optional): LVGL adapter internal cleanup.** If Plan B1 reveals the Whisplay adapter needs further splitting, do it here. Often unnecessary.
+
+Each plan lands on the Phase-B branch; one merge to main when all green.
+
+---
+
+## 7. Testing strategy
+
+- Unit tests for each adapter in isolation (mock hardware where possible).
+- Integration tests for display integration (ensures `app.display` is wired up, `ui_tick` is called, backend receives the canvas, etc.).
+- Integration tests for input (simulate GPIO events, assert `ButtonPressedEvent` on the bus).
+- End-to-end on Pi:
+  - Whisplay: `yoyopod pi validate smoke` on real hardware.
+  - Simulation: `python yoyopod.py --simulate` launches and renders home screen.
+- Visual regression: `yoyopod pi screenshot` captures output; compare against a small baseline set of reference PNGs.
+
+TDD cadence is kept throughout.
+
+---
+
+## 8. Pre-merge gate
+
+Same structure as Phase A:
+
+- `uv run python scripts/quality.py ci` green.
+- `yoyopod pi validate deploy` green.
+- `yoyopod pi validate smoke` green.
+- `yoyopod pi validate lvgl-soak` green.
+- Manual on-Pi: home screen renders correctly on Whisplay; all button events register; simulation mode renders in a browser.
+- No raw LVGL imports outside `backends/display/lvgl/` and `backends/display/whisplay.py`.
+
+---
+
+## 9. Risks
+
+1. **LVGL native shim portability.** Moving the native source under `backends/display/lvgl/native_shim/` may require updating the build script (`yoyopod build lvgl`). Mitigation: Plan B1 Task 1 validates the build works from the new location before moving on.
+2. **Whisplay driver specifics.** The Whisplay adapter embeds hardware knowledge (screen size, rotation, backlight control). Ensure these don't leak into the common display API; keep them inside the Whisplay backend.
+3. **Input timing during migration.** The reader thread model must remain (button debouncing, long-press detection). Moving it into `backends/input/*` doesn't change the threading, but assertions about event ordering need re-testing.
+
+---
+
+## 10. Definition of done
+
+- `src/yoyopod/backends/display/`, `src/yoyopod/backends/input/` populated.
+- `src/yoyopod/integrations/display/`, `src/yoyopod/integrations/input/` populated and registered in `src/yoyopod/app.py`'s integration list.
+- `src/yoyopod/ui/display/` and `src/yoyopod/ui/input/` deleted.
+- `src/yoyopod/ui/lvgl_binding/` absorbed under `backends/display/lvgl/`.
+- All screens still render correctly on all three display adapters.
+- Pre-merge gate green on Pi.
+- This spec marked `Status: Implemented`.
+
+---
+
+*End of design spec.*


### PR DESCRIPTION
## Summary

Complete set of architectural planning docs for the YoyoPod spine + HAL rework:

**Phase A — Spine rewrite** (state store + typed bus + service registry; HA-style)
- [Design spec](docs/superpowers/specs/2026-04-21-phase-a-spine-rewrite-design.md) — 838 lines
- 8 implementation plans covering all 13 internal steps:
  - [Plan 1 — core scaffold](docs/superpowers/plans/2026-04-21-phase-a-core-scaffold.md) (CLI cleanup + Bus/States/Services/Scheduler/App)
  - [Plan 2 — power pilot](docs/superpowers/plans/2026-04-21-phase-a-power-pilot.md)
  - [Plan 3 — easy batch](docs/superpowers/plans/2026-04-21-phase-a-easy-batch.md) (network / location / contacts / cloud)
  - [Plan 4 — focus + diagnostics + screen + voice](docs/superpowers/plans/2026-04-21-phase-a-focus-diag-screen-voice.md)
  - [Plan 5 — music](docs/superpowers/plans/2026-04-21-phase-a-music.md)
  - [Plan 6 — call](docs/superpowers/plans/2026-04-21-phase-a-call.md) (VoIPManager + CallCoordinator split)
  - [Plan 7 — recovery + 17-screen touch-up](docs/superpowers/plans/2026-04-21-phase-a-recovery-and-screens.md)
  - [Plan 8 — dead-code removal + final sweep](docs/superpowers/plans/2026-04-21-phase-a-cleanup.md)

**Phase B — HAL consolidation** (display + input under backends+integrations)
- [Design spec](docs/superpowers/specs/2026-04-21-phase-b-hal-consolidation-design.md)
- [Plan B1 — display HAL](docs/superpowers/plans/2026-04-21-phase-b-display.md)
- [Plan B2 — input HAL](docs/superpowers/plans/2026-04-21-phase-b-input.md)

## What the rework achieves

Against Moustafa's maintainability rule — (1) reduce the layers a reader traces, (2) reduce the state a reader holds in their head:

- Kills the pseudo-reactive event bus (9 of 14 events pub-to-self)
- Collapses the 7–8-hop incoming-call path to 5 direct-call hops
- Single source of truth for domain state: `app.states` entity store (HA-style)
- Deletes 14+ legacy classes (FSMs, coordinators, runtime services, AppContext, VoIPManager, old event bus)
- `app.py` shrinks 685 → ~80 LOC
- Structured JSONL event log for LLM-driven debugging (every state change + command + error)
- Cross-domain coordination via `focus` arbiter (Android AudioFocus pattern)
- Adding a new observer = new file, zero changes to existing integrations

## Decomposition rationale

- **One spec, one branch per phase.** Phase A on `arch/phase-a-spine-rewrite`; Phase B on `arch/phase-b-hal-consolidation`. Each merged only when Pi validation is green.
- **Plans are TDD-structured.** Every new primitive/integration has a failing test before implementation. Full code included in every step so executing LLMs have a concrete target.
- **M-BigBang migration** (chosen over incremental) — cleaner git history, single merge per phase, no "both patterns alive" intermediate state. Accepts the tradeoff that main is frozen for the duration.

## Notes on branch history

This branch was created from a worktree that included two earlier commits (`19d86b7 docs: CLI polish implementation plan`, `d7812ad docs: CLI polish design spec`) that don't appear on the current `origin/main`. They may have been rebased/squashed upstream. Their substance is preserved in the Phase A plans (Plan 1 Task 2 handles the `yoyoctl → yoyopod` cleanup across ~40 live files). If the upstream already shipped that cleanup under a different SHA, Plan 1 Task 2 will be a near-noop when executed.

## This PR contains no code changes

It's purely planning documents. Executing the plans happens on subsequent feature branches (`arch/phase-a-spine-rewrite`, `arch/phase-b-hal-consolidation`) created off the current main at execution time.

## Test plan

- [ ] Review all plan documents for placeholders / contradictions / missing context
- [ ] Confirm the chosen architecture (HA-style A+3) matches intent
- [ ] Verify the phase decomposition (A = spine, B = HAL) fits the roadmap
- [ ] Spot-check Plan 1 and Plan 6 (the hardest ones) for executability by an LLM subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)