### PR TITLE
[codex] PIL and LVGL rendering paths are fully duplicated per screen — 14+ screens maintained twice

### DIFF
--- a/src/yoyopod/ui/screens/base.py
+++ b/src/yoyopod/ui/screens/base.py
@@ -11,12 +11,14 @@ from loguru import logger
 
 from yoyopod.ui.display import Display
 from yoyopod.ui.input.hal import InteractionProfile
+from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
 from yoyopod.ui.screens.router import NavigationRequest
 
 if TYPE_CHECKING:
     from yoyopod.ui.screens.manager import ScreenManager
     from yoyopod.core import AppContext
     from yoyopod.ui.input import InputAction
+    from yoyopod.ui.screens.view import ScreenView
 
 
 class Screen(ABC):
@@ -216,3 +218,49 @@ class Screen(ABC):
                   {'command': str, 'confidence': float, ...}
         """
         pass
+
+
+class LvglScreen(Screen):
+    """Shared retained-LVGL lifecycle for dual-renderer screen controllers."""
+
+    def __init__(
+        self,
+        display: Display,
+        context: Optional['AppContext'] = None,
+        name: str = "Screen",
+    ) -> None:
+        super().__init__(display, context, name)
+        self._lvgl_view: "ScreenView | None" = None
+
+    @abstractmethod
+    def _create_lvgl_view(self, ui_backend: Any) -> "ScreenView":
+        """Return a newly constructed LVGL view for this screen."""
+
+    def _ensure_lvgl_view(self) -> "ScreenView | None":
+        """Return a live retained LVGL view when the backend is active."""
+        if getattr(self.display, "backend_kind", "pil") != "lvgl":
+            self._lvgl_view = None
+            return None
+
+        ui_backend = (
+            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
+        )
+        if ui_backend is None or not getattr(ui_backend, "initialized", False):
+            self._lvgl_view = None
+            return None
+
+        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
+        if self._lvgl_view is not None:
+            return self._lvgl_view
+
+        self._lvgl_view = self._create_lvgl_view(ui_backend)
+        self._lvgl_view.build()
+        return self._lvgl_view
+
+    def _sync_lvgl_view(self) -> bool:
+        """Sync the retained LVGL view, returning False when PIL should render."""
+        lvgl_view = self._ensure_lvgl_view()
+        if lvgl_view is None:
+            return False
+        lvgl_view.sync()
+        return True

--- a/src/yoyopod/ui/screens/music/now_playing.py
+++ b/src/yoyopod/ui/screens/music/now_playing.py
@@ -6,8 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Optional
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.music.lvgl import LvglNowPlayingView
 from yoyopod.ui.screens.music.now_playing_pil_view import render_now_playing_pil
 from yoyopod.ui.screens.theme import (
@@ -24,7 +23,6 @@ from yoyopod.ui.screens.theme import (
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
     from yoyopod.audio.music.models import Track
-    from yoyopod.ui.screens.view import ScreenView
 
 
 @dataclass(frozen=True, slots=True)
@@ -171,7 +169,7 @@ def build_now_playing_actions(
     )
 
 
-class NowPlayingScreen(Screen):
+class NowPlayingScreen(LvglScreen):
     """Current playback screen styled for the new Listen mode."""
 
     def __init__(
@@ -185,7 +183,6 @@ class NowPlayingScreen(Screen):
         super().__init__(display, context, "NowPlaying")
         self._state_provider = state_provider or build_now_playing_state_provider(context=context)
         self._actions = actions or build_now_playing_actions(context=context)
-        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Create the LVGL view when the screen becomes active."""
@@ -196,32 +193,14 @@ class NowPlayingScreen(Screen):
         """Leave the retained LVGL now-playing view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
+    def _create_lvgl_view(self, ui_backend: object) -> LvglNowPlayingView:
+        """Build the retained LVGL view for this screen."""
 
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglNowPlayingView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+        return LvglNowPlayingView(self, ui_backend)
 
     def render(self) -> None:
         """Render the now-playing view."""
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_now_playing_pil(self)
 

--- a/src/yoyopod/ui/screens/music/playlist.py
+++ b/src/yoyopod/ui/screens/music/playlist.py
@@ -8,17 +8,15 @@ from loguru import logger
 
 from yoyopod.audio.music import LocalMusicService
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
-from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.music.lvgl import LvglPlaylistView
 from yoyopod.ui.screens.music.playlist_pil_view import render_playlist_pil
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
-    from yoyopod.ui.screens.view import ScreenView
 
 
-class PlaylistScreen(Screen):
+class PlaylistScreen(LvglScreen):
     """Browse local playlists from the on-device music library."""
 
     def __init__(
@@ -36,7 +34,6 @@ class PlaylistScreen(Screen):
         self.max_visible_items = 3 if display.is_portrait() else 4
         self.loading = False
         self.error_message: str | None = None
-        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Refresh playlists when the screen becomes active."""
@@ -48,24 +45,9 @@ class PlaylistScreen(Screen):
         """Leave the retained LVGL playlist view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
-
-        ui_backend = self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglPlaylistView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+    def _create_lvgl_view(self, ui_backend: object) -> LvglPlaylistView:
+        """Build the retained LVGL view for this screen."""
+        return LvglPlaylistView(self, ui_backend)
 
     def _update_scroll_window(self) -> None:
         """Keep the selected item visible within the current scroll window."""
@@ -159,9 +141,7 @@ class PlaylistScreen(Screen):
 
     def render(self) -> None:
         """Render the local playlist browser."""
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_playlist_pil(self)
 

--- a/src/yoyopod/ui/screens/music/recent.py
+++ b/src/yoyopod/ui/screens/music/recent.py
@@ -8,17 +8,15 @@ from loguru import logger
 
 from yoyopod.audio import LocalMusicService, RecentTrackEntry
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.music.lvgl import LvglPlaylistView
 from yoyopod.ui.screens.music.recent_pil_view import render_recent_tracks_pil
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
-    from yoyopod.ui.screens.view import ScreenView
 
 
-class RecentTracksScreen(Screen):
+class RecentTracksScreen(LvglScreen):
     """Browse and replay recently played local tracks."""
 
     def __init__(
@@ -35,7 +33,6 @@ class RecentTracksScreen(Screen):
         self.scroll_offset = 0
         self.max_visible_items = 3 if display.is_portrait() else 4
         self.error_message: str | None = None
-        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Refresh recent tracks when the screen becomes active."""
@@ -47,26 +44,9 @@ class RecentTracksScreen(Screen):
         """Leave the retained LVGL recent-tracks view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
-
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglPlaylistView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+    def _create_lvgl_view(self, ui_backend: object) -> LvglPlaylistView:
+        """Build the retained LVGL view for this screen."""
+        return LvglPlaylistView(self, ui_backend)
 
     @staticmethod
     def get_title_text() -> str:
@@ -154,9 +134,7 @@ class RecentTracksScreen(Screen):
 
     def render(self) -> None:
         """Render the recent-track browser."""
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_recent_tracks_pil(self)
 

--- a/src/yoyopod/ui/screens/navigation/ask/__init__.py
+++ b/src/yoyopod/ui/screens/navigation/ask/__init__.py
@@ -12,8 +12,7 @@ from yoyopod.coordinators.voice import (
     VoiceSettingsResolver,
 )
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.navigation.lvgl import LvglAskView
 from yoyopod.ui.screens.theme import (
     ASK,
@@ -36,10 +35,9 @@ if TYPE_CHECKING:
     from yoyopod.config import ConfigManager
     from yoyopod.communication.calling.manager import VoIPManager
     from yoyopod.people import PeopleManager
-    from yoyopod.ui.screens.view import ScreenView
 
 
-class AskScreen(Screen):
+class AskScreen(LvglScreen):
     """Unified stateful Ask screen with idle / listening / thinking / reply states."""
 
     _FAMILY_ALIAS_GROUPS: tuple[tuple[str, ...], ...] = (
@@ -98,7 +96,6 @@ class AskScreen(Screen):
         self._quick_command = False
         self._ptt_active = False
         self._auto_return_timer = None
-        self._lvgl_view: "ScreenView | None" = None
         self._bind_voice_runtime()
 
     def enter(self) -> None:
@@ -269,29 +266,9 @@ class AskScreen(Screen):
         self._headline = headline
         self._body = body
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
-
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
-
-        ui_backend = (
-            self.display.get_ui_backend()
-            if hasattr(self.display, "get_ui_backend")
-            else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglAskView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+    def _create_lvgl_view(self, ui_backend: object) -> LvglAskView:
+        """Build the retained LVGL view for this screen."""
+        return LvglAskView(self, ui_backend)
 
     def current_view_model(self) -> tuple[str, str, str, str]:
         """Return title, subtitle, footer, and icon for the current Ask state."""
@@ -304,9 +281,7 @@ class AskScreen(Screen):
     def render(self) -> None:
         """Render the current Ask state."""
 
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
 
         if self._state == "reply":

--- a/src/yoyopod/ui/screens/navigation/hub.py
+++ b/src/yoyopod/ui/screens/navigation/hub.py
@@ -6,8 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Optional
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
-from yoyopod.ui.screens.base import Screen
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.navigation.lvgl import LvglHubView
 from yoyopod.ui.screens.navigation.hub_pil_view import render_hub_pil
 from yoyopod.ui.screens.theme import (
@@ -21,7 +20,6 @@ from yoyopod.ui.screens.theme import (
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
     from yoyopod.audio.music.models import Track
-    from yoyopod.ui.screens.view import ScreenView
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,7 +75,7 @@ def build_hub_listen_subtitle_provider(
     return provider
 
 
-class HubScreen(Screen):
+class HubScreen(LvglScreen):
     """Carousel-style root screen for the one-button Whisplay flow."""
 
     def __init__(
@@ -92,7 +90,6 @@ class HubScreen(Screen):
             listen_subtitle_provider or build_hub_listen_subtitle_provider(display)
         )
         self.selected_index = 0
-        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Refresh lightweight summaries when the hub becomes active."""
@@ -103,26 +100,9 @@ class HubScreen(Screen):
         """Leave the retained LVGL Hub view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
-
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglHubView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+    def _create_lvgl_view(self, ui_backend: object) -> LvglHubView:
+        """Build the retained LVGL view for this screen."""
+        return LvglHubView(self, ui_backend)
 
     def cards(self) -> list[HubCard]:
         """Build the live root-card list."""
@@ -174,9 +154,7 @@ class HubScreen(Screen):
 
     def render(self) -> None:
         """Render the selected root card."""
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_hub_pil(self)
 

--- a/src/yoyopod/ui/screens/navigation/listen.py
+++ b/src/yoyopod/ui/screens/navigation/listen.py
@@ -6,17 +6,15 @@ from typing import TYPE_CHECKING, Optional
 
 from yoyopod.audio.music import LocalLibraryItem, LocalMusicService
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.navigation.lvgl import LvglListenView
 from yoyopod.ui.screens.navigation.listen_pil_view import render_listen_pil
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
-    from yoyopod.ui.screens.view import ScreenView
 
 
-class ListenScreen(Screen):
+class ListenScreen(LvglScreen):
     """Local music landing screen for Playlists, Recent, and Shuffle."""
 
     def __init__(
@@ -30,7 +28,6 @@ class ListenScreen(Screen):
         self.music_service = music_service
         self.items: list[LocalLibraryItem] = []
         self.selected_index = 0
-        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Refresh the local library menu when entering Listen."""
@@ -42,26 +39,9 @@ class ListenScreen(Screen):
         """Leave the retained LVGL Listen view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
-
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglListenView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+    def _create_lvgl_view(self, ui_backend: object) -> LvglListenView:
+        """Build the retained LVGL view for this screen."""
+        return LvglListenView(self, ui_backend)
 
     def _load_items(self) -> None:
         """Load the fixed local-first Listen menu items."""
@@ -80,9 +60,7 @@ class ListenScreen(Screen):
 
     def render(self) -> None:
         """Render the local library menu."""
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_listen_pil(self)
 

--- a/src/yoyopod/ui/screens/system/power_screen.py
+++ b/src/yoyopod/ui/screens/system/power_screen.py
@@ -9,8 +9,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 from loguru import logger
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.system.lvgl import LvglPowerView
 from yoyopod.ui.screens.system.power_rows import (
     PowerPage,
@@ -41,7 +40,6 @@ from yoyopod.ui.screens.theme import (
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
     from yoyopod.power.models import PowerSnapshot
-    from yoyopod.ui.screens.view import ScreenView
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,7 +55,7 @@ class PowerScreenLvglPayload:
     total_pages: int
 
 
-class PowerScreen(Screen):
+class PowerScreen(LvglScreen):
     """Compact Setup screen for power and device care state."""
 
     def __init__(
@@ -76,7 +74,6 @@ class PowerScreen(Screen):
         self.page_index = 0
         self.selected_row = 0
         self.in_detail = False
-        self._lvgl_view: "ScreenView | None" = None
         self._last_gps_query_at = 0.0
         self._gps_refresh_interval_seconds = 2.0
         self._visible_tick_refresh_grace_seconds = 0.5
@@ -100,26 +97,10 @@ class PowerScreen(Screen):
         """Leave the retained LVGL Setup view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
