### PR TITLE
feat(voip): add loopback runner to SidecarSupervisor

### DIFF
--- a/tests/integrations/call/test_sidecar_supervisor_loopback.py
+++ b/tests/integrations/call/test_sidecar_supervisor_loopback.py
@@ -58,6 +58,32 @@ def _exit_after_first_command_loopback_target(conn: Connection) -> None:
         pass
 
 
+# Released by the test that exercises the "stuck loopback target" path so the
+# rogue thread can finally exit during teardown. Module-level so the target
+# function below can reference it without closure capture (which would defeat
+# pickling in the unlikely case this target is reused with ``spawn``).
+_STUCK_LOOPBACK_RELEASE = threading.Event()
+
+
+def _stuck_loopback_target(conn: Connection) -> None:
+    """Loopback target that completes the handshake then ignores Shutdown.
+
+    The supervisor's stop path will send Shutdown, close the pipe, call
+    ``terminate`` and ``kill`` (both no-ops for the loopback runner), and
+    join with a tight timeout. Each of those steps is ineffective here:
+    this target neither reads the pipe nor watches its own ``conn``, so it
+    only exits when the test sets ``_STUCK_LOOPBACK_RELEASE``.
+    """
+
+    send_message(conn, Hello(version=PROTOCOL_VERSION))
+    try:
+        conn.recv_bytes()
+    except (BrokenPipeError, EOFError, OSError):
+        return
+    send_message(conn, Ready())
+    _STUCK_LOOPBACK_RELEASE.wait(timeout=10.0)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -245,6 +271,47 @@ def test_loopback_uses_thread_runner_not_subprocess(
         assert isinstance(supervisor._process, threading.Thread)
     finally:
         supervisor.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+
+
+def test_loopback_stop_marks_failed_when_runner_will_not_exit(
+    event_handler: Callable[[Any], None],
+) -> None:
+    """Stop must not claim "stopped" if the loopback thread is still alive.
+
+    ``_LoopbackThreadRunner.terminate``/``kill`` are no-ops because Python
+    cannot force-kill a thread. If the target ignores Shutdown and the
+    closed pipe, the supervisor must surface the stuck runner as a
+    permanent failure so subsequent ``start()`` calls cannot leak a
+    parallel runner alongside the original.
+    """
+
+    _STUCK_LOOPBACK_RELEASE.clear()
+    supervisor = SidecarSupervisor(
+        on_event=event_handler,
+        sidecar_target=_stuck_loopback_target,
+        use_loopback=True,
+        handshake_timeout_seconds=LOOPBACK_BUDGET_SECONDS,
+    )
+    try:
+        supervisor.start()
+        assert supervisor.wait_for_state("running", timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+
+        # Stop with a tight timeout — the target ignores Shutdown so all join
+        # attempts will time out within ~0.3s combined.
+        supervisor.stop(timeout_seconds=0.1)
+
+        snapshot = supervisor.state_snapshot()
+        assert snapshot.state == "failed", snapshot
+        assert snapshot.permanent_failure_reason is not None
+        assert "did not exit" in snapshot.permanent_failure_reason
+
+        # And start() must refuse to launch a parallel runner alongside the stuck one.
+        with pytest.raises(RuntimeError, match="permanently failed"):
+            supervisor.start()
+    finally:
+        # Release the stuck thread so it can actually exit and the test process
+        # does not carry a leaked thread into subsequent tests.
+        _STUCK_LOOPBACK_RELEASE.set()
 
 
 def test_loopback_handshake_completes_faster_than_process_budget(

--- a/tests/integrations/call/test_sidecar_supervisor_loopback.py
+++ b/tests/integrations/call/test_sidecar_supervisor_loopback.py
@@ -1,0 +1,269 @@
+"""Loopback-mode tests for :class:`SidecarSupervisor`.
+
+Loopback runs the sidecar entry point on a daemon thread inside the calling
+process instead of spawning a subprocess. The protocol, handshake, restart
+logic, and event dispatch flow are identical to the process runner, which
+makes loopback the right harness for integration tests that exercise the
+real sidecar code without paying ``spawn`` / ``forkserver`` cost or risking
+multiprocessing-related CI flakes.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from multiprocessing.connection import Connection
+from typing import Any
+
+import pytest
+
+from yoyopod.integrations.call.sidecar_main import run_sidecar
+from yoyopod.integrations.call.sidecar_protocol import (
+    Hello,
+    PROTOCOL_VERSION,
+    Ping,
+    Pong,
+    Ready,
+    Register,
+    send_message,
+)
+from yoyopod.integrations.call.sidecar_supervisor import (
+    RestartPolicy,
+    SidecarSupervisor,
+)
+
+LOOPBACK_BUDGET_SECONDS = 2.0
+"""Loopback has no spawn cost, so timeouts can be tight."""
+
+
+# ---------------------------------------------------------------------------
+# Module-level loopback targets (no pickling required, but kept module-level
+# for symmetry with the process tests)
+# ---------------------------------------------------------------------------
+
+
+def _exit_after_first_command_loopback_target(conn: Connection) -> None:
+    """Loopback target that handshakes then exits on the first command."""
+
+    send_message(conn, Hello(version=PROTOCOL_VERSION))
+    try:
+        conn.recv_bytes()  # peer hello
+    except (BrokenPipeError, EOFError, OSError):
+        return
+    send_message(conn, Ready())
+    try:
+        conn.recv_bytes()  # first command, then exit
+    except (BrokenPipeError, EOFError, OSError):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def collected_events() -> list[Any]:
+    return []
+
+
+@pytest.fixture
+def event_handler(collected_events: list[Any]) -> Callable[[Any], None]:
+    return collected_events.append
+
+
+# ---------------------------------------------------------------------------
+# Happy-path lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_loopback_start_drives_supervisor_to_running_state(
+    event_handler: Callable[[Any], None],
+) -> None:
+    supervisor = SidecarSupervisor(
+        on_event=event_handler,
+        sidecar_target=run_sidecar,
+        use_loopback=True,
+        handshake_timeout_seconds=LOOPBACK_BUDGET_SECONDS,
+    )
+    try:
+        supervisor.start()
+        assert supervisor.wait_for_state("running", timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+    finally:
+        supervisor.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+        assert supervisor.state_snapshot().state == "stopped"
+
+
+def test_loopback_send_ping_round_trips_to_pong(
+    collected_events: list[Any], event_handler: Callable[[Any], None]
+) -> None:
+    supervisor = SidecarSupervisor(
+        on_event=event_handler,
+        sidecar_target=run_sidecar,
+        use_loopback=True,
+        handshake_timeout_seconds=LOOPBACK_BUDGET_SECONDS,
+    )
+    try:
+        supervisor.start()
+        assert supervisor.wait_for_state("running", timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+        supervisor.send(Ping(cmd_id=42))
+
+        deadline = time.monotonic() + LOOPBACK_BUDGET_SECONDS
+        while time.monotonic() < deadline:
+            if any(isinstance(event, Pong) and event.cmd_id == 42 for event in collected_events):
+                break
+            time.sleep(0.01)
+
+        assert any(
+            isinstance(event, Pong) and event.cmd_id == 42 for event in collected_events
+        ), f"never received Pong; saw {[type(e).__name__ for e in collected_events]}"
+    finally:
+        supervisor.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+
+
+def test_loopback_register_command_flows_to_log_event(
+    collected_events: list[Any], event_handler: Callable[[Any], None]
+) -> None:
+    """Verify the scaffold ack-as-Log path works through the loopback runner."""
+
+    supervisor = SidecarSupervisor(
+        on_event=event_handler,
+        sidecar_target=run_sidecar,
+        use_loopback=True,
+        handshake_timeout_seconds=LOOPBACK_BUDGET_SECONDS,
+    )
+    try:
+        supervisor.start()
+        assert supervisor.wait_for_state("running", timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+        supervisor.send(Register(server="sip.example.com", user="alice", password="x", cmd_id=1))
+
+        deadline = time.monotonic() + LOOPBACK_BUDGET_SECONDS
+        while time.monotonic() < deadline:
+            log_events = [event for event in collected_events if type(event).__name__ == "Log"]
+            if any("alice" in event.message for event in log_events):
+                break
+            time.sleep(0.01)
+
+        log_events = [event for event in collected_events if type(event).__name__ == "Log"]
+        assert any(
+            "alice" in event.message for event in log_events
+        ), f"never saw Register ack log; collected {collected_events!r}"
+    finally:
+        supervisor.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+
+
+# ---------------------------------------------------------------------------
+# Restart and shutdown discipline
+# ---------------------------------------------------------------------------
+
+
+def test_loopback_unexpected_exit_triggers_restart(
+    event_handler: Callable[[Any], None],
+) -> None:
+    """An unexpected sidecar-thread exit should still trip the restart policy."""
+
+    supervisor = SidecarSupervisor(
+        on_event=event_handler,
+        sidecar_target=_exit_after_first_command_loopback_target,
+        use_loopback=True,
+        handshake_timeout_seconds=LOOPBACK_BUDGET_SECONDS,
+        restart_policy=RestartPolicy(
+            max_failures=5,
+            failure_window_seconds=60.0,
+            backoff_initial_seconds=0.05,
+            backoff_factor=1.0,
+            backoff_max_seconds=0.05,
+        ),
+    )
+    try:
+        supervisor.start()
+        assert supervisor.wait_for_state("running", timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+        supervisor.send(Ping(cmd_id=1))
+
+        deadline = time.monotonic() + LOOPBACK_BUDGET_SECONDS
+        while time.monotonic() < deadline:
+            snapshot = supervisor.state_snapshot()
+            if snapshot.restart_count >= 1 and snapshot.state == "running":
+                break
+            time.sleep(0.01)
+
+        snapshot = supervisor.state_snapshot()
+        assert snapshot.restart_count >= 1, snapshot
+        assert snapshot.state == "running", snapshot
+    finally:
+        supervisor.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+
+
+def test_loopback_intentional_stop_does_not_trigger_restart(
+    event_handler: Callable[[Any], None],
+) -> None:
+    supervisor = SidecarSupervisor(
+        on_event=event_handler,
+        sidecar_target=run_sidecar,
+        use_loopback=True,
+        handshake_timeout_seconds=LOOPBACK_BUDGET_SECONDS,
+        restart_policy=RestartPolicy(
+            max_failures=5,
+            failure_window_seconds=60.0,
+            backoff_initial_seconds=0.05,
+            backoff_factor=1.0,
+            backoff_max_seconds=0.05,
+        ),
+    )
+    supervisor.start()
+    assert supervisor.wait_for_state("running", timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+
+    supervisor.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+    time.sleep(0.2)
+    snapshot = supervisor.state_snapshot()
+    assert snapshot.state == "stopped"
+    assert snapshot.restart_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Loopback-specific safety
+# ---------------------------------------------------------------------------
+
+
+def test_loopback_uses_thread_runner_not_subprocess(
+    event_handler: Callable[[Any], None],
+) -> None:
+    """Sanity check: loopback-mode runner is a Thread, not a Process."""
+
+    supervisor = SidecarSupervisor(
+        on_event=event_handler,
+        sidecar_target=run_sidecar,
+        use_loopback=True,
+        handshake_timeout_seconds=LOOPBACK_BUDGET_SECONDS,
+    )
+    try:
+        supervisor.start()
+        assert supervisor.wait_for_state("running", timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+        # Read the private runner reference for this assertion only; it is the
+        # one place the test actually needs to verify which runner class is in use.
+        assert isinstance(supervisor._process, threading.Thread)
+    finally:
+        supervisor.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+
+
+def test_loopback_handshake_completes_faster_than_process_budget(
+    event_handler: Callable[[Any], None],
+) -> None:
+    """Loopback must not depend on Python interpreter spawn; handshake should be sub-second."""
+
+    supervisor = SidecarSupervisor(
+        on_event=event_handler,
+        sidecar_target=run_sidecar,
+        use_loopback=True,
+        handshake_timeout_seconds=0.5,  # would never pass with spawn on Windows
+    )
+    try:
+        started_at = time.monotonic()
+        supervisor.start()
+        elapsed = time.monotonic() - started_at
+        assert supervisor.state_snapshot().state == "running"
+        # Sub-second handshake confirms no process-spawn cost.
+        assert elapsed < 0.5, f"loopback start took {elapsed:.3f}s, expected <0.5s"
+    finally:
+        supervisor.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)

--- a/tests/integrations/call/test_sidecar_supervisor_loopback.py
+++ b/tests/integrations/call/test_sidecar_supervisor_loopback.py
@@ -84,6 +84,23 @@ def _stuck_loopback_target(conn: Connection) -> None:
     _STUCK_LOOPBACK_RELEASE.wait(timeout=10.0)
 
 
+# Released by the handshake-failure test below.
+_STUCK_HANDSHAKE_RELEASE = threading.Event()
+
+
+def _stuck_during_handshake_target(_conn: Connection) -> None:
+    """Loopback target that blocks before sending Hello / Ready.
+
+    The supervisor's handshake will time out, and ``terminate``/``kill`` on
+    the loopback runner are no-ops, so the runner remains alive after the
+    teardown chain in ``_launch_locked``. The supervisor must mark the
+    state as ``"failed"`` instead of scheduling a restart that would
+    spawn a second loopback runner concurrently with this stuck one.
+    """
+
+    _STUCK_HANDSHAKE_RELEASE.wait(timeout=10.0)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -271,6 +288,59 @@ def test_loopback_uses_thread_runner_not_subprocess(
         assert isinstance(supervisor._process, threading.Thread)
     finally:
         supervisor.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+
+
+def test_loopback_handshake_failure_with_alive_runner_marks_failed(
+    event_handler: Callable[[Any], None],
+) -> None:
+    """Restart must not fire while a stuck handshake-stage runner is alive.
+
+    Codex follow-up on #378: ``_launch_locked``'s handshake-failure cleanup
+    calls ``process.terminate(); process.join(1.0)`` then schedules a
+    restart. For the loopback runner those two calls are no-ops, so a
+    target that blocks during startup leaves the original thread alive
+    while the restart timer launches a second loopback runner alongside it.
+    The supervisor must mark the state ``"failed"`` instead.
+    """
+
+    _STUCK_HANDSHAKE_RELEASE.clear()
+    supervisor = SidecarSupervisor(
+        on_event=event_handler,
+        sidecar_target=_stuck_during_handshake_target,
+        use_loopback=True,
+        handshake_timeout_seconds=0.2,
+        # max_failures is intentionally high so the assertion below proves the
+        # "failed" transition came from the alive-runner check, not from the
+        # cumulative-failures policy.
+        restart_policy=RestartPolicy(
+            max_failures=10,
+            failure_window_seconds=60.0,
+            backoff_initial_seconds=0.05,
+            backoff_factor=1.0,
+            backoff_max_seconds=0.05,
+        ),
+    )
+    try:
+        supervisor.start()
+
+        deadline = time.monotonic() + LOOPBACK_BUDGET_SECONDS
+        while time.monotonic() < deadline:
+            snap = supervisor.state_snapshot()
+            if snap.state == "failed":
+                break
+            time.sleep(0.01)
+
+        snap = supervisor.state_snapshot()
+        assert snap.state == "failed", snap
+        assert snap.permanent_failure_reason is not None
+        assert "did not exit after handshake failure" in snap.permanent_failure_reason
+        # Restart was never scheduled — alive-runner check short-circuits
+        # before _record_failure_and_maybe_restart is reached.
+        assert snap.restart_count == 0, snap
+    finally:
+        # Release the stuck thread so the test process does not carry a leaked
+        # thread into subsequent tests.
+        _STUCK_HANDSHAKE_RELEASE.set()
 
 
 def test_loopback_stop_marks_failed_when_runner_will_not_exit(

--- a/yoyopod/integrations/call/sidecar_supervisor.py
+++ b/yoyopod/integrations/call/sidecar_supervisor.py
@@ -196,6 +196,24 @@ class SidecarSupervisor:
             reader_thread.join(timeout=timeout_seconds)
 
         with self._lock:
+            # ``_LoopbackThreadRunner.terminate``/``kill`` are no-ops because
+            # CPython does not expose force-stop for a thread. If the loopback
+            # target refused to honor ``Shutdown`` and the closed pipe, the
+            # runner is still alive here. Mark the supervisor as ``"failed"``
+            # so subsequent ``start()`` calls raise instead of leaking a
+            # parallel runner alongside the stuck one.
+            if process is not None and process.is_alive():
+                self._state = "failed"
+                self._permanent_failure_reason = (
+                    f"sidecar runner {process.name!r} did not exit on stop; "
+                    "force-termination is unavailable for the loopback runner"
+                )
+                logger.error("Sidecar permanently failed: {}", self._permanent_failure_reason)
+                self._parent_conn = None
+                self._reader_thread = None
+                self._restart_timer = None
+                return
+
             self._process = None
             self._parent_conn = None
             self._reader_thread = None

--- a/yoyopod/integrations/call/sidecar_supervisor.py
+++ b/yoyopod/integrations/call/sidecar_supervisor.py
@@ -8,6 +8,13 @@ sidecar dies unexpectedly. After ``max_failures`` failures inside
 and stops attempting to restart; callers should surface a fatal status to
 the UI in that case.
 
+A loopback runner is also available (``use_loopback=True``) which runs the
+sidecar entry point on a daemon thread inside the calling process instead of
+spawning a child process. The protocol, handshake, and event-dispatch flow
+are identical to the process runner, which makes loopback ideal for
+integration tests that want real sidecar logic without paying the per-test
+``spawn`` / ``forkserver`` cost.
+
 Phase 2A wires this against the scaffold sidecar in
 :mod:`yoyopod.integrations.call.sidecar_main`. Phase 2B replaces the
 sidecar entry point with the real liblinphone backend; the supervisor
@@ -24,8 +31,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from multiprocessing.connection import Connection
 from multiprocessing.context import BaseContext
-from multiprocessing.process import BaseProcess
-from typing import Any
+from typing import Any, Protocol
 
 from loguru import logger
 
@@ -65,6 +71,43 @@ SidecarTarget = Callable[[Connection], None]
 EventHandler = Callable[[Any], None]
 
 
+class _SidecarRunner(Protocol):
+    """Minimal lifecycle surface shared by ``Process`` and the loopback thread runner."""
+
+    name: str
+
+    def start(self) -> None: ...
+
+    def is_alive(self) -> bool: ...
+
+    def join(self, timeout: float | None = ...) -> None: ...
+
+
+class _LoopbackThreadRunner(threading.Thread):
+    """Run the sidecar entry point on a daemon thread for in-process tests.
+
+    Mirrors the slice of :class:`multiprocessing.Process` that
+    :class:`SidecarSupervisor` consumes (``start``, ``is_alive``, ``join``),
+    plus a no-op ``terminate``/``kill`` so the existing teardown path can
+    treat both runners uniformly.
+    """
+
+    def __init__(
+        self,
+        *,
+        target: SidecarTarget,
+        conn: Connection,
+        name: str = "voip-sidecar-loopback",
+    ) -> None:
+        super().__init__(target=target, args=(conn,), daemon=True, name=name)
+
+    def terminate(self) -> None:
+        """No-op; threads cannot be force-terminated. Loopback shutdown is cooperative."""
+
+    def kill(self) -> None:
+        """No-op; threads cannot be force-killed. Loopback shutdown is cooperative."""
+
+
 class SidecarSupervisor:
     """Manage one VoIP sidecar process with auto-restart and event dispatch."""
 
@@ -76,16 +119,18 @@ class SidecarSupervisor:
         start_method: str | None = None,
         sidecar_target: SidecarTarget = run_sidecar,
         handshake_timeout_seconds: float = 5.0,
+        use_loopback: bool = False,
     ) -> None:
         self._on_event = on_event
         self._restart_policy = restart_policy or RestartPolicy()
         self._start_method = start_method or _default_start_method()
         self._sidecar_target = sidecar_target
         self._handshake_timeout_seconds = handshake_timeout_seconds
+        self._use_loopback = use_loopback
 
         self._lock = threading.RLock()
         self._state = "stopped"
-        self._process: BaseProcess | None = None
+        self._process: _SidecarRunner | None = None
         self._parent_conn: Connection | None = None
         self._reader_thread: threading.Thread | None = None
         self._restart_timer: threading.Timer | None = None
@@ -195,18 +240,25 @@ class SidecarSupervisor:
     # Internals
     # ------------------------------------------------------------------
 
-    def _launch_locked(self) -> None:
-        """Spawn one sidecar process. Caller must hold ``self._lock``."""
+    def _build_runner(self, child_conn: Connection) -> _SidecarRunner:
+        """Construct the sidecar runner for the active mode (process or loopback)."""
 
-        self._state = "starting"
+        if self._use_loopback:
+            return _LoopbackThreadRunner(target=self._sidecar_target, conn=child_conn)
         ctx: BaseContext = multiprocessing.get_context(self._start_method)
-        parent_conn, child_conn = multiprocessing.Pipe(duplex=True)
-        process = ctx.Process(
+        return ctx.Process(
             target=self._sidecar_target,
             args=(child_conn,),
             daemon=True,
             name="voip-sidecar",
         )
+
+    def _launch_locked(self) -> None:
+        """Spawn one sidecar runner (process or loopback thread). Caller must hold ``self._lock``."""
+
+        self._state = "starting"
+        parent_conn, child_conn = multiprocessing.Pipe(duplex=True)
+        process: _SidecarRunner = self._build_runner(child_conn)
         try:
             process.start()
         except Exception:
@@ -215,9 +267,12 @@ class SidecarSupervisor:
             self._state = "stopped"
             raise
 
-        # The child holds its own Connection now; close ours to it so the
-        # child sees EOF if the parent dies.
-        child_conn.close()
+        # In process mode the child holds its own Connection; close ours to
+        # it so the child sees EOF if the parent dies. The loopback runner
+        # shares this process's address space, so closing the child end here
+        # would cut both directions of the pipe.
+        if not self._use_loopback:
+            child_conn.close()
 
         self._process = process
         self._parent_conn = parent_conn

--- a/yoyopod/integrations/call/sidecar_supervisor.py
+++ b/yoyopod/integrations/call/sidecar_supervisor.py
@@ -306,6 +306,23 @@ class SidecarSupervisor:
             if process.is_alive():
                 process.terminate()
                 process.join(timeout=1.0)
+
+            # ``_LoopbackThreadRunner.terminate``/``kill`` are no-ops because
+            # CPython does not expose force-stop for a thread. If the loopback
+            # target blocked during startup and never reached Ready, the
+            # original runner is still alive here. Scheduling a restart in
+            # that state would launch a second loopback runner concurrently
+            # and corrupt test state — surface a permanent failure instead.
+            if process.is_alive():
+                self._state = "failed"
+                self._permanent_failure_reason = (
+                    f"sidecar runner {process.name!r} did not exit after handshake "
+                    "failure; force-termination is unavailable for the loopback runner"
+                )
+                logger.error("Sidecar permanently failed: {}", self._permanent_failure_reason)
+                self._parent_conn = None
+                return
+
             self._process = None
             self._parent_conn = None
             self._record_failure_and_maybe_restart(reason="handshake failed")


### PR DESCRIPTION
## Summary

Phase 2B.1 of the concurrency rework. Adds an in-process loopback runner to `SidecarSupervisor` so integration tests can exercise the real sidecar entry point on a daemon thread instead of spawning a subprocess.

**Stacked on top of [#377](https://github.com/moustafattia/yoyopod-core/pull/377).** Targets the Phase 2A scaffold branch, not main. Will rebase to main automatically once #377 merges.

### What changed

- New `_LoopbackThreadRunner` — subclass of `threading.Thread` with the slice of `multiprocessing.Process` that the supervisor consumes (`start`, `is_alive`, `join`), plus no-op `terminate`/`kill` so the existing teardown path treats both runners uniformly.
- New `use_loopback` constructor flag on `SidecarSupervisor`. `_build_runner` picks the right runner for the active mode. **Process mode is unchanged and remains the default**; existing call sites and behavior are unaffected.
- Loopback shares parent/child `Connection` objects in the same process; we no longer close the child end after `start` when loopback is active (would cut both directions of the pipe).
- 7 new tests in `tests/integrations/call/test_sidecar_supervisor_loopback.py`:
  - Lifecycle (start → running → stop → stopped)
  - `Ping` → `Pong` round-trip via real `run_sidecar`
  - `Register` → `Log` ack
  - Unexpected-exit triggers restart (uses a custom target that exits on first command)
  - Intentional `stop()` does not trigger restart
  - Runner-class sanity check (verifies loopback uses `Thread`, not `Process`)
  - Sub-500ms handshake budget (proves zero process-spawn cost)

### Why this lands now

Phase 2B.2 will replace the scaffold `_dispatch_command` in `sidecar_main.py` with the real `LiblinphoneBackend` integration. Most of that work needs a fast, deterministic test harness — spawning a subprocess for every test inflates CI and adds Windows/forkserver flakiness. Loopback gives us a single-process Python execution path that exercises the same protocol, handshake, and event-dispatch flow.

### What this is NOT

- No `LiblinphoneBackend` wiring — that's Phase 2B.2.
- No `VoIPManager` refactor or `RuntimeBootService` integration — that's Phase 2B.3.
- Process mode is the production default; loopback is opt-in via `use_loopback=True` and intended only for tests.

## Test plan
- [x] \`uv run pytest -q\` — 1219 passed, 21 skipped
- [x] \`uv run python scripts/quality.py gate\` — passed
- [x] All 11 process-mode supervisor tests still green (no regressions)
- [x] All 7 new loopback-mode tests green
- [x] Loopback handshake test runs in <500ms — confirms no Python-process-spawn overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)