### PR TITLE
[codex] Split FSMs are cosmetic; AppRuntimeState re-merges them into one flat enum

### DIFF
--- a/demos/demo_runtime_state.py
+++ b/demos/demo_runtime_state.py
@@ -13,7 +13,7 @@ import time
 from loguru import logger
 
 from yoyopod.app_context import AppContext
-from yoyopod.coordinators.registry import AppRuntimeState, CoordinatorRuntime
+from yoyopod.coordinators.registry import BaseUIRoute, CoordinatorRuntime
 from yoyopod.fsm import CallFSM, CallInterruptionPolicy, MusicFSM
 from yoyopod.ui.display import Display
 from yoyopod.ui.input import InputAction, get_input_manager
@@ -71,7 +71,7 @@ def main() -> int:
         power_manager=None,
         music_backend=None,
         config_manager=None,
-        ui_state=AppRuntimeState.IDLE,
+        ui_state=BaseUIRoute.HOME,
     )
 
     def log_runtime_state(trigger: str) -> None:
@@ -80,18 +80,22 @@ def main() -> int:
         logger.info(
             "State: {} | Screen: {} | Track: {}",
             state_change.current_state.value,
-            screen_manager.get_current_screen().name if screen_manager.get_current_screen() else "none",
+            (
+                screen_manager.get_current_screen().name
+                if screen_manager.get_current_screen()
+                else "none"
+            ),
             track.title if track else "None",
         )
 
     def show_home() -> None:
-        runtime.set_ui_state(AppRuntimeState.IDLE, trigger="show_home")
+        runtime.set_ui_state(BaseUIRoute.HOME, trigger="show_home")
         screen_manager.clear_stack()
         screen_manager.replace_screen("home")
         log_runtime_state("show_home")
 
     def show_menu(push: bool) -> None:
-        runtime.set_ui_state(AppRuntimeState.MENU, trigger="show_menu")
+        runtime.set_ui_state(BaseUIRoute.MENU, trigger="show_menu")
         if push:
             screen_manager.push_screen("menu")
         else:
@@ -134,7 +138,7 @@ def main() -> int:
                 return
             if selected == "Back":
                 screen_manager.pop_screen()
-                runtime.set_ui_state(AppRuntimeState.IDLE, trigger="menu_back")
+                runtime.set_ui_state(BaseUIRoute.HOME, trigger="menu_back")
                 log_runtime_state("menu_back")
                 return
 
@@ -150,11 +154,11 @@ def main() -> int:
 
         if current_screen == menu_screen:
             screen_manager.pop_screen()
-            runtime.set_ui_state(AppRuntimeState.IDLE, trigger="back_to_home")
+            runtime.set_ui_state(BaseUIRoute.HOME, trigger="back_to_home")
             log_runtime_state("back_to_home")
         elif current_screen == now_playing_screen:
             screen_manager.pop_screen()
-            runtime.set_ui_state(AppRuntimeState.MENU, trigger="back_to_menu")
+            runtime.set_ui_state(BaseUIRoute.MENU, trigger="back_to_menu")
             log_runtime_state("back_to_menu")
 
     def handle_up(_data=None) -> None:

