### PR TITLE
[A06] Decouple pi validate soaks from eager app import

### DIFF
--- a/src/yoyopod/cli/common.py
+++ b/src/yoyopod/cli/common.py
@@ -1,0 +1,11 @@
+"""Compatibility layer for legacy `yoyopod.cli` imports."""
+
+from __future__ import annotations
+
+from yoyopod_cli.common import REPO_ROOT, configure_logging, resolve_config_dir
+
+__all__ = [
+    "REPO_ROOT",
+    "configure_logging",
+    "resolve_config_dir",
+]

--- a/src/yoyopod/cli/pi/music_fixtures.py
+++ b/src/yoyopod/cli/pi/music_fixtures.py
@@ -1,0 +1,29 @@
+"""Compatibility layer for legacy `yoyopod.cli.pi.music_fixtures` imports."""
+
+from __future__ import annotations
+
+from yoyopod_cli.music_fixtures import (
+    DEFAULT_TEST_MUSIC_TARGET_DIR,
+    ProvisionedTestMusicLibrary,
+    TestPlaylistSpec,
+    TestToneSpec,
+    TEST_MUSIC_LIBRARY_VERSION,
+    TEST_MUSIC_MANIFEST_FILENAME,
+    TEST_PLAYLIST_SPECS,
+    TEST_TONE_SPECS,
+    expected_test_music_relative_paths,
+    provision_test_music_library,
+)
+
+__all__ = [
+    "DEFAULT_TEST_MUSIC_TARGET_DIR",
+    "ProvisionedTestMusicLibrary",
+    "TestPlaylistSpec",
+    "TestToneSpec",
+    "TEST_MUSIC_LIBRARY_VERSION",
+    "TEST_MUSIC_MANIFEST_FILENAME",
+    "TEST_PLAYLIST_SPECS",
+    "TEST_TONE_SPECS",
+    "expected_test_music_relative_paths",
+    "provision_test_music_library",
+]

