### PR TITLE
docs: fix yoyopod/app.py bootstrap shell misdescription (#373)

### DIFF
--- a/docs/CANONICAL_STRUCTURE.md
+++ b/docs/CANONICAL_STRUCTURE.md
@@ -96,9 +96,9 @@ YoYoPod uses a hybrid ownership model:
 Frozen canonical package homes:
 
 - `yoyopod/app.py`
-  - thin bootstrap and composition shell only
+  - thin compatibility re-export of `YoyoPodApp` (imports from `yoyopod.core.application`)
 - `yoyopod/main.py`
-  - process entrypoint only
+  - process entrypoint and bootstrap plumbing
 - `yoyopod/config/`
   - typed config loading, composition, and validation
 - `yoyopod/core/`

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -27,11 +27,12 @@ The repo exposes two equivalent application launch surfaces:
 
 Both end up in `yoyopod/main.py`. That entrypoint configures logging,
 writes the PID file, emits the canonical startup marker, and then constructs
-`YoyoPodApp` from `yoyopod/app.py`.
+`YoyoPodApp` (re-exported from `yoyopod/core/application` via `yoyopod/app.py`).
 
 The frozen end state is:
 
-- `yoyopod/app.py`: bootstrap only
+- `yoyopod/app.py`: thin compatibility re-export of `YoyoPodApp`
+- `yoyopod/main.py`: process entrypoint and bootstrap plumbing
 - `yoyopod/core/application.py`: canonical app object
 - `yoyopod/core/`: cross-cutting primitives and mechanics
 - `yoyopod/integrations/`: domain seams
@@ -171,8 +172,8 @@ yoyopod.py / yoyopod.main
 
 ### Application Layer
 
-- `yoyopod/app.py`: thin bootstrap shell
-- `yoyopod/main.py`: package entry point
+- `yoyopod/app.py`: thin compatibility re-export of `YoyoPodApp`
+- `yoyopod/main.py`: process entrypoint and bootstrap plumbing
 - `yoyopod/core/application.py`: canonical scaffold app object
 - `yoyopod/core/bus.py`, `states.py`, `services.py`, `scheduler.py`: frozen spine primitives
 - `yoyopod/core/events.py`: universal state-change and cross-cutting app events only

--- a/rules/architecture.md
+++ b/rules/architecture.md
@@ -53,7 +53,7 @@ yoyopod.py / yoyopod/main.py  (entry points)
 
 ### Entry points and composition
 
-- `yoyopod.py`, `yoyopod/main.py`, and `yoyopod/app.py` are composition and lifecycle layers.
+- `yoyopod.py` is a thin launcher and `yoyopod/main.py` is the process entrypoint and bootstrap plumbing; `yoyopod/app.py` is a thin compatibility re-export of `YoyoPodApp` (real composition lives in `yoyopod/core/application.py` and `yoyopod/core/bootstrap/`).
 - Do not turn entrypoint files into feature homes for UI, business rules, or backend-specific logic.
 - If `YoyoPodApp` grows, extract focused runtime services instead of adding more feature logic there.
 - Treat runtime extraction as incremental work: if a service like `runtime/boot.py` becomes the new blob, split it again instead of calling the cleanup finished.


### PR DESCRIPTION
Fixes #373

Corrects the inaccurate description of yoyopod/app.py as a 'bootstrap shell' / 'bootstrap only' across architecture docs.

**What changed:**
- docs/SYSTEM_ARCHITECTURE.md – restates yoyopod/app.py as a *thin compatibility re-export of YoyoPodApp* and clarifies that yoyopod/main.py holds the actual *process entrypoint and bootstrap plumbing* (both in the frozen-end-state list and the Application Layer section).
- docs/CANONICAL_STRUCTURE.md – applies the same correction to the canonical-package-homes list.

**Why:**
yoyopod/app.py is 5 lines (rom yoyopod.core.application import YoyoPodApp + __all__). The real bootstrap/composition logic lives in yoyopod/main.py and yoyopod/core/bootstrap/. The old wording sent readers to the wrong file.

**Verification:**
- uv run python scripts/quality.py gate ✅
- uv run pytest -q ✅ (1019 passed, 2 skipped)