--- a/src/yoyopod/app.py
+++ b/src/yoyopod/app.py
@@ -22,7 +22,6 @@ from yoyopod.audio import (
 )
 from yoyopod.config import ConfigManager, MediaConfig, YoyoPodConfig
 from yoyopod.coordinators import (
-    AppRuntimeState,
     CallCoordinator,
     CoordinatorRuntime,
     PlaybackCoordinator,
@@ -120,7 +119,7 @@ class YoyoPodApp:
         # Integration state
         self.auto_resume_after_call = True
         self._voip_registered = False
-        self._ui_state = AppRuntimeState.IDLE
+        self._ui_state = "idle"
 
         # Cloud / backend runtime
         self.cloud_manager: Optional[CloudManager] = None
@@ -390,8 +389,8 @@ class YoyoPodApp:
 
         return self.boot_service.get_initial_screen_name()
 
-    def _get_initial_ui_state(self) -> AppRuntimeState:
-        """Compatibility wrapper for initial UI state derivation."""
+    def _get_initial_ui_state(self) -> str:
+        """Compatibility wrapper for initial UI route derivation."""
 
         return self.boot_service.get_initial_ui_state()
 

--- a/src/yoyopod/coordinators/__init__.py
+++ b/src/yoyopod/coordinators/__init__.py
@@ -5,7 +5,7 @@ Coordinator modules for YoyoPod orchestration.
 from yoyopod.coordinators.call import CallCoordinator
 from yoyopod.coordinators.power import PowerCoordinator
 from yoyopod.coordinators.playback import PlaybackCoordinator
-from yoyopod.coordinators.registry import AppRuntimeState, CoordinatorRuntime
+from yoyopod.coordinators.registry import AppRuntimeState, BaseUIRoute, CoordinatorRuntime
 from yoyopod.coordinators.screen import ScreenCoordinator
 from yoyopod.coordinators.voice import (
     VoiceCommandExecutor,
@@ -16,6 +16,7 @@ from yoyopod.coordinators.voice import (
 
 __all__ = [
     "AppRuntimeState",
+    "BaseUIRoute",
     "CallCoordinator",
     "PowerCoordinator",
     "PlaybackCoordinator",

--- a/src/yoyopod/coordinators/call.py
+++ b/src/yoyopod/coordinators/call.py
@@ -25,7 +25,6 @@ from yoyopod.communication.calling.history import CallHistoryEntry, CallHistoryS
 from yoyopod.communication.models import CallState, RegistrationState
 from yoyopod.core import CallSessionState
 
-
 _CONNECTED_CALL_STATES = (CallState.CONNECTED, CallState.STREAMS_RUNNING)
 
 
@@ -258,13 +257,14 @@ class CallCoordinator:
                 )
                 return
 
-        self.runtime.call_fsm.transition("connect")
-        state_change = self.runtime.sync_app_state("call_connected")
-        if state_change.entered(AppRuntimeState.CALL_ACTIVE):
-            logger.info("In call (music paused in background)")
-        self.screen_coordinator.show_in_call()
-        self.stop_ringing()
-        return
+            self.runtime.call_fsm.transition("connect")
+            state_change = self.runtime.sync_app_state("call_connected")
+            if state_change.entered(AppRuntimeState.CALL_ACTIVE):
+                logger.info("In call (music paused in background)")
+            self.screen_coordinator.show_in_call()
+            self.stop_ringing()
+            return
+
         logger.debug("Call state {} does not change coordinator phase", state.value)
 
     def handle_call_ended(self, *, reason: str = "released") -> None:

--- a/src/yoyopod/coordinators/call.py
+++ b/src/yoyopod/coordinators/call.py
@@ -26,6 +26,9 @@ from yoyopod.communication.models import CallState, RegistrationState
 from yoyopod.core import CallSessionState
 
 
+_CONNECTED_CALL_STATES = (CallState.CONNECTED, CallState.STREAMS_RUNNING)
+
+
 @dataclass(slots=True)
 class _CallSessionDraft:
     """One in-progress call, tracked until the final release event."""
@@ -245,9 +248,15 @@ class CallCoordinator:
             self._present_incoming_call_if_ready()
             return
 
-        if state in (CallState.CONNECTED, CallState.STREAMS_RUNNING):
+        if state in _CONNECTED_CALL_STATES:
             if self._active_call_session is not None:
                 self._active_call_session.answered = True
+            if not self.runtime.call_fsm.is_active:
+                logger.debug(
+                    "Ignoring {} while call FSM is idle",
+                    state.value,
+                )
+                return
 
         self.runtime.call_fsm.transition("connect")
         state_change = self.runtime.sync_app_state("call_connected")

--- a/src/yoyopod/coordinators/call.py
+++ b/src/yoyopod/coordinators/call.py
@@ -163,7 +163,7 @@ class CallCoordinator:
 
     def on_enter_call_active_music_paused(self) -> None:
         """Log entry into the active-call-with-paused-music state."""
-        logger.info("In call (music paused in background)")
+        logger.info("In active call")
 
     def _on_incoming_call_event(self, event: IncomingCallEvent) -> None:
         self.handle_incoming_call(event.caller_address, event.caller_name)
@@ -198,6 +198,18 @@ class CallCoordinator:
     def handle_call_state_change(self, state: CallState) -> None:
         """Coordinate high-level call state updates."""
         logger.info(f"Call state changed: {state.value}")
+
+        if state in (CallState.RELEASED, CallState.END, CallState.ERROR):
+            if not self._has_live_call_state():
+                logger.debug("Ignoring duplicate terminal call state {}", state.value)
+                return
+
+            local_end_action = self._consume_pending_terminal_action()
+            if self._active_call_session is not None:
+                self._active_call_session.terminal_state = state
+                self._active_call_session.local_end_action = local_end_action
+            self.handle_call_ended(reason=state.value)
+            return
 
         if state in (
             CallState.OUTGOING,
@@ -237,26 +249,13 @@ class CallCoordinator:
             if self._active_call_session is not None:
                 self._active_call_session.answered = True
 
-            self.runtime.call_fsm.transition("connect")
-            state_change = self.runtime.sync_app_state("call_connected")
-            if state_change.entered(AppRuntimeState.CALL_ACTIVE_MUSIC_PAUSED):
-                logger.info("In call (music paused in background)")
-            self.screen_coordinator.show_in_call()
-            self.stop_ringing()
-            return
-
-        if state in (CallState.RELEASED, CallState.END, CallState.ERROR):
-            if not self._has_live_call_state():
-                logger.debug("Ignoring duplicate terminal call state {}", state.value)
-                return
-
-            local_end_action = self._consume_pending_terminal_action()
-            if self._active_call_session is not None:
-                self._active_call_session.terminal_state = state
-                self._active_call_session.local_end_action = local_end_action
-            self.handle_call_ended(reason=state.value)
-            return
-
+        self.runtime.call_fsm.transition("connect")
+        state_change = self.runtime.sync_app_state("call_connected")
+        if state_change.entered(AppRuntimeState.CALL_ACTIVE):
+            logger.info("In call (music paused in background)")
+        self.screen_coordinator.show_in_call()
+        self.stop_ringing()
+        return
         logger.debug("Call state {} does not change coordinator phase", state.value)
 
     def handle_call_ended(self, *, reason: str = "released") -> None:

--- a/src/yoyopod/coordinators/playback.py
+++ b/src/yoyopod/coordinators/playback.py
@@ -71,7 +71,7 @@ class PlaybackCoordinator:
 
     def on_enter_playing_with_voip(self) -> None:
         """Log entry into the playing-with-VoIP-ready state."""
-        logger.info("Music playing with VoIP ready")
+        logger.info("Music playback resumed")
 
     def _on_track_changed_event(self, event: TrackChangedEvent) -> None:
         self.handle_track_change(event.track)
@@ -112,8 +112,8 @@ class PlaybackCoordinator:
             self.runtime.music_fsm.transition("stop")
 
         state_change = self.runtime.sync_app_state(f"playback_{playback_state}")
-        if state_change.entered(AppRuntimeState.PLAYING_WITH_VOIP):
-            logger.info("Music playing with VoIP ready")
+        if state_change.entered(AppRuntimeState.PLAYING):
+            logger.info("Music now playing")
         self.screen_coordinator.refresh_now_playing_screen()
 
     def handle_availability_change(self, available: bool, reason: str) -> None:

--- a/src/yoyopod/coordinators/playback.py
+++ b/src/yoyopod/coordinators/playback.py
@@ -112,7 +112,7 @@ class PlaybackCoordinator:
             self.runtime.music_fsm.transition("stop")
 
         state_change = self.runtime.sync_app_state(f"playback_{playback_state}")
-        if state_change.entered(AppRuntimeState.PLAYING):
+        if state_change.entered(AppRuntimeState.MUSIC):
             logger.info("Music now playing")
         self.screen_coordinator.refresh_now_playing_screen()
 

--- a/src/yoyopod/coordinators/registry.py
+++ b/src/yoyopod/coordinators/registry.py
@@ -34,6 +34,26 @@ class AppRuntimeState(Enum):
     CALL_ACTIVE = "call_active"
 
 
+class BaseUIRoute(Enum):
+    """Base screen routes used when the split FSMs are otherwise idle."""
+
+    HOME = "home"
+    HUB = "hub"
+    MENU = "menu"
+    ASK = "ask"
+    CALL = "call"
+    CONTACTS = "contacts"
+    LISTEN = "listen"
+    PLAYLISTS = "playlists"
+    PLAYLIST = "playlist"
+    RECENT_TRACKS = "recent_tracks"
+    POWER = "power"
+    NOW_PLAYING = "now_playing"
+    INCOMING_CALL = "incoming_call"
+    OUTGOING_CALL = "outgoing_call"
+    IN_CALL = "in_call"
+
+
 @dataclass(frozen=True, slots=True)
 class AppStateChange:
     """Describe a derived app-state refresh."""
@@ -64,7 +84,7 @@ class CoordinatorRuntime:
     config_manager: ConfigManager | None
     music_backend: MusicBackend | None = None
     context: AppContext | None = None
-    ui_state: str = AppRuntimeState.IDLE.value
+    ui_state: str | Enum = AppRuntimeState.IDLE.value
     voip_ready: bool = False
     power_available: bool = False
     power_snapshot: PowerSnapshot | None = None
@@ -72,27 +92,28 @@ class CoordinatorRuntime:
     previous_app_state: AppRuntimeState | None = field(init=False, default=None)
     state_history: list[AppRuntimeState] = field(init=False, default_factory=list)
 
-    _KNOWN_UI_ROUTES = {
-        "home",
-        "hub",
-        "menu",
-        "ask",
-        "call",
-        "contacts",
-        "listen",
-        "playlists",
-        "playlist",
-        "recent_tracks",
-        "power",
-        "now_playing",
-        "incoming_call",
-        "outgoing_call",
-        "in_call",
+    _KNOWN_UI_ROUTES = frozenset(route.value for route in BaseUIRoute)
+    _LEGACY_UI_ROUTE_ALIASES = {
+        AppRuntimeState.IDLE.value: BaseUIRoute.HOME.value,
     }
 
     def __post_init__(self) -> None:
+        self.ui_state = self._normalize_initial_ui_state(self.ui_state)
         self.current_app_state = self._derive_state()
         self.state_history = [self.current_app_state]
+
+    @staticmethod
+    def _normalize_initial_ui_state(state: str | Enum) -> str:
+        """Coerce constructor-time UI-state inputs into stored string values."""
+
+        return str(state.value if isinstance(state, Enum) else state)
+
+    @classmethod
+    def _coerce_ui_route(cls, state: str | Enum) -> str:
+        """Resolve strings or route-like enums to a known base UI route."""
+
+        ui_state = str(state.value if isinstance(state, Enum) else state)
+        return cls._LEGACY_UI_ROUTE_ALIASES.get(ui_state, ui_state)
 
     def _derive_state(self) -> AppRuntimeState:
         """Derive the current application state from the split FSMs."""
@@ -134,11 +155,11 @@ class CoordinatorRuntime:
 
     def set_ui_state(
         self,
-        state: str | AppRuntimeState,
+        state: str | Enum,
         trigger: str = "ui_state",
     ) -> AppStateChange:
         """Record the active UI route used when music/call FSMs are idle."""
-        ui_state = state.value if isinstance(state, AppRuntimeState) else str(state)
+        ui_state = self._coerce_ui_route(state)
         if ui_state not in self._KNOWN_UI_ROUTES:
             raise ValueError(f"{ui_state} is not a base UI route")
 

--- a/src/yoyopod/coordinators/registry.py
+++ b/src/yoyopod/coordinators/registry.py
@@ -26,13 +26,11 @@ if TYPE_CHECKING:
 
 
 class AppRuntimeState(Enum):
-    """Derived application state used by the production coordinator path."""
+    """Derived application mode used by coordinator-level dispatch and status."""
 
     IDLE = "idle"
-    PLAYING = "playing"
-    PAUSED = "paused"
-    CALL_INCOMING = "call_incoming"
-    CALL_OUTGOING = "call_outgoing"
+    MUSIC = "music"
+    CALL_CONNECTING = "call_connecting"
     CALL_ACTIVE = "call_active"
 
 
@@ -98,20 +96,14 @@ class CoordinatorRuntime:
 
     def _derive_state(self) -> AppRuntimeState:
         """Derive the current application state from the split FSMs."""
-        if self.call_fsm.state == CallSessionState.INCOMING:
-            return AppRuntimeState.CALL_INCOMING
-
-        if self.call_fsm.state == CallSessionState.OUTGOING:
-            return AppRuntimeState.CALL_OUTGOING
+        if self.call_fsm.state in (CallSessionState.INCOMING, CallSessionState.OUTGOING):
+            return AppRuntimeState.CALL_CONNECTING
 
         if self.call_fsm.state == CallSessionState.ACTIVE:
             return AppRuntimeState.CALL_ACTIVE
 
-        if self.music_fsm.state == MusicState.PLAYING:
-            return AppRuntimeState.PLAYING
-
-        if self.music_fsm.state == MusicState.PAUSED:
-            return AppRuntimeState.PAUSED
+        if self.music_fsm.state in (MusicState.PLAYING, MusicState.PAUSED):
+            return AppRuntimeState.MUSIC
 
         return AppRuntimeState.IDLE
 

--- a/src/yoyopod/coordinators/registry.py
+++ b/src/yoyopod/coordinators/registry.py
@@ -29,23 +29,11 @@ class AppRuntimeState(Enum):
     """Derived application state used by the production coordinator path."""
 
     IDLE = "idle"
-    HUB = "hub"
-    MENU = "menu"
     PLAYING = "playing"
     PAUSED = "paused"
-    SETTINGS = "settings"
-    PLAYLIST = "playlist"
-    PLAYLIST_BROWSER = "playlist_browser"
-    POWER = "power"
-    CALL_IDLE = "call_idle"
     CALL_INCOMING = "call_incoming"
     CALL_OUTGOING = "call_outgoing"
     CALL_ACTIVE = "call_active"
-    CONNECTING = "connecting"
-    ERROR = "error"
-    PLAYING_WITH_VOIP = "playing_with_voip"
-    PAUSED_BY_CALL = "paused_by_call"
-    CALL_ACTIVE_MUSIC_PAUSED = "call_active_music_paused"
 
 
 @dataclass(frozen=True, slots=True)
@@ -78,7 +66,7 @@ class CoordinatorRuntime:
     config_manager: ConfigManager | None
     music_backend: MusicBackend | None = None
     context: AppContext | None = None
-    ui_state: AppRuntimeState = AppRuntimeState.IDLE
+    ui_state: str = AppRuntimeState.IDLE.value
     voip_ready: bool = False
     power_available: bool = False
     power_snapshot: PowerSnapshot | None = None
@@ -86,17 +74,22 @@ class CoordinatorRuntime:
     previous_app_state: AppRuntimeState | None = field(init=False, default=None)
     state_history: list[AppRuntimeState] = field(init=False, default_factory=list)
 
-    _UI_STATES = {
-        AppRuntimeState.IDLE,
-        AppRuntimeState.HUB,
-        AppRuntimeState.MENU,
-        AppRuntimeState.SETTINGS,
-        AppRuntimeState.PLAYLIST,
-        AppRuntimeState.PLAYLIST_BROWSER,
-        AppRuntimeState.POWER,
-        AppRuntimeState.CALL_IDLE,
-        AppRuntimeState.CONNECTING,
-        AppRuntimeState.ERROR,
+    _KNOWN_UI_ROUTES = {
+        "home",
+        "hub",
+        "menu",
+        "ask",
+        "call",
+        "contacts",
+        "listen",
+        "playlists",
+        "playlist",
+        "recent_tracks",
+        "power",
+        "now_playing",
+        "incoming_call",
+        "outgoing_call",
+        "in_call",
     }
 
     def __post_init__(self) -> None:
@@ -112,25 +105,15 @@ class CoordinatorRuntime:
             return AppRuntimeState.CALL_OUTGOING
 
         if self.call_fsm.state == CallSessionState.ACTIVE:
-            if self.call_interruption_policy.music_interrupted_by_call:
-                return AppRuntimeState.CALL_ACTIVE_MUSIC_PAUSED
             return AppRuntimeState.CALL_ACTIVE
 
-        if (
-            self.call_interruption_policy.music_interrupted_by_call
-            and self.music_fsm.state == MusicState.PAUSED
-        ):
-            return AppRuntimeState.PAUSED_BY_CALL
-
         if self.music_fsm.state == MusicState.PLAYING:
-            if self.voip_ready:
-                return AppRuntimeState.PLAYING_WITH_VOIP
             return AppRuntimeState.PLAYING
 
         if self.music_fsm.state == MusicState.PAUSED:
             return AppRuntimeState.PAUSED
 
-        return self.ui_state
+        return AppRuntimeState.IDLE
 
     def sync_app_state(self, trigger: str = "sync") -> AppStateChange:
         """Refresh the derived app state after coordinator mutations."""
@@ -159,14 +142,15 @@ class CoordinatorRuntime:
 
     def set_ui_state(
         self,
-        state: AppRuntimeState,
+        state: str | AppRuntimeState,
         trigger: str = "ui_state",
     ) -> AppStateChange:
-        """Update the base UI state used when music and calls are idle."""
-        if state not in self._UI_STATES:
-            raise ValueError(f"{state.value} is not a base UI state")
+        """Record the active UI route used when music/call FSMs are idle."""
+        ui_state = state.value if isinstance(state, AppRuntimeState) else str(state)
+        if ui_state not in self._KNOWN_UI_ROUTES:
+            raise ValueError(f"{ui_state} is not a base UI route")
 
-        self.ui_state = state
+        self.ui_state = ui_state
         return self.sync_app_state(trigger)
 
     def set_voip_ready(self, ready: bool, trigger: str = "voip_ready") -> AppStateChange:
@@ -185,23 +169,18 @@ class CoordinatorRuntime:
         self.power_available = available
 
     def sync_ui_state_for_screen(self, screen_name: str | None) -> AppStateChange | None:
-        """Update the base UI state for non-call overlay screens."""
-        state_by_screen = {
-            "home": AppRuntimeState.IDLE,
-            "hub": AppRuntimeState.HUB,
-            "menu": AppRuntimeState.MENU,
-            "listen": AppRuntimeState.PLAYLIST_BROWSER,
-            "ask": AppRuntimeState.SETTINGS,
-            "playlists": AppRuntimeState.PLAYLIST_BROWSER,
-            "power": AppRuntimeState.POWER,
-            "call": AppRuntimeState.CALL_IDLE,
-            "contacts": AppRuntimeState.CALL_IDLE,
-        }
-        if screen_name is None or screen_name not in state_by_screen:
+        """Update the active UI route for non-overlay navigation events."""
+        if not screen_name:
             return None
 
-        return self.set_ui_state(state_by_screen[screen_name], trigger=f"screen:{screen_name}")
+        screen_name = str(screen_name)
+        if screen_name not in self._KNOWN_UI_ROUTES:
+            return None
+
+        return self.set_ui_state(screen_name, trigger=f"screen:{screen_name}")
 
     def get_state_name(self) -> str:
         """Return the current derived app-state name."""
+        if self.current_app_state == AppRuntimeState.IDLE:
+            return self.ui_state
         return self.current_app_state.value

--- a/src/yoyopod/runtime/boot/__init__.py
+++ b/src/yoyopod/runtime/boot/__init__.py
@@ -40,7 +40,6 @@ from .wiring_boot import WiringBoot
 
 if TYPE_CHECKING:
     from yoyopod.app import YoyoPodApp
-    from yoyopod.coordinators import AppRuntimeState
 
 
 class RuntimeBootService:
@@ -142,7 +141,7 @@ class RuntimeBootService:
     def get_initial_screen_name(self) -> str:
         return self._screens_boot.get_initial_screen_name()
 
-    def get_initial_ui_state(self) -> "AppRuntimeState":
+    def get_initial_ui_state(self) -> str:
         return self._screens_boot.get_initial_ui_state()
 
     def refresh_talk_summary(self) -> None:

--- a/src/yoyopod/runtime/boot/screens_boot.py
+++ b/src/yoyopod/runtime/boot/screens_boot.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from yoyopod.coordinators import AppRuntimeState
 from yoyopod.ui.input import InteractionProfile
 
 if TYPE_CHECKING:
@@ -53,8 +52,8 @@ class ScreensBoot:
             return "hub"
         return "menu"
 
-    def get_initial_ui_state(self) -> AppRuntimeState:
-        """Return the base runtime state for the active interaction profile."""
+    def get_initial_ui_state(self) -> str:
+        """Return the base UI route for the active interaction profile."""
         if self.get_interaction_profile() == InteractionProfile.ONE_BUTTON:
-            return AppRuntimeState.HUB
-        return AppRuntimeState.MENU
+            return "hub"
+        return "menu"

--- a/src/yoyopod/runtime/loop.py
+++ b/src/yoyopod/runtime/loop.py
@@ -126,9 +126,6 @@ class RuntimeLoopService:
             "call_incoming",
             "call_outgoing",
             "call_active",
-            "call_active_music_paused",
-            "paused_by_call",
-            "connecting",
         }
     )
 

--- a/src/yoyopod/runtime/loop.py
+++ b/src/yoyopod/runtime/loop.py
@@ -123,8 +123,7 @@ class RuntimeLoopService:
     _DRAIN_BUDGET_LOG_INTERVAL_SECONDS = 1.0
     _LATENCY_SENSITIVE_STATES = frozenset(
         {
-            "call_incoming",
-            "call_outgoing",
+            "call_connecting",
             "call_active",
         }
     )

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -562,7 +562,7 @@ class OrchestrationHarness:
         screen_manager = FakeScreenManager(screens.screen_lookup())
         app.screen_manager = screen_manager
         app.screen_manager.push_screen("menu")
-        app._ui_state = AppRuntimeState.MENU
+        app._ui_state = "menu"
 
         app._setup_event_subscriptions()
         assert app.call_coordinator is not None
@@ -961,7 +961,7 @@ def test_background_events_wait_for_drain_before_mutating_state() -> None:
     assert app.event_bus.drain() == 2
     assert app.voip_registered
     assert app.music_fsm.state == MusicState.PLAYING
-    assert app.coordinator_runtime.current_app_state == AppRuntimeState.PLAYING_WITH_VOIP
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.PLAYING
 
 
 def test_track_event_refreshes_now_playing_screen_when_visible() -> None:
@@ -1058,16 +1058,20 @@ def test_navigation_updates_runtime_base_state() -> None:
     app, _, screen_manager = _build_app(playback_state="stopped")
 
     screen_manager.push_screen("contacts")
-    assert app.coordinator_runtime.current_app_state == AppRuntimeState.CALL_IDLE
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.IDLE
+    assert app.coordinator_runtime.ui_state == "contacts"
 
     screen_manager.pop_screen()
-    assert app.coordinator_runtime.current_app_state == AppRuntimeState.MENU
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.IDLE
+    assert app.coordinator_runtime.ui_state == "menu"
 
     screen_manager.push_screen("playlists")
-    assert app.coordinator_runtime.current_app_state == AppRuntimeState.PLAYLIST_BROWSER
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.IDLE
+    assert app.coordinator_runtime.ui_state == "playlists"
 
     screen_manager.push_screen("power")
-    assert app.coordinator_runtime.current_app_state == AppRuntimeState.POWER
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.IDLE
+    assert app.coordinator_runtime.ui_state == "power"
 
 
 def test_worker_navigation_waits_for_coordinator_drain_before_syncing_state() -> None:
@@ -1077,9 +1081,11 @@ def test_worker_navigation_waits_for_coordinator_drain_before_syncing_state() ->
     _navigate_from_worker(screen_manager, "contacts")
 
     assert screen_manager.current_screen is app.contact_list_screen
-    assert app.coordinator_runtime.current_app_state == AppRuntimeState.MENU
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.IDLE
+    assert app.coordinator_runtime.ui_state == "menu"
     assert app.event_bus.drain() == 1
-    assert app.coordinator_runtime.current_app_state == AppRuntimeState.CALL_IDLE
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.IDLE
+    assert app.coordinator_runtime.ui_state == "contacts"
 
 
 def test_main_thread_callback_errors_are_contained_and_drain_continues() -> None:
@@ -1117,7 +1123,8 @@ def test_call_end_restores_previous_screen_base_state() -> None:
 
     assert app.event_bus.drain() == 1
     assert screen_manager.current_screen is app.playlist_screen
-    assert app.coordinator_runtime.current_app_state == AppRuntimeState.PLAYLIST_BROWSER
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.IDLE
+    assert app.coordinator_runtime.ui_state == "playlists"
 
 
 def test_manager_recovery_schedules_music_reconnect_off_main_thread() -> None:
@@ -1300,7 +1307,7 @@ def test_standard_profile_starts_on_menu() -> None:
     app.input_manager = InputManager(interaction_profile=InteractionProfile.STANDARD)
 
     assert app._get_initial_screen_name() == "menu"
-    assert app._get_initial_ui_state() == AppRuntimeState.MENU
+    assert app._get_initial_ui_state() == "menu"
 
 
 def test_one_button_profile_starts_on_hub() -> None:
@@ -1310,7 +1317,7 @@ def test_one_button_profile_starts_on_hub() -> None:
     app.input_manager = InputManager(interaction_profile=InteractionProfile.ONE_BUTTON)
 
     assert app._get_initial_screen_name() == "hub"
-    assert app._get_initial_ui_state() == AppRuntimeState.HUB
+    assert app._get_initial_ui_state() == "hub"
 
 
 def test_power_poll_updates_context_runtime_and_visible_screen() -> None:

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -2241,6 +2241,30 @@ def test_runtime_loop_keeps_fast_cadence_during_call_states() -> None:
     assert status["voip_effective_iterate_interval_seconds"] == pytest.approx(0.02)
 
 
+def test_runtime_loop_keeps_fast_cadence_during_call_connecting_state() -> None:
+    """Incoming/outgoing call session phases keep coordinator cadence at latency-sensitive."""
+    harness = OrchestrationHarness.build(
+        power_manager=FakePowerManager([_power_snapshot(available=True, battery_percent=55.0)])
+    )
+    harness.app.voip_manager = FakeRuntimeLoopVoIPManager()
+    harness.app._voip_iterate_interval_seconds = 0.02
+    harness.sync_runtime(call_state=CallSessionState.INCOMING, trigger="call_incoming")
+
+    sleep_seconds = harness.app.runtime_loop.next_sleep_interval_seconds(
+        monotonic_now=1.0,
+        current_time=1.0,
+        last_screen_update=1.0,
+        screen_update_interval=1.0,
+    )
+
+    status = harness.app.get_status()
+    assert sleep_seconds == pytest.approx(0.02)
+    assert status["state"] == AppRuntimeState.CALL_CONNECTING.value
+    assert status["runtime_cadence_mode"] == "latency_sensitive"
+    assert status["runtime_cadence_reason"] == "call_or_connecting_state"
+    assert status["voip_effective_iterate_interval_seconds"] == pytest.approx(0.02)
+
+
 def test_runtime_loop_pending_work_uses_nonzero_backlog_cadence() -> None:
     """Queued work should no longer collapse the coordinator into a zero-sleep spin."""
 

--- a/tests/test_app_orchestration.py
+++ b/tests/test_app_orchestration.py
@@ -961,7 +961,7 @@ def test_background_events_wait_for_drain_before_mutating_state() -> None:
     assert app.event_bus.drain() == 2
     assert app.voip_registered
     assert app.music_fsm.state == MusicState.PLAYING
-    assert app.coordinator_runtime.current_app_state == AppRuntimeState.PLAYING
+    assert app.coordinator_runtime.current_app_state == AppRuntimeState.MUSIC
 
 
 def test_track_event_refreshes_now_playing_screen_when_visible() -> None:

--- a/tests/test_call_coordinator.py
+++ b/tests/test_call_coordinator.py
@@ -202,6 +202,26 @@ def test_connected_backend_state_ignores_connect_while_call_fsm_idle() -> None:
     assert screen_coordinator.show_in_call_calls == 0
 
 
+def test_non_connected_backend_state_does_not_force_in_call_ui() -> None:
+    """Ignore non-terminal backend states that are not real call-connect transitions."""
+    context = AppContext()
+    runtime = _build_runtime(
+        config_manager=_ConfigManagerStub(sip_username="kid@example.com"),
+        context=context,
+    )
+    screen_coordinator = _ScreenCoordinatorStub()
+    coordinator = CallCoordinator(
+        runtime=runtime,
+        screen_coordinator=screen_coordinator,
+        auto_resume_after_call=True,
+    )
+
+    coordinator.handle_call_state_change(CallState.PAUSED)
+
+    assert runtime.call_fsm.state == CallSessionState.IDLE
+    assert screen_coordinator.show_in_call_calls == 0
+
+
 def test_connected_backend_state_activates_call_fsm_when_call_is_starting() -> None:
     """Accept connected/backend-streaming states only after a call session is active."""
     context = AppContext()

--- a/tests/test_call_coordinator.py
+++ b/tests/test_call_coordinator.py
@@ -9,7 +9,7 @@ from yoyopod.communication.calling.history import CallHistoryStore
 from yoyopod.communication.models import CallState, RegistrationState
 from yoyopod.coordinators.call import CallCoordinator
 from yoyopod.coordinators.registry import CoordinatorRuntime
-from yoyopod.core import CallFSM, CallInterruptionPolicy, MusicFSM
+from yoyopod.core import CallFSM, CallInterruptionPolicy, CallSessionState, MusicFSM
 
 
 class _ScreenCoordinatorStub:
@@ -17,6 +17,7 @@ class _ScreenCoordinatorStub:
 
     def __init__(self, voip_manager: _VoipManagerStub | None = None) -> None:
         self.refresh_calls = 0
+        self.show_in_call_calls = 0
         self._voip_manager = voip_manager
 
     def refresh_call_screen_if_visible(self) -> None:
@@ -29,6 +30,7 @@ class _ScreenCoordinatorStub:
         return
 
     def show_in_call(self) -> None:
+        self.show_in_call_calls += 1
         return
 
     def pop_call_screens(self) -> None:
@@ -178,3 +180,44 @@ def test_terminal_call_states_record_rejected_and_failed_history(tmp_path: Path)
     recent = coordinator.call_history_store.list_recent(2)  # type: ignore[union-attr]
     assert recent[0].outcome == "failed"
     assert recent[1].outcome == "rejected"
+
+
+def test_connected_backend_state_ignores_connect_while_call_fsm_idle() -> None:
+    """Ignore backend-connected transitions before the call session is active."""
+    context = AppContext()
+    runtime = _build_runtime(
+        config_manager=_ConfigManagerStub(sip_username="kid@example.com"),
+        context=context,
+    )
+    screen_coordinator = _ScreenCoordinatorStub()
+    coordinator = CallCoordinator(
+        runtime=runtime,
+        screen_coordinator=screen_coordinator,
+        auto_resume_after_call=True,
+    )
+
+    coordinator.handle_call_state_change(CallState.CONNECTED)
+
+    assert runtime.call_fsm.state == CallSessionState.IDLE
+    assert screen_coordinator.show_in_call_calls == 0
+
+
+def test_connected_backend_state_activates_call_fsm_when_call_is_starting() -> None:
+    """Accept connected/backend-streaming states only after a call session is active."""
+    context = AppContext()
+    runtime = _build_runtime(
+        config_manager=_ConfigManagerStub(sip_username="kid@example.com"),
+        context=context,
+    )
+    screen_coordinator = _ScreenCoordinatorStub()
+    coordinator = CallCoordinator(
+        runtime=runtime,
+        screen_coordinator=screen_coordinator,
+        auto_resume_after_call=True,
+    )
+
+    coordinator.handle_call_state_change(CallState.OUTGOING)
+    coordinator.handle_call_state_change(CallState.CONNECTED)
+
+    assert runtime.call_fsm.state == CallSessionState.ACTIVE
+    assert screen_coordinator.show_in_call_calls == 1

--- a/tests/test_fsm_runtime.py
+++ b/tests/test_fsm_runtime.py
@@ -117,22 +117,23 @@ def test_runtime_state_is_derived_from_split_fsms() -> None:
 
     runtime.music_fsm.transition("play")
     state_change = runtime.sync_app_state("playback_playing")
-    assert state_change.entered(AppRuntimeState.PLAYING)
-    assert runtime.current_app_state == AppRuntimeState.PLAYING
+    assert state_change.entered(AppRuntimeState.MUSIC)
+    assert runtime.current_app_state == AppRuntimeState.MUSIC
 
     state_change = runtime.set_voip_ready(True)
     assert not state_change.changed
-    assert runtime.current_app_state == AppRuntimeState.PLAYING
+    assert runtime.current_app_state == AppRuntimeState.MUSIC
 
     runtime.call_interruption_policy.mark_paused_for_call(runtime.music_fsm)
     state_change = runtime.sync_app_state("auto_pause_for_call")
-    assert state_change.entered(AppRuntimeState.PAUSED)
-    assert runtime.current_app_state == AppRuntimeState.PAUSED
+    assert not state_change.changed
+    assert runtime.music_fsm.state == MusicState.PAUSED
+    assert runtime.current_app_state == AppRuntimeState.MUSIC
 
     runtime.call_fsm.transition("incoming")
     state_change = runtime.sync_app_state("incoming_call")
-    assert state_change.entered(AppRuntimeState.CALL_INCOMING)
-    assert runtime.current_app_state == AppRuntimeState.CALL_INCOMING
+    assert state_change.entered(AppRuntimeState.CALL_CONNECTING)
+    assert runtime.current_app_state == AppRuntimeState.CALL_CONNECTING
 
     runtime.call_fsm.transition("connect")
     state_change = runtime.sync_app_state("call_connected")
@@ -143,8 +144,8 @@ def test_runtime_state_is_derived_from_split_fsms() -> None:
     runtime.music_fsm.transition("play")
     runtime.call_interruption_policy.clear()
     state_change = runtime.sync_app_state("call_ended")
-    assert state_change.entered(AppRuntimeState.PLAYING)
-    assert runtime.current_app_state == AppRuntimeState.PLAYING
+    assert state_change.entered(AppRuntimeState.MUSIC)
+    assert runtime.current_app_state == AppRuntimeState.MUSIC
 
 
 def test_runtime_returns_to_base_ui_state_when_music_and_calls_are_idle() -> None:
@@ -156,7 +157,7 @@ def test_runtime_returns_to_base_ui_state_when_music_and_calls_are_idle() -> Non
 
     runtime.music_fsm.transition("play")
     runtime.sync_app_state("load_playlist")
-    assert runtime.current_app_state == AppRuntimeState.PLAYING
+    assert runtime.current_app_state == AppRuntimeState.MUSIC
 
     runtime.music_fsm.transition("stop")
     state_change = runtime.sync_app_state("stop")

--- a/tests/test_fsm_runtime.py
+++ b/tests/test_fsm_runtime.py
@@ -110,9 +110,10 @@ def test_runtime_state_is_derived_from_split_fsms() -> None:
     """CoordinatorRuntime should derive app state from music and call FSMs."""
     runtime = _build_runtime()
 
-    state_change = runtime.set_ui_state(AppRuntimeState.MENU, trigger="test_menu")
-    assert state_change.entered(AppRuntimeState.MENU)
-    assert runtime.current_app_state == AppRuntimeState.MENU
+    state_change = runtime.set_ui_state("menu", trigger="test_menu")
+    assert not state_change.changed
+    assert runtime.current_app_state == AppRuntimeState.IDLE
+    assert runtime.ui_state == "menu"
 
     runtime.music_fsm.transition("play")
     state_change = runtime.sync_app_state("playback_playing")
@@ -120,13 +121,13 @@ def test_runtime_state_is_derived_from_split_fsms() -> None:
     assert runtime.current_app_state == AppRuntimeState.PLAYING
 
     state_change = runtime.set_voip_ready(True)
-    assert state_change.entered(AppRuntimeState.PLAYING_WITH_VOIP)
-    assert runtime.current_app_state == AppRuntimeState.PLAYING_WITH_VOIP
+    assert not state_change.changed
+    assert runtime.current_app_state == AppRuntimeState.PLAYING
 
     runtime.call_interruption_policy.mark_paused_for_call(runtime.music_fsm)
     state_change = runtime.sync_app_state("auto_pause_for_call")
-    assert state_change.entered(AppRuntimeState.PAUSED_BY_CALL)
-    assert runtime.current_app_state == AppRuntimeState.PAUSED_BY_CALL
+    assert state_change.entered(AppRuntimeState.PAUSED)
+    assert runtime.current_app_state == AppRuntimeState.PAUSED
 
     runtime.call_fsm.transition("incoming")
     state_change = runtime.sync_app_state("incoming_call")
@@ -135,23 +136,23 @@ def test_runtime_state_is_derived_from_split_fsms() -> None:
 
     runtime.call_fsm.transition("connect")
     state_change = runtime.sync_app_state("call_connected")
-    assert state_change.entered(AppRuntimeState.CALL_ACTIVE_MUSIC_PAUSED)
-    assert runtime.current_app_state == AppRuntimeState.CALL_ACTIVE_MUSIC_PAUSED
+    assert state_change.entered(AppRuntimeState.CALL_ACTIVE)
+    assert runtime.current_app_state == AppRuntimeState.CALL_ACTIVE
 
     runtime.call_fsm.transition("end")
     runtime.music_fsm.transition("play")
     runtime.call_interruption_policy.clear()
     state_change = runtime.sync_app_state("call_ended")
-    assert state_change.entered(AppRuntimeState.PLAYING_WITH_VOIP)
-    assert runtime.current_app_state == AppRuntimeState.PLAYING_WITH_VOIP
+    assert state_change.entered(AppRuntimeState.PLAYING)
+    assert runtime.current_app_state == AppRuntimeState.PLAYING
 
 
 def test_runtime_returns_to_base_ui_state_when_music_and_calls_are_idle() -> None:
     """The derived app state should fall back to the current base UI state."""
     runtime = _build_runtime()
 
-    runtime.set_ui_state(AppRuntimeState.PLAYLIST_BROWSER, trigger="browse_playlists")
-    assert runtime.current_app_state == AppRuntimeState.PLAYLIST_BROWSER
+    runtime.set_ui_state("playlists", trigger="browse_playlists")
+    assert runtime.ui_state == "playlists"
 
     runtime.music_fsm.transition("play")
     runtime.sync_app_state("load_playlist")
@@ -159,5 +160,6 @@ def test_runtime_returns_to_base_ui_state_when_music_and_calls_are_idle() -> Non
 
     runtime.music_fsm.transition("stop")
     state_change = runtime.sync_app_state("stop")
-    assert state_change.entered(AppRuntimeState.PLAYLIST_BROWSER)
-    assert runtime.current_app_state == AppRuntimeState.PLAYLIST_BROWSER
+    assert state_change.entered(AppRuntimeState.IDLE)
+    assert runtime.current_app_state == AppRuntimeState.IDLE
+    assert runtime.ui_state == "playlists"

--- a/tests/test_fsm_runtime.py
+++ b/tests/test_fsm_runtime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import yoyopod.core.fsm.music as fsm_module
-from yoyopod.coordinators.registry import AppRuntimeState, CoordinatorRuntime
+from yoyopod.coordinators.registry import AppRuntimeState, BaseUIRoute, CoordinatorRuntime
 from yoyopod.core import (
     CallFSM,
     CallInterruptionPolicy,
@@ -13,7 +13,7 @@ from yoyopod.core import (
 )
 
 
-def _build_runtime() -> CoordinatorRuntime:
+def _build_runtime(ui_state: str | BaseUIRoute = AppRuntimeState.IDLE.value) -> CoordinatorRuntime:
     """Create a minimal coordinator runtime for state-derivation tests."""
     return CoordinatorRuntime(
         music_fsm=MusicFSM(),
@@ -23,6 +23,7 @@ def _build_runtime() -> CoordinatorRuntime:
         music_backend=None,
         power_manager=None,
         config_manager=None,
+        ui_state=ui_state,
     )
 
 
@@ -164,3 +165,26 @@ def test_runtime_returns_to_base_ui_state_when_music_and_calls_are_idle() -> Non
     assert state_change.entered(AppRuntimeState.IDLE)
     assert runtime.current_app_state == AppRuntimeState.IDLE
     assert runtime.ui_state == "playlists"
+
+
+def test_runtime_accepts_base_ui_route_enum_inputs() -> None:
+    """Base UI routes should stay usable via enum callers after AppRuntimeState narrowed."""
+    runtime = _build_runtime(ui_state=BaseUIRoute.HOME)
+
+    assert runtime.ui_state == BaseUIRoute.HOME.value
+
+    state_change = runtime.set_ui_state(BaseUIRoute.MENU, trigger="show_menu")
+
+    assert not state_change.changed
+    assert runtime.current_app_state == AppRuntimeState.IDLE
+    assert runtime.ui_state == BaseUIRoute.MENU.value
+
+
+def test_runtime_maps_legacy_idle_runtime_enum_to_home_route() -> None:
+    """Legacy idle enum inputs should continue to land on the home UI route."""
+    runtime = _build_runtime()
+
+    state_change = runtime.set_ui_state(AppRuntimeState.IDLE, trigger="legacy_home")
+
+    assert not state_change.changed
+    assert runtime.ui_state == BaseUIRoute.HOME.value


### PR DESCRIPTION
Implements issue #220. Generated by wrapper-owned workflow watchdog.