+    def _create_lvgl_view(self, ui_backend: object) -> LvglPowerView:
+        """Build the retained LVGL view for this screen."""
 
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglPowerView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+        return LvglPowerView(self, ui_backend)
 
     def render(self) -> None:
         """Render the active Setup page."""

--- a/src/yoyopod/ui/screens/voip/call_history.py
+++ b/src/yoyopod/ui/screens/voip/call_history.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 from loguru import logger
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.voip.call_actions import CallActions
 from yoyopod.ui.screens.voip.call_history_pil_view import render_call_history_pil
 from yoyopod.ui.screens.voip.lvgl.call_history_view import LvglCallHistoryView
@@ -16,10 +15,9 @@ from yoyopod.ui.screens.voip.lvgl.call_history_view import LvglCallHistoryView
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
     from yoyopod.communication.calling.history import CallHistoryEntry, CallHistoryStore
-    from yoyopod.ui.screens.view import ScreenView
 
 
-class CallHistoryScreen(Screen):
+class CallHistoryScreen(LvglScreen):
     """Show recent and missed calls, with quick redial when possible."""
 
     def __init__(
@@ -39,7 +37,6 @@ class CallHistoryScreen(Screen):
         self.selected_index = 0
         self.scroll_offset = 0
         self.max_visible_items = 4 if display.is_portrait() else 5
-        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Refresh call history and clear the unseen-missed badge count."""
@@ -54,25 +51,10 @@ class CallHistoryScreen(Screen):
         """Leave the retained LVGL call-history view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
+    def _create_lvgl_view(self, ui_backend: object) -> LvglCallHistoryView:
+        """Build the retained LVGL view for this screen."""
 
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglCallHistoryView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+        return LvglCallHistoryView(self, ui_backend)
 
     def _load_entries(self) -> None:
         """Load the recent calls from persistent storage."""
@@ -115,9 +97,7 @@ class CallHistoryScreen(Screen):
 
     def render(self) -> None:
         """Render the recent-calls list."""
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_call_history_pil(self)
 

--- a/src/yoyopod/ui/screens/voip/contact_list.py
+++ b/src/yoyopod/ui/screens/voip/contact_list.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING, Callable, Literal, Optional
 from loguru import logger
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.theme import talk_monogram
 from yoyopod.ui.screens.voip.call_actions import CallActions
 from yoyopod.ui.screens.voip.contact_list_pil_view import render_contact_list_pil
@@ -17,10 +16,9 @@ from yoyopod.ui.screens.voip.lvgl import LvglContactListView
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
     from yoyopod.people import Contact
-    from yoyopod.ui.screens.view import ScreenView
 
 
-class ContactListScreen(Screen):
+class ContactListScreen(LvglScreen):
     """Full contact list for calling or picking a voice-note recipient."""
 
     def __init__(
@@ -40,7 +38,6 @@ class ContactListScreen(Screen):
         self.selected_index = 0
         self.scroll_offset = 0
         self.max_visible_items = 4 if display.is_portrait() else 5
-        self._lvgl_view: "ScreenView | None" = None
 
     @property
     def title_text(self) -> str:
@@ -72,26 +69,10 @@ class ContactListScreen(Screen):
         """Leave the retained LVGL contacts view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
+    def _create_lvgl_view(self, ui_backend: object) -> LvglContactListView:
+        """Build the retained LVGL view for this screen."""
 
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglContactListView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+        return LvglContactListView(self, ui_backend)
 
     def load_contacts(self) -> None:
         """Load contacts from the people directory."""
@@ -103,9 +84,7 @@ class ContactListScreen(Screen):
 
     def render(self) -> None:
         """Render the contact list."""
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_contact_list_pil(self)
 

--- a/src/yoyopod/ui/screens/voip/in_call.py
+++ b/src/yoyopod/ui/screens/voip/in_call.py
@@ -7,17 +7,15 @@ from typing import TYPE_CHECKING, Optional
 from loguru import logger
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.voip.in_call_pil_view import render_in_call_pil
 from yoyopod.ui.screens.voip.lvgl import LvglInCallView
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
-    from yoyopod.ui.screens.view import ScreenView
 
 
-class InCallScreen(Screen):
+class InCallScreen(LvglScreen):
     """Active call screen showing duration and mute state."""
 
     def __init__(
@@ -28,7 +26,6 @@ class InCallScreen(Screen):
     ) -> None:
         super().__init__(display, context, "InCall")
         self.voip_manager = voip_manager
-        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Create the LVGL view when the screen becomes active."""
@@ -40,27 +37,10 @@ class InCallScreen(Screen):
         """Leave the retained LVGL in-call view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
+    def _create_lvgl_view(self, ui_backend: object) -> LvglInCallView:
+        """Build the retained LVGL view for this screen."""
 
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
-
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglInCallView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+        return LvglInCallView(self, ui_backend)
 
     @staticmethod
     def format_duration(seconds: int) -> str:
@@ -72,10 +52,7 @@ class InCallScreen(Screen):
 
     def render(self) -> None:
         """Render the active-call screen."""
-
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_in_call_pil(self)
 

--- a/src/yoyopod/ui/screens/voip/incoming_call.py
+++ b/src/yoyopod/ui/screens/voip/incoming_call.py
@@ -7,18 +7,16 @@ from typing import TYPE_CHECKING, Optional
 from loguru import logger
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.voip.call_actions import CallActions
 from yoyopod.ui.screens.voip.incoming_call_pil_view import render_incoming_call_pil
 from yoyopod.ui.screens.voip.lvgl import LvglIncomingCallView
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
-    from yoyopod.ui.screens.view import ScreenView
 
 
-class IncomingCallScreen(Screen):
+class IncomingCallScreen(LvglScreen):
     """Incoming call surface with answer and reject actions."""
 
     def __init__(
@@ -35,7 +33,6 @@ class IncomingCallScreen(Screen):
         self.caller_address = caller_address
         self.caller_name = caller_name
         self.ring_animation_frame = 0
-        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Create the LVGL view when the screen becomes active."""
@@ -47,32 +44,14 @@ class IncomingCallScreen(Screen):
         """Leave the retained LVGL incoming-call view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
+    def _create_lvgl_view(self, ui_backend: object) -> LvglIncomingCallView:
+        """Build the retained LVGL view for this screen."""
 
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglIncomingCallView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+        return LvglIncomingCallView(self, ui_backend)
 
     def render(self) -> None:
         """Render the incoming call screen."""
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_incoming_call_pil(self)
 

--- a/src/yoyopod/ui/screens/voip/outgoing_call.py
+++ b/src/yoyopod/ui/screens/voip/outgoing_call.py
@@ -7,18 +7,16 @@ from typing import TYPE_CHECKING, Optional
 from loguru import logger
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.voip.call_actions import CallActions
 from yoyopod.ui.screens.voip.outgoing_call_pil_view import render_outgoing_call_pil
 from yoyopod.ui.screens.voip.lvgl import LvglOutgoingCallView
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
-    from yoyopod.ui.screens.view import ScreenView
 
 
-class OutgoingCallScreen(Screen):
+class OutgoingCallScreen(LvglScreen):
     """Outgoing call surface while dialing or ringing."""
 
     def __init__(
@@ -35,7 +33,6 @@ class OutgoingCallScreen(Screen):
         self.callee_address = callee_address
         self.callee_name = callee_name
         self.ring_animation_frame = 0
-        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Create the LVGL view when the screen becomes active."""
@@ -47,32 +44,14 @@ class OutgoingCallScreen(Screen):
         """Leave the retained LVGL outgoing-call view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
+    def _create_lvgl_view(self, ui_backend: object) -> LvglOutgoingCallView:
+        """Build the retained LVGL view for this screen."""
 
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglOutgoingCallView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+        return LvglOutgoingCallView(self, ui_backend)
 
     def render(self) -> None:
         """Render the outgoing-call screen."""
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_outgoing_call_pil(self)
 

--- a/src/yoyopod/ui/screens/voip/quick_call.py
+++ b/src/yoyopod/ui/screens/voip/quick_call.py
@@ -6,8 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Optional
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.theme import (
     INK,
     draw_empty_state,
@@ -22,7 +21,6 @@ if TYPE_CHECKING:
     from yoyopod.core import AppContext
     from yoyopod.communication.calling.history import CallHistoryStore
     from yoyopod.people import Contact
-    from yoyopod.ui.screens.view import ScreenView
 
 
 @dataclass(slots=True)
@@ -46,7 +44,7 @@ class TalkDeckCard:
     icon_key: str | None = None
 
 
-class CallScreen(Screen):
+class CallScreen(LvglScreen):
     """Talk screen showing one person at a time."""
 
     _MAX_CONTACTS = 10
@@ -66,7 +64,6 @@ class CallScreen(Screen):
         self.people: list[TalkPerson] = []
         self.deck_cards: list[TalkDeckCard] = []
         self.selected_index = 0
-        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Refresh the contact deck when Talk becomes active."""
@@ -79,27 +76,10 @@ class CallScreen(Screen):
         """Leave the retained LVGL Talk view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
+    def _create_lvgl_view(self, ui_backend: object) -> LvglCallView:
+        """Build the retained LVGL view for this screen."""
 
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
-
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglCallView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+        return LvglCallView(self, ui_backend)
 
     def _sorted_contacts(self) -> list["Contact"]:
         """Return contacts ordered for child-facing Talk access."""
@@ -229,10 +209,7 @@ class CallScreen(Screen):
 
     def render(self) -> None:
         """Render the Talk contact deck."""
-
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
 
         theme = render_backdrop(self.display, "talk")

--- a/src/yoyopod/ui/screens/voip/talk_contact.py
+++ b/src/yoyopod/ui/screens/voip/talk_contact.py
@@ -8,15 +8,13 @@ from typing import TYPE_CHECKING, Optional
 from loguru import logger
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.theme import talk_monogram
 from yoyopod.ui.screens.voip.lvgl.talk_contact_view import LvglTalkContactView
 from yoyopod.ui.screens.voip.talk_contact_pil_view import render_talk_contact_pil
 
 if TYPE_CHECKING:
     from yoyopod.core import AppContext
-    from yoyopod.ui.screens.view import ScreenView
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,7 +26,7 @@ class TalkAction:
     subtitle: str = ""
 
 
-class TalkContactScreen(Screen):
+class TalkContactScreen(LvglScreen):
     """Action picker for the currently selected Talk contact."""
 
     def __init__(
@@ -40,7 +38,6 @@ class TalkContactScreen(Screen):
         super().__init__(display, context, "TalkContact")
         self.voip_manager = voip_manager
         self.selected_index = 0
-        self._lvgl_view: "ScreenView | None" = None
 
     def enter(self) -> None:
         """Reset the action cursor and create the LVGL view when active."""
@@ -53,27 +50,10 @@ class TalkContactScreen(Screen):
         """Leave the retained LVGL action view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> "ScreenView | None":
-        """Create an LVGL view when the Whisplay renderer is active."""
+    def _create_lvgl_view(self, ui_backend: object) -> LvglTalkContactView:
+        """Build the retained LVGL view for this screen."""
 
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
-
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = current_retained_view(self._lvgl_view, ui_backend)
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglTalkContactView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+        return LvglTalkContactView(self, ui_backend)
 
     def current_contact_name(self) -> str:
         """Return the child-facing selected contact name."""
@@ -150,10 +130,7 @@ class TalkContactScreen(Screen):
 
     def render(self) -> None:
         """Render the contact action picker."""
-
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_talk_contact_pil(self)
 

--- a/src/yoyopod/ui/screens/voip/voice_note.py
+++ b/src/yoyopod/ui/screens/voip/voice_note.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Callable, Optional
 
 from yoyopod.ui.display import Display
-from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.lvgl_lifecycle import current_retained_view
+from yoyopod.ui.screens.base import LvglScreen
 from yoyopod.ui.screens.theme import SUCCESS, WARNING, talk_monogram
 from yoyopod.ui.screens.voip.lvgl.voice_note_view import LvglVoiceNoteView
 from yoyopod.ui.screens.voip.voice_note_models import (
@@ -34,7 +33,7 @@ __all__ = [
 ]
 
 
-class VoiceNoteScreen(Screen):
+class VoiceNoteScreen(LvglScreen):
     """Kid-facing voice-note flow with real record, review, and send states."""
 
     def __init__(
@@ -51,7 +50,6 @@ class VoiceNoteScreen(Screen):
         self._recording_controller = VoiceNoteRecordingController(self._actions)
         self._state = "ready"
         self._selected_action_index = 0
-        self._lvgl_view: LvglVoiceNoteView | None = None
 
     def enter(self) -> None:
         """Reset the voice-note flow when opened."""
@@ -66,28 +64,10 @@ class VoiceNoteScreen(Screen):
         """Leave the retained LVGL voice-note view alive across transitions."""
         super().exit()
 
-    def _ensure_lvgl_view(self) -> LvglVoiceNoteView | None:
-        if getattr(self.display, "backend_kind", "pil") != "lvgl":
-            self._lvgl_view = None
-            return None
+    def _create_lvgl_view(self, ui_backend: object) -> LvglVoiceNoteView:
+        """Build the retained LVGL view for this screen."""
 
-        ui_backend = (
-            self.display.get_ui_backend() if hasattr(self.display, "get_ui_backend") else None
-        )
-        if ui_backend is None or not getattr(ui_backend, "initialized", False):
-            self._lvgl_view = None
-            return None
-
-        self._lvgl_view = cast(
-            LvglVoiceNoteView | None,
-            current_retained_view(cast(Any, self._lvgl_view), ui_backend),
-        )
-        if self._lvgl_view is not None:
-            return self._lvgl_view
-
-        self._lvgl_view = LvglVoiceNoteView(self, ui_backend)
-        self._lvgl_view.build()
-        return self._lvgl_view
+        return LvglVoiceNoteView(self, ui_backend)
 
     def wants_ptt_passthrough(self) -> bool:
         """Return True when the single-button adapter should emit raw PTT hold events."""
@@ -238,9 +218,7 @@ class VoiceNoteScreen(Screen):
         """Render the current voice-note flow state."""
 
         self._sync_state_from_provider(default_state=self._state)
-        lvgl_view = self._ensure_lvgl_view()
-        if lvgl_view is not None:
-            lvgl_view.sync()
+        if self._sync_lvgl_view():
             return
         render_voice_note_pil(self)
 


### PR DESCRIPTION
Implements issue #222. Generated by wrapper-owned workflow watchdog.