--- a/src/yoyopod/cli/pi/navigation.py
+++ b/src/yoyopod/cli/pi/navigation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from yoyopod_cli._pi_validate_helpers import (
+from yoyopod_cli.pi_validate_helpers import (
     NavigationSoakFailure,
     NavigationSoakStats,
     NavigationSoakRunner,

--- a/src/yoyopod/cli/pi/navigation.py
+++ b/src/yoyopod/cli/pi/navigation.py
@@ -1,0 +1,17 @@
+"""CLI navigation soak helpers compatibility surface."""
+
+from __future__ import annotations
+
+from yoyopod_cli._pi_validate_helpers import (
+    NavigationSoakFailure,
+    NavigationSoakStats,
+    NavigationSoakRunner,
+    run_navigation_soak,
+)
+
+__all__ = [
+    "NavigationSoakFailure",
+    "NavigationSoakStats",
+    "NavigationSoakRunner",
+    "run_navigation_soak",
+]

--- a/src/yoyopod/cli/pi/stability.py
+++ b/src/yoyopod/cli/pi/stability.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from yoyopod_cli._pi_validate_helpers import NavigationSoakError, run_navigation_idle_soak
+from yoyopod_cli.pi_validate_helpers import NavigationSoakError, run_navigation_idle_soak
 
 __all__ = [
     "NavigationSoakError",

--- a/src/yoyopod/cli/pi/stability.py
+++ b/src/yoyopod/cli/pi/stability.py
@@ -1,0 +1,10 @@
+"""CLI stability helpers compatibility surface."""
+
+from __future__ import annotations
+
+from yoyopod_cli._pi_validate_helpers import NavigationSoakError, run_navigation_idle_soak
+
+__all__ = [
+    "NavigationSoakError",
+    "run_navigation_idle_soak",
+]

--- a/tests/test_pi_validate_helpers.py
+++ b/tests/test_pi_validate_helpers.py
@@ -4,6 +4,7 @@ import sys
 from types import ModuleType, SimpleNamespace
 
 from yoyopod_cli import _pi_validate_helpers as helpers
+from yoyopod_cli import pi_validate_helpers as public_helpers
 
 
 def test_wait_for_route_accepts_transition_completed_in_final_pump(
@@ -27,6 +28,58 @@ def test_wait_for_route_accepts_transition_completed_in_final_pump(
     monkeypatch.setattr(helpers, "_pump_app", fake_pump_app)
 
     helpers._wait_for_route(object(), "ask", timeout_seconds=1.0)
+
+
+def test_default_app_factory_wraps_imported_app_with_stable_soak_surface(
+    monkeypatch,
+) -> None:
+    class _FakeApp:
+        def __init__(self, *, config_dir: str, simulate: bool) -> None:
+            self.config_dir = config_dir
+            self.simulate = simulate
+            self.display = SimpleNamespace(backend_kind="lvgl")
+            self.screen_manager = None
+            self.input_manager = None
+            self.local_music_service = None
+            self.music_backend = None
+            self.runtime_loop = SimpleNamespace(configured_voip_iterate_interval_seconds=0.25)
+            self.recovery_service = None
+            self.power_runtime = None
+            self.screen_power_service = None
+            self.event_bus = None
+            self.context = None
+            self._screen_timeout_seconds = 12.5
+            self._shutdown_completed = True
+            self._last_user_activity_at = 0.0
+
+        def setup(self) -> bool:
+            return True
+
+        def stop(self) -> None:
+            return None
+
+    fake_app_module = ModuleType("yoyopod.app")
+    fake_app_module.YoyoPodApp = _FakeApp
+    monkeypatch.setitem(sys.modules, "yoyopod.app", fake_app_module)
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: 100.0)
+
+    handle = helpers._default_app_factory(config_dir="test-config", simulate=True)
+    wrapped_app = getattr(handle, "_app")
+
+    assert handle.config_dir == "test-config"
+    assert handle.simulate is True
+    assert handle.voip_iterate_interval_seconds == 0.25
+    assert handle.screen_timeout_seconds == 12.5
+    assert handle.shutdown_completed is True
+
+    handle.simulate_inactivity(idle_for_seconds=7.0)
+
+    assert wrapped_app._last_user_activity_at == 93.0
+
+
+def test_public_pi_validate_helpers_alias_reexports_internal_helpers() -> None:
+    assert public_helpers.run_navigation_soak is helpers.run_navigation_soak
+    assert public_helpers.run_navigation_idle_soak is helpers.run_navigation_idle_soak
 
 
 def test_navigation_idle_soak_resets_hub_selection_between_cycles(

--- a/tests/test_yoyopod_cli_pi_validate.py
+++ b/tests/test_yoyopod_cli_pi_validate.py
@@ -1,6 +1,12 @@
 """Tests for yoyopod_cli.pi_validate."""
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 from typer.testing import CliRunner
 
 from yoyopod_cli.pi_validate import app
@@ -11,6 +17,42 @@ def _collect_option_names(click_cmd: object) -> set[str]:
     for param in getattr(click_cmd, "params", []):
         names.update(getattr(param, "opts", []))
     return names
+
+
+def test_stability_commands_import_without_app_runtime() -> None:
+    """Importing the validate command set should not eagerly import the full app runtime."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    pythonpath_parts = [str(repo_root / "src"), str(repo_root)]
+    existing_pythonpath = env.get("PYTHONPATH")
+    if existing_pythonpath:
+        pythonpath_parts.append(existing_pythonpath)
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+
+    command = """
+import importlib
+import sys
+import json
+
+importlib.import_module("yoyopod_cli.pi_validate")
+
+loaded = "yoyopod.app" in sys.modules
+print(json.dumps(loaded))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", command],
+        capture_output=True,
+        check=True,
+        cwd=str(repo_root),
+        env=env,
+        text=True,
+    )
+    assert not json.loads(result.stdout), (
+        "yoyopod_cli.pi_validate imported the full app runtime: "
+        f"loaded={result.stdout.strip()}"
+    )
 
 
 def test_deploy_help() -> None:

--- a/yoyopod_cli/_pi_validate_helpers.py
+++ b/yoyopod_cli/_pi_validate_helpers.py
@@ -11,7 +11,7 @@ import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterator, cast
+from typing import Any, Callable, Iterator, Protocol, cast
 
 from loguru import logger
 
@@ -23,8 +23,49 @@ from yoyopod_cli.music_fixtures import (
 from yoyopod.events import UserActivityEvent
 from yoyopod.ui.input import InputAction, InteractionProfile
 
-if TYPE_CHECKING:
+
+class _NavigationSoakAppHandle(Protocol):
+    """Minimal runtime surface used by soak helpers."""
+
+    config_dir: str
+    simulate: bool
+    display: Any
+    screen_manager: Any
+    input_manager: Any
+    local_music_service: Any
+    music_backend: Any
+    runtime_loop: Any
+    recovery_service: Any
+    power_runtime: Any
+    screen_power_service: Any
+    event_bus: Any
+    context: Any
+    _voip_iterate_interval_seconds: float
+    _screen_timeout_seconds: float | None
+    _last_user_activity_at: float
+    _shutdown_completed: bool
+
+    def setup(self) -> bool:
+        """Initialize app resources."""
+
+    def stop(self) -> None:
+        """Shut down app resources."""
+
+
+class _NavigationSoakAppFactory(Protocol):
+    """Factory for constructing a narrow app handle for soak execution."""
+
+    def __call__(self, *, config_dir: str, simulate: bool) -> _NavigationSoakAppHandle:
+        """Create a new app handle for a soak run."""
+
+
+def _default_app_factory(*, config_dir: str, simulate: bool) -> _NavigationSoakAppHandle:
+    """Default app factory used when callers do not provide one."""
+
     from yoyopod.app import YoyoPodApp
+
+    return YoyoPodApp(config_dir=config_dir, simulate=simulate)
+
 
 # ---------------------------------------------------------------------------
 # Stability soak (ported from src/yoyopod/cli/pi/stability.py)
@@ -245,7 +286,7 @@ def _temporary_env(updates: dict[str, str]) -> Iterator[None]:
                 os.environ[name] = previous
 
 
-def _pump_app(app: "YoyoPodApp", duration_seconds: float) -> None:
+def _pump_app(app: _NavigationSoakAppHandle, duration_seconds: float) -> None:
     """Pump the coordinator-thread services without entering the full app loop."""
 
     deadline = time.monotonic() + max(0.0, duration_seconds)
@@ -260,7 +301,7 @@ def _pump_app(app: "YoyoPodApp", duration_seconds: float) -> None:
         time.sleep(0.05)
 
 
-def _current_route(app: "YoyoPodApp") -> str:
+def _current_route(app: _NavigationSoakAppHandle) -> str:
     """Return the current route name or a stable placeholder."""
 
     if app.screen_manager is None or app.screen_manager.current_screen is None:
@@ -271,7 +312,7 @@ def _current_route(app: "YoyoPodApp") -> str:
     return str(app.screen_manager.current_screen.name)
 
 
-def _dispatch_action(app: "YoyoPodApp", action: InputAction) -> None:
+def _dispatch_action(app: _NavigationSoakAppHandle, action: InputAction) -> None:
     """Drive one semantic action through the same screen handler path as live input."""
 
     if app.screen_manager is None or app.screen_manager.current_screen is None:
@@ -301,7 +342,7 @@ def _reset_selection(screen: object) -> None:
 
 
 def _wait_for_route(
-    app: "YoyoPodApp",
+    app: _NavigationSoakAppHandle,
     route_name: str,
     *,
     timeout_seconds: float,
@@ -321,7 +362,7 @@ def _wait_for_route(
 
 
 def _wait_for_track(
-    app: "YoyoPodApp",
+    app: _NavigationSoakAppHandle,
     *,
     timeout_seconds: float,
     expected_library: ProvisionedTestMusicLibrary | None,
@@ -351,7 +392,7 @@ def _wait_for_track(
     )
 
 
-def _exercise_sleep_wake(app: "YoyoPodApp") -> str:
+def _exercise_sleep_wake(app: _NavigationSoakAppHandle) -> str:
     """Force one idle sleep/wake cycle against the current app instance."""
 
     timeout_seconds = max(1.0, float(app._screen_timeout_seconds or 0.0))
@@ -398,10 +439,12 @@ def run_navigation_idle_soak(
     with_music: bool = False,
     provision_test_music: bool = True,
     test_music_dir: str = DEFAULT_TEST_MUSIC_TARGET_DIR,
+    app_factory: _NavigationSoakAppFactory | None = None,
 ) -> NavigationSoakReport:
     """Run the deterministic target-side navigation and idle stability soak."""
 
-    from yoyopod.app import YoyoPodApp
+    if app_factory is None:
+        app_factory = _default_app_factory
 
     music_dir, expected_library = _prepare_validation_music_dir(
         with_music=with_music,
@@ -413,7 +456,7 @@ def run_navigation_idle_soak(
         env_updates["YOYOPOD_MUSIC_DIR"] = str(music_dir)
 
     with _temporary_env(env_updates):
-        app = YoyoPodApp(config_dir=config_dir, simulate=simulate)
+        app = app_factory(config_dir=config_dir, simulate=simulate)
         if not app.setup():
             raise NavigationSoakError("app setup failed")
 
@@ -580,7 +623,7 @@ def _temporary_env_var(name: str, value: str | None) -> Iterator[None]:
 class _RuntimePump:
     """Drive the app loop without entering the long-running production loop."""
 
-    def __init__(self, app: "YoyoPodApp", stats: NavigationSoakStats) -> None:
+    def __init__(self, app: _NavigationSoakAppHandle, stats: NavigationSoakStats) -> None:
         self._app = app
         self._stats = stats
         self._last_screen_update = time.time()
@@ -637,6 +680,7 @@ class NavigationSoakRunner:
         provision_test_music: bool,
         test_music_dir: str,
         skip_sleep: bool,
+        app_factory: _NavigationSoakAppFactory | None = None,
     ) -> None:
         self.config_dir = config_dir
         self.cycles = max(1, cycles)
@@ -649,13 +693,12 @@ class NavigationSoakRunner:
         self.skip_sleep = skip_sleep
 
         self.stats = NavigationSoakStats()
-        self._app: "YoyoPodApp | None" = None
+        self._app: _NavigationSoakAppHandle | None = None
         self._pump: _RuntimePump | None = None
+        self._app_factory = _default_app_factory if app_factory is None else app_factory
 
     def run(self) -> tuple[bool, str]:
         """Run the full soak and return success plus one-line details."""
-
-        from yoyopod.app import YoyoPodApp
 
         music_dir_override = None
         if self.with_playback and self.provision_test_music:
@@ -667,7 +710,7 @@ class NavigationSoakRunner:
             )
 
         with _temporary_env_var("YOYOPOD_MUSIC_DIR", music_dir_override):
-            app = YoyoPodApp(config_dir=self.config_dir, simulate=False)
+            app = self._app_factory(config_dir=self.config_dir, simulate=False)
             self._app = app
             if not app.setup():
                 try:
@@ -708,7 +751,7 @@ class NavigationSoakRunner:
         return True, self._summary_details()
 
     @property
-    def app(self) -> "YoyoPodApp":
+    def app(self) -> _NavigationSoakAppHandle:
         """Return the active app or raise when the runner is uninitialized."""
 
         if self._app is None:
@@ -1110,6 +1153,7 @@ def run_navigation_soak(
     provision_test_music: bool = True,
     test_music_dir: str = DEFAULT_TEST_MUSIC_TARGET_DIR,
     skip_sleep: bool = False,
+    app_factory: _NavigationSoakAppFactory | None = None,
 ) -> tuple[bool, str]:
     """Run the target-hardware navigation and idle stability soak."""
 
@@ -1123,5 +1167,6 @@ def run_navigation_soak(
         provision_test_music=provision_test_music,
         test_music_dir=test_music_dir,
         skip_sleep=skip_sleep,
+        app_factory=app_factory,
     )
     return runner.run()

--- a/yoyopod_cli/_pi_validate_helpers.py
+++ b/yoyopod_cli/_pi_validate_helpers.py
@@ -27,29 +27,165 @@ from yoyopod.ui.input import InputAction, InteractionProfile
 class _NavigationSoakAppHandle(Protocol):
     """Minimal runtime surface used by soak helpers."""
 
-    config_dir: str
-    simulate: bool
-    display: Any
-    screen_manager: Any
-    input_manager: Any
-    local_music_service: Any
-    music_backend: Any
-    runtime_loop: Any
-    recovery_service: Any
-    power_runtime: Any
-    screen_power_service: Any
-    event_bus: Any
-    context: Any
-    _voip_iterate_interval_seconds: float
-    _screen_timeout_seconds: float
-    _last_user_activity_at: float
-    _shutdown_completed: bool
+    @property
+    def config_dir(self) -> str:
+        """Return the config directory used for the soak app."""
+
+    @property
+    def simulate(self) -> bool:
+        """Return whether the soak app is running in simulation mode."""
+
+    @property
+    def display(self) -> Any:
+        """Return the active display facade."""
+
+    @property
+    def screen_manager(self) -> Any:
+        """Return the active screen manager."""
+
+    @property
+    def input_manager(self) -> Any:
+        """Return the active input manager."""
+
+    @property
+    def local_music_service(self) -> Any:
+        """Return the local music service used by the soak."""
+
+    @property
+    def music_backend(self) -> Any:
+        """Return the music backend used by the soak."""
+
+    @property
+    def runtime_loop(self) -> Any:
+        """Return the runtime loop service."""
+
+    @property
+    def recovery_service(self) -> Any:
+        """Return the recovery service."""
+
+    @property
+    def power_runtime(self) -> Any:
+        """Return the power runtime facade."""
+
+    @property
+    def screen_power_service(self) -> Any:
+        """Return the screen power service."""
+
+    @property
+    def event_bus(self) -> Any:
+        """Return the typed event bus."""
+
+    @property
+    def context(self) -> Any:
+        """Return the shared runtime context."""
 
     def setup(self) -> bool:
         """Initialize app resources."""
 
     def stop(self) -> None:
         """Shut down app resources."""
+
+    @property
+    def voip_iterate_interval_seconds(self) -> float:
+        """Return the configured runtime-loop VoIP iterate cadence."""
+
+    @property
+    def screen_timeout_seconds(self) -> float:
+        """Return the configured inactivity timeout used for screen sleep."""
+
+    @property
+    def shutdown_completed(self) -> bool:
+        """Return whether the app completed shutdown during the soak."""
+
+    def simulate_inactivity(self, *, idle_for_seconds: float) -> None:
+        """Pretend the app has been idle long enough to trigger sleep."""
+
+
+@dataclass(slots=True)
+class _YoyoPodAppNavigationSoakHandle:
+    """Adapter that exposes a stable soak surface for ``YoyoPodApp``."""
+
+    _app: Any
+
+    @property
+    def config_dir(self) -> str:
+        return str(self._app.config_dir)
+
+    @property
+    def simulate(self) -> bool:
+        return bool(self._app.simulate)
+
+    @property
+    def display(self) -> Any:
+        return self._app.display
+
+    @property
+    def screen_manager(self) -> Any:
+        return self._app.screen_manager
+
+    @property
+    def input_manager(self) -> Any:
+        return self._app.input_manager
+
+    @property
+    def local_music_service(self) -> Any:
+        return self._app.local_music_service
+
+    @property
+    def music_backend(self) -> Any:
+        return self._app.music_backend
+
+    @property
+    def runtime_loop(self) -> Any:
+        return self._app.runtime_loop
+
+    @property
+    def recovery_service(self) -> Any:
+        return self._app.recovery_service
+
+    @property
+    def power_runtime(self) -> Any:
+        return self._app.power_runtime
+
+    @property
+    def screen_power_service(self) -> Any:
+        return self._app.screen_power_service
+
+    @property
+    def event_bus(self) -> Any:
+        return self._app.event_bus
+
+    @property
+    def context(self) -> Any:
+        return self._app.context
+
+    def setup(self) -> bool:
+        return bool(self._app.setup())
+
+    def stop(self) -> None:
+        self._app.stop()
+
+    @property
+    def voip_iterate_interval_seconds(self) -> float:
+        runtime_loop = self.runtime_loop
+        if runtime_loop is None:
+            raise NavigationSoakError("runtime loop is unavailable for navigation soak")
+        return float(runtime_loop.configured_voip_iterate_interval_seconds)
+
+    @property
+    def screen_timeout_seconds(self) -> float:
+        return float(getattr(self._app, "_screen_timeout_seconds", 0.0))
+
+    @property
+    def shutdown_completed(self) -> bool:
+        return bool(getattr(self._app, "_shutdown_completed", False))
+
+    def simulate_inactivity(self, *, idle_for_seconds: float) -> None:
+        setattr(
+            self._app,
+            "_last_user_activity_at",
+            time.monotonic() - max(0.0, idle_for_seconds),
+        )
 
 
 class _NavigationSoakAppFactory(Protocol):
@@ -64,7 +200,7 @@ def _default_app_factory(*, config_dir: str, simulate: bool) -> _NavigationSoakA
 
     from yoyopod.app import YoyoPodApp
 
-    return YoyoPodApp(config_dir=config_dir, simulate=simulate)
+    return _YoyoPodAppNavigationSoakHandle(YoyoPodApp(config_dir=config_dir, simulate=simulate))
 
 
 # ---------------------------------------------------------------------------
@@ -395,8 +531,8 @@ def _wait_for_track(
 def _exercise_sleep_wake(app: _NavigationSoakAppHandle) -> str:
     """Force one idle sleep/wake cycle against the current app instance."""
 
-    timeout_seconds = max(1.0, float(app._screen_timeout_seconds or 0.0))
-    app._last_user_activity_at = time.monotonic() - timeout_seconds - 1.0
+    timeout_seconds = max(1.0, app.screen_timeout_seconds)
+    app.simulate_inactivity(idle_for_seconds=timeout_seconds + 1.0)
     _pump_app(app, 0.35)
     if app.context is None or app.context.screen.awake:
         raise NavigationSoakError("screen did not enter sleep during soak")
@@ -444,6 +580,7 @@ def run_navigation_idle_soak(
     """Run the deterministic target-side navigation and idle stability soak."""
 
     if app_factory is None:
+        # Test seam so helper unit tests do not need to import the full runtime.
         app_factory = _default_app_factory
 
     music_dir, expected_library = _prepare_validation_music_dir(
@@ -634,7 +771,7 @@ class _RuntimePump:
 
         deadline = time.monotonic() + max(0.0, duration_seconds)
         while time.monotonic() < deadline:
-            time.sleep(min(0.05, max(0.01, self._app._voip_iterate_interval_seconds)))
+            time.sleep(min(0.05, max(0.01, self._app.voip_iterate_interval_seconds)))
             monotonic_now = time.monotonic()
             current_time = time.time()
             iteration_started_at = time.monotonic()
@@ -657,7 +794,7 @@ class _RuntimePump:
             snapshot = self._app.runtime_loop.timing_snapshot(now=monotonic_now)
             self._stats.observe_snapshot(snapshot)
 
-            if self._app._shutdown_completed:
+            if self._app.shutdown_completed:
                 raise NavigationSoakFailure(
                     "app completed shutdown unexpectedly during navigation soak"
                 )
@@ -695,6 +832,7 @@ class NavigationSoakRunner:
         self.stats = NavigationSoakStats()
         self._app: _NavigationSoakAppHandle | None = None
         self._pump: _RuntimePump | None = None
+        # Test seam so unit tests can drive the runner without importing YoyoPodApp.
         self._app_factory = _default_app_factory if app_factory is None else app_factory
 
     def run(self) -> tuple[bool, str]:
@@ -1124,12 +1262,12 @@ class NavigationSoakRunner:
             self.stats.sleep_wake_status = "skipped"
             return
 
-        timeout_seconds = float(self.app._screen_timeout_seconds or 0.0)
+        timeout_seconds = self.app.screen_timeout_seconds
         if timeout_seconds <= 0.0:
             self.stats.sleep_wake_status = "timeout_disabled"
             return
 
-        self.app._last_user_activity_at = time.monotonic() - timeout_seconds - 1.0
+        self.app.simulate_inactivity(idle_for_seconds=timeout_seconds + 1.0)
         self.pump.run_for(max(0.35, self.hold_seconds))
         if self.app.context is None or self.app.context.screen.awake:
             raise NavigationSoakFailure("screen did not enter sleep during navigation soak")

--- a/yoyopod_cli/_pi_validate_helpers.py
+++ b/yoyopod_cli/_pi_validate_helpers.py
@@ -41,7 +41,7 @@ class _NavigationSoakAppHandle(Protocol):
     event_bus: Any
     context: Any
     _voip_iterate_interval_seconds: float
-    _screen_timeout_seconds: float | None
+    _screen_timeout_seconds: float
     _last_user_activity_at: float
     _shutdown_completed: bool
 

--- a/yoyopod_cli/pi_validate.py
+++ b/yoyopod_cli/pi_validate.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Callable, Protocol, cast
 
 import typer
 
-from yoyopod_cli._pi_validate_helpers import (
+from yoyopod_cli.pi_validate_helpers import (
     NavigationSoakError,
     run_navigation_idle_soak,
     run_navigation_soak,

--- a/yoyopod_cli/pi_validate.py
+++ b/yoyopod_cli/pi_validate.py
@@ -1817,6 +1817,8 @@ def stability(
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
 ) -> None:
     """Run a repeated navigation and idle stability pass on the target checkout."""
+    from yoyopod.app import YoyoPodApp
+
     configure_logging(verbose)
     resolved_music_dir = test_music_dir or DEFAULT_TEST_MUSIC_TARGET_DIR
     try:
@@ -1830,6 +1832,9 @@ def stability(
             with_music=with_music,
             provision_test_music=provision_test_music,
             test_music_dir=resolved_music_dir,
+            app_factory=lambda *, config_dir, simulate: YoyoPodApp(
+                config_dir=config_dir, simulate=simulate
+            ),
         )
     except NavigationSoakError as exc:
         from loguru import logger
@@ -1899,6 +1904,7 @@ def navigation(
 ) -> None:
     """Run the one-button target navigation and idle stability soak on LVGL hardware."""
     from loguru import logger
+    from yoyopod.app import YoyoPodApp
 
     configure_logging(verbose)
     resolved_music_dir = test_music_dir or DEFAULT_TEST_MUSIC_TARGET_DIR
@@ -1913,6 +1919,9 @@ def navigation(
         provision_test_music=provision_test_music,
         test_music_dir=resolved_music_dir,
         skip_sleep=skip_sleep,
+        app_factory=lambda *, config_dir, simulate: YoyoPodApp(
+            config_dir=config_dir, simulate=simulate
+        ),
     )
     if ok:
         logger.info("Navigation soak passed: {}", details)
@@ -1969,6 +1978,7 @@ def lvgl(
 ) -> None:
     """Run a deterministic LVGL navigation and idle soak pass against YoyoPod."""
     from loguru import logger
+    from yoyopod.app import YoyoPodApp
 
     configure_logging(verbose)
     resolved_music_dir = test_music_dir or DEFAULT_TEST_MUSIC_TARGET_DIR
@@ -1983,6 +1993,9 @@ def lvgl(
             with_music=with_music,
             provision_test_music=provision_test_music,
             test_music_dir=resolved_music_dir,
+            app_factory=lambda *, config_dir, simulate: YoyoPodApp(
+                config_dir=config_dir, simulate=simulate
+            ),
         )
     except NavigationSoakError as exc:
         logger.error(f"LVGL soak failed: {exc}")

--- a/yoyopod_cli/pi_validate.py
+++ b/yoyopod_cli/pi_validate.py
@@ -1817,8 +1817,6 @@ def stability(
     verbose: Annotated[bool, typer.Option("--verbose", help="Enable DEBUG logging.")] = False,
 ) -> None:
     """Run a repeated navigation and idle stability pass on the target checkout."""
-    from yoyopod.app import YoyoPodApp
-
     configure_logging(verbose)
     resolved_music_dir = test_music_dir or DEFAULT_TEST_MUSIC_TARGET_DIR
     try:
@@ -1832,9 +1830,6 @@ def stability(
             with_music=with_music,
             provision_test_music=provision_test_music,
             test_music_dir=resolved_music_dir,
-            app_factory=lambda *, config_dir, simulate: YoyoPodApp(
-                config_dir=config_dir, simulate=simulate
-            ),
         )
     except NavigationSoakError as exc:
         from loguru import logger
@@ -1904,7 +1899,6 @@ def navigation(
 ) -> None:
     """Run the one-button target navigation and idle stability soak on LVGL hardware."""
     from loguru import logger
-    from yoyopod.app import YoyoPodApp
 
     configure_logging(verbose)
     resolved_music_dir = test_music_dir or DEFAULT_TEST_MUSIC_TARGET_DIR
@@ -1919,9 +1913,6 @@ def navigation(
         provision_test_music=provision_test_music,
         test_music_dir=resolved_music_dir,
         skip_sleep=skip_sleep,
-        app_factory=lambda *, config_dir, simulate: YoyoPodApp(
-            config_dir=config_dir, simulate=simulate
-        ),
     )
     if ok:
         logger.info("Navigation soak passed: {}", details)
@@ -1978,7 +1969,6 @@ def lvgl(
 ) -> None:
     """Run a deterministic LVGL navigation and idle soak pass against YoyoPod."""
     from loguru import logger
-    from yoyopod.app import YoyoPodApp
 
     configure_logging(verbose)
     resolved_music_dir = test_music_dir or DEFAULT_TEST_MUSIC_TARGET_DIR
@@ -1993,9 +1983,6 @@ def lvgl(
             with_music=with_music,
             provision_test_music=provision_test_music,
             test_music_dir=resolved_music_dir,
-            app_factory=lambda *, config_dir, simulate: YoyoPodApp(
-                config_dir=config_dir, simulate=simulate
-            ),
         )
     except NavigationSoakError as exc:
         logger.error(f"LVGL soak failed: {exc}")

--- a/yoyopod_cli/pi_validate_helpers.py
+++ b/yoyopod_cli/pi_validate_helpers.py
@@ -1,0 +1,21 @@
+"""Public helper surface for Pi validation soak utilities."""
+
+from __future__ import annotations
+
+from yoyopod_cli._pi_validate_helpers import (
+    NavigationSoakError,
+    NavigationSoakFailure,
+    NavigationSoakRunner,
+    NavigationSoakStats,
+    run_navigation_idle_soak,
+    run_navigation_soak,
+)
+
+__all__ = [
+    "NavigationSoakError",
+    "NavigationSoakFailure",
+    "NavigationSoakRunner",
+    "NavigationSoakStats",
+    "run_navigation_idle_soak",
+    "run_navigation_soak",
+]


### PR DESCRIPTION
## Summary
- move the pi validate navigation/stability soak implementation into `yoyopod_cli` so the CLI can load without importing `yoyopod.app`
- keep `src/yoyopod/cli/pi/{navigation,stability}.py` as thin compatibility re-export surfaces
- add a narrow soak app handle protocol plus tests that assert `yoyopod_cli.pi_validate` does not eagerly load the full runtime

## Why
`yoyoctl` was importing `YoyoPodApp` through the soak helpers during CLI startup, which dragged in the full runtime stack (LVGL, mpv, liblinphone, coordinators, and related services) just to register CLI commands. This change keeps app construction lazy inside the actual soak execution path and preserves compatibility for existing helper imports.

## Validation
- `uv run python scripts/quality.py ci`

Fixes #223