### PR TITLE
chore(github): add review issue-form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/README.md
+++ b/.github/ISSUE_TEMPLATE/README.md
@@ -1,0 +1,79 @@
+# Review issue templates
+
+Four YAML issue forms for the YoYoPod codebase review workflow:
+
+| Template | Lens |
+|---|---|
+| `review-architecture.yml` | Boundaries, coupling, state ownership, threading, layering, dependency direction. |
+| `review-code-quality.yml` | Error handling, logging, dead code, naming, idioms, perf hot-paths, security. |
+| `review-testing.yml` | Coverage gaps, brittle tests, mocks-vs-reality, CI gate gaps, missing integration. |
+| `review-docs.yml` | Stale, missing, inaccurate, or contradictory documentation. |
+
+## Obsolescence-prevention contract
+
+Every template enforces:
+
+1. **Source commit SHA is required.** Every finding pins to the exact snapshot it was reviewed against.
+2. **No SLOC fields.** Findings are observational, not line-count heuristics.
+3. **"Suggested direction" not "Proposed fix".** Framing survives reorganization even when specific mechanisms rot.
+4. **File paths primary, line numbers optional.** Paths are stabler across refactors.
+
+## Reviewer workflow (for agents using `gh` CLI)
+
+YAML issue forms enforce field validation only for web submissions. Agents filing via
+`gh issue create --body` must mirror the field schema in their rendered body and apply
+severity/effort/review-round labels manually:
+
+```bash
+gh issue create \
+  --title "[Arch] <short finding title>" \
+  --body "$(cat <<'EOF'
+### Finding ID
+A01
+
+### Source commit SHA
+<full SHA>
+
+### Concern type
+boundary
+
+### Invariant violated
+rules/architecture.md §"Dependency Direction"
+
+### Severity
+high
+
+### Effort
+medium
+
+### Files affected
+yoyopod/core/loop.py
+yoyopod/core/application.py
+
+### Finding
+<what's wrong, observed at the pinned SHA>
+
+### Impact
+<what breaks / what rule or doc it violates>
+
+### Suggested direction
+<observational guidance, not prescriptive file splits>
+
+### References
+rules/architecture.md
+docs/SYSTEM_ARCHITECTURE.md
+EOF
+)" \
+  --label "architecture" \
+  --label "review" \
+  --label "review:2026-04-23" \
+  --label "severity:high" \
+  --label "effort:medium"
+```
+
+Template files under this directory are the schema contract. Field order and labels
+in the body must match the corresponding `.yml` file's `body:` entries.
+
+## See also
+
+- Spec: [docs/superpowers/specs/2026-04-23-review-issue-templates-design.md](../../docs/superpowers/specs/2026-04-23-review-issue-templates-design.md)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/review-architecture.yml
+++ b/.github/ISSUE_TEMPLATE/review-architecture.yml
@@ -1,0 +1,118 @@
+name: Review finding — Architecture
+description: File a clean-architecture finding from a codebase review (boundaries, coupling, state ownership, threading, layering).
+title: "[Arch] "
+labels: ["architecture", "review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for architecture findings produced during a codebase review.
+        See `.github/ISSUE_TEMPLATE/README.md` for the reviewer contract.
+
+  - type: input
+    id: finding-id
+    attributes:
+      label: Finding ID
+      description: Short reviewer-assigned ID, e.g. `A01`. Optional but helpful for cross-referencing a review summary issue.
+      placeholder: A01
+    validations:
+      required: false
+
+  - type: input
+    id: source-commit-sha
+    attributes:
+      label: Source commit SHA
+      description: The exact commit SHA the finding was observed against. Pins the finding so it remains triage-able after future refactors.
+      placeholder: 8f624ed2...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: concern-type
+    attributes:
+      label: Concern type
+      description: Which architectural concern does this finding hit?
+      options:
+        - boundary
+        - coupling
+        - state-ownership
+        - threading
+        - layering
+        - dependency-direction
+    validations:
+      required: true
+
+  - type: input
+    id: invariant-violated
+    attributes:
+      label: Invariant violated
+      description: Which rule, doc, or architectural invariant does this finding violate? Reference the rule or doc section if possible.
+      placeholder: rules/architecture.md §"Dependency Direction"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - small
+        - medium
+        - large
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-affected
+    attributes:
+      label: Files affected
+      description: Code paths, one per line. Line numbers are optional — paths are primary because they survive refactors better than line numbers.
+      placeholder: |
+        yoyopod/core/loop.py
+        yoyopod/core/application.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: finding
+    attributes:
+      label: Finding
+      description: What's wrong, observed at the pinned SHA. Describe the current behaviour concretely.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What breaks, what's risked, or which rule/doc it violates. Explain why this finding matters.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-direction
+    attributes:
+      label: Suggested direction
+      description: Observational, not prescriptive. State a principle or invariant to restore — avoid prescribing exact file splits or method signatures, since they rot when the codebase reorganizes.
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to `rules/*.md`, `docs/*.md`, prior issues, or external best-practice references.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/review-code-quality.yml
+++ b/.github/ISSUE_TEMPLATE/review-code-quality.yml
@@ -1,0 +1,111 @@
+name: Review finding — Code quality
+description: File a code-quality finding from a codebase review (error handling, logging, dead code, naming, idioms, perf hot-paths, security).
+title: "[CQ] "
+labels: ["code-quality", "review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for code-quality findings produced during a codebase review.
+        Perf and security findings ride on this form via the `Concern type` dropdown
+        until finding volume justifies their own templates.
+        See `.github/ISSUE_TEMPLATE/README.md` for the reviewer contract.
+
+  - type: input
+    id: finding-id
+    attributes:
+      label: Finding ID
+      description: Short reviewer-assigned ID, e.g. `CQ01`. Optional but helpful for cross-referencing a review summary issue.
+      placeholder: CQ01
+    validations:
+      required: false
+
+  - type: input
+    id: source-commit-sha
+    attributes:
+      label: Source commit SHA
+      description: The exact commit SHA the finding was observed against. Pins the finding so it remains triage-able after future refactors.
+      placeholder: 8f624ed2...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: concern-type
+    attributes:
+      label: Concern type
+      description: Which code-quality concern does this finding hit?
+      options:
+        - error-handling
+        - logging
+        - dead-code
+        - naming
+        - idioms
+        - perf-hotpath
+        - security
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - small
+        - medium
+        - large
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-affected
+    attributes:
+      label: Files affected
+      description: Code paths, one per line. Line numbers are optional — paths are primary because they survive refactors better than line numbers.
+      placeholder: |
+        yoyopod/core/bus.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: finding
+    attributes:
+      label: Finding
+      description: What's wrong, observed at the pinned SHA. Describe the current behaviour concretely.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What breaks, what's risked, or which rule/doc it violates. Explain why this finding matters.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-direction
+    attributes:
+      label: Suggested direction
+      description: Observational, not prescriptive. State a principle or property to restore.
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to `rules/*.md`, `docs/*.md`, prior issues, or external best-practice references.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/review-docs.yml
+++ b/.github/ISSUE_TEMPLATE/review-docs.yml
@@ -1,0 +1,124 @@
+name: Review finding — Docs
+description: File a documentation finding from a codebase review (stale, missing, inaccurate, or contradictory docs).
+title: "[Docs] "
+labels: ["docs", "review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for documentation findings produced during a codebase review.
+        See `.github/ISSUE_TEMPLATE/README.md` for the reviewer contract.
+
+  - type: input
+    id: finding-id
+    attributes:
+      label: Finding ID
+      description: Short reviewer-assigned ID, e.g. `D01`. Optional but helpful for cross-referencing a review summary issue.
+      placeholder: D01
+    validations:
+      required: false
+
+  - type: input
+    id: source-commit-sha
+    attributes:
+      label: Source commit SHA
+      description: The exact commit SHA the finding was observed against.
+      placeholder: 8f624ed2...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: doc-problem
+    attributes:
+      label: Doc problem
+      description: What's wrong with the documentation?
+      options:
+        - stale
+        - missing
+        - inaccurate
+        - contradictory
+    validations:
+      required: true
+
+  - type: input
+    id: doc-location
+    attributes:
+      label: Doc location
+      description: Path to the affected doc, or "N/A — doc missing" if the doc should exist but does not.
+      placeholder: docs/SYSTEM_ARCHITECTURE.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-it-should-say
+    attributes:
+      label: What it should say
+      description: The corrected or intended content. Optional — reviewers may flag a problem without yet knowing the resolution.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - small
+        - medium
+        - large
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-affected
+    attributes:
+      label: Files affected
+      description: Doc paths (plus any related code paths), one per line.
+      placeholder: |
+        docs/SYSTEM_ARCHITECTURE.md
+        yoyopod/core/application.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: finding
+    attributes:
+      label: Finding
+      description: What the doc currently says (or fails to say), observed at the pinned SHA.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who's misled and how. What decisions are people making based on the stale/inaccurate content.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-direction
+    attributes:
+      label: Suggested direction
+      description: Observational, not prescriptive. What the correct narrative should convey rather than verbatim replacement text (that goes in "What it should say").
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to related docs, rules, or prior issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/review-testing.yml
+++ b/.github/ISSUE_TEMPLATE/review-testing.yml
@@ -1,0 +1,116 @@
+name: Review finding — Testing
+description: File a testing finding from a codebase review (missing coverage, brittle tests, mock-vs-reality drift, CI gate gaps, integration gaps).
+title: "[Test] "
+labels: ["testing", "review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for testing findings produced during a codebase review.
+        See `.github/ISSUE_TEMPLATE/README.md` for the reviewer contract.
+
+  - type: input
+    id: finding-id
+    attributes:
+      label: Finding ID
+      description: Short reviewer-assigned ID, e.g. `T01`. Optional but helpful for cross-referencing a review summary issue.
+      placeholder: T01
+    validations:
+      required: false
+
+  - type: input
+    id: source-commit-sha
+    attributes:
+      label: Source commit SHA
+      description: The exact commit SHA the finding was observed against.
+      placeholder: 8f624ed2...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: gap-type
+    attributes:
+      label: Gap type
+      description: What kind of testing gap is this?
+      options:
+        - missing-coverage
+        - brittle-test
+        - mock-vs-reality
+        - CI-gate-gap
+        - integration-gap
+    validations:
+      required: true
+
+  - type: textarea
+    id: test-gap-or-assertion
+    attributes:
+      label: Test gap or failing assertion
+      description: The concrete test shape that's missing or broken. A minimal failing assertion, a behaviour currently uncovered, or the specific CI step that isn't gating what it should.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - small
+        - medium
+        - large
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-affected
+    attributes:
+      label: Files affected
+      description: Production code paths and/or test paths, one per line.
+      placeholder: |
+        yoyopod/core/bus.py
+        tests/core/test_bus.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: finding
+    attributes:
+      label: Finding
+      description: What's wrong or missing, observed at the pinned SHA.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What regressions could slip through, or what's currently asserted that doesn't reflect production behaviour.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-direction
+    attributes:
+      label: Suggested direction
+      description: Observational, not prescriptive. The shape of the test to add, or the mock to replace with an integration path.
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to `rules/*.md`, `docs/*.md`, prior issues, or external references.
+    validations:
+      required: false

--- a/docs/superpowers/plans/2026-04-23-review-issue-templates.md
+++ b/docs/superpowers/plans/2026-04-23-review-issue-templates.md
@@ -1,0 +1,1209 @@
+# Review Issue Templates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship four GitHub YAML issue-form templates (architecture, code-quality, testing, docs) plus supporting config and labels so the upcoming second codebase review lands findings in a standardized, obsolescence-resistant shape.
+
+**Architecture:** Four declarative YAML files under `.github/ISSUE_TEMPLATE/` plus a `config.yml`. Each template auto-applies a static label set; severity/effort/concern-type are captured as in-body form fields, and the reviewing agent applies matching GitHub labels post-creation via `gh issue edit --add-label`. A short README under `.github/ISSUE_TEMPLATE/` documents the contract so the reviewing agent (and future humans) know the expected body shape.
+
+**Tech Stack:** GitHub issue forms (YAML v1), `gh` CLI, Python (only for YAML-parse verification). No application code changes.
+
+**Spec:** [docs/superpowers/specs/2026-04-23-review-issue-templates-design.md](../specs/2026-04-23-review-issue-templates-design.md)
+
+---
+
+## File structure
+
+Files created by this plan:
+
+| Path | Responsibility |
+|---|---|
+| `.github/ISSUE_TEMPLATE/config.yml` | Leaves blank-issue filing enabled; no contact links. |
+| `.github/ISSUE_TEMPLATE/review-architecture.yml` | Arch findings form (boundary/coupling/state/threading/etc.). |
+| `.github/ISSUE_TEMPLATE/review-code-quality.yml` | Code-quality findings form (error-handling/naming/idioms/etc.). |
+| `.github/ISSUE_TEMPLATE/review-testing.yml` | Test-gap findings form (coverage/brittle/mock-vs-reality/etc.). |
+| `.github/ISSUE_TEMPLATE/review-docs.yml` | Docs findings form (stale/missing/inaccurate/contradictory). |
+| `.github/ISSUE_TEMPLATE/README.md` | Reviewer contract: field order, label-application workflow, SHA-pinning rule. |
+
+Files modified: none.
+
+Labels created on the remote repo via `gh`:
+
+- `code-quality`
+- `testing`
+- `docs`
+- `review`
+- `review:2026-04-23`
+
+---
+
+## Pre-flight
+
+- [ ] **Step 1: Confirm worktree and branch**
+
+Run:
+
+```bash
+git status
+git branch --show-current
+```
+
+Expected: clean working tree on branch `claude/romantic-khorana-d1618a` (or similar review-prep branch). The spec file from the prior session is already committed.
+
+- [ ] **Step 2: Confirm `.github/ISSUE_TEMPLATE/` does not exist yet**
+
+Run:
+
+```bash
+ls .github/ISSUE_TEMPLATE 2>/dev/null || echo "directory absent — ok to create"
+```
+
+Expected: "directory absent — ok to create".
+
+- [ ] **Step 3: Create the directory**
+
+```bash
+mkdir -p .github/ISSUE_TEMPLATE
+```
+
+Expected: directory exists, no output.
+
+---
+
+## Task 1: `config.yml` + reviewer README
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/config.yml`
+- Create: `.github/ISSUE_TEMPLATE/README.md`
+
+- [ ] **Step 1: Write the YAML-parse verification one-liner**
+
+This is our "test": the YAML must parse, and `blank_issues_enabled` must be `true`.
+
+```bash
+python -c "import yaml, sys; d = yaml.safe_load(open('.github/ISSUE_TEMPLATE/config.yml')); assert d['blank_issues_enabled'] is True, d; print('ok')"
+```
+
+- [ ] **Step 2: Run it to verify it fails (file doesn't exist yet)**
+
+Expected: `FileNotFoundError` or similar, non-zero exit.
+
+- [ ] **Step 3: Write `config.yml`**
+
+```yaml
+blank_issues_enabled: true
+```
+
+- [ ] **Step 4: Run the verification — expect pass**
+
+```bash
+python -c "import yaml, sys; d = yaml.safe_load(open('.github/ISSUE_TEMPLATE/config.yml')); assert d['blank_issues_enabled'] is True, d; print('ok')"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 5: Write the reviewer README**
+
+Create `.github/ISSUE_TEMPLATE/README.md` with the following exact content:
+
+```markdown
+# Review issue templates
+
+Four YAML issue forms for the YoYoPod codebase review workflow:
+
+| Template | Lens |
+|---|---|
+| `review-architecture.yml` | Boundaries, coupling, state ownership, threading, layering, dependency direction. |
+| `review-code-quality.yml` | Error handling, logging, dead code, naming, idioms, perf hot-paths, security. |
+| `review-testing.yml` | Coverage gaps, brittle tests, mocks-vs-reality, CI gate gaps, missing integration. |
+| `review-docs.yml` | Stale, missing, inaccurate, or contradictory documentation. |
+
+## Obsolescence-prevention contract
+
+Every template enforces:
+
+1. **Source commit SHA is required.** Every finding pins to the exact snapshot it was reviewed against.
+2. **No SLOC fields.** Findings are observational, not line-count heuristics.
+3. **"Suggested direction" not "Proposed fix".** Framing survives reorganization even when specific mechanisms rot.
+4. **File paths primary, line numbers optional.** Paths are stabler across refactors.
+
+## Reviewer workflow (for agents using `gh` CLI)
+
+YAML issue forms enforce field validation only for web submissions. Agents filing via
+`gh issue create --body` must mirror the field schema in their rendered body and apply
+severity/effort/review-round labels manually:
+
+```bash
+gh issue create \
+  --title "[Arch] <short finding title>" \
+  --body "$(cat <<'EOF'
+### Finding ID
+A01
+
+### Source commit SHA
+<full SHA>
+
+### Concern type
+boundary
+
+### Invariant violated
+rules/architecture.md §"Dependency Direction"
+
+### Severity
+high
+
+### Effort
+medium
+
+### Files affected
+yoyopod/core/loop.py
+yoyopod/core/application.py
+
+### Finding
+<what's wrong, observed at the pinned SHA>
+
+### Impact
+<what breaks / what rule or doc it violates>
+
+### Suggested direction
+<observational guidance, not prescriptive file splits>
+
+### References
+rules/architecture.md
+docs/SYSTEM_ARCHITECTURE.md
+EOF
+)" \
+  --label "architecture" \
+  --label "review" \
+  --label "review:2026-04-23" \
+  --label "severity:high" \
+  --label "effort:medium"
+```
+
+Template files under this directory are the schema contract. Field order and labels
+in the body must match the corresponding `.yml` file's `body:` entries.
+
+## See also
+
+- Spec: [docs/superpowers/specs/2026-04-23-review-issue-templates-design.md](../../docs/superpowers/specs/2026-04-23-review-issue-templates-design.md)
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/README.md
+git commit -m "$(cat <<'EOF'
+chore(github): add issue-template config and reviewer README
+
+Scaffolds .github/ISSUE_TEMPLATE/ with a config.yml that leaves blank
+issues enabled and a README describing the reviewer contract (SHA
+pinning, no SLOC, observational "suggested direction" framing, and the
+gh CLI labeling workflow for agent-filed findings).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `review-architecture.yml`
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/review-architecture.yml`
+
+- [ ] **Step 1: Write the YAML-parse + schema verification**
+
+```bash
+python - <<'PY'
+import yaml
+doc = yaml.safe_load(open('.github/ISSUE_TEMPLATE/review-architecture.yml'))
+assert doc['name'] == 'Review finding — Architecture'
+assert doc['title'] == '[Arch] '
+assert set(doc['labels']) == {'architecture', 'review'}
+ids = [b.get('id') for b in doc['body'] if b['type'] != 'markdown']
+expected = [
+    'finding-id', 'source-commit-sha', 'concern-type', 'invariant-violated',
+    'severity', 'effort', 'files-affected', 'finding', 'impact',
+    'suggested-direction', 'references',
+]
+assert ids == expected, (ids, expected)
+print('ok')
+PY
+```
+
+- [ ] **Step 2: Run to verify it fails (file absent)**
+
+Expected: `FileNotFoundError`.
+
+- [ ] **Step 3: Write `review-architecture.yml`**
+
+```yaml
+name: Review finding — Architecture
+description: File a clean-architecture finding from a codebase review (boundaries, coupling, state ownership, threading, layering).
+title: "[Arch] "
+labels: ["architecture", "review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for architecture findings produced during a codebase review.
+        See `.github/ISSUE_TEMPLATE/README.md` for the reviewer contract.
+
+  - type: input
+    id: finding-id
+    attributes:
+      label: Finding ID
+      description: Short reviewer-assigned ID, e.g. `A01`. Optional but helpful for cross-referencing a review summary issue.
+      placeholder: A01
+    validations:
+      required: false
+
+  - type: input
+    id: source-commit-sha
+    attributes:
+      label: Source commit SHA
+      description: The exact commit SHA the finding was observed against. Pins the finding so it remains triage-able after future refactors.
+      placeholder: 8f624ed2...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: concern-type
+    attributes:
+      label: Concern type
+      description: Which architectural concern does this finding hit?
+      options:
+        - boundary
+        - coupling
+        - state-ownership
+        - threading
+        - layering
+        - dependency-direction
+    validations:
+      required: true
+
+  - type: input
+    id: invariant-violated
+    attributes:
+      label: Invariant violated
+      description: Which rule, doc, or architectural invariant does this finding violate? Reference the rule or doc section if possible.
+      placeholder: rules/architecture.md §"Dependency Direction"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - small
+        - medium
+        - large
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-affected
+    attributes:
+      label: Files affected
+      description: Code paths, one per line. Line numbers are optional — paths are primary because they survive refactors better than line numbers.
+      placeholder: |
+        yoyopod/core/loop.py
+        yoyopod/core/application.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: finding
+    attributes:
+      label: Finding
+      description: What's wrong, observed at the pinned SHA. Describe the current behaviour concretely.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What breaks, what's risked, or which rule/doc it violates. Explain why this finding matters.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-direction
+    attributes:
+      label: Suggested direction
+      description: Observational, not prescriptive. State a principle or invariant to restore — avoid prescribing exact file splits or method signatures, since they rot when the codebase reorganizes.
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to `rules/*.md`, `docs/*.md`, prior issues, or external best-practice references.
+    validations:
+      required: false
+```
+
+- [ ] **Step 4: Run verification — expect pass**
+
+```bash
+python - <<'PY'
+import yaml
+doc = yaml.safe_load(open('.github/ISSUE_TEMPLATE/review-architecture.yml'))
+assert doc['name'] == 'Review finding — Architecture'
+assert doc['title'] == '[Arch] '
+assert set(doc['labels']) == {'architecture', 'review'}
+ids = [b.get('id') for b in doc['body'] if b['type'] != 'markdown']
+expected = [
+    'finding-id', 'source-commit-sha', 'concern-type', 'invariant-violated',
+    'severity', 'effort', 'files-affected', 'finding', 'impact',
+    'suggested-direction', 'references',
+]
+assert ids == expected, (ids, expected)
+print('ok')
+PY
+```
+
+Expected: `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/review-architecture.yml
+git commit -m "$(cat <<'EOF'
+chore(github): add review-architecture issue form
+
+YAML issue form for architecture findings. Enforces SHA pinning and
+uses observational "suggested direction" framing instead of prescriptive
+fix proposals.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `review-code-quality.yml`
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/review-code-quality.yml`
+
+- [ ] **Step 1: Write the YAML-parse + schema verification**
+
+```bash
+python - <<'PY'
+import yaml
+doc = yaml.safe_load(open('.github/ISSUE_TEMPLATE/review-code-quality.yml'))
+assert doc['name'] == 'Review finding — Code quality'
+assert doc['title'] == '[CQ] '
+assert set(doc['labels']) == {'code-quality', 'review'}
+ids = [b.get('id') for b in doc['body'] if b['type'] != 'markdown']
+expected = [
+    'finding-id', 'source-commit-sha', 'concern-type',
+    'severity', 'effort', 'files-affected', 'finding', 'impact',
+    'suggested-direction', 'references',
+]
+assert ids == expected, (ids, expected)
+options = {o for b in doc['body'] if b.get('id') == 'concern-type' for o in b['attributes']['options']}
+assert {'error-handling', 'logging', 'dead-code', 'naming', 'idioms', 'perf-hotpath', 'security'} <= options
+print('ok')
+PY
+```
+
+- [ ] **Step 2: Run to verify it fails (file absent)**
+
+Expected: `FileNotFoundError`.
+
+- [ ] **Step 3: Write `review-code-quality.yml`**
+
+```yaml
+name: Review finding — Code quality
+description: File a code-quality finding from a codebase review (error handling, logging, dead code, naming, idioms, perf hot-paths, security).
+title: "[CQ] "
+labels: ["code-quality", "review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for code-quality findings produced during a codebase review.
+        Perf and security findings ride on this form via the `Concern type` dropdown
+        until finding volume justifies their own templates.
+        See `.github/ISSUE_TEMPLATE/README.md` for the reviewer contract.
+
+  - type: input
+    id: finding-id
+    attributes:
+      label: Finding ID
+      description: Short reviewer-assigned ID, e.g. `CQ01`. Optional but helpful for cross-referencing a review summary issue.
+      placeholder: CQ01
+    validations:
+      required: false
+
+  - type: input
+    id: source-commit-sha
+    attributes:
+      label: Source commit SHA
+      description: The exact commit SHA the finding was observed against. Pins the finding so it remains triage-able after future refactors.
+      placeholder: 8f624ed2...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: concern-type
+    attributes:
+      label: Concern type
+      description: Which code-quality concern does this finding hit?
+      options:
+        - error-handling
+        - logging
+        - dead-code
+        - naming
+        - idioms
+        - perf-hotpath
+        - security
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - small
+        - medium
+        - large
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-affected
+    attributes:
+      label: Files affected
+      description: Code paths, one per line. Line numbers are optional — paths are primary because they survive refactors better than line numbers.
+      placeholder: |
+        yoyopod/core/bus.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: finding
+    attributes:
+      label: Finding
+      description: What's wrong, observed at the pinned SHA. Describe the current behaviour concretely.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What breaks, what's risked, or which rule/doc it violates. Explain why this finding matters.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-direction
+    attributes:
+      label: Suggested direction
+      description: Observational, not prescriptive. State a principle or property to restore.
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to `rules/*.md`, `docs/*.md`, prior issues, or external best-practice references.
+    validations:
+      required: false
+```
+
+- [ ] **Step 4: Run verification — expect pass**
+
+```bash
+python - <<'PY'
+import yaml
+doc = yaml.safe_load(open('.github/ISSUE_TEMPLATE/review-code-quality.yml'))
+assert doc['name'] == 'Review finding — Code quality'
+assert doc['title'] == '[CQ] '
+assert set(doc['labels']) == {'code-quality', 'review'}
+ids = [b.get('id') for b in doc['body'] if b['type'] != 'markdown']
+expected = [
+    'finding-id', 'source-commit-sha', 'concern-type',
+    'severity', 'effort', 'files-affected', 'finding', 'impact',
+    'suggested-direction', 'references',
+]
+assert ids == expected, (ids, expected)
+options = {o for b in doc['body'] if b.get('id') == 'concern-type' for o in b['attributes']['options']}
+assert {'error-handling', 'logging', 'dead-code', 'naming', 'idioms', 'perf-hotpath', 'security'} <= options
+print('ok')
+PY
+```
+
+Expected: `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/review-code-quality.yml
+git commit -m "$(cat <<'EOF'
+chore(github): add review-code-quality issue form
+
+YAML issue form for code-quality findings. Perf and security findings
+ride on this form via the concern-type dropdown until volume justifies
+their own templates.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `review-testing.yml`
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/review-testing.yml`
+
+- [ ] **Step 1: Write the YAML-parse + schema verification**
+
+```bash
+python - <<'PY'
+import yaml
+doc = yaml.safe_load(open('.github/ISSUE_TEMPLATE/review-testing.yml'))
+assert doc['name'] == 'Review finding — Testing'
+assert doc['title'] == '[Test] '
+assert set(doc['labels']) == {'testing', 'review'}
+ids = [b.get('id') for b in doc['body'] if b['type'] != 'markdown']
+expected = [
+    'finding-id', 'source-commit-sha', 'gap-type', 'test-gap-or-assertion',
+    'severity', 'effort', 'files-affected', 'finding', 'impact',
+    'suggested-direction', 'references',
+]
+assert ids == expected, (ids, expected)
+options = {o for b in doc['body'] if b.get('id') == 'gap-type' for o in b['attributes']['options']}
+assert {'missing-coverage', 'brittle-test', 'mock-vs-reality', 'CI-gate-gap', 'integration-gap'} <= options
+print('ok')
+PY
+```
+
+- [ ] **Step 2: Run to verify it fails (file absent)**
+
+Expected: `FileNotFoundError`.
+
+- [ ] **Step 3: Write `review-testing.yml`**
+
+```yaml
+name: Review finding — Testing
+description: File a testing finding from a codebase review (missing coverage, brittle tests, mock-vs-reality drift, CI gate gaps, integration gaps).
+title: "[Test] "
+labels: ["testing", "review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for testing findings produced during a codebase review.
+        See `.github/ISSUE_TEMPLATE/README.md` for the reviewer contract.
+
+  - type: input
+    id: finding-id
+    attributes:
+      label: Finding ID
+      description: Short reviewer-assigned ID, e.g. `T01`. Optional but helpful for cross-referencing a review summary issue.
+      placeholder: T01
+    validations:
+      required: false
+
+  - type: input
+    id: source-commit-sha
+    attributes:
+      label: Source commit SHA
+      description: The exact commit SHA the finding was observed against.
+      placeholder: 8f624ed2...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: gap-type
+    attributes:
+      label: Gap type
+      description: What kind of testing gap is this?
+      options:
+        - missing-coverage
+        - brittle-test
+        - mock-vs-reality
+        - CI-gate-gap
+        - integration-gap
+    validations:
+      required: true
+
+  - type: textarea
+    id: test-gap-or-assertion
+    attributes:
+      label: Test gap or failing assertion
+      description: The concrete test shape that's missing or broken. A minimal failing assertion, a behaviour currently uncovered, or the specific CI step that isn't gating what it should.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - small
+        - medium
+        - large
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-affected
+    attributes:
+      label: Files affected
+      description: Production code paths and/or test paths, one per line.
+      placeholder: |
+        yoyopod/core/bus.py
+        tests/core/test_bus.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: finding
+    attributes:
+      label: Finding
+      description: What's wrong or missing, observed at the pinned SHA.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What regressions could slip through, or what's currently asserted that doesn't reflect production behaviour.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-direction
+    attributes:
+      label: Suggested direction
+      description: Observational, not prescriptive. The shape of the test to add, or the mock to replace with an integration path.
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to `rules/*.md`, `docs/*.md`, prior issues, or external references.
+    validations:
+      required: false
+```
+
+- [ ] **Step 4: Run verification — expect pass**
+
+```bash
+python - <<'PY'
+import yaml
+doc = yaml.safe_load(open('.github/ISSUE_TEMPLATE/review-testing.yml'))
+assert doc['name'] == 'Review finding — Testing'
+assert doc['title'] == '[Test] '
+assert set(doc['labels']) == {'testing', 'review'}
+ids = [b.get('id') for b in doc['body'] if b['type'] != 'markdown']
+expected = [
+    'finding-id', 'source-commit-sha', 'gap-type', 'test-gap-or-assertion',
+    'severity', 'effort', 'files-affected', 'finding', 'impact',
+    'suggested-direction', 'references',
+]
+assert ids == expected, (ids, expected)
+options = {o for b in doc['body'] if b.get('id') == 'gap-type' for o in b['attributes']['options']}
+assert {'missing-coverage', 'brittle-test', 'mock-vs-reality', 'CI-gate-gap', 'integration-gap'} <= options
+print('ok')
+PY
+```
+
+Expected: `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/review-testing.yml
+git commit -m "$(cat <<'EOF'
+chore(github): add review-testing issue form
+
+YAML issue form for testing findings: coverage gaps, brittle tests,
+mock-vs-reality drift, CI gate gaps, integration gaps.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `review-docs.yml`
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/review-docs.yml`
+
+- [ ] **Step 1: Write the YAML-parse + schema verification**
+
+```bash
+python - <<'PY'
+import yaml
+doc = yaml.safe_load(open('.github/ISSUE_TEMPLATE/review-docs.yml'))
+assert doc['name'] == 'Review finding — Docs'
+assert doc['title'] == '[Docs] '
+assert set(doc['labels']) == {'docs', 'review'}
+ids = [b.get('id') for b in doc['body'] if b['type'] != 'markdown']
+expected = [
+    'finding-id', 'source-commit-sha', 'doc-problem', 'doc-location',
+    'what-it-should-say',
+    'severity', 'effort', 'files-affected', 'finding', 'impact',
+    'suggested-direction', 'references',
+]
+assert ids == expected, (ids, expected)
+options = {o for b in doc['body'] if b.get('id') == 'doc-problem' for o in b['attributes']['options']}
+assert {'stale', 'missing', 'inaccurate', 'contradictory'} <= options
+# doc-location must be required
+loc_field = next(b for b in doc['body'] if b.get('id') == 'doc-location')
+assert loc_field.get('validations', {}).get('required') is True
+print('ok')
+PY
+```
+
+- [ ] **Step 2: Run to verify it fails (file absent)**
+
+Expected: `FileNotFoundError`.
+
+- [ ] **Step 3: Write `review-docs.yml`**
+
+```yaml
+name: Review finding — Docs
+description: File a documentation finding from a codebase review (stale, missing, inaccurate, or contradictory docs).
+title: "[Docs] "
+labels: ["docs", "review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for documentation findings produced during a codebase review.
+        See `.github/ISSUE_TEMPLATE/README.md` for the reviewer contract.
+
+  - type: input
+    id: finding-id
+    attributes:
+      label: Finding ID
+      description: Short reviewer-assigned ID, e.g. `D01`. Optional but helpful for cross-referencing a review summary issue.
+      placeholder: D01
+    validations:
+      required: false
+
+  - type: input
+    id: source-commit-sha
+    attributes:
+      label: Source commit SHA
+      description: The exact commit SHA the finding was observed against.
+      placeholder: 8f624ed2...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: doc-problem
+    attributes:
+      label: Doc problem
+      description: What's wrong with the documentation?
+      options:
+        - stale
+        - missing
+        - inaccurate
+        - contradictory
+    validations:
+      required: true
+
+  - type: input
+    id: doc-location
+    attributes:
+      label: Doc location
+      description: Path to the affected doc, or "N/A — doc missing" if the doc should exist but does not.
+      placeholder: docs/SYSTEM_ARCHITECTURE.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-it-should-say
+    attributes:
+      label: What it should say
+      description: The corrected or intended content. Optional — reviewers may flag a problem without yet knowing the resolution.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - small
+        - medium
+        - large
+    validations:
+      required: true
+
+  - type: textarea
+    id: files-affected
+    attributes:
+      label: Files affected
+      description: Doc paths (plus any related code paths), one per line.
+      placeholder: |
+        docs/SYSTEM_ARCHITECTURE.md
+        yoyopod/core/application.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: finding
+    attributes:
+      label: Finding
+      description: What the doc currently says (or fails to say), observed at the pinned SHA.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who's misled and how. What decisions are people making based on the stale/inaccurate content.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-direction
+    attributes:
+      label: Suggested direction
+      description: Observational, not prescriptive. What the correct narrative should convey rather than verbatim replacement text (that goes in "What it should say").
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to related docs, rules, or prior issues.
+    validations:
+      required: false
+```
+
+- [ ] **Step 4: Run verification — expect pass**
+
+```bash
+python - <<'PY'
+import yaml
+doc = yaml.safe_load(open('.github/ISSUE_TEMPLATE/review-docs.yml'))
+assert doc['name'] == 'Review finding — Docs'
+assert doc['title'] == '[Docs] '
+assert set(doc['labels']) == {'docs', 'review'}
+ids = [b.get('id') for b in doc['body'] if b['type'] != 'markdown']
+expected = [
+    'finding-id', 'source-commit-sha', 'doc-problem', 'doc-location',
+    'what-it-should-say',
+    'severity', 'effort', 'files-affected', 'finding', 'impact',
+    'suggested-direction', 'references',
+]
+assert ids == expected, (ids, expected)
+options = {o for b in doc['body'] if b.get('id') == 'doc-problem' for o in b['attributes']['options']}
+assert {'stale', 'missing', 'inaccurate', 'contradictory'} <= options
+loc_field = next(b for b in doc['body'] if b.get('id') == 'doc-location')
+assert loc_field.get('validations', {}).get('required') is True
+print('ok')
+PY
+```
+
+Expected: `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/review-docs.yml
+git commit -m "$(cat <<'EOF'
+chore(github): add review-docs issue form
+
+YAML issue form for documentation findings (stale, missing, inaccurate,
+contradictory). "Doc location" is required; "What it should say" is
+optional so reviewers can flag a problem without yet knowing the exact
+replacement.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Full-suite verification locally
+
+**Files:** none (verification only)
+
+This task ensures every template parses and conforms to schema in one pass, before pushing.
+
+- [ ] **Step 1: Run the cross-template verification**
+
+```bash
+python - <<'PY'
+import yaml
+from pathlib import Path
+
+expected_by_file = {
+    '.github/ISSUE_TEMPLATE/review-architecture.yml': {
+        'name': 'Review finding — Architecture',
+        'title': '[Arch] ',
+        'labels': {'architecture', 'review'},
+    },
+    '.github/ISSUE_TEMPLATE/review-code-quality.yml': {
+        'name': 'Review finding — Code quality',
+        'title': '[CQ] ',
+        'labels': {'code-quality', 'review'},
+    },
+    '.github/ISSUE_TEMPLATE/review-testing.yml': {
+        'name': 'Review finding — Testing',
+        'title': '[Test] ',
+        'labels': {'testing', 'review'},
+    },
+    '.github/ISSUE_TEMPLATE/review-docs.yml': {
+        'name': 'Review finding — Docs',
+        'title': '[Docs] ',
+        'labels': {'docs', 'review'},
+    },
+}
+
+# Common field IDs present in every template
+common_ids = {
+    'finding-id', 'source-commit-sha', 'severity', 'effort',
+    'files-affected', 'finding', 'impact', 'suggested-direction', 'references',
+}
+
+for path, expected in expected_by_file.items():
+    assert Path(path).exists(), f'missing: {path}'
+    doc = yaml.safe_load(open(path))
+    assert doc['name'] == expected['name'], (path, doc['name'])
+    assert doc['title'] == expected['title'], (path, doc['title'])
+    assert set(doc['labels']) == expected['labels'], (path, doc['labels'])
+    ids = {b.get('id') for b in doc['body'] if b['type'] != 'markdown'}
+    missing = common_ids - ids
+    assert not missing, (path, missing)
+
+cfg = yaml.safe_load(open('.github/ISSUE_TEMPLATE/config.yml'))
+assert cfg['blank_issues_enabled'] is True
+assert Path('.github/ISSUE_TEMPLATE/README.md').exists()
+print('all templates ok')
+PY
+```
+
+Expected: `all templates ok`.
+
+- [ ] **Step 2: Run the project quality gate**
+
+Per `CLAUDE.md`, we run the same gate CI runs. These changes don't touch Python code, but the rule is unconditional.
+
+```bash
+uv run python scripts/quality.py gate
+```
+
+Expected: gate passes (no new format/lint/type findings introduced by these YAML files; the gate paths are Python-only).
+
+- [ ] **Step 3: Run the project test suite**
+
+```bash
+uv run pytest -q
+```
+
+Expected: test suite passes on Linux CI. On Windows, known platform-specific failures exist per `CLAUDE.md` — only flag NEW failures vs. main. YAML file additions should not affect any test.
+
+---
+
+## Task 7: Push branch and open PR
+
+**Files:** none (remote interaction)
+
+This task pushes the branch and opens a PR. The PR is review-only scaffolding — no code changes — so it should be straightforward to merge.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin HEAD
+```
+
+Expected: push succeeds; the remote prints a link to open a PR.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "chore(github): add review issue-form templates" --body "$(cat <<'EOF'
+## Summary
+
+- Adds four YAML issue-form templates under `.github/ISSUE_TEMPLATE/` for the upcoming second codebase review: architecture, code-quality, testing, docs.
+- Adds `config.yml` (leaves blank issues enabled) and a reviewer README documenting the contract.
+- Every form requires a source commit SHA so findings pin to a reviewed snapshot — prior review (#224–#235) rotted because findings referenced paths/line counts that the arch rework deleted. Observational "Suggested direction" framing replaces prescriptive "Proposed fix" for the same reason.
+- No application code changes.
+
+## Spec
+
+- [docs/superpowers/specs/2026-04-23-review-issue-templates-design.md](docs/superpowers/specs/2026-04-23-review-issue-templates-design.md)
+
+## Follow-up (post-merge)
+
+Labels need to be created on the remote repo before the review round runs. See Task 8 in the plan — these require an explicit OK from the user before the agent runs `gh label create` against the shared repo.
+
+## Test plan
+
+- [x] Each YAML template parses via `python -c "import yaml; yaml.safe_load(open('...'))"`.
+- [x] Each template has the expected `name`, `title`, `labels`, and field-id set verified by a cross-template check in Task 6.
+- [x] `uv run python scripts/quality.py gate` passes.
+- [x] `uv run pytest -q` passes on Linux CI.
+- [ ] After merge: open `https://github.com/moustafattia/yoyopod-core/issues/new/choose` in a browser and confirm all four templates appear with their fields rendered correctly.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL returned. Record the URL; the user may want to review before merging.
+
+- [ ] **Step 3: Report the PR URL to the user**
+
+Display the PR URL as a markdown link so the user can open it.
+
+---
+
+## Task 8: Create the remote labels (gated on user approval)
+
+**Files:** none (remote interaction with shared state)
+
+> **⚠️ This task modifies shared repo state.** `gh label create` creates labels visible to everyone and affecting future automations. Do NOT run without explicit user approval. If the user hasn't confirmed, pause and ask.
+
+- [ ] **Step 1: Ask the user to confirm label creation**
+
+Prompt the user:
+
+> "Ready to create the review labels on the remote repo (`code-quality`, `testing`, `docs`, `review`, `review:2026-04-23`)? These are new labels that will be visible in the repo issue sidebar. OK to proceed, or wait until the PR merges?"
+
+Wait for explicit approval. If the user says wait, stop this task and mark the plan complete with a note that labels are pending.
+
+- [ ] **Step 2: Create `code-quality` label**
+
+```bash
+gh label create code-quality --repo moustafattia/yoyopod-core --color fbca04 --description "Code-quality finding: error handling, naming, idioms, logging, dead code, perf hot-paths, security"
+```
+
+Expected: label created, or a message that it already exists (idempotent — non-fatal).
+
+- [ ] **Step 3: Create `testing` label**
+
+```bash
+gh label create testing --repo moustafattia/yoyopod-core --color 0e8a16 --description "Testing finding: coverage gaps, brittle tests, mock-vs-reality drift, CI gate gaps"
+```
+
+Expected: label created, or "already exists".
+
+- [ ] **Step 4: Create `docs` label**
+
+```bash
+gh label create docs --repo moustafattia/yoyopod-core --color 0075ca --description "Docs finding: stale, missing, inaccurate, or contradictory documentation"
+```
+
+Expected: label created, or "already exists".
+
+- [ ] **Step 5: Create `review` label**
+
+```bash
+gh label create review --repo moustafattia/yoyopod-core --color 5319e7 --description "Stable parent label for findings produced by any codebase review round"
+```
+
+Expected: label created, or "already exists".
+
+- [ ] **Step 6: Create `review:2026-04-23` label**
+
+```bash
+gh label create review:2026-04-23 --repo moustafattia/yoyopod-core --color 5319e7 --description "Findings from the 2026-04-23 codebase review round"
+```
+
+Expected: label created, or "already exists".
+
+- [ ] **Step 7: Verify all five labels exist**
+
+```bash
+gh label list --repo moustafattia/yoyopod-core --json name --jq '.[].name' | grep -E "^(code-quality|testing|docs|review|review:2026-04-23)$" | sort
+```
+
+Expected: all five label names printed, one per line, in sorted order:
+
+```
+code-quality
+docs
+review
+review:2026-04-23
+testing
+```
+
+---
+
+## Done criteria
+
+- [ ] All four templates under `.github/ISSUE_TEMPLATE/` parse as valid YAML and pass the Task 6 cross-template verification.
+- [ ] `.github/ISSUE_TEMPLATE/config.yml` exists and sets `blank_issues_enabled: true`.
+- [ ] `.github/ISSUE_TEMPLATE/README.md` documents the reviewer contract.
+- [ ] `uv run python scripts/quality.py gate` and `uv run pytest -q` pass.
+- [ ] Branch pushed, PR opened.
+- [ ] (Gated on user OK) Five new labels live on `moustafattia/yoyopod-core`.
+- [ ] (Post-merge, manual) Visual confirmation at `https://github.com/moustafattia/yoyopod-core/issues/new/choose`.

--- a/docs/superpowers/specs/2026-04-23-review-issue-templates-design.md
+++ b/docs/superpowers/specs/2026-04-23-review-issue-templates-design.md
@@ -1,0 +1,164 @@
+# Review Issue Templates — Design Spec
+
+**Date:** 2026-04-23
+**Status:** Approved (brainstorming session)
+**Scope:** Create GitHub issue-form templates for the upcoming second codebase review (clean architecture, best practice, docs).
+
+---
+
+## Context
+
+YoYoPod just completed a "COMPLETE ARCH REWORK" (commit `8f624ed`, PR #317). A prior review on 2026-04-18 produced 12 architecture findings (`#224`–`#235`), all of which were closed as `obsolete` on 2026-04-23 because every code path they cited was renamed or deleted by the rework. Key failure modes of the prior review template:
+
+1. **No commit pin** — findings didn't record the reviewed snapshot, so after a large refactor there was no way to retrace what the reviewer actually saw.
+2. **SLOC-driven findings** — several issues led with line-count thresholds the user doesn't care about.
+3. **Prescriptive "Proposed fix"** — e.g. "split `loop.py` → `loop_cadence.py + loop_dispatch.py`". When the file was restructured entirely, the prescription became meaningless even where the underlying concern might still apply.
+4. **Ad-hoc body format** — no enforced schema; fields drifted between findings.
+
+The second review needs templates that are (a) machine-fillable by a reviewing agent, (b) resistant to code reorganization, (c) narrow enough that each finding has one clear lens.
+
+---
+
+## Goals
+
+- Standardize the shape of review findings so they remain triage-able after future refactors.
+- Cover the three stated review concerns (clean architecture, best practice, docs) with enough granularity that each finding lands in a purpose-built form.
+- Keep the template count low — four, not seven — so signal isn't diluted across too many buckets.
+- Make commit-SHA pinning a required field so findings are frozen against a reviewed snapshot.
+- Replace prescriptive "Proposed fix" framing with observational "Suggested direction" framing.
+
+## Non-goals
+
+- Human-filed bug reports / feature requests (left to blank issues; a separate bug template could be added later but is out of scope here).
+- Automating review execution. The templates only define how findings land — the reviewing agent is a separate concern.
+- Tracking SLOC or any line-count-based heuristic.
+
+---
+
+## Design
+
+### File layout
+
+```
+.github/ISSUE_TEMPLATE/
+  review-architecture.yml
+  review-code-quality.yml
+  review-testing.yml
+  review-docs.yml
+  config.yml            # leaves blank-issue filing enabled
+```
+
+### Common fields (present in all four templates)
+
+Ordered as they appear in the form:
+
+| Order | Field | Control | Required | Purpose |
+|-------|-------|---------|----------|---------|
+| 1 | Finding ID | `input` | no | e.g. `A01`, `CQ03`. Cross-refs a review summary issue. |
+| 2 | Source commit SHA | `input` | **yes** | Pins the finding to the reviewed snapshot. Survives later refactors. |
+| 3 | Severity | `dropdown` | yes | `critical` / `high` / `medium` / `low`. |
+| 4 | Effort | `dropdown` | yes | `small` / `medium` / `large`. |
+| 5 | Files affected | `textarea` | yes | Code paths, one per line. Line numbers optional — paths are primary. |
+| 6 | Finding | `textarea` | yes | What's wrong, observed at the pinned SHA. |
+| 7 | Impact | `textarea` | yes | What breaks / what rule or doc it violates. |
+| 8 | Suggested direction | `textarea` | no | Observational, not prescriptive. Principles over file names. |
+| 9 | References | `textarea` | no | `rules/*.md`, `docs/*.md`, external links. |
+
+### Per-template specialization
+
+#### `review-architecture.yml`
+- **Auto-labels:** `architecture`, `review`
+- **Title prefix:** `[Arch] `
+- **Extra fields:**
+  - `Concern type` (dropdown, required): `boundary` / `coupling` / `state-ownership` / `threading` / `layering` / `dependency-direction`
+  - `Invariant violated` (input, optional): free text pointing at a rule or doc invariant
+
+#### `review-code-quality.yml`
+- **Auto-labels:** `code-quality`, `review`
+- **Title prefix:** `[CQ] `
+- **Extra fields:**
+  - `Concern type` (dropdown, required): `error-handling` / `logging` / `dead-code` / `naming` / `idioms` / `perf-hotpath` / `security`
+- **Note:** perf and security ride on this template via the dropdown until finding volume justifies their own templates.
+
+#### `review-testing.yml`
+- **Auto-labels:** `testing`, `review`
+- **Title prefix:** `[Test] `
+- **Extra fields:**
+  - `Gap type` (dropdown, required): `missing-coverage` / `brittle-test` / `mock-vs-reality` / `CI-gate-gap` / `integration-gap`
+  - `Test gap or failing assertion` (textarea, required): the concrete test shape or assertion that's missing/broken
+
+#### `review-docs.yml`
+- **Auto-labels:** `docs`, `review`
+- **Title prefix:** `[Docs] `
+- **Extra fields:**
+  - `Doc problem` (dropdown, required): `stale` / `missing` / `inaccurate` / `contradictory`
+  - `Doc location` (input, required): path to the affected doc (or "N/A — doc missing")
+  - `What it should say` (textarea, optional): the corrected or intended content
+
+### `config.yml`
+
+```yaml
+blank_issues_enabled: true
+```
+
+Leaves blank issues on — review forms are additive, not exclusive. A future bug-report template can slot in without blocking ad-hoc human reports.
+
+---
+
+## Labels to create in the repo
+
+New labels required (the `obsolete` label is already present from the prior cleanup):
+
+| Label | Color (suggested) | Purpose |
+|---|---|---|
+| `code-quality` | `#fbca04` | Applied by `review-code-quality.yml`. |
+| `testing` | `#0e8a16` | Applied by `review-testing.yml`. |
+| `docs` | `#0075ca` | Applied by `review-docs.yml`. Create new rather than reusing existing `documentation` so the `review-*` label family is consistently named. |
+| `review` | `#5319e7` | Stable parent label applied by all four templates. |
+| `review:2026-04-23` | `#5319e7` | Per-review-round child label, created fresh each review. |
+
+Existing usable labels (no change): `architecture`, `severity:{critical,high,medium,low}`, `effort:{small,medium,large}`, `perf`, `tech-debt`, `pi-zero`, `obsolete`.
+
+Note: YAML issue forms can only apply **static** labels via the `labels:` frontmatter field. Severity and Effort dropdowns are form-body fields, not labels — the reviewing agent applies matching `severity:*` / `effort:*` labels via `gh issue edit --add-label` after creation (or the web submitter adds them manually).
+
+---
+
+## Obsolescence-prevention contract
+
+Baked into every template:
+
+1. **Commit SHA required.** The pinned snapshot is the authoritative reference — not the current HEAD, not the PR at triage time.
+2. **No SLOC fields.** Arch cleanliness is the concern, not line counts. (Confirmed with user during brainstorming.)
+3. **"Suggested direction" not "Proposed fix".** Prior review prescribed exact file splits that rotted when the codebase reorganized. Observational framing survives reorganization even when the specific mechanism no longer applies.
+4. **Paths are primary, line numbers are optional.** Paths are stabler than line numbers across refactors.
+5. **Finding + Impact separated.** The prior template collapsed "current behavior" and "why it violates X" into a single prose paragraph. Splitting them makes each finding easier to skim and reason about during triage.
+
+---
+
+## Reviewer workflow
+
+The reviewing agent is expected to:
+
+1. Run a structured audit against a pinned commit (typically `main` HEAD at review start).
+2. For each finding, generate a title, pick the right template, fill the form fields (body).
+3. Submit via `gh issue create --body <rendered-body> --label "<static-labels-from-template>" --label "severity:<x>" --label "effort:<y>" --label "review:YYYY-MM-DD"`.
+4. Optionally create a tracking issue that cross-references all findings by Finding ID.
+
+Because `gh issue create` doesn't enforce YAML form structure from the CLI, the template file is a **schema contract** the agent reads to know which fields to render. The form's enforcement kicks in only for web submissions — which is acceptable given this is review-only.
+
+---
+
+## Open questions
+
+None at the time of design approval. The user confirmed Option 2 (four templates) and YAML form format.
+
+---
+
+## Next steps
+
+1. Transition to `writing-plans` skill to produce an implementation plan covering:
+   - Four YAML form files with exact field schemas.
+   - `config.yml`.
+   - Label creation via `gh label create` (three or four new labels).
+   - A brief README or entry in the repo root explaining the review workflow.
+   - Verification: a dry-run of the forms by opening each in GitHub's web UI.


### PR DESCRIPTION
## Summary

- Adds four YAML issue-form templates under `.github/ISSUE_TEMPLATE/` for the upcoming second codebase review: architecture, code-quality, testing, docs.
- Adds `config.yml` (leaves blank issues enabled) and a reviewer README documenting the contract.
- Every form requires a source commit SHA so findings pin to a reviewed snapshot — prior review (#224–#235) rotted because findings referenced paths/line counts that the arch rework deleted. Observational "Suggested direction" framing replaces prescriptive "Proposed fix" for the same reason.
- No application code changes.

## Spec and plan

- Spec: [docs/superpowers/specs/2026-04-23-review-issue-templates-design.md](https://github.com/moustafattia/yoyopod-core/blob/claude/romantic-khorana-d1618a/docs/superpowers/specs/2026-04-23-review-issue-templates-design.md)
- Plan: [docs/superpowers/plans/2026-04-23-review-issue-templates.md](https://github.com/moustafattia/yoyopod-core/blob/claude/romantic-khorana-d1618a/docs/superpowers/plans/2026-04-23-review-issue-templates.md)

## Follow-up (post-merge)

Labels need to be created on the remote repo before the review round runs. See Task 8 in the plan — these require an explicit OK before running `gh label create` against the shared repo:

- `code-quality`, `testing`, `docs`, `review`, `review:2026-04-23`

## Test plan

- [x] Each YAML template parses via `python -c "import yaml; yaml.safe_load(open('...'))"`.
- [x] Each template has the expected `name`, `title`, `labels`, and field-id set verified by the cross-template check.
- [x] `uv run python scripts/quality.py gate` passes.
- [x] `uv run pytest -q` passes (1019 passed, 2 skipped).
- [ ] After merge: open `https://github.com/moustafattia/yoyopod-core/issues/new/choose` in a browser and confirm all four templates appear with their fields rendered correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)