### PR TITLE
[codex] Runtime hybrid phase 0 and worker foundation

### DIFF
--- a/docs/PI_PROFILING_WORKFLOW.md
+++ b/docs/PI_PROFILING_WORKFLOW.md
@@ -14,6 +14,61 @@ For the Raspberry Pi Zero 2 W, treat target-hardware results as the source of
 truth. Desktop simulation is still useful, but it is a fast triage step, not
 proof that the Pi will behave the same way.
 
+## Runtime Hybrid Phase 0 Baseline
+
+Use this workflow before moving voice and network work into sidecar workers.
+The goal is to capture responsiveness and PSS/RSS with the current
+single-supervisor runtime so Phase 2/3 changes can be compared against a real
+target-hardware baseline.
+
+Enable responsiveness captures for the dev-lane run:
+
+```bash
+export YOYOPOD_RESPONSIVENESS_WATCHDOG_ENABLED=true
+export YOYOPOD_RESPONSIVENESS_STALL_THRESHOLD_SECONDS=5
+export YOYOPOD_RESPONSIVENESS_RECENT_INPUT_WINDOW_SECONDS=3
+```
+
+Deploy and confirm the dev lane:
+
+```bash
+yoyopod remote mode activate dev
+yoyopod remote sync --branch <branch>
+yoyopod remote status
+```
+
+Capture a status snapshot and recent logs after the exercise:
+
+```bash
+yoyopod remote logs --lines 200
+```
+
+Record these fields from logs, status output, and any generated responsiveness
+captures:
+
+- `responsiveness_input_to_action_p95_ms`
+- `responsiveness_action_to_visible_p95_ms`
+- `runtime_loop_gap_seconds`
+- `runtime_main_thread_drain_seconds`
+- `runtime_blocking_span_name`
+- `runtime_blocking_span_seconds`
+- `process_memory_rss_kb`
+- `process_memory_pss_kb`
+- `workers`
+
+Run a one-hour mixed soak that covers:
+
+- idle screen wake/sleep
+- music navigation and playback
+- incoming or simulated VoIP state changes
+- voice command path with current local settings
+- cellular/network reconnect or status polling
+- low-risk power/status screen navigation
+
+The pre-worker baseline is not pass/fail. Use it to identify the top stalls
+and memory pressure before Phase 2/3, then keep the raw notes with the branch
+or release artifacts they describe.
+
 ## 1. Install the profiling tools
 
 The repo now tracks the common Python-side tools in the `dev` extra:

--- a/docs/PI_PROFILING_WORKFLOW.md
+++ b/docs/PI_PROFILING_WORKFLOW.md
@@ -21,7 +21,12 @@ The goal is to capture responsiveness and PSS/RSS with the current
 single-supervisor runtime so Phase 2/3 changes can be compared against a real
 target-hardware baseline.
 
-Enable responsiveness captures for the dev-lane run:
+Enable responsiveness captures for the dev-lane run in the Pi service/runtime
+environment. These exports are examples of the values the service must see;
+running them only in the local shell before `yoyopod remote sync` does not
+guarantee they will be present in the systemd service environment. Apply the
+same values through the Pi runtime environment or config used by the dev-lane
+service:
 
 ```bash
 export YOYOPOD_RESPONSIVENESS_WATCHDOG_ENABLED=true
@@ -37,14 +42,16 @@ yoyopod remote sync --branch <branch>
 yoyopod remote status
 ```
 
-Capture a status snapshot and recent logs after the exercise:
+Capture recent logs and a status snapshot after the exercise:
 
 ```bash
 yoyopod remote logs --lines 200
+yoyopod remote status
 ```
 
 Record these fields from logs, status output, and any generated responsiveness
-captures:
+captures. Keep null or missing values in the baseline notes too, because some
+fields may be absent until enough samples or captures exist:
 
 - `responsiveness_input_to_action_p95_ms`
 - `responsiveness_action_to_visible_p95_ms`

--- a/docs/superpowers/plans/2026-04-25-runtime-hybrid-phase-0-1.md
+++ b/docs/superpowers/plans/2026-04-25-runtime-hybrid-phase-0-1.md
@@ -1,0 +1,2157 @@
+# Runtime Hybrid Phase 0-1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the responsiveness, memory, and worker-runtime foundation required before moving voice or network into sidecar processes.
+
+**Architecture:** This plan implements the prerequisite slice from `docs/superpowers/specs/2026-04-25-runtime-hybrid-architecture-design.md`: Phase 0 instrumentation plus Phase 1 worker runtime. The Python supervisor remains the sole owner of UI, state, bus, scheduler, music/call coordination, and navigation. Worker support is added as an idle foundation with fake-worker tests; no production subsystem is moved out of process in this plan.
+
+**Tech Stack:** Python 3.12, stdlib `subprocess`, `threading`, `queue`, NDJSON over stdio, existing `RuntimeLoopService`, `MainThreadScheduler`, `Bus`, `RuntimeStatusService`, `uv`, pytest. No ZeroMQ, msgpack, asyncio migration, Go worker, or network sidecar in this plan.
+
+---
+
+## Scope Check
+
+The approved design covers multiple phases: instrumentation, worker runtime, Go voice worker, Python network worker, and a later VoIP decision gate. A single implementation plan for all phases would be too broad. This plan intentionally covers only the first executable slice:
+
+1. Phase 0 responsiveness and memory baseline instrumentation.
+2. Phase 1 neutral worker runtime with protocol, bounded queues, restart/backoff, cancellation, and fake-worker tests.
+
+Follow-up plans should be written after this lands:
+
+1. Go cloud voice worker.
+2. Python network worker.
+3. VoIP sidecar feasibility, only if measurements prove it is necessary.
+
+---
+
+## File Structure
+
+Create:
+
+- `yoyopod/core/diagnostics/memory.py`
+  - Parses Linux `/proc/<pid>/smaps_rollup` and `/proc/<pid>/status`.
+  - Returns PSS/RSS/private-dirty snapshots without adding runtime dependencies.
+
+- `yoyopod/core/workers/__init__.py`
+  - Public exports for worker protocol and supervisor primitives.
+
+- `yoyopod/core/workers/protocol.py`
+  - Validates and serializes worker NDJSON envelopes.
+  - Contains no process-management logic.
+
+- `yoyopod/core/workers/process.py`
+  - Owns one child process, stdout/stderr reader threads, bounded receive queue, send lock, stop/terminate/kill behavior, and process stats.
+
+- `yoyopod/core/workers/supervisor.py`
+  - Owns named workers, restart/backoff state, non-blocking polling, request timeout/cancellation bookkeeping, and status snapshots.
+
+- `tests/core/diagnostics/test_memory.py`
+  - Unit tests for PSS/RSS parsing and unavailable `/proc` behavior.
+
+- `tests/core/workers/test_protocol.py`
+  - Unit tests for envelope validation.
+
+- `tests/core/workers/test_process.py`
+  - Integration tests with temporary fake worker scripts.
+
+- `tests/core/workers/test_supervisor.py`
+  - Unit/integration tests for restart/backoff, timeout, degraded state, and status snapshots.
+
+Modify:
+
+- `yoyopod/core/status.py`
+  - Extend `RuntimeMetricsStore` with latency samples and expose status snapshot keys.
+  - Include current-process memory snapshot in runtime status.
+
+- `yoyopod/core/application.py`
+  - Add `worker_supervisor`.
+  - Add `note_visible_refresh()`.
+  - Stop workers before legacy runtime resources during shutdown.
+
+- `yoyopod/core/loop.py`
+  - Record main-thread drain duration.
+  - Record visible refresh after screen refresh.
+  - Poll the worker supervisor once per loop iteration without blocking.
+  - Surface worker queue/restart/request metrics in `timing_snapshot()`.
+
+- `yoyopod/core/events.py`
+  - Add worker-domain event dataclasses that can be published on the main-thread bus.
+
+- `yoyopod/core/__init__.py`
+  - Export new worker event dataclasses through the existing lazy `_PUBLIC_EXPORTS` map.
+
+- `docs/PI_PROFILING_WORKFLOW.md`
+  - Add the exact target-hardware commands for baseline PSS and responsiveness collection.
+
+---
+
+## Task 1: Runtime Responsiveness Metrics
+
+**Files:**
+
+- Modify: `yoyopod/core/status.py`
+- Modify: `yoyopod/core/application.py`
+- Test: `tests/core/test_runtime_metrics.py`
+
+- [ ] **Step 1: Write failing tests for latency samples**
+
+Add these tests to `tests/core/test_runtime_metrics.py`:
+
+```python
+def test_runtime_metrics_records_input_to_action_latency() -> None:
+    store = RuntimeMetricsStore()
+
+    store.note_input_activity(SimpleNamespace(value="select"), captured_at=10.0)
+    store.note_handled_input(action_name="select", handled_at=10.035)
+
+    snapshot = store.responsiveness_snapshot(now=11.0)
+
+    assert snapshot["responsiveness_input_to_action_count"] == 1
+    assert snapshot["responsiveness_input_to_action_p95_ms"] == 35.0
+    assert snapshot["responsiveness_input_to_action_last_ms"] == 35.0
+    assert snapshot["responsiveness_last_input_to_action_name"] == "select"
+
+
+def test_runtime_metrics_records_action_to_visible_refresh_latency() -> None:
+    store = RuntimeMetricsStore()
+
+    store.note_input_activity(SimpleNamespace(value="down"), captured_at=20.0)
+    store.note_handled_input(action_name="down", handled_at=20.010)
+    store.note_visible_refresh(refreshed_at=20.085)
+
+    snapshot = store.responsiveness_snapshot(now=21.0)
+
+    assert snapshot["responsiveness_action_to_visible_count"] == 1
+    assert snapshot["responsiveness_action_to_visible_p95_ms"] == 75.0
+    assert snapshot["responsiveness_action_to_visible_last_ms"] == 75.0
+    assert snapshot["responsiveness_last_visible_action_name"] == "down"
+
+
+def test_runtime_metrics_ignores_refresh_without_handled_input() -> None:
+    store = RuntimeMetricsStore()
+
+    store.note_visible_refresh(refreshed_at=30.0)
+
+    snapshot = store.responsiveness_snapshot(now=31.0)
+
+    assert snapshot["responsiveness_action_to_visible_count"] == 0
+    assert snapshot["responsiveness_action_to_visible_p95_ms"] is None
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_runtime_metrics.py -q
+```
+
+Expected: failures mentioning `RuntimeMetricsStore` has no `responsiveness_snapshot` or `note_visible_refresh`.
+
+- [ ] **Step 3: Add metrics dataclass and deques**
+
+In `yoyopod/core/status.py`, add imports:
+
+```python
+from collections import deque
+from dataclasses import dataclass
+from typing import Literal
+```
+
+Add below the `TYPE_CHECKING` block:
+
+```python
+LatencyKind = Literal["input_to_action", "action_to_visible"]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeLatencySample:
+    """One user-visible responsiveness measurement."""
+
+    kind: LatencyKind
+    action_name: str | None
+    duration_seconds: float
+    recorded_at: float
+```
+
+In `RuntimeMetricsStore.__init__()`, add:
+
+```python
+self._input_to_action_samples: deque[RuntimeLatencySample] = deque(maxlen=256)
+self._action_to_visible_samples: deque[RuntimeLatencySample] = deque(maxlen=256)
+self._last_handled_input_for_refresh_at = 0.0
+self._last_handled_input_for_refresh_action_name: str | None = None
+```
+
+- [ ] **Step 4: Implement latency recording methods**
+
+Update `RuntimeMetricsStore.note_handled_input()`:
+
+```python
+def note_handled_input(
+    self,
+    *,
+    action_name: str | None,
+    handled_at: float,
+) -> None:
+    """Record semantic user activity after the coordinator handles it."""
+
+    self.last_input_handled_at = handled_at
+    self.last_input_handled_action_name = action_name
+    self._last_handled_input_for_refresh_at = handled_at
+    self._last_handled_input_for_refresh_action_name = action_name
+    if self.last_input_activity_at <= 0.0:
+        return
+
+    duration_seconds = max(0.0, handled_at - self.last_input_activity_at)
+    self._input_to_action_samples.append(
+        RuntimeLatencySample(
+            kind="input_to_action",
+            action_name=action_name,
+            duration_seconds=duration_seconds,
+            recorded_at=handled_at,
+        )
+    )
+```
+
+Add:
+
+```python
+def note_visible_refresh(self, *, refreshed_at: float) -> None:
+    """Record the first visible refresh after the latest handled input."""
+
+    if self._last_handled_input_for_refresh_at <= 0.0:
+        return
+
+    duration_seconds = max(0.0, refreshed_at - self._last_handled_input_for_refresh_at)
+    self._action_to_visible_samples.append(
+        RuntimeLatencySample(
+            kind="action_to_visible",
+            action_name=self._last_handled_input_for_refresh_action_name,
+            duration_seconds=duration_seconds,
+            recorded_at=refreshed_at,
+        )
+    )
+    self._last_handled_input_for_refresh_at = 0.0
+    self._last_handled_input_for_refresh_action_name = None
+
+def responsiveness_snapshot(self, *, now: float) -> dict[str, float | int | str | None]:
+    """Return compact responsiveness metrics for status and diagnostics."""
+
+    input_samples = list(self._input_to_action_samples)
+    visible_samples = list(self._action_to_visible_samples)
+    last_input = input_samples[-1] if input_samples else None
+    last_visible = visible_samples[-1] if visible_samples else None
+    return {
+        "responsiveness_input_to_action_count": len(input_samples),
+        "responsiveness_input_to_action_p50_ms": _percentile_ms(input_samples, 0.50),
+        "responsiveness_input_to_action_p95_ms": _percentile_ms(input_samples, 0.95),
+        "responsiveness_input_to_action_max_ms": _max_ms(input_samples),
+        "responsiveness_input_to_action_last_ms": _sample_ms(last_input),
+        "responsiveness_last_input_to_action_name": (
+            last_input.action_name if last_input is not None else None
+        ),
+        "responsiveness_action_to_visible_count": len(visible_samples),
+        "responsiveness_action_to_visible_p50_ms": _percentile_ms(visible_samples, 0.50),
+        "responsiveness_action_to_visible_p95_ms": _percentile_ms(visible_samples, 0.95),
+        "responsiveness_action_to_visible_max_ms": _max_ms(visible_samples),
+        "responsiveness_action_to_visible_last_ms": _sample_ms(last_visible),
+        "responsiveness_last_visible_action_name": (
+            last_visible.action_name if last_visible is not None else None
+        ),
+        "responsiveness_snapshot_age_seconds": 0.0 if now > 0.0 else None,
+    }
+```
+
+Add helper functions near `_jsonify()`:
+
+```python
+def _sample_ms(sample: RuntimeLatencySample | None) -> float | None:
+    if sample is None:
+        return None
+    return round(sample.duration_seconds * 1000.0, 3)
+
+
+def _max_ms(samples: list[RuntimeLatencySample]) -> float | None:
+    if not samples:
+        return None
+    return round(max(sample.duration_seconds for sample in samples) * 1000.0, 3)
+
+
+def _percentile_ms(samples: list[RuntimeLatencySample], ratio: float) -> float | None:
+    if not samples:
+        return None
+    ordered = sorted(sample.duration_seconds for sample in samples)
+    index = int(round((len(ordered) - 1) * ratio))
+    return round(ordered[index] * 1000.0, 3)
+```
+
+- [ ] **Step 5: Add app methods**
+
+In `yoyopod/core/application.py`, replace `note_input_activity()` with:
+
+```python
+def note_input_activity(
+    self,
+    action: object,
+    _data: Any | None = None,
+    *,
+    captured_at: float | None = None,
+) -> None:
+    """Record raw or semantic input activity before the coordinator drains it."""
+
+    self.runtime_metrics.note_input_activity(action, _data, captured_at=captured_at)
+```
+
+Then add after `note_handled_input()`:
+
+```python
+def note_visible_refresh(self, *, refreshed_at: float) -> None:
+    """Record that a visible screen refresh happened on the coordinator thread."""
+
+    self.runtime_metrics.note_visible_refresh(refreshed_at=refreshed_at)
+```
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_runtime_metrics.py -q
+```
+
+Expected: all tests in the file pass.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add yoyopod/core/status.py yoyopod/core/application.py tests/core/test_runtime_metrics.py
+git commit -m "feat: track runtime responsiveness latency"
+```
+
+---
+
+## Task 2: Hook Refresh and Drain Metrics Into the Runtime Loop
+
+**Files:**
+
+- Modify: `yoyopod/core/loop.py`
+- Modify: `yoyopod/core/status.py`
+- Test: create `tests/core/test_runtime_loop_metrics.py`
+
+- [ ] **Step 1: Write focused loop tests**
+
+Create `tests/core/test_runtime_loop_metrics.py`:
+
+```python
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from yoyopod.core.application import YoyoPodApp
+
+
+class _ScreenManager:
+    def __init__(self) -> None:
+        self.refresh_count = 0
+
+    def get_current_screen(self) -> object:
+        return SimpleNamespace(route_name="hub")
+
+    def refresh_current_screen_for_visible_tick(self) -> None:
+        self.refresh_count += 1
+
+
+def test_visible_screen_refresh_records_action_to_visible_latency() -> None:
+    app = YoyoPodApp()
+    screen_manager = _ScreenManager()
+    app.screen_manager = screen_manager
+    app.app_state_runtime = SimpleNamespace(get_state_name=lambda: "idle")
+    app.call_interruption_policy = SimpleNamespace(music_interrupted_by_call=False)
+    app._screen_awake = True
+    app.note_input_activity(SimpleNamespace(value="select"), 0, captured_at=100.0)
+    app.note_handled_input(action_name="select", handled_at=100.020)
+
+    app.runtime_loop.run_iteration(
+        monotonic_now=100.100,
+        current_time=200.0,
+        last_screen_update=198.0,
+        screen_update_interval=1.0,
+    )
+
+    snapshot = app.runtime_metrics.responsiveness_snapshot(now=101.0)
+    assert screen_manager.refresh_count == 1
+    assert snapshot["responsiveness_action_to_visible_count"] == 1
+    assert snapshot["responsiveness_last_visible_action_name"] == "select"
+
+
+def test_timing_snapshot_includes_drain_duration() -> None:
+    app = YoyoPodApp()
+    app.runtime_loop.process_pending_main_thread_actions()
+
+    snapshot = app.runtime_loop.timing_snapshot(now=1.0)
+
+    assert "runtime_main_thread_drain_seconds" in snapshot
+    assert snapshot["runtime_main_thread_drain_seconds"] is not None
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_runtime_loop_metrics.py -q
+```
+
+Expected: failure because visible refresh does not record latency and drain duration is not exposed.
+
+- [ ] **Step 3: Store main-thread drain duration**
+
+In `yoyopod/core/loop.py`, add an instance field in `RuntimeLoopService.__init__()`:
+
+```python
+self._last_main_thread_drain_duration_seconds = 0.0
+```
+
+At the end of `process_pending_main_thread_actions()` before `return`, add:
+
+```python
+self._last_main_thread_drain_duration_seconds = max(0.0, time.monotonic() - started_at)
+```
+
+At the end of `_process_pending_main_thread_actions_for_iteration()` before `return`, add:
+
+```python
+self._last_main_thread_drain_duration_seconds = max(0.0, time.monotonic() - started_at)
+```
+
+- [ ] **Step 4: Record visible refresh**
+
+In `RuntimeLoopService.run_iteration()`, replace the visible refresh block:
+
+```python
+self._measure_blocking_span(
+    "visible_screen_refresh",
+    screen_manager.refresh_current_screen_for_visible_tick,
+)
+return current_time
+```
+
+with:
+
+```python
+self._measure_blocking_span(
+    "visible_screen_refresh",
+    screen_manager.refresh_current_screen_for_visible_tick,
+)
+self.app.note_visible_refresh(refreshed_at=time.monotonic())
+return current_time
+```
+
+- [ ] **Step 5: Expose drain duration in timing snapshot**
+
+In `RuntimeLoopService.timing_snapshot()`, add:
+
+```python
+"runtime_main_thread_drain_seconds": (
+    self._last_main_thread_drain_duration_seconds
+    if self._last_loop_iteration_started_at > 0.0
+    or self._last_main_thread_drain_duration_seconds > 0.0
+    else None
+),
+```
+
+- [ ] **Step 6: Expose responsiveness snapshot through runtime status**
+
+In `RuntimeStatusService.get_status()`, add this near the final `**self.app.runtime_loop.timing_snapshot(...)` merge:
+
+```python
+**runtime_metrics.responsiveness_snapshot(now=monotonic_now),
+```
+
+The end of the returned dict should include both responsiveness keys and loop timing keys.
+
+- [ ] **Step 7: Run tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_runtime_metrics.py tests/core/test_runtime_loop_metrics.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add yoyopod/core/loop.py yoyopod/core/status.py yoyopod/core/application.py tests/core/test_runtime_loop_metrics.py tests/core/test_runtime_metrics.py
+git commit -m "feat: expose runtime responsiveness diagnostics"
+```
+
+---
+
+## Task 3: PSS/RSS Memory Snapshot Helper
+
+**Files:**
+
+- Create: `yoyopod/core/diagnostics/memory.py`
+- Modify: `yoyopod/core/status.py`
+- Test: `tests/core/diagnostics/test_memory.py`
+
+- [ ] **Step 1: Write memory parser tests**
+
+Create `tests/core/diagnostics/test_memory.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from yoyopod.core.diagnostics.memory import (
+    ProcessMemorySnapshot,
+    collect_process_memory,
+    parse_smaps_rollup,
+    parse_status_rss_kb,
+)
+
+
+def test_parse_smaps_rollup_extracts_pss_rss_and_private_dirty() -> None:
+    text = """
+Rss:               42184 kB
+Pss:               19928 kB
+Private_Dirty:      7120 kB
+SwapPss:              0 kB
+""".strip()
+
+    snapshot = parse_smaps_rollup(text, pid=123)
+
+    assert snapshot == ProcessMemorySnapshot(
+        pid=123,
+        rss_kb=42184,
+        pss_kb=19928,
+        private_dirty_kb=7120,
+        source="smaps_rollup",
+    )
+
+
+def test_parse_status_rss_kb_extracts_vmrss() -> None:
+    text = """
+Name:\tpython
+VmRSS:\t   35100 kB
+Threads:\t4
+""".strip()
+
+    assert parse_status_rss_kb(text) == 35100
+
+
+def test_collect_process_memory_uses_status_when_smaps_missing(tmp_path: Path) -> None:
+    proc_dir = tmp_path / "123"
+    proc_dir.mkdir(parents=True)
+    (proc_dir / "status").write_text("VmRSS:\t2048 kB\n", encoding="utf-8")
+
+    snapshot = collect_process_memory(pid=123, proc_root=tmp_path)
+
+    assert snapshot.pid == 123
+    assert snapshot.rss_kb == 2048
+    assert snapshot.pss_kb is None
+    assert snapshot.source == "status"
+
+
+def test_collect_process_memory_returns_unavailable_when_proc_missing(tmp_path: Path) -> None:
+    snapshot = collect_process_memory(pid=999, proc_root=tmp_path)
+
+    assert snapshot.pid == 999
+    assert snapshot.rss_kb is None
+    assert snapshot.pss_kb is None
+    assert snapshot.source == "unavailable"
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/core/diagnostics/test_memory.py -q
+```
+
+Expected: import failure because `yoyopod.core.diagnostics.memory` does not exist.
+
+- [ ] **Step 3: Implement memory helper**
+
+Create `yoyopod/core/diagnostics/memory.py`:
+
+```python
+"""Small process memory snapshot helpers for Pi diagnostics."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessMemorySnapshot:
+    """Best-effort memory snapshot for one process."""
+
+    pid: int
+    rss_kb: int | None
+    pss_kb: int | None
+    private_dirty_kb: int | None
+    source: str
+
+
+def collect_process_memory(
+    *,
+    pid: int | None = None,
+    proc_root: Path = Path("/proc"),
+) -> ProcessMemorySnapshot:
+    """Return PSS/RSS when Linux procfs exposes it, else a safe unavailable snapshot."""
+
+    actual_pid = os.getpid() if pid is None else int(pid)
+    proc_dir = proc_root / str(actual_pid)
+    smaps_path = proc_dir / "smaps_rollup"
+    status_path = proc_dir / "status"
+
+    if smaps_path.exists():
+        return parse_smaps_rollup(smaps_path.read_text(encoding="utf-8"), pid=actual_pid)
+
+    if status_path.exists():
+        return ProcessMemorySnapshot(
+            pid=actual_pid,
+            rss_kb=parse_status_rss_kb(status_path.read_text(encoding="utf-8")),
+            pss_kb=None,
+            private_dirty_kb=None,
+            source="status",
+        )
+
+    return ProcessMemorySnapshot(
+        pid=actual_pid,
+        rss_kb=None,
+        pss_kb=None,
+        private_dirty_kb=None,
+        source="unavailable",
+    )
+
+
+def parse_smaps_rollup(text: str, *, pid: int) -> ProcessMemorySnapshot:
+    """Parse the memory fields used by the runtime architecture spec."""
+
+    values = _parse_kb_fields(text)
+    return ProcessMemorySnapshot(
+        pid=pid,
+        rss_kb=values.get("Rss"),
+        pss_kb=values.get("Pss"),
+        private_dirty_kb=values.get("Private_Dirty"),
+        source="smaps_rollup",
+    )
+
+
+def parse_status_rss_kb(text: str) -> int | None:
+    """Parse VmRSS from /proc/<pid>/status."""
+
+    return _parse_kb_fields(text).get("VmRSS")
+
+
+def _parse_kb_fields(text: str) -> dict[str, int]:
+    values: dict[str, int] = {}
+    for raw_line in text.splitlines():
+        if ":" not in raw_line:
+            continue
+        key, raw_value = raw_line.split(":", 1)
+        parts = raw_value.strip().split()
+        if len(parts) < 2 or parts[1] != "kB":
+            continue
+        try:
+            values[key.strip()] = int(parts[0])
+        except ValueError:
+            continue
+    return values
+```
+
+- [ ] **Step 4: Add memory fields to status**
+
+In `yoyopod/core/status.py`, add:
+
+```python
+from yoyopod.core.diagnostics.memory import collect_process_memory
+```
+
+Inside `RuntimeStatusService.get_status()`, after `monotonic_now = time.monotonic()`, add:
+
+```python
+process_memory = collect_process_memory()
+```
+
+Add these keys to the returned dict:
+
+```python
+"process_memory_pid": process_memory.pid,
+"process_memory_rss_kb": process_memory.rss_kb,
+"process_memory_pss_kb": process_memory.pss_kb,
+"process_memory_private_dirty_kb": process_memory.private_dirty_kb,
+"process_memory_source": process_memory.source,
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/diagnostics/test_memory.py tests/core/test_runtime_metrics.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add yoyopod/core/diagnostics/memory.py yoyopod/core/status.py tests/core/diagnostics/test_memory.py
+git commit -m "feat: add process memory diagnostics"
+```
+
+---
+
+## Task 4: Worker NDJSON Protocol
+
+**Files:**
+
+- Create: `yoyopod/core/workers/__init__.py`
+- Create: `yoyopod/core/workers/protocol.py`
+- Test: `tests/core/workers/test_protocol.py`
+
+- [ ] **Step 1: Write protocol tests**
+
+Create `tests/core/workers/test_protocol.py`:
+
+```python
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from yoyopod.core.workers.protocol import (
+    WorkerEnvelope,
+    WorkerProtocolError,
+    encode_envelope,
+    make_envelope,
+    parse_envelope_line,
+)
+
+
+def test_parse_envelope_line_accepts_valid_ndjson() -> None:
+    line = json.dumps(
+        {
+            "schema_version": 1,
+            "kind": "event",
+            "type": "network.status",
+            "request_id": "req-1",
+            "timestamp_ms": 1777100000000,
+            "deadline_ms": 5000,
+            "payload": {"online": True},
+        }
+    )
+
+    envelope = parse_envelope_line(line)
+
+    assert envelope == WorkerEnvelope(
+        schema_version=1,
+        kind="event",
+        type="network.status",
+        request_id="req-1",
+        timestamp_ms=1777100000000,
+        deadline_ms=5000,
+        payload={"online": True},
+    )
+
+
+def test_parse_envelope_line_rejects_unknown_schema() -> None:
+    with pytest.raises(WorkerProtocolError, match="schema_version"):
+        parse_envelope_line('{"schema_version": 2, "kind": "event", "type": "x", "payload": {}}')
+
+
+def test_parse_envelope_line_rejects_non_dict_payload() -> None:
+    with pytest.raises(WorkerProtocolError, match="payload"):
+        parse_envelope_line('{"schema_version": 1, "kind": "event", "type": "x", "payload": []}')
+
+
+def test_encode_envelope_returns_newline_terminated_json() -> None:
+    envelope = make_envelope(
+        kind="command",
+        type="voice.cancel",
+        payload={"request_id": "abc"},
+        request_id="abc",
+        timestamp_ms=1777100000001,
+        deadline_ms=100,
+    )
+
+    encoded = encode_envelope(envelope)
+
+    assert encoded.endswith("\n")
+    assert parse_envelope_line(encoded) == envelope
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/core/workers/test_protocol.py -q
+```
+
+Expected: import failure because worker protocol package does not exist.
+
+- [ ] **Step 3: Implement protocol module**
+
+Create `yoyopod/core/workers/protocol.py`:
+
+```python
+"""Language-neutral NDJSON protocol for YoYoPod worker sidecars."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+SUPPORTED_SCHEMA_VERSION = 1
+VALID_KINDS = frozenset({"command", "event", "result", "error", "heartbeat"})
+
+
+class WorkerProtocolError(ValueError):
+    """Raised when one worker protocol line cannot be accepted."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerEnvelope:
+    """One validated worker protocol message."""
+
+    schema_version: int
+    kind: str
+    type: str
+    request_id: str | None = None
+    timestamp_ms: int = 0
+    deadline_ms: int = 0
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+def make_envelope(
+    *,
+    kind: str,
+    type: str,
+    payload: dict[str, Any] | None = None,
+    request_id: str | None = None,
+    timestamp_ms: int = 0,
+    deadline_ms: int = 0,
+) -> WorkerEnvelope:
+    """Create a validated envelope using the current schema."""
+
+    return _validate(
+        {
+            "schema_version": SUPPORTED_SCHEMA_VERSION,
+            "kind": kind,
+            "type": type,
+            "request_id": request_id,
+            "timestamp_ms": timestamp_ms,
+            "deadline_ms": deadline_ms,
+            "payload": dict(payload or {}),
+        }
+    )
+
+
+def parse_envelope_line(line: str | bytes) -> WorkerEnvelope:
+    """Parse one newline-delimited JSON worker message."""
+
+    if isinstance(line, bytes):
+        line = line.decode("utf-8", errors="replace")
+    try:
+        raw = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise WorkerProtocolError(f"invalid JSON: {exc.msg}") from exc
+    return _validate(raw)
+
+
+def encode_envelope(envelope: WorkerEnvelope) -> str:
+    """Serialize one envelope as stable newline-delimited JSON."""
+
+    payload = {
+        "schema_version": envelope.schema_version,
+        "kind": envelope.kind,
+        "type": envelope.type,
+        "request_id": envelope.request_id,
+        "timestamp_ms": envelope.timestamp_ms,
+        "deadline_ms": envelope.deadline_ms,
+        "payload": envelope.payload,
+    }
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n"
+
+
+def _validate(raw: object) -> WorkerEnvelope:
+    if not isinstance(raw, dict):
+        raise WorkerProtocolError("worker envelope must be a JSON object")
+
+    schema_version = raw.get("schema_version")
+    if schema_version != SUPPORTED_SCHEMA_VERSION:
+        raise WorkerProtocolError(
+            f"unsupported schema_version {schema_version!r}; expected {SUPPORTED_SCHEMA_VERSION}"
+        )
+
+    kind = raw.get("kind")
+    if not isinstance(kind, str) or kind not in VALID_KINDS:
+        raise WorkerProtocolError(f"invalid kind {kind!r}")
+
+    message_type = raw.get("type")
+    if not isinstance(message_type, str) or not message_type:
+        raise WorkerProtocolError("type must be a non-empty string")
+
+    payload = raw.get("payload", {})
+    if not isinstance(payload, dict):
+        raise WorkerProtocolError("payload must be an object")
+
+    request_id = raw.get("request_id")
+    if request_id is not None and not isinstance(request_id, str):
+        raise WorkerProtocolError("request_id must be a string or null")
+
+    return WorkerEnvelope(
+        schema_version=SUPPORTED_SCHEMA_VERSION,
+        kind=kind,
+        type=message_type,
+        request_id=request_id,
+        timestamp_ms=_coerce_non_negative_int(raw.get("timestamp_ms", 0), "timestamp_ms"),
+        deadline_ms=_coerce_non_negative_int(raw.get("deadline_ms", 0), "deadline_ms"),
+        payload=dict(payload),
+    )
+
+
+def _coerce_non_negative_int(value: object, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise WorkerProtocolError(f"{field_name} must be a non-negative integer")
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError) as exc:
+        raise WorkerProtocolError(f"{field_name} must be a non-negative integer") from exc
+    if coerced < 0:
+        raise WorkerProtocolError(f"{field_name} must be a non-negative integer")
+    return coerced
+```
+
+Create `yoyopod/core/workers/__init__.py`:
+
+```python
+"""Worker process primitives for YoYoPod runtime sidecars."""
+
+from yoyopod.core.workers.protocol import (
+    SUPPORTED_SCHEMA_VERSION,
+    WorkerEnvelope,
+    WorkerProtocolError,
+    encode_envelope,
+    make_envelope,
+    parse_envelope_line,
+)
+
+__all__ = [
+    "SUPPORTED_SCHEMA_VERSION",
+    "WorkerEnvelope",
+    "WorkerProtocolError",
+    "encode_envelope",
+    "make_envelope",
+    "parse_envelope_line",
+]
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/workers/test_protocol.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add yoyopod/core/workers/__init__.py yoyopod/core/workers/protocol.py tests/core/workers/test_protocol.py
+git commit -m "feat: add worker message protocol"
+```
+
+---
+
+## Task 5: Single Worker Process Runtime
+
+**Files:**
+
+- Create: `yoyopod/core/workers/process.py`
+- Modify: `yoyopod/core/workers/__init__.py`
+- Test: `tests/core/workers/test_process.py`
+
+- [ ] **Step 1: Write process runtime tests**
+
+Create `tests/core/workers/test_process.py`:
+
+```python
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from yoyopod.core.workers.process import WorkerProcessConfig, WorkerProcessRuntime
+
+
+def _write_worker(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "fake_worker.py"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_worker_process_round_trips_envelopes(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import json
+import sys
+
+for line in sys.stdin:
+    msg = json.loads(line)
+    sys.stdout.write(json.dumps({
+        "schema_version": 1,
+        "kind": "result",
+        "type": msg["type"],
+        "request_id": msg.get("request_id"),
+        "timestamp_ms": msg.get("timestamp_ms", 0),
+        "deadline_ms": 0,
+        "payload": {"ok": True, "echo": msg.get("payload", {})},
+    }) + "\\n")
+    sys.stdout.flush()
+""".strip(),
+    )
+    runtime = WorkerProcessRuntime(
+        WorkerProcessConfig(
+            name="echo",
+            argv=[sys.executable, "-u", str(worker)],
+            receive_queue_size=4,
+        )
+    )
+
+    runtime.start()
+    try:
+        assert runtime.send_command(
+            type="voice.transcribe",
+            payload={"path": "/tmp/audio.wav"},
+            request_id="req-1",
+            timestamp_ms=1000,
+            deadline_ms=5000,
+        )
+        messages = runtime.wait_for_messages(count=1, timeout_seconds=2.0)
+    finally:
+        runtime.stop(grace_seconds=0.2)
+
+    assert len(messages) == 1
+    assert messages[0].kind == "result"
+    assert messages[0].request_id == "req-1"
+    assert messages[0].payload["echo"] == {"path": "/tmp/audio.wav"}
+
+
+def test_worker_process_counts_malformed_stdout(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import sys
+sys.stdout.write("not json\\n")
+sys.stdout.flush()
+""".strip(),
+    )
+    runtime = WorkerProcessRuntime(
+        WorkerProcessConfig(name="bad", argv=[sys.executable, "-u", str(worker)])
+    )
+
+    runtime.start()
+    try:
+        runtime.wait_until_exited(timeout_seconds=2.0)
+        runtime.drain_messages()
+        snapshot = runtime.snapshot()
+    finally:
+        runtime.stop(grace_seconds=0.1)
+
+    assert snapshot.protocol_errors >= 1
+
+
+def test_worker_process_stop_is_bounded_for_stuck_worker(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import time
+time.sleep(60)
+""".strip(),
+    )
+    runtime = WorkerProcessRuntime(
+        WorkerProcessConfig(name="stuck", argv=[sys.executable, "-u", str(worker)])
+    )
+
+    runtime.start()
+    runtime.stop(grace_seconds=0.05)
+
+    snapshot = runtime.snapshot()
+    assert snapshot.running is False
+    assert snapshot.terminated is True
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/core/workers/test_process.py -q
+```
+
+Expected: import failure because `WorkerProcessRuntime` does not exist.
+
+- [ ] **Step 3: Implement process runtime dataclasses**
+
+Create `yoyopod/core/workers/process.py` with these imports and dataclasses:
+
+```python
+"""One child-process runtime for NDJSON worker sidecars."""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from queue import Empty, Full, Queue
+from typing import TextIO
+
+from loguru import logger
+
+from yoyopod.core.workers.protocol import (
+    WorkerEnvelope,
+    WorkerProtocolError,
+    encode_envelope,
+    make_envelope,
+    parse_envelope_line,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerProcessConfig:
+    """Configuration for one managed worker process."""
+
+    name: str
+    argv: list[str]
+    cwd: str | None = None
+    env: dict[str, str] | None = None
+    receive_queue_size: int = 64
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerProcessSnapshot:
+    """Observable state for one worker process."""
+
+    name: str
+    running: bool
+    pid: int | None
+    returncode: int | None
+    received_messages: int
+    protocol_errors: int
+    dropped_messages: int
+    stderr_lines: int
+    terminated: bool
+    killed: bool
+```
+
+- [ ] **Step 4: Implement process runtime core**
+
+Continue `process.py`:
+
+```python
+class WorkerProcessRuntime:
+    """Manage stdio for one worker child process without blocking the UI loop."""
+
+    def __init__(self, config: WorkerProcessConfig) -> None:
+        self.config = config
+        self._process: subprocess.Popen[str] | None = None
+        self._messages: Queue[WorkerEnvelope] = Queue(maxsize=max(1, config.receive_queue_size))
+        self._stdin_lock = threading.Lock()
+        self._reader_threads: list[threading.Thread] = []
+        self._received_messages = 0
+        self._protocol_errors = 0
+        self._dropped_messages = 0
+        self._stderr_lines = 0
+        self._terminated = False
+        self._killed = False
+
+    def start(self) -> None:
+        """Start the child process and stdout/stderr reader threads."""
+
+        if self.running:
+            return
+        self._process = subprocess.Popen(
+            self.config.argv,
+            cwd=self.config.cwd,
+            env=self.config.env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        assert self._process.stdout is not None
+        assert self._process.stderr is not None
+        self._reader_threads = [
+            self._start_reader("stdout", self._process.stdout),
+            self._start_reader("stderr", self._process.stderr),
+        ]
+
+    @property
+    def running(self) -> bool:
+        """Return whether the child process is still alive."""
+
+        return self._process is not None and self._process.poll() is None
+
+    def send_command(
+        self,
+        *,
+        type: str,
+        payload: dict[str, object] | None = None,
+        request_id: str | None = None,
+        timestamp_ms: int = 0,
+        deadline_ms: int = 0,
+    ) -> bool:
+        """Write one command envelope to worker stdin."""
+
+        envelope = make_envelope(
+            kind="command",
+            type=type,
+            payload=payload,
+            request_id=request_id,
+            timestamp_ms=timestamp_ms,
+            deadline_ms=deadline_ms,
+        )
+        return self.send(envelope)
+
+    def send(self, envelope: WorkerEnvelope) -> bool:
+        """Write one envelope to worker stdin and report whether it was accepted."""
+
+        process = self._process
+        if process is None or process.stdin is None or process.poll() is not None:
+            return False
+        with self._stdin_lock:
+            try:
+                process.stdin.write(encode_envelope(envelope))
+                process.stdin.flush()
+                return True
+            except (BrokenPipeError, OSError, ValueError):
+                return False
+```
+
+- [ ] **Step 5: Implement nonblocking drains and bounded stop**
+
+Append:
+
+```python
+    def drain_messages(self, limit: int | None = None) -> list[WorkerEnvelope]:
+        """Return available worker messages without blocking."""
+
+        messages: list[WorkerEnvelope] = []
+        while limit is None or len(messages) < limit:
+            try:
+                messages.append(self._messages.get_nowait())
+            except Empty:
+                break
+        return messages
+
+    def wait_for_messages(
+        self,
+        *,
+        count: int,
+        timeout_seconds: float,
+    ) -> list[WorkerEnvelope]:
+        """Testing helper that waits for a small number of messages."""
+
+        deadline = time.monotonic() + timeout_seconds
+        messages: list[WorkerEnvelope] = []
+        while len(messages) < count and time.monotonic() < deadline:
+            messages.extend(self.drain_messages(limit=count - len(messages)))
+            if len(messages) >= count:
+                break
+            time.sleep(0.01)
+        return messages
+
+    def wait_until_exited(self, *, timeout_seconds: float) -> bool:
+        """Testing helper that waits for process exit."""
+
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            if self._process is None or self._process.poll() is not None:
+                return True
+            time.sleep(0.01)
+        return False
+
+    def stop(self, *, grace_seconds: float = 1.0) -> None:
+        """Stop the worker with bounded terminate/kill behavior."""
+
+        process = self._process
+        if process is None:
+            return
+        if process.poll() is None:
+            try:
+                self.send_command(type="worker.stop", payload={}, deadline_ms=int(grace_seconds * 1000))
+            except Exception:
+                pass
+            deadline = time.monotonic() + max(0.0, grace_seconds)
+            while process.poll() is None and time.monotonic() < deadline:
+                time.sleep(0.01)
+        if process.poll() is None:
+            process.terminate()
+            self._terminated = True
+            try:
+                process.wait(timeout=max(0.05, grace_seconds))
+            except subprocess.TimeoutExpired:
+                process.kill()
+                self._killed = True
+                process.wait(timeout=1.0)
+        self._join_readers(timeout_seconds=0.2)
+```
+
+- [ ] **Step 6: Implement readers and snapshot**
+
+Append:
+
+```python
+    def snapshot(self) -> WorkerProcessSnapshot:
+        """Return the observable process state."""
+
+        process = self._process
+        return WorkerProcessSnapshot(
+            name=self.config.name,
+            running=self.running,
+            pid=process.pid if process is not None else None,
+            returncode=process.poll() if process is not None else None,
+            received_messages=self._received_messages,
+            protocol_errors=self._protocol_errors,
+            dropped_messages=self._dropped_messages,
+            stderr_lines=self._stderr_lines,
+            terminated=self._terminated,
+            killed=self._killed,
+        )
+
+    def _start_reader(self, stream_name: str, stream: TextIO) -> threading.Thread:
+        thread = threading.Thread(
+            target=self._read_stream,
+            args=(stream_name, stream),
+            name=f"yoyopod-worker-{self.config.name}-{stream_name}",
+            daemon=True,
+        )
+        thread.start()
+        return thread
+
+    def _read_stream(self, stream_name: str, stream: TextIO) -> None:
+        for line in stream:
+            if stream_name == "stderr":
+                self._stderr_lines += 1
+                logger.info("worker {} stderr: {}", self.config.name, line.rstrip())
+                continue
+            try:
+                envelope = parse_envelope_line(line)
+            except WorkerProtocolError:
+                self._protocol_errors += 1
+                continue
+            try:
+                self._messages.put_nowait(envelope)
+                self._received_messages += 1
+            except Full:
+                self._dropped_messages += 1
+
+    def _join_readers(self, *, timeout_seconds: float) -> None:
+        for thread in self._reader_threads:
+            thread.join(timeout=timeout_seconds)
+```
+
+- [ ] **Step 7: Export process runtime**
+
+Update `yoyopod/core/workers/__init__.py`:
+
+```python
+from yoyopod.core.workers.process import (
+    WorkerProcessConfig,
+    WorkerProcessRuntime,
+    WorkerProcessSnapshot,
+)
+```
+
+Add these names to `__all__`.
+
+- [ ] **Step 8: Run process tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/workers/test_protocol.py tests/core/workers/test_process.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+git add yoyopod/core/workers/process.py yoyopod/core/workers/__init__.py tests/core/workers/test_process.py
+git commit -m "feat: add worker process runtime"
+```
+
+---
+
+## Task 6: Worker Supervisor, Events, and Status
+
+**Files:**
+
+- Create: `yoyopod/core/workers/supervisor.py`
+- Modify: `yoyopod/core/events.py`
+- Modify: `yoyopod/core/__init__.py`
+- Modify: `yoyopod/core/workers/__init__.py`
+- Test: `tests/core/workers/test_supervisor.py`
+
+- [ ] **Step 1: Write supervisor tests**
+
+Create `tests/core/workers/test_supervisor.py`:
+
+```python
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from yoyopod.core.bus import Bus
+from yoyopod.core.events import WorkerDomainStateChangedEvent
+from yoyopod.core.scheduler import MainThreadScheduler
+from yoyopod.core.workers.process import WorkerProcessConfig
+from yoyopod.core.workers.supervisor import WorkerSupervisor
+
+
+def _write_worker(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "fake_worker.py"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_supervisor_publishes_worker_messages_on_main_bus(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import json
+import sys
+sys.stdout.write(json.dumps({
+    "schema_version": 1,
+    "kind": "event",
+    "type": "fake.ready",
+    "request_id": None,
+    "timestamp_ms": 1,
+    "deadline_ms": 0,
+    "payload": {"ready": True},
+}) + "\\n")
+sys.stdout.flush()
+for line in sys.stdin:
+    pass
+""".strip(),
+    )
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    seen = []
+    bus.subscribe(WorkerDomainStateChangedEvent, seen.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(name="voice", argv=[sys.executable, "-u", str(worker)]),
+    )
+
+    supervisor.start("voice")
+    try:
+        supervisor.poll()
+        bus.drain()
+    finally:
+        supervisor.stop_all(grace_seconds=0.1)
+
+    snapshot = supervisor.snapshot()
+    assert snapshot["voice"]["received_messages"] >= 1
+
+
+def test_supervisor_marks_crashed_worker_degraded(tmp_path: Path) -> None:
+    worker = _write_worker(tmp_path, "raise SystemExit(7)")
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    events = []
+    bus.subscribe(WorkerDomainStateChangedEvent, events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus, restart_backoff_seconds=60.0)
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(name="voice", argv=[sys.executable, "-u", str(worker)]),
+    )
+
+    supervisor.start("voice")
+    supervisor.wait_until_exited("voice", timeout_seconds=2.0)
+    supervisor.poll()
+    bus.drain()
+
+    assert supervisor.snapshot()["voice"]["state"] == "degraded"
+    assert events[-1].domain == "voice"
+    assert events[-1].state == "degraded"
+
+
+def test_supervisor_request_timeout_sends_cancel(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import json
+import sys
+for line in sys.stdin:
+    msg = json.loads(line)
+    if msg["type"] == "voice.cancel":
+        sys.stdout.write(json.dumps({
+            "schema_version": 1,
+            "kind": "result",
+            "type": "voice.cancelled",
+            "request_id": msg.get("request_id"),
+            "timestamp_ms": 1,
+            "deadline_ms": 0,
+            "payload": {"cancelled": True},
+        }) + "\\n")
+        sys.stdout.flush()
+""".strip(),
+    )
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(name="voice", argv=[sys.executable, "-u", str(worker)]),
+    )
+
+    supervisor.start("voice")
+    try:
+        assert supervisor.send_request(
+            "voice",
+            type="voice.transcribe",
+            payload={"path": "/tmp/a.wav"},
+            request_id="req-timeout",
+            timeout_seconds=0.01,
+        )
+        supervisor.poll(monotonic_now=100.0)
+        supervisor.poll(monotonic_now=101.0)
+        messages = supervisor.drain_worker_messages("voice")
+    finally:
+        supervisor.stop_all(grace_seconds=0.1)
+
+    assert supervisor.snapshot()["voice"]["request_timeouts"] == 1
+    assert any(message.type == "voice.cancelled" for message in messages)
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/core/workers/test_supervisor.py -q
+```
+
+Expected: imports fail because supervisor and worker events do not exist.
+
+- [ ] **Step 3: Add worker events**
+
+In `yoyopod/core/events.py`, add:
+
+```python
+@dataclass(frozen=True, slots=True)
+class WorkerDomainStateChangedEvent:
+    """Published when one worker-backed domain changes availability."""
+
+    domain: str
+    state: str
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerMessageReceivedEvent:
+    """Published when a worker emits a protocol event or result."""
+
+    domain: str
+    kind: str
+    type: str
+    request_id: str | None
+    payload: dict[str, Any]
+```
+
+Add both names to `events.py` `__all__`.
+
+In `yoyopod/core/__init__.py`, add these entries to `_PUBLIC_EXPORTS`:
+
+```python
+"WorkerDomainStateChangedEvent": (
+    "yoyopod.core.events",
+    "WorkerDomainStateChangedEvent",
+),
+"WorkerMessageReceivedEvent": (
+    "yoyopod.core.events",
+    "WorkerMessageReceivedEvent",
+),
+```
+
+- [ ] **Step 4: Implement supervisor dataclasses**
+
+Create `yoyopod/core/workers/supervisor.py`:
+
+```python
+"""Supervisor for named YoYoPod worker processes."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+from yoyopod.core.bus import Bus
+from yoyopod.core.events import (
+    WorkerDomainStateChangedEvent,
+    WorkerMessageReceivedEvent,
+)
+from yoyopod.core.scheduler import MainThreadScheduler
+from yoyopod.core.workers.process import WorkerProcessConfig, WorkerProcessRuntime
+from yoyopod.core.workers.protocol import WorkerEnvelope
+
+
+@dataclass(slots=True)
+class _WorkerSlot:
+    config: WorkerProcessConfig
+    runtime: WorkerProcessRuntime | None = None
+    state: str = "stopped"
+    restart_count: int = 0
+    next_restart_at: float = 0.0
+    request_deadlines: dict[str, float] = field(default_factory=dict)
+    request_timeouts: int = 0
+    last_reason: str = ""
+```
+
+- [ ] **Step 5: Implement supervisor lifecycle**
+
+Append:
+
+```python
+class WorkerSupervisor:
+    """Own worker lifecycle while publishing only on the supervisor main thread."""
+
+    def __init__(
+        self,
+        *,
+        scheduler: MainThreadScheduler,
+        bus: Bus,
+        restart_backoff_seconds: float = 1.0,
+        max_restarts: int = 3,
+    ) -> None:
+        self._scheduler = scheduler
+        self._bus = bus
+        self._restart_backoff_seconds = max(0.0, restart_backoff_seconds)
+        self._max_restarts = max(0, max_restarts)
+        self._workers: dict[str, _WorkerSlot] = {}
+
+    def register(self, domain: str, config: WorkerProcessConfig) -> None:
+        """Register one worker domain before it is started."""
+
+        if domain in self._workers:
+            raise ValueError(f"worker domain {domain!r} is already registered")
+        self._workers[domain] = _WorkerSlot(config=config)
+
+    def start(self, domain: str) -> None:
+        """Start one worker domain."""
+
+        slot = self._workers[domain]
+        runtime = WorkerProcessRuntime(slot.config)
+        runtime.start()
+        slot.runtime = runtime
+        self._set_state(domain, slot, "running", "started")
+
+    def stop_all(self, *, grace_seconds: float = 1.0) -> None:
+        """Stop all registered workers with bounded waits."""
+
+        for domain, slot in self._workers.items():
+            if slot.runtime is not None:
+                slot.runtime.stop(grace_seconds=grace_seconds)
+            self._set_state(domain, slot, "stopped", "stop_all")
+```
+
+- [ ] **Step 6: Implement poll, messages, and timeouts**
+
+Append:
+
+```python
+    def poll(self, *, monotonic_now: float | None = None) -> int:
+        """Advance worker state without blocking."""
+
+        now = time.monotonic() if monotonic_now is None else monotonic_now
+        processed = 0
+        for domain, slot in self._workers.items():
+            runtime = slot.runtime
+            if runtime is None:
+                continue
+            messages = runtime.drain_messages()
+            processed += len(messages)
+            for message in messages:
+                if message.request_id is not None:
+                    slot.request_deadlines.pop(message.request_id, None)
+                self._bus.publish(
+                    WorkerMessageReceivedEvent(
+                        domain=domain,
+                        kind=message.kind,
+                        type=message.type,
+                        request_id=message.request_id,
+                        payload=message.payload,
+                    )
+                )
+            self._expire_requests(domain, slot, now=now)
+            if not runtime.running and slot.state == "running":
+                self._handle_exit(domain, slot, now=now)
+            if slot.state == "degraded" and slot.next_restart_at > 0.0 and now >= slot.next_restart_at:
+                self._restart_if_allowed(domain, slot, now=now)
+        return processed
+
+    def send_request(
+        self,
+        domain: str,
+        *,
+        type: str,
+        payload: dict[str, object],
+        request_id: str,
+        timeout_seconds: float,
+    ) -> bool:
+        """Send one request and remember its timeout."""
+
+        slot = self._workers[domain]
+        runtime = slot.runtime
+        if runtime is None:
+            return False
+        sent = runtime.send_command(
+            type=type,
+            payload=payload,
+            request_id=request_id,
+            timestamp_ms=int(time.time() * 1000),
+            deadline_ms=int(max(0.0, timeout_seconds) * 1000),
+        )
+        if sent:
+            slot.request_deadlines[request_id] = time.monotonic() + max(0.0, timeout_seconds)
+        return sent
+
+    def drain_worker_messages(self, domain: str) -> list[WorkerEnvelope]:
+        """Testing helper for messages that have not yet been consumed by poll."""
+
+        runtime = self._workers[domain].runtime
+        return [] if runtime is None else runtime.drain_messages()
+
+    def wait_until_exited(self, domain: str, *, timeout_seconds: float) -> bool:
+        """Testing helper that waits for one worker process to exit."""
+
+        runtime = self._workers[domain].runtime
+        return True if runtime is None else runtime.wait_until_exited(timeout_seconds=timeout_seconds)
+```
+
+- [ ] **Step 7: Implement state transitions and snapshots**
+
+Append:
+
+```python
+    def snapshot(self) -> dict[str, dict[str, object]]:
+        """Return status-ready worker health data."""
+
+        result: dict[str, dict[str, object]] = {}
+        for domain, slot in self._workers.items():
+            process_snapshot = slot.runtime.snapshot() if slot.runtime is not None else None
+            result[domain] = {
+                "state": slot.state,
+                "restart_count": slot.restart_count,
+                "next_restart_at": slot.next_restart_at,
+                "last_reason": slot.last_reason,
+                "pending_requests": len(slot.request_deadlines),
+                "request_timeouts": slot.request_timeouts,
+                "running": process_snapshot.running if process_snapshot is not None else False,
+                "pid": process_snapshot.pid if process_snapshot is not None else None,
+                "received_messages": (
+                    process_snapshot.received_messages if process_snapshot is not None else 0
+                ),
+                "protocol_errors": (
+                    process_snapshot.protocol_errors if process_snapshot is not None else 0
+                ),
+                "dropped_messages": (
+                    process_snapshot.dropped_messages if process_snapshot is not None else 0
+                ),
+            }
+        return result
+
+    def _expire_requests(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
+        expired = [
+            request_id
+            for request_id, deadline in slot.request_deadlines.items()
+            if deadline <= now
+        ]
+        for request_id in expired:
+            slot.request_deadlines.pop(request_id, None)
+            slot.request_timeouts += 1
+            if slot.runtime is not None:
+                slot.runtime.send_command(
+                    type=f"{domain}.cancel",
+                    payload={"request_id": request_id},
+                    request_id=request_id,
+                    timestamp_ms=int(time.time() * 1000),
+                    deadline_ms=1000,
+                )
+
+    def _handle_exit(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
+        slot.next_restart_at = now + self._restart_backoff_seconds
+        self._set_state(domain, slot, "degraded", "process_exited")
+
+    def _restart_if_allowed(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
+        if slot.restart_count >= self._max_restarts:
+            slot.next_restart_at = 0.0
+            self._set_state(domain, slot, "disabled", "max_restarts_exceeded")
+            return
+        slot.restart_count += 1
+        self.start(domain)
+
+    def _set_state(self, domain: str, slot: _WorkerSlot, state: str, reason: str) -> None:
+        if slot.state == state and slot.last_reason == reason:
+            return
+        slot.state = state
+        slot.last_reason = reason
+        self._bus.publish(
+            WorkerDomainStateChangedEvent(domain=domain, state=state, reason=reason)
+        )
+```
+
+- [ ] **Step 8: Export supervisor**
+
+Update `yoyopod/core/workers/__init__.py`:
+
+```python
+from yoyopod.core.workers.supervisor import WorkerSupervisor
+```
+
+Add `"WorkerSupervisor"` to `__all__`.
+
+- [ ] **Step 9: Run supervisor tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/workers/test_protocol.py tests/core/workers/test_process.py tests/core/workers/test_supervisor.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 10: Commit**
+
+Run:
+
+```bash
+git add yoyopod/core/events.py yoyopod/core/__init__.py yoyopod/core/workers/__init__.py yoyopod/core/workers/supervisor.py tests/core/workers/test_supervisor.py
+git commit -m "feat: add worker supervisor"
+```
+
+---
+
+## Task 7: Integrate Worker Supervisor Into App and Loop
+
+**Files:**
+
+- Modify: `yoyopod/core/application.py`
+- Modify: `yoyopod/core/loop.py`
+- Modify: `yoyopod/core/status.py`
+- Test: `tests/core/workers/test_supervisor.py`
+- Test: `tests/core/test_runtime_loop_metrics.py`
+
+- [ ] **Step 1: Add app integration tests**
+
+Append to `tests/core/workers/test_supervisor.py`:
+
+```python
+from yoyopod.core.application import YoyoPodApp
+from yoyopod.core.workers.supervisor import WorkerSupervisor
+
+
+def test_app_owns_worker_supervisor() -> None:
+    app = YoyoPodApp()
+
+    assert isinstance(app.worker_supervisor, WorkerSupervisor)
+    assert app.get_status
+
+
+def test_status_includes_worker_snapshot() -> None:
+    app = YoyoPodApp()
+    app.app_state_runtime = type("State", (), {"get_state_name": lambda self: "idle"})()
+    app.call_interruption_policy = type(
+        "Policy",
+        (),
+        {"music_interrupted_by_call": False},
+    )()
+
+    status = app.get_status()
+
+    assert status["workers"] == {}
+```
+
+Append to `tests/core/test_runtime_loop_metrics.py`:
+
+```python
+def test_runtime_loop_polls_worker_supervisor() -> None:
+    app = YoyoPodApp()
+    calls = []
+    app.worker_supervisor = SimpleNamespace(
+        poll=lambda: calls.append("poll") or 0,
+        snapshot=lambda: {},
+    )
+    app.app_state_runtime = SimpleNamespace(get_state_name=lambda: "idle")
+    app.call_interruption_policy = SimpleNamespace(music_interrupted_by_call=False)
+
+    app.runtime_loop.run_iteration(
+        monotonic_now=10.0,
+        current_time=20.0,
+        last_screen_update=20.0,
+        screen_update_interval=1.0,
+    )
+
+    assert calls == ["poll"]
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/core/workers/test_supervisor.py tests/core/test_runtime_loop_metrics.py -q
+```
+
+Expected: failure because app does not own `worker_supervisor` and loop does not poll it.
+
+- [ ] **Step 3: Add app-owned supervisor**
+
+In `yoyopod/core/application.py`, import:
+
+```python
+from yoyopod.core.workers import WorkerSupervisor
+```
+
+In `YoyoPodApp.__init__()`, after `self.runtime_metrics = RuntimeMetricsStore()`, add:
+
+```python
+self.worker_supervisor = WorkerSupervisor(scheduler=self.scheduler, bus=self.bus)
+```
+
+- [ ] **Step 4: Stop workers before legacy resources**
+
+In `YoyoPodApp.stop()`, before `_teardown_registered_integrations()`, add:
+
+```python
+self.worker_supervisor.stop_all(grace_seconds=1.0)
+```
+
+This stop is safe when no workers are registered.
+
+- [ ] **Step 5: Poll workers in runtime loop**
+
+In `RuntimeLoopService.run_iteration()`, after the `main_thread_actions` span and before manager recovery, add:
+
+```python
+self._measure_blocking_span(
+    "worker_poll",
+    self.app.worker_supervisor.poll,
+)
+```
+
+- [ ] **Step 6: Expose worker snapshot in status and timing snapshot**
+
+In `RuntimeStatusService.get_status()`, add:
+
+```python
+"workers": self.app.worker_supervisor.snapshot(),
+```
+
+In `RuntimeLoopService.timing_snapshot()`, add:
+
+```python
+"runtime_worker_count": len(self.app.worker_supervisor.snapshot()),
+```
+
+- [ ] **Step 7: Run tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/workers/test_supervisor.py tests/core/test_runtime_loop_metrics.py tests/core/test_runtime_metrics.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add yoyopod/core/application.py yoyopod/core/loop.py yoyopod/core/status.py tests/core/workers/test_supervisor.py tests/core/test_runtime_loop_metrics.py
+git commit -m "feat: integrate worker supervisor with runtime"
+```
+
+---
+
+## Task 8: Diagnostics Workflow Documentation
+
+**Files:**
+
+- Modify: `docs/PI_PROFILING_WORKFLOW.md`
+- Test: documentation review by command output
+
+- [ ] **Step 1: Add target-hardware profiling section**
+
+Add this section to `docs/PI_PROFILING_WORKFLOW.md`:
+
+```markdown
+## Runtime Hybrid Phase 0 Baseline
+
+Use this before moving voice or network into sidecar workers. The goal is to capture responsiveness and PSS/RSS with the current single-supervisor runtime.
+
+### Enable responsiveness captures
+
+```bash
+export YOYOPOD_RESPONSIVENESS_WATCHDOG_ENABLED=true
+export YOYOPOD_RESPONSIVENESS_STALL_THRESHOLD_SECONDS=5
+export YOYOPOD_RESPONSIVENESS_RECENT_INPUT_WINDOW_SECONDS=3
+```
+
+### Start the dev lane
+
+```bash
+yoyopod remote mode activate dev
+yoyopod remote sync --branch <branch>
+yoyopod remote status
+```
+
+### Capture status snapshots
+
+Run this before the mixed soak, during voice activity, during network reconnect, and after the soak:
+
+```bash
+yoyopod remote logs --lines 200
+```
+
+In the JSON status or captured diagnostics, record these fields:
+
+- `responsiveness_input_to_action_p95_ms`
+- `responsiveness_action_to_visible_p95_ms`
+- `runtime_loop_gap_seconds`
+- `runtime_main_thread_drain_seconds`
+- `runtime_blocking_span_name`
+- `runtime_blocking_span_seconds`
+- `process_memory_rss_kb`
+- `process_memory_pss_kb`
+- `workers`
+
+### One-hour mixed soak notes
+
+During the soak, exercise:
+
+- idle screen wake/sleep
+- music navigation and playback
+- incoming or simulated VoIP state changes
+- voice command path with current local settings
+- cellular/network reconnect or status polling
+- low-risk power/status screen navigation
+
+The acceptance target for the pre-worker baseline is not pass/fail. The goal is to identify top stalls and memory pressure before Phase 2 and Phase 3.
+```
+
+- [ ] **Step 2: Verify docs render as plain Markdown**
+
+Run:
+
+```bash
+Get-Content docs/PI_PROFILING_WORKFLOW.md | Select-String -Pattern "Runtime Hybrid Phase 0 Baseline"
+```
+
+Expected: the heading is printed once.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add docs/PI_PROFILING_WORKFLOW.md
+git commit -m "docs: add runtime hybrid profiling workflow"
+```
+
+---
+
+## Task 9: Final Verification
+
+**Files:**
+
+- Verify all files changed by Tasks 1-8.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_runtime_metrics.py tests/core/test_runtime_loop_metrics.py tests/core/diagnostics/test_memory.py tests/core/workers/test_protocol.py tests/core/workers/test_process.py tests/core/workers/test_supervisor.py -q
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 2: Run required quality gate**
+
+Run:
+
+```bash
+uv run python scripts/quality.py gate
+```
+
+Expected: `result=passed`.
+
+- [ ] **Step 3: Run full test suite**
+
+Run:
+
+```bash
+uv run pytest -q
+```
+
+Expected: full suite passes. On Windows, compare any failures against current known Windows-only failures before changing code. Do not ignore new failures in files touched by this plan.
+
+- [ ] **Step 4: Inspect final status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: clean working tree after all task commits.
+
+---
+
+## Self-Review
+
+**Spec coverage:** This plan implements Phase 0 and Phase 1 from the design spec. It covers input-to-action latency, action-to-visible-refresh latency, loop/drain/blocking diagnostics, PSS/RSS snapshots, NDJSON worker envelopes, bounded queues, malformed message handling, worker stop bounds, restart/degraded state, cancellation on timeout, worker status, and fake-worker tests.
+
+**Explicitly deferred:** Go cloud voice worker, Python network sidecar, cloud provider API shape, temp audio payload lifetime, worker binary packaging, and VoIP sidecar decision. These require follow-up plans after this foundation is merged and measured.
+
+**Type consistency:** The plan consistently uses `WorkerEnvelope`, `WorkerProcessConfig`, `WorkerProcessRuntime`, `WorkerSupervisor`, `WorkerDomainStateChangedEvent`, and `WorkerMessageReceivedEvent`.
+
+**No new runtime dependencies:** Memory diagnostics use procfs only. Worker runtime uses stdlib process/thread/queue primitives. IPC stays NDJSON over stdio.
+
+**Commit discipline:** Each task ends with a narrow commit. Before the final branch handoff, run both required repo checks: `uv run python scripts/quality.py gate` and `uv run pytest -q`.

--- a/docs/superpowers/specs/2026-04-25-runtime-hybrid-architecture-design.md
+++ b/docs/superpowers/specs/2026-04-25-runtime-hybrid-architecture-design.md
@@ -1,0 +1,518 @@
+# Runtime Hybrid Architecture Design
+
+**Date:** 2026-04-25
+**Owner:** Moustafa
+**Status:** Draft for review
+**Target hardware:** Raspberry Pi Zero 2W
+**Related PR:** GitHub PR #376, `feat(core): add BackgroundExecutor for off-thread work`
+
+---
+
+## 1. Problem
+
+YoYoPod currently behaves like a mostly single-threaded Python application with scattered background work. The main runtime loop owns LVGL, input handling, app state, scheduling, and event delivery. Some subsystems already use threads or native subprocesses, but the concurrency model is not yet an explicit runtime architecture.
+
+The goal is to improve responsiveness on a Raspberry Pi Zero 2W and make better use of its four Cortex-A53 cores without turning the application into seven loosely coordinated services. The GIL prevents CPU-bound Python threads from running Python bytecode in parallel inside one process, but process boundaries and native workers can use additional cores. Threads are still useful for blocking I/O, native extensions that release the GIL, subprocess supervision, and sleep/poll loops.
+
+The design must protect the small-screen UI experience first. A faster architecture that makes call handling, state ownership, or shutdown behavior harder to reason about would be a bad trade.
+
+---
+
+## 2. Goals
+
+- Keep button-to-visible-response latency consistently low under background load.
+- Use additional CPU cores where it matters, especially for voice and blocking hardware I/O.
+- Reduce RAM pressure by avoiding local STT model loading by default.
+- Keep UI, app state, call/music coordination, screen navigation, `Bus`, and `MainThreadScheduler` in one Python supervisor process.
+- Move selected blocking or memory-heavy work behind process boundaries with explicit protocols.
+- Make worker crashes degrade one domain instead of crashing the whole app.
+- Keep the first implementation inspectable and debuggable on a Pi over SSH.
+- Preserve the current codebase's main-thread scheduling pattern: background work returns facts/results to the main thread; the main thread applies state.
+
+---
+
+## 3. Non-goals
+
+- Do not split YoYoPod into seven OS processes in the first architecture pass.
+- Do not move LVGL, screen management, `Bus`, `MainThreadScheduler`, `AppStateRuntime`, `CallRuntime`, or `MusicRuntime` out of the supervisor.
+- Do not make ZeroMQ/msgpack a phase-one dependency.
+- Do not rewrite the network/modem stack in Go before measurements prove it is worth the risk.
+- Do not move VoIP/liblinphone to a sidecar in the first worker wave.
+- Do not guarantee offline voice commands when cloud voice is selected.
+- Do not attempt a full asyncio migration as part of the first process split.
+
+---
+
+## 4. Success Criteria
+
+Responsiveness targets on target hardware:
+
+- Input event to handled action p95 under 50 ms during mixed background work.
+- Handled action to visible LVGL refresh p95 under 100 ms.
+- No main-loop gap over 250 ms during a one-hour mixed soak unless explicitly classified as an expected shutdown/reboot path.
+- No synchronous supervisor wait on voice, network, cloud, or worker shutdown paths during normal UI operation.
+
+Reliability targets:
+
+- A voice worker crash disables voice and produces visible degraded state, but UI, music, network status, and VoIP continue.
+- A network worker crash disables or degrades cellular/GPS/network facts, but UI, music, local navigation, and active app loop continue.
+- Worker queues are bounded. Overflow is counted and reported rather than growing without limit.
+- Shutdown has bounded waits. A stuck worker must not hang `app.stop()` indefinitely.
+
+RAM targets:
+
+- Cloud-first voice should reduce memory versus the current local Vosk default.
+- The first two workers should fit comfortably on Pi Zero 2W after measuring proportional set size (PSS), not only RSS.
+- Local STT models may remain available as an explicit opt-in, but they are not loaded by default.
+
+---
+
+## 5. Architecture Decision
+
+Use a hybrid architecture:
+
+```text
+Python supervisor process
+  owns UI, app state, bus, scheduler, navigation, music/call coordination
+
+Go voice worker process
+  owns cloud STT/TTS streaming, cancellation, and voice request lifecycle
+
+Python network worker process
+  owns serial/modem/GPS/PPP polling and emits network facts
+
+Optional future workers
+  only added after instrumentation shows a concrete stall, crash, or memory problem
+```
+
+The supervisor is the only process allowed to mutate application state. Workers are fact producers and command executors. They report observations and results; they do not own global truth.
+
+This design rejects a first-pass seven-process split because YoYoPod's hardest problem is not raw CPU scheduling. The first bottleneck to prove and fix is responsiveness under blocking I/O and heavy voice paths. A broad service split would add RAM overhead, IPC complexity, ordering bugs, restart policy questions, and more deployment surface before the measurements justify it.
+
+---
+
+## 6. Supervisor Responsibilities
+
+The Python supervisor remains the runtime authority for:
+
+- LVGL pumping and screen rendering.
+- Input event handling.
+- Screen navigation.
+- `Bus` delivery.
+- `MainThreadScheduler` draining.
+- App state transitions.
+- Call and music coordination.
+- User-visible degraded states.
+- Worker lifecycle supervision.
+- Applying worker facts to app-owned state.
+
+The supervisor must not perform blocking worker calls on the UI path. It sends commands with deadlines and continues pumping the loop. Worker results are delivered back through the scheduler/bus seam already used by the current runtime.
+
+---
+
+## 7. Worker Protocol
+
+Phase one uses stdio plus newline-delimited JSON (NDJSON).
+
+```text
+supervisor stdin -> worker commands
+worker stdout    -> supervisor events/results
+worker stderr    -> logs
+```
+
+This is intentionally boring:
+
+- easy to inspect with shell tools
+- language-neutral
+- no broker process
+- no new native dependency
+- suitable for Go, Python, Rust, or C workers
+- easy to fake in tests
+
+Each message envelope includes:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "command | event | result | error | heartbeat",
+  "type": "voice.transcribe | network.status | ...",
+  "request_id": "optional stable request id",
+  "timestamp_ms": 1777100000000,
+  "deadline_ms": 5000,
+  "payload": {}
+}
+```
+
+Protocol rules:
+
+- Unknown `schema_version` is rejected with a structured protocol error.
+- Unknown `type` is ignored or rejected based on message kind, then counted.
+- Commands that expect replies carry `request_id`.
+- Long-running work must support cancellation when practical.
+- Worker stdout is protocol-only. Human logs go to stderr.
+- Supervisor receive queues are bounded.
+- Supervisor send queues are bounded.
+- Queue overflow is a health signal and may drop low-priority events.
+- `timestamp_ms` is Unix epoch milliseconds for diagnostics.
+- `deadline_ms` is a relative budget from worker receipt time. A value of `0` means no explicit deadline, and should be rare.
+- Large or binary payloads are not embedded in NDJSON. Use temp file paths, inherited file descriptors, or worker-owned streams.
+
+ZeroMQ/msgpack remains a later option. It becomes attractive only if measured IPC overhead, fan-out shape, or multi-client patterns justify it. The first design wants a crisp process contract more than maximum theoretical IPC speed.
+
+---
+
+## 8. Go Voice Worker
+
+Voice is the best first non-Python worker because it has the clearest payoff:
+
+- cloud STT/TTS avoids local Vosk memory pressure
+- Go avoids Python interpreter overhead in the worker
+- Go has good standard-library support for HTTP, JSON, process signals, contexts, cancellation, and streaming I/O
+- cross-compilation to Pi is straightforward
+- implementation speed is better than Rust for this project phase
+
+Responsibilities:
+
+- Handle cloud STT requests.
+- Handle cloud TTS requests.
+- Stream or chunk audio to the chosen provider.
+- Enforce request deadlines.
+- Cancel active voice work when the supervisor sends cancellation.
+- Report degraded state when cloud voice is unavailable.
+- Emit structured timing and memory diagnostics.
+
+Initial audio boundary:
+
+- Keep raw audio out of JSON envelopes.
+- Prefer the existing Python capture path writing a bounded temp audio file, then pass the file path and metadata to the Go worker for cloud STT.
+- For cloud TTS, prefer the Go worker writing a bounded temp audio file and returning its path to the supervisor.
+- Later, if latency measurements justify it, move capture or playback-adjacent streaming fully into the Go worker under the same command/result contract.
+
+Out of scope for the first voice worker:
+
+- owning UI state
+- executing app commands directly
+- owning wake word policy
+- replacing call audio
+- guaranteeing offline STT
+
+Offline behavior:
+
+- voice commands are unavailable when cloud voice is unavailable
+- local tones/status prompts still work where already supported
+- UI shows voice degraded/unavailable
+- music, VoIP, navigation, and non-voice controls continue
+
+---
+
+## 9. Python Network Worker
+
+Network should be split after the worker runtime exists, but it should remain Python initially.
+
+Reasons:
+
+- existing `pyserial`, SIM7600, PPP, and GPS code is already Python-oriented
+- serial and modem behavior is hardware-sensitive
+- rewriting it while changing process boundaries would multiply risk
+- a Python sidecar still isolates serial stalls from the UI loop
+
+Responsibilities:
+
+- Poll modem/network status.
+- Manage serial interaction that can block or stall.
+- Emit GPS/location facts if still owned by the network stack at implementation time.
+- Emit connection state, signal quality, and error facts.
+- Accept explicit reconnect/reset-style commands from the supervisor when supported.
+
+The network worker does not decide navigation, user messaging, or app state. It only reports facts and command results.
+
+---
+
+## 10. VoIP Decision
+
+Do not create a VoIP sidecar in the first worker wave.
+
+Liblinphone already lives behind a native backend and has tight coupling to call state, audio device behavior, ringing, active-call transitions, message events, and screen navigation. Moving it out of process might improve crash isolation, but it is unlikely to improve RAM and could create subtle ordering and audio bugs.
+
+Phase zero and phase one must instrument VoIP carefully:
+
+- duration of `iterate` or equivalent background calls
+- callback-to-main-thread latency
+- incoming-call event latency
+- call state transition latency
+- audio-device contention
+- crashes or native wedges
+
+VoIP becomes a candidate sidecar only if measurements show one of these:
+
+- liblinphone blocks the supervisor enough to violate responsiveness targets
+- liblinphone crashes or wedges the process
+- call audio requires isolation from other audio paths
+- shutdown/restart of VoIP is needed without restarting UI
+
+Until then, keeping VoIP in-process is the simpler and safer design.
+
+---
+
+## 11. PR #376 Alignment
+
+PR #376 is aligned as an enabling step, not the final architecture.
+
+It improves the current runtime by grouping ad-hoc threads behind a shared `BackgroundExecutor`, registering long-running pollers, and returning background results to the main thread. That matches the direction of this design: explicit lanes, centralized shutdown, and main-thread state application.
+
+Before using it as a foundation, the implementation plan must address two risks found during review:
+
+1. Executor shutdown must be bounded. A stuck I/O task must not make `app.stop()` block forever.
+2. Watchdog feeding must not share a saturated general I/O pool. It needs a dedicated safety lane or a design that cannot be starved by cloud/network work.
+
+Useful follow-ups from PR #376:
+
+- queue depth and pending-task diagnostics
+- bounded submit wrappers or explicit backpressure
+- named lanes for safety-critical work versus ordinary I/O
+- consistent "background result posts to main thread" helpers
+
+PR #376 should be treated as a cleanup bridge toward the process-worker runtime, not as a substitute for it.
+
+---
+
+## 12. RAM Budget Model
+
+Use PSS as the main memory metric because RSS double-counts shared pages across processes.
+
+Rough planning estimates before measurement:
+
+```text
+Python sidecar process: 30-70 MB PSS
+Go sidecar process:     12-30 MB PSS
+Rust/C sidecar process:  5-20 MB PSS
+Cloud voice active:     40-70 MB PSS incremental, depending on buffers/provider client
+Local Vosk active:     100-180+ MB incremental, depending on model and keep-loaded mode
+```
+
+Expected direction:
+
+- Go cloud voice worker adds process overhead, but removes local Vosk as the default memory resident.
+- Python network worker adds memory, but isolates serial/modem stalls.
+- Net memory may still improve if Vosk was previously kept loaded.
+- VoIP sidecar is likely RAM-neutral or worse, because it adds another interpreter/process boundary while still needing native liblinphone resources.
+
+The spec does not claim exact savings. Phase zero must measure baseline PSS, and each worker phase must include before/after memory snapshots under equivalent scenarios.
+
+---
+
+## 13. Instrumentation First
+
+Phase zero is required before worker extraction.
+
+Add or extend diagnostics for:
+
+- input event received timestamp
+- action handler start and finish
+- next visible LVGL refresh after action
+- main-loop gaps
+- scheduler drain duration
+- bus drain duration
+- blocking span attribution
+- worker queue depth once workers exist
+- worker restart count
+- worker request latency
+- PSS snapshots by process
+
+The important product metric is not "uses all four cores." The important metric is "the device reacts immediately while background work is happening." CPU utilization is supporting evidence only.
+
+---
+
+## 14. Phase Plan
+
+### Phase 0: Responsiveness and memory baseline
+
+Measure the current runtime without changing architecture.
+
+Deliverables:
+
+- button-to-action latency metric
+- action-to-visible-refresh latency metric
+- main-loop gap metric
+- blocking-span labels for known risky paths
+- PSS/RSS snapshot helper for Pi runs
+- one-hour mixed soak report format
+
+Exit criteria:
+
+- baseline numbers collected on target hardware
+- top responsiveness offenders identified
+- local Vosk memory impact measured with keep-loaded on and off
+
+### Phase 1: Worker runtime
+
+Build the supervisor-side process runtime without moving major subsystems yet.
+
+Deliverables:
+
+- worker process launcher
+- NDJSON envelope parser/writer
+- bounded send and receive queues
+- request/reply tracking
+- deadline and cancellation support
+- heartbeat support
+- restart/backoff policy
+- fake worker test harness
+- degraded-state reporting path
+
+Exit criteria:
+
+- fake worker crash does not crash supervisor
+- fake worker hang does not block UI loop or shutdown forever
+- queue overflow is counted and visible
+- tests cover malformed messages, unknown schema, restart, timeout, and cancellation
+
+### Phase 2: Go cloud voice worker
+
+Move cloud STT/TTS request execution to the Go worker.
+
+Deliverables:
+
+- Go worker skeleton and build path for Pi
+- cloud STT command path
+- cloud TTS command path
+- cancellation/deadline handling
+- voice degraded-state mapping
+- local Vosk disabled by default
+- fallback local tones/status prompts preserved where applicable
+
+Exit criteria:
+
+- UI remains responsive during voice requests
+- cloud outage degrades voice only
+- worker crash degrades voice only
+- measured memory is lower than or acceptable versus current local voice baseline
+
+### Phase 3: Python network worker
+
+Move blocking serial/modem/GPS/PPP polling into a Python sidecar.
+
+Deliverables:
+
+- network worker entrypoint
+- modem/GPS/network fact events
+- supervisor network-state adapter
+- reconnect/reset command path where supported
+- degraded-state behavior for worker crash or serial failure
+
+Exit criteria:
+
+- serial stalls do not produce main-loop gaps over target
+- network worker crash does not crash UI
+- network facts update through the main-thread state path
+- hardware smoke run confirms modem behavior
+
+### Phase 4: VoIP decision gate
+
+Do not implement by default. Decide from measurements.
+
+Deliverables if needed:
+
+- VoIP sidecar feasibility note
+- measured reason for sidecar split
+- audio-device ownership plan
+- call-state protocol design
+
+Exit criteria:
+
+- either VoIP remains in-process with evidence, or a separate VoIP design is approved before implementation
+
+---
+
+## 15. Error Handling
+
+Worker failures map to domain degradation, not global failure.
+
+Supervisor behavior:
+
+- mark domain degraded
+- show or expose user-visible unavailable state where appropriate
+- cancel outstanding requests for the failed worker
+- restart with bounded exponential backoff
+- stop restarting after a configured threshold and keep domain disabled
+- continue pumping UI during restart/backoff
+
+Worker behavior:
+
+- never write non-protocol text to stdout
+- write logs to stderr
+- return structured errors for expected failures
+- exit non-zero for unrecoverable startup/runtime failures
+- honor cancellation and deadlines where practical
+
+Shutdown behavior:
+
+- send graceful stop command if the worker protocol is alive
+- wait for a bounded grace period
+- terminate if needed
+- kill only after terminate fails or exceeds timeout
+- never wait indefinitely on ordinary shutdown
+
+---
+
+## 16. Testing Strategy
+
+Unit tests:
+
+- message envelope validation
+- schema/version rejection
+- request/reply matching
+- cancellation and timeout behavior
+- bounded queue overflow
+- restart/backoff state transitions
+- degraded-state mapping
+
+Integration tests:
+
+- fake worker emits events and supervisor applies them on main-thread scheduler
+- fake worker crashes and supervisor continues
+- fake worker hangs and shutdown remains bounded
+- malformed worker output is rejected and counted
+- slow worker responses do not block UI-loop simulation
+
+Hardware validation:
+
+- Pi Zero 2W one-hour mixed soak
+- voice request under cloud success/failure/timeout
+- network serial stall simulation or real modem failure test
+- memory snapshots before and after each phase
+- active call smoke after worker runtime changes, even before any VoIP split
+
+Regression checks:
+
+- `uv run python scripts/quality.py gate`
+- `uv run pytest -q`
+
+---
+
+## 17. Open Implementation Decisions
+
+These are intentionally left for the implementation plan, not the architecture spec:
+
+- exact cloud STT/TTS provider API shape
+- exact Go module layout
+- exact process binary packaging inside dev/prod lanes
+- exact temp-file lifetime and cleanup ownership for voice audio payloads
+- specific PSS snapshot command format for Pi diagnostics
+- exact queue sizes and restart thresholds
+
+The implementation plan must pick concrete defaults for these before code changes begin.
+
+---
+
+## 18. Final Recommendation
+
+Proceed with the hybrid design:
+
+1. Instrument first.
+2. Add a small, language-neutral worker runtime.
+3. Move cloud voice to a Go worker.
+4. Move network/modem polling to a Python worker.
+5. Keep VoIP in-process until measurements prove that a sidecar is necessary.
+
+This gives YoYoPod the performance benefit of multiple cores where the current runtime most needs it, while keeping the small-screen product behavior understandable and safe.

--- a/tests/core/diagnostics/test_memory.py
+++ b/tests/core/diagnostics/test_memory.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from yoyopod.core.diagnostics.memory import (
+    ProcessMemorySnapshot,
+    collect_process_memory,
+    parse_smaps_rollup,
+    parse_status_rss_kb,
+)
+
+
+def test_parse_smaps_rollup_extracts_pss_rss_and_private_dirty() -> None:
+    text = """
+Rss:               42184 kB
+Pss:               19928 kB
+Private_Dirty:      7120 kB
+SwapPss:              0 kB
+""".strip()
+
+    snapshot = parse_smaps_rollup(text, pid=123)
+
+    assert snapshot == ProcessMemorySnapshot(
+        pid=123,
+        rss_kb=42184,
+        pss_kb=19928,
+        private_dirty_kb=7120,
+        source="smaps_rollup",
+    )
+
+
+def test_parse_status_rss_kb_extracts_vmrss() -> None:
+    text = """
+Name:\tpython
+VmRSS:\t   35100 kB
+Threads:\t4
+""".strip()
+
+    assert parse_status_rss_kb(text) == 35100
+
+
+def test_collect_process_memory_uses_status_when_smaps_missing(tmp_path: Path) -> None:
+    proc_dir = tmp_path / "123"
+    proc_dir.mkdir(parents=True)
+    (proc_dir / "status").write_text("VmRSS:\t2048 kB\n", encoding="utf-8")
+
+    snapshot = collect_process_memory(pid=123, proc_root=tmp_path)
+
+    assert snapshot.pid == 123
+    assert snapshot.rss_kb == 2048
+    assert snapshot.pss_kb is None
+    assert snapshot.source == "status"
+
+
+def test_collect_process_memory_returns_unavailable_when_proc_missing(
+    tmp_path: Path,
+) -> None:
+    snapshot = collect_process_memory(pid=999, proc_root=tmp_path)
+
+    assert snapshot.pid == 999
+    assert snapshot.rss_kb is None
+    assert snapshot.pss_kb is None
+    assert snapshot.source == "unavailable"

--- a/tests/core/diagnostics/test_memory.py
+++ b/tests/core/diagnostics/test_memory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from yoyopod.core.diagnostics.memory import (
     ProcessMemorySnapshot,
@@ -50,6 +51,55 @@ def test_collect_process_memory_uses_status_when_smaps_missing(tmp_path: Path) -
     assert snapshot.rss_kb == 2048
     assert snapshot.pss_kb is None
     assert snapshot.source == "status"
+
+
+def test_collect_process_memory_uses_status_when_smaps_read_fails(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    proc_dir = tmp_path / "123"
+    proc_dir.mkdir(parents=True)
+    smaps_path = proc_dir / "smaps_rollup"
+    smaps_path.write_text("Rss: 9999 kB\n", encoding="utf-8")
+    status_path = proc_dir / "status"
+    status_path.write_text("VmRSS:\t2048 kB\n", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: Any, **kwargs: Any) -> str:
+        if path == smaps_path:
+            raise PermissionError("smaps unavailable")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    snapshot = collect_process_memory(pid=123, proc_root=tmp_path)
+
+    assert snapshot.pid == 123
+    assert snapshot.rss_kb == 2048
+    assert snapshot.pss_kb is None
+    assert snapshot.source == "status"
+
+
+def test_collect_process_memory_returns_unavailable_when_proc_reads_fail(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    proc_dir = tmp_path / "123"
+    proc_dir.mkdir(parents=True)
+    (proc_dir / "smaps_rollup").write_text("Rss: 9999 kB\n", encoding="utf-8")
+    (proc_dir / "status").write_text("VmRSS:\t2048 kB\n", encoding="utf-8")
+
+    def read_text(_path: Path, *args: Any, **kwargs: Any) -> str:
+        raise FileNotFoundError("procfs race")
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    snapshot = collect_process_memory(pid=123, proc_root=tmp_path)
+
+    assert snapshot.pid == 123
+    assert snapshot.rss_kb is None
+    assert snapshot.pss_kb is None
+    assert snapshot.source == "unavailable"
 
 
 def test_collect_process_memory_returns_unavailable_when_proc_missing(

--- a/tests/core/test_bootstrap.py
+++ b/tests/core/test_bootstrap.py
@@ -146,6 +146,12 @@ class _FakeApp:
     def note_input_activity(self, _data=None) -> None:
         return None
 
+    def note_handled_input(self, *, action_name: str | None, handled_at: float) -> None:
+        return None
+
+    def note_visible_refresh(self, *, refreshed_at: float) -> None:
+        return None
+
 
 class _FakeVoipManager:
     def __init__(self) -> None:
@@ -242,14 +248,24 @@ def test_init_core_components_schedules_screen_actions_for_lvgl_backend(monkeypa
         lambda **_kwargs: fake_input_manager,
     )
 
-    def _capture_screen_manager(display, input_manager, action_scheduler=None):
+    def _capture_screen_manager(
+        display,
+        input_manager,
+        action_scheduler=None,
+        on_action_handled=None,
+        on_visible_refresh=None,
+    ):
         captured["display"] = display
         captured["input_manager"] = input_manager
         captured["action_scheduler"] = action_scheduler
+        captured["on_action_handled"] = on_action_handled
+        captured["on_visible_refresh"] = on_visible_refresh
         return SimpleNamespace(
             display=display,
             input_manager=input_manager,
             action_scheduler=action_scheduler,
+            on_action_handled=on_action_handled,
+            on_visible_refresh=on_visible_refresh,
         )
 
     monkeypatch.setattr(boot_module, "ScreenManager", _capture_screen_manager)
@@ -260,6 +276,10 @@ def test_init_core_components_schedules_screen_actions_for_lvgl_backend(monkeypa
     assert captured["display"].backend_kind == "lvgl"
     assert captured["input_manager"] is fake_input_manager
     assert captured["action_scheduler"] is scheduled_callback
+    assert captured["on_action_handled"].__self__ is app
+    assert captured["on_action_handled"].__func__ is _FakeApp.note_handled_input
+    assert captured["on_visible_refresh"].__self__ is app
+    assert captured["on_visible_refresh"].__func__ is _FakeApp.note_visible_refresh
     assert fake_input_manager.started is True
 
 

--- a/tests/core/test_bootstrap.py
+++ b/tests/core/test_bootstrap.py
@@ -142,6 +142,7 @@ class _FakeApp:
         self.call_interruption_policy = None
         self._lvgl_backend = None
         self._lvgl_input_bridge = None
+        self._screen_awake = True
 
     def note_input_activity(self, _data=None) -> None:
         return None
@@ -254,18 +255,21 @@ def test_init_core_components_schedules_screen_actions_for_lvgl_backend(monkeypa
         action_scheduler=None,
         on_action_handled=None,
         on_visible_refresh=None,
+        is_screen_visible=None,
     ):
         captured["display"] = display
         captured["input_manager"] = input_manager
         captured["action_scheduler"] = action_scheduler
         captured["on_action_handled"] = on_action_handled
         captured["on_visible_refresh"] = on_visible_refresh
+        captured["is_screen_visible"] = is_screen_visible
         return SimpleNamespace(
             display=display,
             input_manager=input_manager,
             action_scheduler=action_scheduler,
             on_action_handled=on_action_handled,
             on_visible_refresh=on_visible_refresh,
+            is_screen_visible=is_screen_visible,
         )
 
     monkeypatch.setattr(boot_module, "ScreenManager", _capture_screen_manager)
@@ -280,6 +284,7 @@ def test_init_core_components_schedules_screen_actions_for_lvgl_backend(monkeypa
     assert captured["on_action_handled"].__func__ is _FakeApp.note_handled_input
     assert captured["on_visible_refresh"].__self__ is app
     assert captured["on_visible_refresh"].__func__ is _FakeApp.note_visible_refresh
+    assert captured["is_screen_visible"]() is True
     assert fake_input_manager.started is True
 
 

--- a/tests/core/test_runtime_loop_metrics.py
+++ b/tests/core/test_runtime_loop_metrics.py
@@ -89,3 +89,23 @@ def test_runtime_status_includes_responsiveness_and_loop_timing() -> None:
     assert "responsiveness_input_to_action_count" in status
     assert "responsiveness_action_to_visible_count" in status
     assert "runtime_main_thread_drain_seconds" in status
+
+
+def test_runtime_loop_polls_worker_supervisor() -> None:
+    app = YoyoPodApp()
+    calls: list[str] = []
+    app.worker_supervisor = SimpleNamespace(
+        poll=lambda: calls.append("poll") or 0,
+        snapshot=lambda: {},
+    )
+    app.app_state_runtime = SimpleNamespace(get_state_name=lambda: "idle")
+    app.call_interruption_policy = SimpleNamespace(music_interrupted_by_call=False)
+
+    app.runtime_loop.run_iteration(
+        monotonic_now=10.0,
+        current_time=20.0,
+        last_screen_update=20.0,
+        screen_update_interval=1.0,
+    )
+
+    assert calls == ["poll"]

--- a/tests/core/test_runtime_loop_metrics.py
+++ b/tests/core/test_runtime_loop_metrics.py
@@ -1,0 +1,67 @@
+"""Runtime loop metrics integration tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from yoyopod.core.application import YoyoPodApp
+
+
+class _ScreenManager:
+    def __init__(self) -> None:
+        self.refresh_count = 0
+        self.screen_stack: list[object] = []
+
+    def get_current_screen(self) -> object:
+        return SimpleNamespace(route_name="hub")
+
+    def refresh_current_screen_for_visible_tick(self) -> None:
+        self.refresh_count += 1
+
+
+def test_visible_screen_refresh_records_action_to_visible_latency() -> None:
+    app = YoyoPodApp()
+    screen_manager = _ScreenManager()
+    app.screen_manager = screen_manager
+    app.app_state_runtime = SimpleNamespace(get_state_name=lambda: "idle")
+    app.call_interruption_policy = SimpleNamespace(music_interrupted_by_call=False)
+    app._screen_awake = True
+    app.note_input_activity(SimpleNamespace(value="select"), 0, captured_at=100.0)
+    app.note_handled_input(action_name="select", handled_at=100.020)
+
+    app.runtime_loop.run_iteration(
+        monotonic_now=100.100,
+        current_time=200.0,
+        last_screen_update=198.0,
+        screen_update_interval=1.0,
+    )
+
+    snapshot = app.runtime_metrics.responsiveness_snapshot(now=101.0)
+    assert screen_manager.refresh_count == 1
+    assert snapshot["responsiveness_action_to_visible_count"] == 1
+    assert snapshot["responsiveness_last_visible_action_name"] == "select"
+
+
+def test_timing_snapshot_includes_drain_duration() -> None:
+    app = YoyoPodApp()
+    app.runtime_loop.process_pending_main_thread_actions()
+
+    snapshot = app.runtime_loop.timing_snapshot(now=1.0)
+
+    assert "runtime_main_thread_drain_seconds" in snapshot
+    assert snapshot["runtime_main_thread_drain_seconds"] is not None
+
+
+def test_runtime_status_includes_responsiveness_and_loop_timing() -> None:
+    app = YoyoPodApp()
+    screen_manager = _ScreenManager()
+    app.screen_manager = screen_manager
+    app.app_state_runtime = SimpleNamespace(get_state_name=lambda: "idle")
+    app.call_interruption_policy = SimpleNamespace(music_interrupted_by_call=False)
+    app.runtime_loop.process_pending_main_thread_actions()
+
+    status = app.status_service.get_status()
+
+    assert "responsiveness_input_to_action_count" in status
+    assert "responsiveness_action_to_visible_count" in status
+    assert "runtime_main_thread_drain_seconds" in status

--- a/tests/core/test_runtime_loop_metrics.py
+++ b/tests/core/test_runtime_loop_metrics.py
@@ -80,6 +80,19 @@ def test_user_activity_event_does_not_record_handled_action_latency() -> None:
     assert snapshot["responsiveness_action_to_visible_count"] == 0
 
 
+def test_handled_input_matches_pending_marker_by_action_name() -> None:
+    app = YoyoPodApp()
+    app.note_input_activity(SimpleNamespace(value="select"), 0, captured_at=100.0)
+    app.note_input_activity(SimpleNamespace(value="back"), 0, captured_at=100.020)
+
+    app.note_handled_input(action_name="back", handled_at=100.030)
+
+    snapshot = app.runtime_metrics.responsiveness_snapshot(now=101.0)
+    assert snapshot["responsiveness_input_to_action_count"] == 1
+    assert snapshot["responsiveness_last_input_to_action_name"] == "back"
+    assert snapshot["responsiveness_input_to_action_last_ms"] == 10.0
+
+
 def test_timing_snapshot_includes_drain_duration() -> None:
     app = YoyoPodApp()
     app.runtime_loop.process_pending_main_thread_actions()

--- a/tests/core/test_runtime_loop_metrics.py
+++ b/tests/core/test_runtime_loop_metrics.py
@@ -8,15 +8,17 @@ from yoyopod.core.application import YoyoPodApp
 
 
 class _ScreenManager:
-    def __init__(self) -> None:
+    def __init__(self, *, refresh_result: bool = True) -> None:
         self.refresh_count = 0
+        self.refresh_result = refresh_result
         self.screen_stack: list[object] = []
 
     def get_current_screen(self) -> object:
         return SimpleNamespace(route_name="hub")
 
-    def refresh_current_screen_for_visible_tick(self) -> None:
+    def refresh_current_screen_for_visible_tick(self) -> bool:
         self.refresh_count += 1
+        return self.refresh_result
 
 
 def test_visible_screen_refresh_records_action_to_visible_latency() -> None:
@@ -40,6 +42,28 @@ def test_visible_screen_refresh_records_action_to_visible_latency() -> None:
     assert screen_manager.refresh_count == 1
     assert snapshot["responsiveness_action_to_visible_count"] == 1
     assert snapshot["responsiveness_last_visible_action_name"] == "select"
+
+
+def test_visible_screen_refresh_ignores_noop_visible_tick() -> None:
+    app = YoyoPodApp()
+    screen_manager = _ScreenManager(refresh_result=False)
+    app.screen_manager = screen_manager
+    app.app_state_runtime = SimpleNamespace(get_state_name=lambda: "idle")
+    app.call_interruption_policy = SimpleNamespace(music_interrupted_by_call=False)
+    app._screen_awake = True
+    app.note_input_activity(SimpleNamespace(value="select"), 0, captured_at=100.0)
+    app.note_handled_input(action_name="select", handled_at=100.020)
+
+    app.runtime_loop.run_iteration(
+        monotonic_now=100.100,
+        current_time=200.0,
+        last_screen_update=198.0,
+        screen_update_interval=1.0,
+    )
+
+    snapshot = app.runtime_metrics.responsiveness_snapshot(now=101.0)
+    assert screen_manager.refresh_count == 1
+    assert snapshot["responsiveness_action_to_visible_count"] == 0
 
 
 def test_timing_snapshot_includes_drain_duration() -> None:

--- a/tests/core/test_runtime_loop_metrics.py
+++ b/tests/core/test_runtime_loop_metrics.py
@@ -90,6 +90,13 @@ def test_timing_snapshot_includes_drain_duration() -> None:
     assert snapshot["runtime_main_thread_drain_seconds"] is not None
 
 
+def test_runtime_loop_exposes_configured_voip_iterate_interval() -> None:
+    app = YoyoPodApp()
+    app._voip_iterate_interval_seconds = 0.125
+
+    assert app.runtime_loop.configured_voip_iterate_interval_seconds == 0.125
+
+
 def test_runtime_status_includes_responsiveness_and_loop_timing() -> None:
     app = YoyoPodApp()
     screen_manager = _ScreenManager()

--- a/tests/core/test_runtime_loop_metrics.py
+++ b/tests/core/test_runtime_loop_metrics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from yoyopod.core.application import YoyoPodApp
+from yoyopod.core.events import UserActivityEvent
 
 
 class _ScreenManager:
@@ -63,6 +64,19 @@ def test_visible_screen_refresh_ignores_noop_visible_tick() -> None:
 
     snapshot = app.runtime_metrics.responsiveness_snapshot(now=101.0)
     assert screen_manager.refresh_count == 1
+    assert snapshot["responsiveness_action_to_visible_count"] == 0
+
+
+def test_user_activity_event_does_not_record_handled_action_latency() -> None:
+    app = YoyoPodApp()
+    app.note_input_activity(SimpleNamespace(value="select"), 0, captured_at=100.0)
+
+    app.screen_power_service.handle_user_activity_event(
+        UserActivityEvent(action_name="select")
+    )
+
+    snapshot = app.runtime_metrics.responsiveness_snapshot(now=101.0)
+    assert snapshot["responsiveness_input_to_action_count"] == 0
     assert snapshot["responsiveness_action_to_visible_count"] == 0
 
 

--- a/tests/core/test_runtime_metrics.py
+++ b/tests/core/test_runtime_metrics.py
@@ -77,6 +77,31 @@ def test_runtime_metrics_correlates_backlogged_inputs_fifo() -> None:
     assert snapshot["responsiveness_input_to_action_last_ms"] == 25.0
 
 
+def test_runtime_metrics_ignores_raw_activity_for_input_to_action_queue() -> None:
+    store = RuntimeMetricsStore()
+
+    store.note_input_activity(None, captured_at=9.0)
+    store.note_input_activity(SimpleNamespace(value="select"), captured_at=10.0)
+    store.note_handled_input(action_name="select", handled_at=10.050)
+
+    snapshot = store.responsiveness_snapshot(now=11.0)
+
+    assert snapshot["responsiveness_input_to_action_count"] == 1
+    assert snapshot["responsiveness_input_to_action_last_ms"] == 50.0
+
+
+def test_runtime_metrics_does_not_sample_raw_activity_without_semantic_marker() -> None:
+    store = RuntimeMetricsStore()
+
+    store.note_input_activity(None, captured_at=9.0)
+    store.note_handled_input(action_name="select", handled_at=10.050)
+
+    snapshot = store.responsiveness_snapshot(now=11.0)
+
+    assert snapshot["responsiveness_input_to_action_count"] == 0
+    assert snapshot["responsiveness_input_to_action_last_ms"] is None
+
+
 def test_runtime_metrics_records_action_to_visible_refresh_latency() -> None:
     store = RuntimeMetricsStore()
 

--- a/tests/core/test_runtime_metrics.py
+++ b/tests/core/test_runtime_metrics.py
@@ -33,3 +33,43 @@ def test_runtime_metrics_store_records_input_and_capture_markers() -> None:
     assert store.last_responsiveness_capture_artifacts == {
         "snapshot": "/tmp/capture.json"
     }
+
+
+def test_runtime_metrics_records_input_to_action_latency() -> None:
+    store = RuntimeMetricsStore()
+
+    store.note_input_activity(SimpleNamespace(value="select"), captured_at=10.0)
+    store.note_handled_input(action_name="select", handled_at=10.035)
+
+    snapshot = store.responsiveness_snapshot(now=11.0)
+
+    assert snapshot["responsiveness_input_to_action_count"] == 1
+    assert snapshot["responsiveness_input_to_action_p95_ms"] == 35.0
+    assert snapshot["responsiveness_input_to_action_last_ms"] == 35.0
+    assert snapshot["responsiveness_last_input_to_action_name"] == "select"
+
+
+def test_runtime_metrics_records_action_to_visible_refresh_latency() -> None:
+    store = RuntimeMetricsStore()
+
+    store.note_input_activity(SimpleNamespace(value="down"), captured_at=20.0)
+    store.note_handled_input(action_name="down", handled_at=20.010)
+    store.note_visible_refresh(refreshed_at=20.085)
+
+    snapshot = store.responsiveness_snapshot(now=21.0)
+
+    assert snapshot["responsiveness_action_to_visible_count"] == 1
+    assert snapshot["responsiveness_action_to_visible_p95_ms"] == 75.0
+    assert snapshot["responsiveness_action_to_visible_last_ms"] == 75.0
+    assert snapshot["responsiveness_last_visible_action_name"] == "down"
+
+
+def test_runtime_metrics_ignores_refresh_without_handled_input() -> None:
+    store = RuntimeMetricsStore()
+
+    store.note_visible_refresh(refreshed_at=30.0)
+
+    snapshot = store.responsiveness_snapshot(now=31.0)
+
+    assert snapshot["responsiveness_action_to_visible_count"] == 0
+    assert snapshot["responsiveness_action_to_visible_p95_ms"] is None

--- a/tests/core/test_runtime_metrics.py
+++ b/tests/core/test_runtime_metrics.py
@@ -49,6 +49,19 @@ def test_runtime_metrics_records_input_to_action_latency() -> None:
     assert snapshot["responsiveness_last_input_to_action_name"] == "select"
 
 
+def test_runtime_metrics_percentile_uses_half_up_indexing() -> None:
+    store = RuntimeMetricsStore()
+
+    store.note_input_activity(SimpleNamespace(value="first"), captured_at=10.0)
+    store.note_handled_input(action_name="first", handled_at=10.010)
+    store.note_input_activity(SimpleNamespace(value="second"), captured_at=20.0)
+    store.note_handled_input(action_name="second", handled_at=20.050)
+
+    snapshot = store.responsiveness_snapshot(now=21.0)
+
+    assert snapshot["responsiveness_input_to_action_p50_ms"] == 50.0
+
+
 def test_runtime_metrics_records_action_to_visible_refresh_latency() -> None:
     store = RuntimeMetricsStore()
 

--- a/tests/core/test_runtime_metrics.py
+++ b/tests/core/test_runtime_metrics.py
@@ -62,6 +62,21 @@ def test_runtime_metrics_percentile_uses_half_up_indexing() -> None:
     assert snapshot["responsiveness_input_to_action_p50_ms"] == 50.0
 
 
+def test_runtime_metrics_correlates_backlogged_inputs_fifo() -> None:
+    store = RuntimeMetricsStore()
+
+    store.note_input_activity(SimpleNamespace(value="first"), captured_at=10.0)
+    store.note_input_activity(SimpleNamespace(value="second"), captured_at=20.0)
+    store.note_handled_input(action_name="first", handled_at=10.050)
+    store.note_handled_input(action_name="second", handled_at=20.025)
+
+    snapshot = store.responsiveness_snapshot(now=21.0)
+
+    assert snapshot["responsiveness_input_to_action_count"] == 2
+    assert snapshot["responsiveness_input_to_action_max_ms"] == 50.0
+    assert snapshot["responsiveness_input_to_action_last_ms"] == 25.0
+
+
 def test_runtime_metrics_records_action_to_visible_refresh_latency() -> None:
     store = RuntimeMetricsStore()
 

--- a/tests/core/workers/test_process.py
+++ b/tests/core/workers/test_process.py
@@ -20,10 +20,10 @@ class _BlockingStdin:
         self.write_entered = threading.Event()
         self.release_write = threading.Event()
 
-    def write(self, _data: str) -> int:
+    def write(self, data: bytes) -> int:
         self.write_entered.set()
         self.release_write.wait(timeout=5.0)
-        return 0
+        return len(data)
 
     def flush(self) -> None:
         return None
@@ -31,9 +31,9 @@ class _BlockingStdin:
 
 class _RecordingStdin:
     def __init__(self) -> None:
-        self.writes: list[str] = []
+        self.writes: list[bytes] = []
 
-    def write(self, data: str) -> int:
+    def write(self, data: bytes) -> int:
         self.writes.append(data)
         return len(data)
 
@@ -140,6 +140,34 @@ sys.stdout.flush()
 
     assert snapshot.protocol_errors >= 1
     assert snapshot.received_messages == 0
+
+
+def test_worker_process_counts_invalid_utf8_stdout_without_losing_reader(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import sys
+sys.stdout.buffer.write(b"\\xff\\n")
+sys.stdout.buffer.write(b'{"schema_version":1,"kind":"event","type":"voice.ready","request_id":null,"timestamp_ms":1,"deadline_ms":0,"payload":{"ok":true}}\\n')
+sys.stdout.flush()
+""".strip(),
+    )
+    runtime = WorkerProcessRuntime(
+        WorkerProcessConfig(name="bad-utf8", argv=[sys.executable, "-u", str(worker)])
+    )
+
+    runtime.start()
+    try:
+        messages = runtime.wait_for_messages(count=1, timeout_seconds=2.0)
+        runtime.stop(grace_seconds=0.1)
+        snapshot = runtime.snapshot()
+    finally:
+        runtime.stop(grace_seconds=0.1)
+
+    assert len(messages) == 1
+    assert messages[0].type == "voice.ready"
+    assert snapshot.protocol_errors >= 1
+    assert snapshot.received_messages == 1
 
 
 def test_worker_process_stop_is_bounded_for_stuck_worker(tmp_path: Path) -> None:
@@ -286,7 +314,7 @@ def test_worker_process_writer_survives_json_encoding_failure() -> None:
     assert snapshot.send_failures == 1
     assert snapshot.sent_messages == 1
     assert len(stdin.writes) == 1
-    assert '"request_id":"good"' in stdin.writes[0]
+    assert b'"request_id":"good"' in stdin.writes[0]
 
 
 def test_worker_process_writer_exits_after_process_exit() -> None:

--- a/tests/core/workers/test_process.py
+++ b/tests/core/workers/test_process.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from yoyopod.core.workers.process import WorkerProcessConfig, WorkerProcessRuntime
+
+
+def _write_worker(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "fake_worker.py"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_worker_process_round_trips_envelopes(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import json
+import sys
+
+for line in sys.stdin:
+    msg = json.loads(line)
+    sys.stdout.write(json.dumps({
+        "schema_version": 1,
+        "kind": "result",
+        "type": "voice.transcribe",
+        "request_id": msg["request_id"],
+        "timestamp_ms": 1001,
+        "deadline_ms": 0,
+        "payload": {"path": msg["payload"]["path"], "ok": True},
+    }) + "\\n")
+    sys.stdout.flush()
+""".strip(),
+    )
+    runtime = WorkerProcessRuntime(
+        WorkerProcessConfig(
+            name="echo",
+            argv=[sys.executable, "-u", str(worker)],
+            receive_queue_size=4,
+        )
+    )
+
+    runtime.start()
+    try:
+        assert runtime.send_command(
+            type="voice.transcribe",
+            payload={"path": "/tmp/audio.wav"},
+            request_id="req-1",
+            timestamp_ms=1000,
+            deadline_ms=5000,
+        )
+        messages = runtime.wait_for_messages(count=1, timeout_seconds=2.0)
+    finally:
+        runtime.stop(grace_seconds=0.2)
+
+    assert len(messages) == 1
+    assert messages[0].kind == "result"
+    assert messages[0].type == "voice.transcribe"
+    assert messages[0].request_id == "req-1"
+    assert messages[0].payload == {"path": "/tmp/audio.wav", "ok": True}
+    snapshot = runtime.snapshot()
+    assert snapshot.received_messages == 1
+    assert snapshot.protocol_errors == 0
+
+
+def test_worker_process_counts_malformed_stdout(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import sys
+sys.stdout.write("not json\\n")
+sys.stdout.flush()
+""".strip(),
+    )
+    runtime = WorkerProcessRuntime(
+        WorkerProcessConfig(name="bad", argv=[sys.executable, "-u", str(worker)])
+    )
+
+    runtime.start()
+    try:
+        assert runtime.wait_until_exited(timeout_seconds=2.0)
+        runtime.drain_messages()
+        snapshot = runtime.snapshot()
+    finally:
+        runtime.stop(grace_seconds=0.1)
+
+    assert snapshot.protocol_errors >= 1
+    assert snapshot.received_messages == 0
+
+
+def test_worker_process_stop_is_bounded_for_stuck_worker(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import time
+time.sleep(60)
+""".strip(),
+    )
+    runtime = WorkerProcessRuntime(
+        WorkerProcessConfig(name="stuck", argv=[sys.executable, "-u", str(worker)])
+    )
+
+    runtime.start()
+    runtime.stop(grace_seconds=0.05)
+
+    snapshot = runtime.snapshot()
+    assert snapshot.running is False
+    assert snapshot.terminated is True

--- a/tests/core/workers/test_process.py
+++ b/tests/core/workers/test_process.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 from pathlib import Path
 
 from yoyopod.core.workers.process import WorkerProcessConfig, WorkerProcessRuntime
@@ -80,7 +81,7 @@ sys.stdout.flush()
     runtime.start()
     try:
         assert runtime.wait_until_exited(timeout_seconds=2.0)
-        runtime.drain_messages()
+        runtime.stop(grace_seconds=0.1)
         snapshot = runtime.snapshot()
     finally:
         runtime.stop(grace_seconds=0.1)
@@ -103,6 +104,41 @@ time.sleep(60)
 
     runtime.start()
     runtime.stop(grace_seconds=0.05)
+
+    snapshot = runtime.snapshot()
+    assert snapshot.running is False
+    assert snapshot.terminated is True
+
+
+def test_worker_process_stop_is_bounded_when_send_lock_is_busy(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import time
+time.sleep(60)
+""".strip(),
+    )
+    runtime = WorkerProcessRuntime(
+        WorkerProcessConfig(name="contended", argv=[sys.executable, "-u", str(worker)])
+    )
+
+    runtime.start()
+    runtime._stdin_lock.acquire()
+    stop_thread = threading.Thread(
+        target=runtime.stop,
+        kwargs={"grace_seconds": 0.05},
+        daemon=True,
+    )
+
+    try:
+        stop_thread.start()
+        stop_thread.join(timeout=0.5)
+        assert stop_thread.is_alive() is False
+    finally:
+        if runtime._stdin_lock.locked():
+            runtime._stdin_lock.release()
+        stop_thread.join(timeout=2.0)
+        runtime.stop(grace_seconds=0.05)
 
     snapshot = runtime.snapshot()
     assert snapshot.running is False

--- a/tests/core/workers/test_process.py
+++ b/tests/core/workers/test_process.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import threading
 from pathlib import Path
+from typing import Any, cast
 
 from yoyopod.core.workers.process import WorkerProcessConfig, WorkerProcessRuntime
 
@@ -11,6 +12,44 @@ def _write_worker(tmp_path: Path, body: str) -> Path:
     path = tmp_path / "fake_worker.py"
     path.write_text(body, encoding="utf-8")
     return path
+
+
+class _BlockingStdin:
+    def __init__(self) -> None:
+        self.write_entered = threading.Event()
+        self.release_write = threading.Event()
+
+    def write(self, _data: str) -> int:
+        self.write_entered.set()
+        self.release_write.wait(timeout=5.0)
+        return 0
+
+    def flush(self) -> None:
+        return None
+
+
+class _FakeProcess:
+    pid = 1234
+
+    def __init__(self) -> None:
+        self.stdin = _BlockingStdin()
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.returncode or 0
 
 
 def test_worker_process_round_trips_envelopes(tmp_path: Path) -> None:
@@ -123,6 +162,7 @@ time.sleep(60)
     )
 
     runtime.start()
+    # Intentionally reaches into the private lock to reproduce send/stop contention.
     runtime._stdin_lock.acquire()
     stop_thread = threading.Thread(
         target=runtime.stop,
@@ -143,3 +183,25 @@ time.sleep(60)
     snapshot = runtime.snapshot()
     assert snapshot.running is False
     assert snapshot.terminated is True
+
+
+def test_worker_process_stop_is_bounded_when_graceful_send_blocks() -> None:
+    runtime = WorkerProcessRuntime(WorkerProcessConfig(name="blocked", argv=["unused"]))
+    process = _FakeProcess()
+    runtime._process = cast(Any, process)
+    stop_thread = threading.Thread(
+        target=runtime.stop,
+        kwargs={"grace_seconds": 0.05},
+        daemon=True,
+    )
+
+    try:
+        stop_thread.start()
+        assert process.stdin.write_entered.wait(timeout=0.5)
+        stop_thread.join(timeout=0.5)
+        assert stop_thread.is_alive() is False
+    finally:
+        process.stdin.release_write.set()
+        stop_thread.join(timeout=2.0)
+
+    assert process.terminated is True

--- a/tests/core/workers/test_process.py
+++ b/tests/core/workers/test_process.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, cast
 
@@ -205,3 +206,48 @@ def test_worker_process_stop_is_bounded_when_graceful_send_blocks() -> None:
         stop_thread.join(timeout=2.0)
 
     assert process.terminated is True
+
+
+def test_worker_process_send_uses_bounded_outbound_queue_when_stdin_blocks() -> None:
+    runtime = WorkerProcessRuntime(
+        WorkerProcessConfig(
+            name="blocked-send",
+            argv=["unused"],
+            send_queue_size=1,
+        )
+    )
+    process = _FakeProcess()
+    runtime._process = cast(Any, process)
+    runtime._start_writer()
+
+    try:
+        assert runtime.send_command(type="voice.transcribe", payload={}, request_id="req-1")
+        assert process.stdin.write_entered.wait(timeout=0.5)
+        assert runtime.send_command(type="voice.transcribe", payload={}, request_id="req-2")
+
+        started_at = time.monotonic()
+        assert (
+            runtime.send_command(type="voice.transcribe", payload={}, request_id="req-3")
+            is False
+        )
+        elapsed_seconds = time.monotonic() - started_at
+        snapshot = runtime.snapshot()
+    finally:
+        process.stdin.release_write.set()
+
+    assert elapsed_seconds < 0.1
+    assert snapshot.dropped_sends == 1
+    assert snapshot.queued_sends == 1
+
+
+def test_worker_process_writer_exits_after_process_exit() -> None:
+    runtime = WorkerProcessRuntime(WorkerProcessConfig(name="exited", argv=["unused"]))
+    process = _FakeProcess()
+    process.returncode = 7
+    runtime._process = cast(Any, process)
+
+    runtime._start_writer()
+    assert runtime._writer_thread is not None
+    runtime._writer_thread.join(timeout=0.5)
+
+    assert runtime._writer_thread.is_alive() is False

--- a/tests/core/workers/test_process.py
+++ b/tests/core/workers/test_process.py
@@ -29,11 +29,23 @@ class _BlockingStdin:
         return None
 
 
+class _RecordingStdin:
+    def __init__(self) -> None:
+        self.writes: list[str] = []
+
+    def write(self, data: str) -> int:
+        self.writes.append(data)
+        return len(data)
+
+    def flush(self) -> None:
+        return None
+
+
 class _FakeProcess:
     pid = 1234
 
-    def __init__(self) -> None:
-        self.stdin = _BlockingStdin()
+    def __init__(self, stdin: object | None = None) -> None:
+        self.stdin = _BlockingStdin() if stdin is None else stdin
         self.returncode: int | None = None
         self.terminated = False
         self.killed = False
@@ -238,6 +250,43 @@ def test_worker_process_send_uses_bounded_outbound_queue_when_stdin_blocks() -> 
     assert elapsed_seconds < 0.1
     assert snapshot.dropped_sends == 1
     assert snapshot.queued_sends == 1
+
+
+def test_worker_process_writer_survives_json_encoding_failure() -> None:
+    stdin = _RecordingStdin()
+    process = _FakeProcess(stdin=stdin)
+    runtime = WorkerProcessRuntime(WorkerProcessConfig(name="encoding", argv=["unused"]))
+    runtime._process = cast(Any, process)
+    runtime._start_writer()
+
+    try:
+        assert runtime.send_command(
+            type="voice.transcribe",
+            payload={"raw": b"not-json"},
+            request_id="bad",
+        )
+        assert runtime.send_command(
+            type="voice.transcribe",
+            payload={"path": "/tmp/audio.wav"},
+            request_id="good",
+        )
+
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            snapshot = runtime.snapshot()
+            if snapshot.send_failures == 1 and snapshot.sent_messages == 1:
+                break
+            time.sleep(0.01)
+        else:
+            snapshot = runtime.snapshot()
+    finally:
+        runtime._request_writer_shutdown()
+        runtime._join_writer(timeout_seconds=0.5)
+
+    assert snapshot.send_failures == 1
+    assert snapshot.sent_messages == 1
+    assert len(stdin.writes) == 1
+    assert '"request_id":"good"' in stdin.writes[0]
 
 
 def test_worker_process_writer_exits_after_process_exit() -> None:

--- a/tests/core/workers/test_protocol.py
+++ b/tests/core/workers/test_protocol.py
@@ -42,6 +42,20 @@ def test_parse_valid_envelope_line() -> None:
     assert VALID_KINDS == {"command", "event", "result", "error", "heartbeat"}
 
 
+def test_valid_kinds_is_immutable() -> None:
+    assert isinstance(VALID_KINDS, frozenset)
+    assert not hasattr(VALID_KINDS, "add")
+
+
+def test_make_envelope_copies_payload() -> None:
+    payload = {"text": "hello"}
+
+    envelope = make_envelope(kind="result", type="voice.transcribe", payload=payload)
+    payload["text"] = "changed"
+
+    assert envelope.payload == {"text": "hello"}
+
+
 def test_parse_rejects_unknown_schema_version() -> None:
     with pytest.raises(WorkerProtocolError, match="schema_version"):
         parse_envelope_line(

--- a/tests/core/workers/test_protocol.py
+++ b/tests/core/workers/test_protocol.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from yoyopod.core.workers.protocol import (
+    SUPPORTED_SCHEMA_VERSION,
+    VALID_KINDS,
+    WorkerEnvelope,
+    WorkerProtocolError,
+    encode_envelope,
+    make_envelope,
+    parse_envelope_line,
+)
+
+
+def test_parse_valid_envelope_line() -> None:
+    envelope = parse_envelope_line(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "event",
+                "type": "network.status",
+                "request_id": None,
+                "timestamp_ms": 1777100000000,
+                "deadline_ms": 5000,
+                "payload": {"connected": True},
+            }
+        )
+    )
+
+    assert envelope == WorkerEnvelope(
+        schema_version=SUPPORTED_SCHEMA_VERSION,
+        kind="event",
+        type="network.status",
+        request_id=None,
+        timestamp_ms=1777100000000,
+        deadline_ms=5000,
+        payload={"connected": True},
+    )
+    assert VALID_KINDS == {"command", "event", "result", "error", "heartbeat"}
+
+
+def test_parse_rejects_unknown_schema_version() -> None:
+    with pytest.raises(WorkerProtocolError, match="schema_version"):
+        parse_envelope_line(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "kind": "event",
+                    "type": "network.status",
+                    "payload": {},
+                }
+            )
+        )
+
+
+def test_parse_rejects_non_dict_payload() -> None:
+    with pytest.raises(WorkerProtocolError, match="payload"):
+        parse_envelope_line(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "event",
+                    "type": "network.status",
+                    "payload": [],
+                }
+            )
+        )
+
+
+def test_encode_envelope_is_newline_terminated_and_round_trips() -> None:
+    envelope = make_envelope(
+        kind="result",
+        type="voice.transcribe",
+        request_id="req-1",
+        timestamp_ms=1777100000000,
+        deadline_ms=2500,
+        payload={"text": "hello"},
+    )
+
+    encoded = encode_envelope(envelope)
+
+    assert encoded.endswith("\n")
+    assert "\n" not in encoded[:-1]
+    assert encoded == (
+        '{"schema_version":1,"kind":"result","type":"voice.transcribe",'
+        '"request_id":"req-1","timestamp_ms":1777100000000,'
+        '"deadline_ms":2500,"payload":{"text":"hello"}}\n'
+    )
+    assert parse_envelope_line(encoded) == envelope
+
+
+@pytest.mark.parametrize("line", ["{", b"{"])
+def test_parse_rejects_invalid_json(line: str | bytes) -> None:
+    with pytest.raises(WorkerProtocolError, match="invalid JSON"):
+        parse_envelope_line(line)
+
+
+@pytest.mark.parametrize("line", ["[]", "null", '"hello"'])
+def test_parse_rejects_non_object_envelope(line: str) -> None:
+    with pytest.raises(WorkerProtocolError, match="object"):
+        parse_envelope_line(line)
+
+
+@pytest.mark.parametrize("kind", ["", "unknown", 5, None])
+def test_parse_rejects_invalid_kind(kind: object) -> None:
+    with pytest.raises(WorkerProtocolError, match="kind"):
+        parse_envelope_line(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": kind,
+                    "type": "voice.transcribe",
+                    "payload": {},
+                }
+            )
+        )
+
+
+@pytest.mark.parametrize("type_value", ["", "   ", 5, None])
+def test_parse_rejects_empty_or_non_string_type(type_value: object) -> None:
+    with pytest.raises(WorkerProtocolError, match="type"):
+        parse_envelope_line(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "event",
+                    "type": type_value,
+                    "payload": {},
+                }
+            )
+        )
+
+
+@pytest.mark.parametrize("request_id", [5, False, {}, []])
+def test_parse_rejects_non_string_non_null_request_id(request_id: object) -> None:
+    with pytest.raises(WorkerProtocolError, match="request_id"):
+        parse_envelope_line(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "kind": "result",
+                    "type": "voice.transcribe",
+                    "request_id": request_id,
+                    "payload": {},
+                }
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("timestamp_ms", -1),
+        ("deadline_ms", -1),
+        ("timestamp_ms", 1.2),
+        ("deadline_ms", 1.2),
+        ("timestamp_ms", True),
+        ("deadline_ms", False),
+    ],
+)
+def test_parse_rejects_invalid_timestamp_and_deadline(
+    field_name: str,
+    value: object,
+) -> None:
+    data = {
+        "schema_version": 1,
+        "kind": "event",
+        "type": "network.status",
+        "payload": {},
+    }
+    data[field_name] = value
+
+    with pytest.raises(WorkerProtocolError, match=field_name):
+        parse_envelope_line(json.dumps(data))
+
+
+def test_parse_accepts_bytes_line() -> None:
+    envelope = parse_envelope_line(
+        b'{"schema_version":1,"kind":"heartbeat","type":"worker.alive","payload":{}}\n'
+    )
+
+    assert envelope.kind == "heartbeat"
+    assert envelope.type == "worker.alive"

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -494,6 +494,30 @@ def test_supervisor_ignores_late_non_cancel_result_after_retry_reuses_request_id
     assert len(slot.request_deadlines) == 1
 
 
+def test_supervisor_prunes_request_attempt_when_stale_timeout_retention_expires() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    slot = supervisor._workers["voice"]
+    slot.runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda limit=None: [],
+            send_command=lambda **_kwargs: True,
+        ),
+    )
+    slot.state = "running"
+    slot.request_attempts["req-stale"] = 7
+    slot.stale_request_ids["req-stale"] = 5.0
+
+    supervisor.poll(monotonic_now=5.0)
+
+    assert slot.stale_request_ids == {}
+    assert slot.request_attempts == {}
+
+
 def test_supervisor_caps_published_worker_messages_per_poll() -> None:
     bus = Bus()
     scheduler = MainThreadScheduler()

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -12,6 +12,7 @@ from yoyopod.core.events import (
     WorkerDomainStateChangedEvent,
     WorkerMessageReceivedEvent,
 )
+from yoyopod.core.application import YoyoPodApp
 from yoyopod.core.scheduler import MainThreadScheduler
 from yoyopod.core.workers.process import WorkerProcessConfig
 from yoyopod.core.workers.supervisor import WorkerSupervisor
@@ -333,3 +334,24 @@ def test_supervisor_restart_spawn_failure_stays_contained(tmp_path: Path) -> Non
     assert snapshot["next_restart_at"] == 0.0
     assert events[-1].state == "degraded"
     assert events[-1].reason == "restart_failed"
+
+
+def test_app_owns_worker_supervisor() -> None:
+    app = YoyoPodApp()
+
+    assert isinstance(app.worker_supervisor, WorkerSupervisor)
+    assert app.get_status
+
+
+def test_status_includes_worker_snapshot() -> None:
+    app = YoyoPodApp()
+    app.app_state_runtime = type("State", (), {"get_state_name": lambda self: "idle"})()
+    app.call_interruption_policy = type(
+        "Policy",
+        (),
+        {"music_interrupted_by_call": False},
+    )()
+
+    status = app.get_status()
+
+    assert status["workers"] == {}

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from typing import Callable, cast
+
+from yoyopod.core.bus import Bus
+from yoyopod.core.events import (
+    WorkerDomainStateChangedEvent,
+    WorkerMessageReceivedEvent,
+)
+from yoyopod.core.scheduler import MainThreadScheduler
+from yoyopod.core.workers.process import WorkerProcessConfig
+from yoyopod.core.workers.supervisor import WorkerSupervisor
+
+
+def _write_worker(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "fake_worker.py"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _poll_until(assertion: Callable[[], bool], *, timeout_seconds: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if assertion():
+            return
+        time.sleep(0.01)
+    assert assertion()
+
+
+def test_supervisor_publishes_worker_messages_on_main_bus(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import json
+import sys
+sys.stdout.write(json.dumps({
+    "schema_version": 1,
+    "kind": "event",
+    "type": "fake.ready",
+    "request_id": None,
+    "timestamp_ms": 1,
+    "deadline_ms": 0,
+    "payload": {"ready": True},
+}) + "\\n")
+sys.stdout.flush()
+for line in sys.stdin:
+    pass
+""".strip(),
+    )
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    state_events: list[WorkerDomainStateChangedEvent] = []
+    message_events: list[WorkerMessageReceivedEvent] = []
+    bus.subscribe(WorkerDomainStateChangedEvent, state_events.append)
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(name="voice", argv=[sys.executable, "-u", str(worker)]),
+    )
+
+    supervisor.start("voice")
+    try:
+        _poll_until(lambda: supervisor.poll() >= 1)
+        bus.drain()
+        snapshot = supervisor.snapshot()
+    finally:
+        supervisor.stop_all(grace_seconds=0.1)
+
+    assert state_events[0] == WorkerDomainStateChangedEvent(
+        domain="voice",
+        state="running",
+        reason="started",
+    )
+    assert message_events == [
+        WorkerMessageReceivedEvent(
+            domain="voice",
+            kind="event",
+            type="fake.ready",
+            request_id=None,
+            payload={"ready": True},
+        )
+    ]
+    assert cast(int, snapshot["voice"]["received_messages"]) >= 1
+
+
+def test_supervisor_marks_crashed_worker_degraded(tmp_path: Path) -> None:
+    worker = _write_worker(tmp_path, "raise SystemExit(7)")
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    events: list[WorkerDomainStateChangedEvent] = []
+    bus.subscribe(WorkerDomainStateChangedEvent, events.append)
+    supervisor = WorkerSupervisor(
+        scheduler=scheduler,
+        bus=bus,
+        restart_backoff_seconds=60.0,
+    )
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(name="voice", argv=[sys.executable, "-u", str(worker)]),
+    )
+
+    supervisor.start("voice")
+    supervisor.wait_until_exited("voice", timeout_seconds=2.0)
+    supervisor.poll()
+    bus.drain()
+
+    assert supervisor.snapshot()["voice"]["state"] == "degraded"
+    assert events[-1].domain == "voice"
+    assert events[-1].state == "degraded"
+    assert events[-1].reason == "process_exited"
+
+
+def test_supervisor_request_timeout_sends_cancel(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import json
+import sys
+for line in sys.stdin:
+    msg = json.loads(line)
+    if msg["type"] == "voice.cancel":
+        sys.stdout.write(json.dumps({
+            "schema_version": 1,
+            "kind": "result",
+            "type": "voice.cancelled",
+            "request_id": msg.get("request_id"),
+            "timestamp_ms": 1,
+            "deadline_ms": 0,
+            "payload": {"cancelled": True},
+        }) + "\\n")
+        sys.stdout.flush()
+""".strip(),
+    )
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(name="voice", argv=[sys.executable, "-u", str(worker)]),
+    )
+
+    supervisor.start("voice")
+    try:
+        assert supervisor.send_request(
+            "voice",
+            type="voice.transcribe",
+            payload={"path": "/tmp/a.wav"},
+            request_id="req-timeout",
+            timeout_seconds=0.01,
+        )
+        time.sleep(0.05)
+        supervisor.poll()
+        _poll_until(lambda: supervisor.poll() >= 1)
+        bus.drain()
+        snapshot = supervisor.snapshot()
+    finally:
+        supervisor.stop_all(grace_seconds=0.1)
+
+    assert snapshot["voice"]["request_timeouts"] == 1
+    assert snapshot["voice"]["pending_requests"] == 0
+    assert any(message.type == "voice.cancelled" for message in message_events)

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -16,7 +16,7 @@ from yoyopod.core.events import (
 from yoyopod.core.application import YoyoPodApp
 from yoyopod.core.scheduler import MainThreadScheduler
 from yoyopod.core.workers.process import WorkerProcessConfig
-from yoyopod.core.workers.protocol import make_envelope
+from yoyopod.core.workers.protocol import WorkerEnvelope, make_envelope
 from yoyopod.core.workers.supervisor import WorkerSupervisor
 
 
@@ -183,7 +183,7 @@ def test_supervisor_drops_late_result_after_request_timeout() -> None:
         object,
         SimpleNamespace(
             running=True,
-            drain_messages=lambda: [],
+            drain_messages=lambda limit=None: [],
             send_command=lambda **_kwargs: False,
         ),
     )
@@ -197,7 +197,7 @@ def test_supervisor_drops_late_result_after_request_timeout() -> None:
         object,
         SimpleNamespace(
             running=True,
-            drain_messages=lambda: [
+            drain_messages=lambda limit=None: [
                 make_envelope(
                     kind="result",
                     type="voice.transcribe",
@@ -227,7 +227,7 @@ def test_supervisor_drops_stale_cancelled_payload_without_cancel_ack_type() -> N
         object,
         SimpleNamespace(
             running=True,
-            drain_messages=lambda: [
+            drain_messages=lambda limit=None: [
                 make_envelope(
                     kind="result",
                     type="voice.transcribe",
@@ -259,7 +259,7 @@ def test_supervisor_expires_request_before_processing_late_result_in_same_poll()
         object,
         SimpleNamespace(
             running=True,
-            drain_messages=lambda: [
+            drain_messages=lambda limit=None: [
                 make_envelope(
                     kind="result",
                     type="voice.transcribe",
@@ -294,7 +294,7 @@ def test_supervisor_accepts_retry_with_same_request_id_after_timeout() -> None:
         object,
         SimpleNamespace(
             running=True,
-            drain_messages=lambda: [],
+            drain_messages=lambda limit=None: [],
             send_command=lambda **_kwargs: True,
         ),
     )
@@ -316,7 +316,7 @@ def test_supervisor_accepts_retry_with_same_request_id_after_timeout() -> None:
         object,
         SimpleNamespace(
             running=True,
-            drain_messages=lambda: [
+            drain_messages=lambda limit=None: [
                 make_envelope(
                     kind="result",
                     type="voice.transcribe",
@@ -353,7 +353,7 @@ def test_supervisor_ignores_late_cancel_ack_after_retry_reuses_request_id() -> N
         object,
         SimpleNamespace(
             running=True,
-            drain_messages=lambda: [],
+            drain_messages=lambda limit=None: [],
             send_command=lambda **_kwargs: True,
         ),
     )
@@ -375,7 +375,7 @@ def test_supervisor_ignores_late_cancel_ack_after_retry_reuses_request_id() -> N
         object,
         SimpleNamespace(
             running=True,
-            drain_messages=lambda: [
+            drain_messages=lambda limit=None: [
                 make_envelope(
                     kind="result",
                     type="voice.cancelled",
@@ -393,6 +393,54 @@ def test_supervisor_ignores_late_cancel_ack_after_retry_reuses_request_id() -> N
     assert message_events == []
     assert slot.request_deadlines["req-retry"] == pytest.approx(retry_deadline)
     assert len(slot.request_deadlines) == 1
+
+
+def test_supervisor_caps_published_worker_messages_per_poll() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    drain_limits: list[int | None] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(
+        scheduler=scheduler,
+        bus=bus,
+        max_messages_per_poll=2,
+    )
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    worker_messages = [
+        make_envelope(
+            kind="event",
+            type="voice.event",
+            request_id=None,
+            payload={"index": index},
+        )
+        for index in range(3)
+    ]
+
+    def drain_messages(limit: int | None = None) -> list[WorkerEnvelope]:
+        drain_limits.append(limit)
+        count = len(worker_messages) if limit is None else min(limit, len(worker_messages))
+        drained = worker_messages[:count]
+        del worker_messages[:count]
+        return drained
+
+    slot = supervisor._workers["voice"]
+    slot.runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=drain_messages,
+            send_command=lambda **_kwargs: True,
+        ),
+    )
+    slot.state = "running"
+
+    assert supervisor.poll(monotonic_now=1.0) == 2
+    bus.drain()
+
+    assert drain_limits == [2]
+    assert [event.payload["index"] for event in message_events] == [0, 1]
+    assert [message.payload["index"] for message in worker_messages] == [2]
 
 
 def test_supervisor_rejects_duplicate_start_without_replacing_runtime(tmp_path: Path) -> None:

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Callable, cast
 
 import pytest
@@ -15,6 +16,7 @@ from yoyopod.core.events import (
 from yoyopod.core.application import YoyoPodApp
 from yoyopod.core.scheduler import MainThreadScheduler
 from yoyopod.core.workers.process import WorkerProcessConfig
+from yoyopod.core.workers.protocol import make_envelope
 from yoyopod.core.workers.supervisor import WorkerSupervisor
 
 
@@ -168,6 +170,49 @@ for line in sys.stdin:
     assert snapshot["voice"]["request_timeouts"] == 1
     assert snapshot["voice"]["pending_requests"] == 0
     assert any(message.type == "voice.cancelled" for message in message_events)
+
+
+def test_supervisor_drops_late_result_after_request_timeout() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda: [],
+            send_command=lambda **_kwargs: False,
+        ),
+    )
+    slot = supervisor._workers["voice"]
+    slot.runtime = runtime
+    slot.state = "running"
+    slot.request_deadlines["req-timeout"] = 1.0
+
+    supervisor.poll(monotonic_now=2.0)
+    runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda: [
+                make_envelope(
+                    kind="result",
+                    type="voice.transcribe",
+                    request_id="req-timeout",
+                    payload={"text": "late"},
+                )
+            ],
+            send_command=lambda **_kwargs: False,
+        ),
+    )
+    slot.runtime = runtime
+    supervisor.poll(monotonic_now=2.1)
+    bus.drain()
+
+    assert message_events == []
 
 
 def test_supervisor_rejects_duplicate_start_without_replacing_runtime(tmp_path: Path) -> None:
@@ -334,6 +379,32 @@ def test_supervisor_restart_spawn_failure_stays_contained(tmp_path: Path) -> Non
     assert snapshot["next_restart_at"] == 0.0
     assert events[-1].state == "degraded"
     assert events[-1].reason == "restart_failed"
+
+
+def test_supervisor_initial_spawn_failure_stays_contained(tmp_path: Path) -> None:
+    missing_dir = tmp_path / "missing-cwd"
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    events: list[WorkerDomainStateChangedEvent] = []
+    bus.subscribe(WorkerDomainStateChangedEvent, events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(
+            name="voice",
+            argv=[sys.executable, "-u", "-c", "print('unused')"],
+            cwd=str(missing_dir),
+        ),
+    )
+
+    assert supervisor.start("voice") is False
+    bus.drain()
+    snapshot = supervisor.snapshot()["voice"]
+
+    assert snapshot["state"] == "degraded"
+    assert snapshot["last_reason"] == "start_failed"
+    assert events[-1].state == "degraded"
+    assert events[-1].reason == "start_failed"
 
 
 def test_app_owns_worker_supervisor() -> None:

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -720,6 +720,64 @@ def test_supervisor_caps_published_worker_messages_per_poll() -> None:
     assert [message.payload["index"] for message in worker_messages] == [2]
 
 
+def test_supervisor_redistributes_unused_poll_budget_from_idle_domains() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(
+        scheduler=scheduler,
+        bus=bus,
+        max_messages_per_poll=8,
+    )
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    supervisor.register("network", WorkerProcessConfig(name="network", argv=["unused"]))
+    supervisor.register("cloud", WorkerProcessConfig(name="cloud", argv=["unused"]))
+
+    voice_messages = [
+        make_envelope(
+            kind="event",
+            type="voice.event",
+            request_id=None,
+            payload={"index": index},
+        )
+        for index in range(5)
+    ]
+    drain_limits: list[int | None] = []
+
+    def make_runtime(messages: list[WorkerEnvelope], *, record_limits: bool = False) -> object:
+        def drain_messages(limit: int | None = None) -> list[WorkerEnvelope]:
+            if record_limits:
+                drain_limits.append(limit)
+            count = len(messages) if limit is None else min(limit, len(messages))
+            drained = messages[:count]
+            del messages[:count]
+            return drained
+
+        return cast(
+            object,
+            SimpleNamespace(
+                running=True,
+                drain_messages=drain_messages,
+                send_command=lambda **_kwargs: True,
+            ),
+        )
+
+    supervisor._workers["voice"].runtime = make_runtime(voice_messages, record_limits=True)
+    supervisor._workers["voice"].state = "running"
+    supervisor._workers["network"].runtime = make_runtime([])
+    supervisor._workers["network"].state = "running"
+    supervisor._workers["cloud"].runtime = make_runtime([])
+    supervisor._workers["cloud"].state = "running"
+
+    assert supervisor.poll(monotonic_now=1.0) == 5
+    bus.drain()
+
+    assert [event.payload["index"] for event in message_events] == [0, 1, 2, 3, 4]
+    assert voice_messages == []
+    assert drain_limits == [2, 6]
+
+
 def test_supervisor_rotates_message_budget_across_worker_domains() -> None:
     bus = Bus()
     scheduler = MainThreadScheduler()

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -5,6 +5,8 @@ import time
 from pathlib import Path
 from typing import Callable, cast
 
+import pytest
+
 from yoyopod.core.bus import Bus
 from yoyopod.core.events import (
     WorkerDomainStateChangedEvent,
@@ -165,3 +167,169 @@ for line in sys.stdin:
     assert snapshot["voice"]["request_timeouts"] == 1
     assert snapshot["voice"]["pending_requests"] == 0
     assert any(message.type == "voice.cancelled" for message in message_events)
+
+
+def test_supervisor_rejects_duplicate_start_without_replacing_runtime(tmp_path: Path) -> None:
+    worker = _write_worker(
+        tmp_path,
+        """
+import time
+time.sleep(60)
+""".strip(),
+    )
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(name="voice", argv=[sys.executable, "-u", str(worker)]),
+    )
+
+    supervisor.start("voice")
+    try:
+        first_snapshot = supervisor.snapshot()["voice"]
+        with pytest.raises(RuntimeError, match="already running"):
+            supervisor.start("voice")
+        second_snapshot = supervisor.snapshot()["voice"]
+    finally:
+        supervisor.stop_all(grace_seconds=0.1)
+
+    assert first_snapshot["running"] is True
+    assert second_snapshot["running"] is True
+    assert second_snapshot["pid"] == first_snapshot["pid"]
+
+
+def test_supervisor_restart_waits_for_backoff(tmp_path: Path) -> None:
+    worker = _write_worker(tmp_path, "raise SystemExit(7)")
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    events: list[WorkerDomainStateChangedEvent] = []
+    bus.subscribe(WorkerDomainStateChangedEvent, events.append)
+    supervisor = WorkerSupervisor(
+        scheduler=scheduler,
+        bus=bus,
+        restart_backoff_seconds=5.0,
+        max_restarts=1,
+    )
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(name="voice", argv=[sys.executable, "-u", str(worker)]),
+    )
+
+    supervisor.start("voice")
+    supervisor.wait_until_exited("voice", timeout_seconds=2.0)
+    supervisor.poll(monotonic_now=10.0)
+    supervisor.poll(monotonic_now=14.9)
+    bus.drain()
+    snapshot = supervisor.snapshot()["voice"]
+
+    assert snapshot["state"] == "degraded"
+    assert snapshot["restart_count"] == 0
+    assert snapshot["next_restart_at"] == 15.0
+    assert [event.state for event in events].count("degraded") == 1
+
+
+def test_supervisor_restarts_after_backoff_when_allowed(tmp_path: Path) -> None:
+    worker = _write_worker(tmp_path, "raise SystemExit(7)")
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    events: list[WorkerDomainStateChangedEvent] = []
+    bus.subscribe(WorkerDomainStateChangedEvent, events.append)
+    supervisor = WorkerSupervisor(
+        scheduler=scheduler,
+        bus=bus,
+        restart_backoff_seconds=5.0,
+        max_restarts=1,
+    )
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(name="voice", argv=[sys.executable, "-u", str(worker)]),
+    )
+
+    supervisor.start("voice")
+    supervisor.wait_until_exited("voice", timeout_seconds=2.0)
+    supervisor.poll(monotonic_now=10.0)
+    supervisor.poll(monotonic_now=15.0)
+    bus.drain()
+    snapshot = supervisor.snapshot()["voice"]
+    supervisor.stop_all(grace_seconds=0.1)
+
+    assert snapshot["state"] == "running"
+    assert snapshot["restart_count"] == 1
+    assert snapshot["next_restart_at"] == 0.0
+    assert events[-1].state == "running"
+    assert events[-1].reason == "started"
+
+
+def test_supervisor_disables_after_max_restarts(tmp_path: Path) -> None:
+    worker = _write_worker(tmp_path, "raise SystemExit(7)")
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    events: list[WorkerDomainStateChangedEvent] = []
+    bus.subscribe(WorkerDomainStateChangedEvent, events.append)
+    supervisor = WorkerSupervisor(
+        scheduler=scheduler,
+        bus=bus,
+        restart_backoff_seconds=1.0,
+        max_restarts=0,
+    )
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(name="voice", argv=[sys.executable, "-u", str(worker)]),
+    )
+
+    supervisor.start("voice")
+    supervisor.wait_until_exited("voice", timeout_seconds=2.0)
+    supervisor.poll(monotonic_now=10.0)
+    supervisor.poll(monotonic_now=11.0)
+    bus.drain()
+    snapshot = supervisor.snapshot()["voice"]
+
+    assert snapshot["state"] == "disabled"
+    assert snapshot["last_reason"] == "max_restarts_exceeded"
+    assert snapshot["restart_count"] == 0
+    assert snapshot["next_restart_at"] == 0.0
+    assert events[-1] == WorkerDomainStateChangedEvent(
+        domain="voice",
+        state="disabled",
+        reason="max_restarts_exceeded",
+    )
+
+
+def test_supervisor_restart_spawn_failure_stays_contained(tmp_path: Path) -> None:
+    worker_dir = tmp_path / "worker-cwd"
+    worker_dir.mkdir()
+    worker = _write_worker(tmp_path, "raise SystemExit(7)")
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    events: list[WorkerDomainStateChangedEvent] = []
+    bus.subscribe(WorkerDomainStateChangedEvent, events.append)
+    supervisor = WorkerSupervisor(
+        scheduler=scheduler,
+        bus=bus,
+        restart_backoff_seconds=1.0,
+        max_restarts=1,
+    )
+    supervisor.register(
+        "voice",
+        WorkerProcessConfig(
+            name="voice",
+            argv=[sys.executable, "-u", str(worker)],
+            cwd=str(worker_dir),
+        ),
+    )
+
+    supervisor.start("voice")
+    supervisor.wait_until_exited("voice", timeout_seconds=2.0)
+    worker_dir.rmdir()
+    supervisor.poll(monotonic_now=10.0)
+    supervisor.poll(monotonic_now=11.0)
+    bus.drain()
+    snapshot = supervisor.snapshot()["voice"]
+
+    assert snapshot["state"] == "degraded"
+    assert snapshot["last_reason"] == "restart_failed"
+    assert snapshot["restart_count"] == 1
+    assert snapshot["next_restart_at"] == 0.0
+    assert events[-1].state == "degraded"
+    assert events[-1].reason == "restart_failed"

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -556,6 +556,85 @@ def test_supervisor_ignores_late_non_cancel_result_after_retry_reuses_request_id
     assert len(slot.request_deadlines) == 1
 
 
+def test_supervisor_retries_expired_request_before_poll_without_accepting_old_attempt() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    sent_commands: list[dict[str, object]] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda limit=None: [],
+            send_command=lambda **kwargs: sent_commands.append(kwargs) or True,
+        ),
+    )
+    slot = supervisor._workers["voice"]
+    slot.runtime = runtime
+    slot.state = "running"
+
+    assert supervisor.send_request(
+        "voice",
+        type="voice.transcribe",
+        payload={"path": "/tmp/first.wav"},
+        request_id="req-retry",
+        timeout_seconds=10.0,
+    )
+    first_attempt = cast(
+        int,
+        cast(dict[str, object], sent_commands[-1])["payload"][
+            supervisor._REQUEST_ATTEMPT_PAYLOAD_KEY
+        ],
+    )
+    slot.request_deadlines["req-retry"] = time.monotonic() - 1.0
+
+    assert supervisor.send_request(
+        "voice",
+        type="voice.transcribe",
+        payload={"path": "/tmp/retry.wav"},
+        request_id="req-retry",
+        timeout_seconds=10.0,
+    )
+    retry_attempt = cast(
+        int,
+        cast(dict[str, object], sent_commands[-1])["payload"][
+            supervisor._REQUEST_ATTEMPT_PAYLOAD_KEY
+        ],
+    )
+    retry_deadline = slot.request_deadlines["req-retry"]
+    assert retry_attempt == first_attempt + 1
+    assert sent_commands[-2]["type"] == "voice.cancel"
+
+    slot.runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda limit=None: [
+                make_envelope(
+                    kind="result",
+                    type="voice.transcribe",
+                    request_id="req-retry",
+                    payload={
+                        "text": "late stale result",
+                        supervisor._REQUEST_ATTEMPT_PAYLOAD_KEY: first_attempt,
+                    },
+                )
+            ],
+            send_command=lambda **kwargs: sent_commands.append(kwargs) or True,
+        ),
+    )
+
+    supervisor.poll(monotonic_now=time.monotonic())
+    bus.drain()
+
+    assert message_events == []
+    assert slot.request_deadlines["req-retry"] == pytest.approx(retry_deadline)
+    assert len(slot.request_deadlines) == 1
+
+
 def test_supervisor_prunes_request_attempt_when_stale_timeout_retention_expires() -> None:
     bus = Bus()
     scheduler = MainThreadScheduler()

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -342,6 +342,59 @@ def test_supervisor_accepts_retry_with_same_request_id_after_timeout() -> None:
     assert slot.stale_request_ids == {}
 
 
+def test_supervisor_ignores_late_cancel_ack_after_retry_reuses_request_id() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda: [],
+            send_command=lambda **_kwargs: True,
+        ),
+    )
+    slot = supervisor._workers["voice"]
+    slot.runtime = runtime
+    slot.state = "running"
+    slot.request_deadlines["req-retry"] = 1.0
+
+    supervisor.poll(monotonic_now=2.0)
+    assert supervisor.send_request(
+        "voice",
+        type="voice.transcribe",
+        payload={"path": "/tmp/retry.wav"},
+        request_id="req-retry",
+        timeout_seconds=10.0,
+    )
+    retry_deadline = slot.request_deadlines["req-retry"]
+    slot.runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda: [
+                make_envelope(
+                    kind="result",
+                    type="voice.cancelled",
+                    request_id="req-retry",
+                    payload={"cancelled": True},
+                )
+            ],
+            send_command=lambda **_kwargs: True,
+        ),
+    )
+
+    supervisor.poll(monotonic_now=2.1)
+    bus.drain()
+
+    assert message_events == []
+    assert slot.request_deadlines["req-retry"] == pytest.approx(retry_deadline)
+    assert len(slot.request_deadlines) == 1
+
+
 def test_supervisor_rejects_duplicate_start_without_replacing_runtime(tmp_path: Path) -> None:
     worker = _write_worker(
         tmp_path,

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -352,6 +352,68 @@ def test_supervisor_accepts_retry_with_same_request_id_after_timeout() -> None:
     assert slot.stale_request_ids == {}
 
 
+def test_supervisor_accepts_retry_reply_without_private_attempt_marker() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    sent_commands: list[dict[str, object]] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda limit=None: [],
+            send_command=lambda **kwargs: sent_commands.append(kwargs) or True,
+        ),
+    )
+    slot = supervisor._workers["voice"]
+    slot.runtime = runtime
+    slot.state = "running"
+    slot.request_deadlines["req-retry"] = 1.0
+
+    supervisor.poll(monotonic_now=2.0)
+
+    assert supervisor.send_request(
+        "voice",
+        type="voice.transcribe",
+        payload={"path": "/tmp/retry.wav"},
+        request_id="req-retry",
+        timeout_seconds=10.0,
+    )
+    slot.runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda limit=None: [
+                make_envelope(
+                    kind="result",
+                    type="voice.transcribe",
+                    request_id="req-retry",
+                    payload={"text": "retry ok"},
+                )
+            ],
+            send_command=lambda **_kwargs: True,
+        ),
+    )
+
+    supervisor.poll(monotonic_now=2.1)
+    bus.drain()
+
+    assert message_events == [
+        WorkerMessageReceivedEvent(
+            domain="voice",
+            kind="result",
+            type="voice.transcribe",
+            request_id="req-retry",
+            payload={"text": "retry ok"},
+        )
+    ]
+    assert "req-retry" not in slot.request_deadlines
+    assert "req-retry" not in slot.request_attempts
+
+
 def test_supervisor_ignores_late_cancel_ack_after_retry_reuses_request_id() -> None:
     bus = Bus()
     scheduler = MainThreadScheduler()
@@ -559,6 +621,55 @@ def test_supervisor_keeps_request_tracking_for_non_terminal_worker_event() -> No
     ]
     assert slot.request_deadlines["req-progress"] == pytest.approx(10.0)
     assert slot.request_attempts["req-progress"] == 1
+
+
+def test_supervisor_delivers_active_cancel_ack_for_explicit_cancel_request() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    slot = supervisor._workers["voice"]
+    slot.runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda limit=None: [
+                make_envelope(
+                    kind="result",
+                    type="voice.cancelled",
+                    request_id="req-cancel",
+                    payload={"cancelled": True},
+                )
+            ],
+            send_command=lambda **_kwargs: True,
+        ),
+    )
+    slot.state = "running"
+
+    assert supervisor.send_request(
+        "voice",
+        type="voice.cancel",
+        payload={"request_id": "req-target"},
+        request_id="req-cancel",
+        timeout_seconds=10.0,
+    )
+
+    supervisor.poll(monotonic_now=1.0)
+    bus.drain()
+
+    assert message_events == [
+        WorkerMessageReceivedEvent(
+            domain="voice",
+            kind="result",
+            type="voice.cancelled",
+            request_id="req-cancel",
+            payload={"cancelled": True},
+        )
+    ]
+    assert "req-cancel" not in slot.request_deadlines
+    assert "req-cancel" not in slot.request_attempts
 
 
 def test_supervisor_caps_published_worker_messages_per_poll() -> None:

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -518,6 +518,49 @@ def test_supervisor_prunes_request_attempt_when_stale_timeout_retention_expires(
     assert slot.request_attempts == {}
 
 
+def test_supervisor_keeps_request_tracking_for_non_terminal_worker_event() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    slot = supervisor._workers["voice"]
+    slot.runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda limit=None: [
+                make_envelope(
+                    kind="event",
+                    type="voice.progress",
+                    request_id="req-progress",
+                    payload={"state": "streaming"},
+                )
+            ],
+            send_command=lambda **_kwargs: True,
+        ),
+    )
+    slot.state = "running"
+    slot.request_deadlines["req-progress"] = 10.0
+    slot.request_attempts["req-progress"] = 1
+
+    supervisor.poll(monotonic_now=1.0)
+    bus.drain()
+
+    assert message_events == [
+        WorkerMessageReceivedEvent(
+            domain="voice",
+            kind="event",
+            type="voice.progress",
+            request_id="req-progress",
+            payload={"state": "streaming"},
+        )
+    ]
+    assert slot.request_deadlines["req-progress"] == pytest.approx(10.0)
+    assert slot.request_attempts["req-progress"] == 1
+
+
 def test_supervisor_caps_published_worker_messages_per_poll() -> None:
     bus = Bus()
     scheduler = MainThreadScheduler()

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -215,6 +215,38 @@ def test_supervisor_drops_late_result_after_request_timeout() -> None:
     assert message_events == []
 
 
+def test_supervisor_drops_stale_cancelled_payload_without_cancel_ack_type() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    slot = supervisor._workers["voice"]
+    slot.runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda: [
+                make_envelope(
+                    kind="result",
+                    type="voice.transcribe",
+                    request_id="req-timeout",
+                    payload={"cancelled": True, "text": "late"},
+                )
+            ],
+            send_command=lambda **_kwargs: False,
+        ),
+    )
+    slot.state = "running"
+    slot.stale_request_ids["req-timeout"] = 30.0
+
+    supervisor.poll(monotonic_now=2.0)
+    bus.drain()
+
+    assert message_events == []
+
+
 def test_supervisor_expires_request_before_processing_late_result_in_same_poll() -> None:
     bus = Bus()
     scheduler = MainThreadScheduler()

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -443,6 +443,106 @@ def test_supervisor_caps_published_worker_messages_per_poll() -> None:
     assert [message.payload["index"] for message in worker_messages] == [2]
 
 
+def test_supervisor_checks_exit_and_restart_even_when_message_budget_is_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    restart_calls: list[tuple[str, float]] = []
+    supervisor = WorkerSupervisor(
+        scheduler=scheduler,
+        bus=bus,
+        max_messages_per_poll=1,
+    )
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    supervisor.register("network", WorkerProcessConfig(name="network", argv=["unused"]))
+    supervisor.register("cloud", WorkerProcessConfig(name="cloud", argv=["unused"]))
+
+    voice_messages = [
+        make_envelope(
+            kind="event",
+            type="voice.event",
+            request_id=None,
+            payload={"index": 0},
+        )
+    ]
+    voice_runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda limit=None: voice_messages[: (limit or len(voice_messages))],
+            send_command=lambda **_kwargs: True,
+            start=lambda: None,
+            snapshot=lambda: SimpleNamespace(
+                running=True,
+                pid=1,
+                received_messages=1,
+                protocol_errors=0,
+                dropped_messages=0,
+                sent_messages=0,
+                queued_sends=0,
+                dropped_sends=0,
+                send_failures=0,
+            ),
+        ),
+    )
+    exited_runtime = cast(
+        object,
+        SimpleNamespace(
+            running=False,
+            drain_messages=lambda limit=None: [],
+            send_command=lambda **_kwargs: True,
+            snapshot=lambda: SimpleNamespace(
+                running=False,
+                pid=2,
+                received_messages=0,
+                protocol_errors=0,
+                dropped_messages=0,
+                sent_messages=0,
+                queued_sends=0,
+                dropped_sends=0,
+                send_failures=0,
+            ),
+        ),
+    )
+    degraded_runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda limit=None: [],
+            send_command=lambda **_kwargs: True,
+            snapshot=lambda: SimpleNamespace(
+                running=True,
+                pid=3,
+                received_messages=0,
+                protocol_errors=0,
+                dropped_messages=0,
+                sent_messages=0,
+                queued_sends=0,
+                dropped_sends=0,
+                send_failures=0,
+            ),
+        ),
+    )
+    supervisor._workers["voice"].runtime = voice_runtime
+    supervisor._workers["voice"].state = "running"
+    supervisor._workers["network"].runtime = exited_runtime
+    supervisor._workers["network"].state = "running"
+    supervisor._workers["cloud"].runtime = degraded_runtime
+    supervisor._workers["cloud"].state = "degraded"
+    supervisor._workers["cloud"].next_restart_at = 1.0
+
+    def restart_if_allowed(domain: str, slot, *, now: float) -> None:
+        restart_calls.append((domain, now))
+
+    monkeypatch.setattr(supervisor, "_restart_if_allowed", restart_if_allowed)
+
+    supervisor.poll(monotonic_now=1.0)
+
+    assert supervisor._workers["network"].state == "degraded"
+    assert restart_calls == [("cloud", 1.0)]
+
+
 def test_supervisor_rejects_duplicate_start_without_replacing_runtime(tmp_path: Path) -> None:
     worker = _write_worker(
         tmp_path,

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -215,6 +215,42 @@ def test_supervisor_drops_late_result_after_request_timeout() -> None:
     assert message_events == []
 
 
+def test_supervisor_expires_request_before_processing_late_result_in_same_poll() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    sent_commands: list[dict[str, object]] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda: [
+                make_envelope(
+                    kind="result",
+                    type="voice.transcribe",
+                    request_id="req-late",
+                    payload={"text": "late"},
+                )
+            ],
+            send_command=lambda **kwargs: sent_commands.append(kwargs) is None or True,
+        ),
+    )
+    slot = supervisor._workers["voice"]
+    slot.runtime = runtime
+    slot.state = "running"
+    slot.request_deadlines["req-late"] = 1.0
+
+    supervisor.poll(monotonic_now=2.0)
+    bus.drain()
+
+    assert message_events == []
+    assert slot.request_timeouts == 1
+    assert sent_commands[0]["type"] == "voice.cancel"
+
+
 def test_supervisor_accepts_retry_with_same_request_id_after_timeout() -> None:
     bus = Bus()
     scheduler = MainThreadScheduler()

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -215,6 +215,65 @@ def test_supervisor_drops_late_result_after_request_timeout() -> None:
     assert message_events == []
 
 
+def test_supervisor_accepts_retry_with_same_request_id_after_timeout() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda: [],
+            send_command=lambda **_kwargs: True,
+        ),
+    )
+    slot = supervisor._workers["voice"]
+    slot.runtime = runtime
+    slot.state = "running"
+    slot.request_deadlines["req-retry"] = 1.0
+
+    supervisor.poll(monotonic_now=2.0)
+
+    assert supervisor.send_request(
+        "voice",
+        type="voice.transcribe",
+        payload={"path": "/tmp/retry.wav"},
+        request_id="req-retry",
+        timeout_seconds=10.0,
+    )
+    slot.runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda: [
+                make_envelope(
+                    kind="result",
+                    type="voice.transcribe",
+                    request_id="req-retry",
+                    payload={"text": "retry ok"},
+                )
+            ],
+            send_command=lambda **_kwargs: True,
+        ),
+    )
+    supervisor.poll(monotonic_now=2.1)
+    bus.drain()
+
+    assert message_events == [
+        WorkerMessageReceivedEvent(
+            domain="voice",
+            kind="result",
+            type="voice.transcribe",
+            request_id="req-retry",
+            payload={"text": "retry ok"},
+        )
+    ]
+    assert slot.stale_request_ids == {}
+
+
 def test_supervisor_rejects_duplicate_start_without_replacing_runtime(tmp_path: Path) -> None:
     worker = _write_worker(
         tmp_path,

--- a/tests/core/workers/test_supervisor.py
+++ b/tests/core/workers/test_supervisor.py
@@ -287,6 +287,7 @@ def test_supervisor_accepts_retry_with_same_request_id_after_timeout() -> None:
     bus = Bus()
     scheduler = MainThreadScheduler()
     message_events: list[WorkerMessageReceivedEvent] = []
+    sent_commands: list[dict[str, object]] = []
     bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
     supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
     supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
@@ -295,7 +296,7 @@ def test_supervisor_accepts_retry_with_same_request_id_after_timeout() -> None:
         SimpleNamespace(
             running=True,
             drain_messages=lambda limit=None: [],
-            send_command=lambda **_kwargs: True,
+            send_command=lambda **kwargs: sent_commands.append(kwargs) or True,
         ),
     )
     slot = supervisor._workers["voice"]
@@ -312,6 +313,12 @@ def test_supervisor_accepts_retry_with_same_request_id_after_timeout() -> None:
         request_id="req-retry",
         timeout_seconds=10.0,
     )
+    retry_attempt = cast(
+        int,
+        cast(dict[str, object], sent_commands[-1])["payload"][
+            supervisor._REQUEST_ATTEMPT_PAYLOAD_KEY
+        ],
+    )
     slot.runtime = cast(
         object,
         SimpleNamespace(
@@ -321,7 +328,10 @@ def test_supervisor_accepts_retry_with_same_request_id_after_timeout() -> None:
                     kind="result",
                     type="voice.transcribe",
                     request_id="req-retry",
-                    payload={"text": "retry ok"},
+                    payload={
+                        "text": "retry ok",
+                        supervisor._REQUEST_ATTEMPT_PAYLOAD_KEY: retry_attempt,
+                    },
                 )
             ],
             send_command=lambda **_kwargs: True,
@@ -346,6 +356,7 @@ def test_supervisor_ignores_late_cancel_ack_after_retry_reuses_request_id() -> N
     bus = Bus()
     scheduler = MainThreadScheduler()
     message_events: list[WorkerMessageReceivedEvent] = []
+    sent_commands: list[dict[str, object]] = []
     bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
     supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
     supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
@@ -354,7 +365,7 @@ def test_supervisor_ignores_late_cancel_ack_after_retry_reuses_request_id() -> N
         SimpleNamespace(
             running=True,
             drain_messages=lambda limit=None: [],
-            send_command=lambda **_kwargs: True,
+            send_command=lambda **kwargs: sent_commands.append(kwargs) or True,
         ),
     )
     slot = supervisor._workers["voice"]
@@ -370,6 +381,12 @@ def test_supervisor_ignores_late_cancel_ack_after_retry_reuses_request_id() -> N
         request_id="req-retry",
         timeout_seconds=10.0,
     )
+    retry_attempt = cast(
+        int,
+        cast(dict[str, object], sent_commands[-1])["payload"][
+            supervisor._REQUEST_ATTEMPT_PAYLOAD_KEY
+        ],
+    )
     retry_deadline = slot.request_deadlines["req-retry"]
     slot.runtime = cast(
         object,
@@ -380,10 +397,92 @@ def test_supervisor_ignores_late_cancel_ack_after_retry_reuses_request_id() -> N
                     kind="result",
                     type="voice.cancelled",
                     request_id="req-retry",
-                    payload={"cancelled": True},
+                    payload={
+                        "cancelled": True,
+                        supervisor._REQUEST_ATTEMPT_PAYLOAD_KEY: retry_attempt - 1,
+                    },
                 )
             ],
             send_command=lambda **_kwargs: True,
+        ),
+    )
+
+    supervisor.poll(monotonic_now=2.1)
+    bus.drain()
+
+    assert message_events == []
+    assert slot.request_deadlines["req-retry"] == pytest.approx(retry_deadline)
+    assert len(slot.request_deadlines) == 1
+
+
+def test_supervisor_ignores_late_non_cancel_result_after_retry_reuses_request_id() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    sent_commands: list[dict[str, object]] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(scheduler=scheduler, bus=bus)
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda limit=None: [],
+            send_command=lambda **kwargs: sent_commands.append(kwargs) or True,
+        ),
+    )
+    slot = supervisor._workers["voice"]
+    slot.runtime = runtime
+    slot.state = "running"
+
+    assert supervisor.send_request(
+        "voice",
+        type="voice.transcribe",
+        payload={"path": "/tmp/first.wav"},
+        request_id="req-retry",
+        timeout_seconds=10.0,
+    )
+    first_attempt = cast(
+        int,
+        cast(dict[str, object], sent_commands[-1])["payload"][
+            supervisor._REQUEST_ATTEMPT_PAYLOAD_KEY
+        ],
+    )
+    slot.request_deadlines["req-retry"] = 1.0
+
+    supervisor.poll(monotonic_now=2.0)
+
+    assert supervisor.send_request(
+        "voice",
+        type="voice.transcribe",
+        payload={"path": "/tmp/retry.wav"},
+        request_id="req-retry",
+        timeout_seconds=10.0,
+    )
+    retry_attempt = cast(
+        int,
+        cast(dict[str, object], sent_commands[-1])["payload"][
+            supervisor._REQUEST_ATTEMPT_PAYLOAD_KEY
+        ],
+    )
+    retry_deadline = slot.request_deadlines["req-retry"]
+    assert retry_attempt == first_attempt + 1
+    slot.runtime = cast(
+        object,
+        SimpleNamespace(
+            running=True,
+            drain_messages=lambda limit=None: [
+                make_envelope(
+                    kind="result",
+                    type="voice.transcribe",
+                    request_id="req-retry",
+                    payload={
+                        "text": "late stale result",
+                        supervisor._REQUEST_ATTEMPT_PAYLOAD_KEY: first_attempt,
+                    },
+                )
+            ],
+            send_command=lambda **kwargs: sent_commands.append(kwargs) or True,
         ),
     )
 
@@ -441,6 +540,75 @@ def test_supervisor_caps_published_worker_messages_per_poll() -> None:
     assert drain_limits == [2]
     assert [event.payload["index"] for event in message_events] == [0, 1]
     assert [message.payload["index"] for message in worker_messages] == [2]
+
+
+def test_supervisor_rotates_message_budget_across_worker_domains() -> None:
+    bus = Bus()
+    scheduler = MainThreadScheduler()
+    message_events: list[WorkerMessageReceivedEvent] = []
+    bus.subscribe(WorkerMessageReceivedEvent, message_events.append)
+    supervisor = WorkerSupervisor(
+        scheduler=scheduler,
+        bus=bus,
+        max_messages_per_poll=1,
+    )
+    supervisor.register("voice", WorkerProcessConfig(name="voice", argv=["unused"]))
+    supervisor.register("network", WorkerProcessConfig(name="network", argv=["unused"]))
+
+    voice_messages = [
+        make_envelope(
+            kind="event",
+            type="voice.event",
+            request_id=None,
+            payload={"domain": "voice", "index": 0},
+        ),
+        make_envelope(
+            kind="event",
+            type="voice.event",
+            request_id=None,
+            payload={"domain": "voice", "index": 1},
+        ),
+    ]
+    network_messages = [
+        make_envelope(
+            kind="event",
+            type="network.event",
+            request_id=None,
+            payload={"domain": "network", "index": 0},
+        )
+    ]
+
+    def make_runtime(messages: list[WorkerEnvelope]) -> object:
+        def drain_messages(limit: int | None = None) -> list[WorkerEnvelope]:
+            count = len(messages) if limit is None else min(limit, len(messages))
+            drained = messages[:count]
+            del messages[:count]
+            return drained
+
+        return cast(
+            object,
+            SimpleNamespace(
+                running=True,
+                drain_messages=drain_messages,
+                send_command=lambda **_kwargs: True,
+            ),
+        )
+
+    supervisor._workers["voice"].runtime = make_runtime(voice_messages)
+    supervisor._workers["voice"].state = "running"
+    supervisor._workers["network"].runtime = make_runtime(network_messages)
+    supervisor._workers["network"].state = "running"
+
+    assert supervisor.poll(monotonic_now=1.0) == 1
+    assert supervisor.poll(monotonic_now=2.0) == 1
+    bus.drain()
+
+    assert [(event.domain, event.payload["index"]) for event in message_events] == [
+        ("voice", 0),
+        ("network", 0),
+    ]
+    assert [message.payload["index"] for message in voice_messages] == [1]
+    assert network_messages == []
 
 
 def test_supervisor_checks_exit_and_restart_even_when_message_budget_is_exhausted(

--- a/tests/e2e/test_app_orchestration.py
+++ b/tests/e2e/test_app_orchestration.py
@@ -1978,10 +1978,9 @@ def test_status_exposes_input_and_responsiveness_markers() -> None:
 
     app, _, _ = _build_app(playback_state="stopped")
 
-    app.note_input_activity(SimpleNamespace(value="select"))
-    _publish_from_worker(app, UserActivityEvent(action_name="select"))
-
-    assert app.runtime_loop.process_pending_main_thread_actions() >= 1
+    captured_at = time.monotonic() - 0.02
+    app.note_input_activity(SimpleNamespace(value="select"), captured_at=captured_at)
+    app.note_handled_input(action_name="select", handled_at=time.monotonic())
 
     app.record_responsiveness_capture(
         captured_at=time.monotonic(),
@@ -1997,6 +1996,7 @@ def test_status_exposes_input_and_responsiveness_markers() -> None:
     assert status["last_input_action"] == "select"
     assert status["handled_input_activity_age_seconds"] is not None
     assert status["last_handled_input_action"] == "select"
+    assert status["responsiveness_input_to_action_count"] == 1
     assert status["responsiveness_last_capture_reason"] == "coordinator_stall_after_input"
     assert status["responsiveness_last_capture_scope"] == "input_to_runtime_handoff"
     assert status["responsiveness_last_capture_artifacts"] == {"snapshot": "/tmp/test.json"}

--- a/tests/ui/test_input_navigation.py
+++ b/tests/ui/test_input_navigation.py
@@ -104,6 +104,21 @@ class _DynamicModeScreen(Screen):
         return self.simple_one_button_navigation
 
 
+class _ActionRecordingScreen(Screen):
+    """Minimal screen double that records semantic actions and renders."""
+
+    def __init__(self, display: Display) -> None:
+        super().__init__(display, AppContext(), "ActionRecording")
+        self.select_calls = 0
+        self.render_calls = 0
+
+    def on_select(self, data: Optional[Any] = None) -> None:
+        self.select_calls += 1
+
+    def render(self) -> None:
+        self.render_calls += 1
+
+
 def test_semantic_input_navigation() -> None:
     """Semantic actions should drive the registered screens correctly."""
     display = Display(simulate=True)
@@ -226,6 +241,42 @@ def test_screen_manager_refreshes_input_modes_without_rebinding_callbacks() -> N
         assert adapter.double_tap_select_enabled is False
         assert input_manager.registration_calls == list(InputAction)
         assert input_manager.clear_calls == 0
+    finally:
+        display.cleanup()
+
+
+def test_screen_manager_reports_actual_action_and_visible_refresh() -> None:
+    """Input latency should be sampled from the screen action, not only activity."""
+    display = Display(simulate=True)
+    input_manager = InputManager()
+    handled_actions: list[str | None] = []
+    visible_refreshes: list[float] = []
+
+    def record_visible_refresh(*, refreshed_at: float) -> None:
+        visible_refreshes.append(refreshed_at)
+
+    screen_manager = ScreenManager(
+        display,
+        input_manager,
+        on_action_handled=lambda action_name, handled_at: handled_actions.append(
+            action_name
+        ),
+        on_visible_refresh=record_visible_refresh,
+    )
+    screen = _ActionRecordingScreen(display)
+    screen_manager.register_screen("action", screen)
+
+    try:
+        screen_manager.replace_screen("action")
+        handled_actions.clear()
+        visible_refreshes.clear()
+
+        input_manager.simulate_action(InputAction.SELECT)
+
+        assert screen.select_calls == 1
+        assert handled_actions == ["select"]
+        assert len(visible_refreshes) == 1
+        assert screen.render_calls >= 2
     finally:
         display.cleanup()
 

--- a/tests/ui/test_input_navigation.py
+++ b/tests/ui/test_input_navigation.py
@@ -281,6 +281,37 @@ def test_screen_manager_reports_actual_action_and_visible_refresh() -> None:
         display.cleanup()
 
 
+def test_screen_manager_skips_visible_refresh_metric_when_display_asleep() -> None:
+    """A render while asleep should not consume the pending visible-refresh marker."""
+    display = Display(simulate=True)
+    input_manager = InputManager()
+    visible_refreshes: list[float] = []
+
+    def record_visible_refresh(*, refreshed_at: float) -> None:
+        visible_refreshes.append(refreshed_at)
+
+    screen_manager = ScreenManager(
+        display,
+        input_manager,
+        on_visible_refresh=record_visible_refresh,
+        is_screen_visible=lambda: False,
+    )
+    screen = _ActionRecordingScreen(display)
+    screen_manager.register_screen("action", screen)
+
+    try:
+        screen_manager.replace_screen("action")
+        visible_refreshes.clear()
+
+        input_manager.simulate_action(InputAction.SELECT)
+
+        assert screen.select_calls == 1
+        assert visible_refreshes == []
+        assert screen.render_calls >= 2
+    finally:
+        display.cleanup()
+
+
 def test_screen_base_requires_semantic_handlers_only() -> None:
     """The base Screen contract should not expose legacy button-named handlers."""
     display = Display(simulate=True)

--- a/yoyopod/core/__init__.py
+++ b/yoyopod/core/__init__.py
@@ -64,6 +64,14 @@ _PUBLIC_EXPORTS = {
     "VoipRuntimeState": ("yoyopod.core.app_context", "VoipRuntimeState"),
     "VoiceInteractionState": ("yoyopod.core.app_context", "VoiceInteractionState"),
     "VoiceState": ("yoyopod.core.app_context", "VoiceState"),
+    "WorkerDomainStateChangedEvent": (
+        "yoyopod.core.events",
+        "WorkerDomainStateChangedEvent",
+    ),
+    "WorkerMessageReceivedEvent": (
+        "yoyopod.core.events",
+        "WorkerMessageReceivedEvent",
+    ),
     "YoyoPodApp": ("yoyopod.core.application", "YoyoPodApp"),
     "build_logging_runtime_config": ("yoyopod.core.logging", "build_logging_runtime_config"),
     "format_device_label": ("yoyopod.core.hardware", "format_device_label"),

--- a/yoyopod/core/application.py
+++ b/yoyopod/core/application.py
@@ -49,6 +49,7 @@ from yoyopod.core.event_subscriptions import RuntimeEventSubscriptions
 from yoyopod.core.loop import RuntimeLoopService
 from yoyopod.core.status import RuntimeMetricsStore
 from yoyopod.core.recovery import RecoveryState, RuntimeRecoveryService
+from yoyopod.core.workers import WorkerSupervisor
 from yoyopod.integrations.call import VoiceNoteEventHandler
 from yoyopod.integrations.network import NetworkEventHandler
 from yoyopod.integrations.display import ScreenPowerService
@@ -216,6 +217,7 @@ class YoyoPodApp:
 
         self.runtime_metrics = RuntimeMetricsStore()
         self.cross_screen_overlays = CrossScreenOverlayRuntime()
+        self.worker_supervisor = WorkerSupervisor(scheduler=self.scheduler, bus=self.bus)
 
         # Runtime services
         self.screen_power_service = ScreenPowerService(self)
@@ -306,6 +308,7 @@ class YoyoPodApp:
             return
 
         self.bus.publish(LifecycleEvent(phase="stopping"))
+        self.worker_supervisor.stop_all(grace_seconds=1.0)
         self._teardown_registered_integrations()
 
         if self._legacy_setup_complete or self._has_runtime_resources():

--- a/yoyopod/core/application.py
+++ b/yoyopod/core/application.py
@@ -385,10 +385,16 @@ class YoyoPodApp:
 
         return self.scheduler.pending_count()
 
-    def note_input_activity(self, action: object, _data: Any | None = None) -> None:
+    def note_input_activity(
+        self,
+        action: object,
+        _data: Any | None = None,
+        *,
+        captured_at: float | None = None,
+    ) -> None:
         """Record raw or semantic input activity before the coordinator drains it."""
 
-        self.runtime_metrics.note_input_activity(action, _data)
+        self.runtime_metrics.note_input_activity(action, _data, captured_at=captured_at)
 
     def note_handled_input(
         self,
@@ -402,6 +408,11 @@ class YoyoPodApp:
             action_name=action_name,
             handled_at=handled_at,
         )
+
+    def note_visible_refresh(self, *, refreshed_at: float) -> None:
+        """Record that a visible screen refresh happened on the coordinator thread."""
+
+        self.runtime_metrics.note_visible_refresh(refreshed_at=refreshed_at)
 
     def record_responsiveness_capture(
         self,

--- a/yoyopod/core/bootstrap/components_boot.py
+++ b/yoyopod/core/bootstrap/components_boot.py
@@ -180,6 +180,8 @@ class ComponentsBoot:
                 display,
                 self.app.input_manager,
                 action_scheduler=self.app.scheduler.run_on_main,
+                on_action_handled=self.app.note_handled_input,
+                on_visible_refresh=self.app.note_visible_refresh,
             )
             return True
         except Exception:

--- a/yoyopod/core/bootstrap/components_boot.py
+++ b/yoyopod/core/bootstrap/components_boot.py
@@ -182,6 +182,7 @@ class ComponentsBoot:
                 action_scheduler=self.app.scheduler.run_on_main,
                 on_action_handled=self.app.note_handled_input,
                 on_visible_refresh=self.app.note_visible_refresh,
+                is_screen_visible=lambda: self.app._screen_awake,
             )
             return True
         except Exception:

--- a/yoyopod/core/diagnostics/memory.py
+++ b/yoyopod/core/diagnostics/memory.py
@@ -1,0 +1,86 @@
+"""Small process memory snapshot helpers for Pi diagnostics."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessMemorySnapshot:
+    """Best-effort memory snapshot for one process."""
+
+    pid: int
+    rss_kb: int | None
+    pss_kb: int | None
+    private_dirty_kb: int | None
+    source: str
+
+
+def collect_process_memory(
+    *,
+    pid: int | None = None,
+    proc_root: Path = Path("/proc"),
+) -> ProcessMemorySnapshot:
+    """Return PSS/RSS when Linux procfs exposes it, else a safe unavailable snapshot."""
+
+    actual_pid = os.getpid() if pid is None else int(pid)
+    proc_dir = proc_root / str(actual_pid)
+    smaps_path = proc_dir / "smaps_rollup"
+    status_path = proc_dir / "status"
+
+    if smaps_path.exists():
+        return parse_smaps_rollup(smaps_path.read_text(encoding="utf-8"), pid=actual_pid)
+
+    if status_path.exists():
+        return ProcessMemorySnapshot(
+            pid=actual_pid,
+            rss_kb=parse_status_rss_kb(status_path.read_text(encoding="utf-8")),
+            pss_kb=None,
+            private_dirty_kb=None,
+            source="status",
+        )
+
+    return ProcessMemorySnapshot(
+        pid=actual_pid,
+        rss_kb=None,
+        pss_kb=None,
+        private_dirty_kb=None,
+        source="unavailable",
+    )
+
+
+def parse_smaps_rollup(text: str, *, pid: int) -> ProcessMemorySnapshot:
+    """Parse the memory fields used by the runtime architecture spec."""
+
+    values = _parse_kb_fields(text)
+    return ProcessMemorySnapshot(
+        pid=pid,
+        rss_kb=values.get("Rss"),
+        pss_kb=values.get("Pss"),
+        private_dirty_kb=values.get("Private_Dirty"),
+        source="smaps_rollup",
+    )
+
+
+def parse_status_rss_kb(text: str) -> int | None:
+    """Parse VmRSS from /proc/<pid>/status."""
+
+    return _parse_kb_fields(text).get("VmRSS")
+
+
+def _parse_kb_fields(text: str) -> dict[str, int]:
+    values: dict[str, int] = {}
+    for raw_line in text.splitlines():
+        if ":" not in raw_line:
+            continue
+        key, raw_value = raw_line.split(":", 1)
+        parts = raw_value.strip().split()
+        if len(parts) < 2 or parts[1] != "kB":
+            continue
+        try:
+            values[key.strip()] = int(parts[0])
+        except ValueError:
+            continue
+    return values

--- a/yoyopod/core/diagnostics/memory.py
+++ b/yoyopod/core/diagnostics/memory.py
@@ -30,13 +30,15 @@ def collect_process_memory(
     smaps_path = proc_dir / "smaps_rollup"
     status_path = proc_dir / "status"
 
-    if smaps_path.exists():
-        return parse_smaps_rollup(smaps_path.read_text(encoding="utf-8"), pid=actual_pid)
+    smaps_text = _safe_read_text(smaps_path)
+    if smaps_text is not None:
+        return parse_smaps_rollup(smaps_text, pid=actual_pid)
 
-    if status_path.exists():
+    status_text = _safe_read_text(status_path)
+    if status_text is not None:
         return ProcessMemorySnapshot(
             pid=actual_pid,
-            rss_kb=parse_status_rss_kb(status_path.read_text(encoding="utf-8")),
+            rss_kb=parse_status_rss_kb(status_text),
             pss_kb=None,
             private_dirty_kb=None,
             source="status",
@@ -68,6 +70,15 @@ def parse_status_rss_kb(text: str) -> int | None:
     """Parse VmRSS from /proc/<pid>/status."""
 
     return _parse_kb_fields(text).get("VmRSS")
+
+
+def _safe_read_text(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
 
 
 def _parse_kb_fields(text: str) -> dict[str, int]:

--- a/yoyopod/core/events.py
+++ b/yoyopod/core/events.py
@@ -74,6 +74,26 @@ class BackendStoppedEvent:
     reason: str = ""
 
 
+@dataclass(frozen=True, slots=True)
+class WorkerDomainStateChangedEvent:
+    """Published when one worker-backed domain changes availability."""
+
+    domain: str
+    state: str
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerMessageReceivedEvent:
+    """Published when a worker emits a protocol event or result."""
+
+    domain: str
+    kind: str
+    type: str
+    request_id: str | None
+    payload: dict[str, Any]
+
+
 __all__ = [
     "AudioFocusGrantedEvent",
     "AudioFocusLostEvent",
@@ -84,6 +104,6 @@ __all__ = [
     "ScreenChangedEvent",
     "StateChangedEvent",
     "UserActivityEvent",
+    "WorkerDomainStateChangedEvent",
+    "WorkerMessageReceivedEvent",
 ]
-
-

--- a/yoyopod/core/loop.py
+++ b/yoyopod/core/loop.py
@@ -133,6 +133,8 @@ class RuntimeLoopService:
         self._last_loop_iteration_started_at = 0.0
         self._last_runtime_loop_gap_seconds = 0.0
         self._last_runtime_iteration_duration_seconds = 0.0
+        self._last_main_thread_drain_duration_seconds = 0.0
+        self._main_thread_drain_recorded = False
         self._last_voip_iterate_started_at = 0.0
         self._last_voip_timing_sample_id = 0
         self._last_voip_schedule_delay_seconds = 0.0
@@ -222,6 +224,11 @@ class RuntimeLoopService:
             threshold_seconds=self._SLOW_MAIN_THREAD_DRAIN_WARNING_SECONDS,
             detail=self._main_thread_drain_detail(result),
         )
+        self._last_main_thread_drain_duration_seconds = max(
+            0.0,
+            time.monotonic() - started_at,
+        )
+        self._main_thread_drain_recorded = True
         return result.total_processed
 
     def _process_pending_main_thread_actions_for_iteration(self) -> int:
@@ -247,6 +254,11 @@ class RuntimeLoopService:
             threshold_seconds=self._SLOW_MAIN_THREAD_DRAIN_WARNING_SECONDS,
             detail=self._main_thread_drain_detail(result),
         )
+        self._last_main_thread_drain_duration_seconds = max(
+            0.0,
+            time.monotonic() - started_at,
+        )
+        self._main_thread_drain_recorded = True
         return result.total_processed
 
     def _scheduler_drain_budget(self) -> int:
@@ -680,6 +692,7 @@ class RuntimeLoopService:
                     "visible_screen_refresh",
                     screen_manager.refresh_current_screen_for_visible_tick,
                 )
+                self.app.note_visible_refresh(refreshed_at=time.monotonic())
                 return current_time
 
             return last_screen_update
@@ -827,6 +840,12 @@ class RuntimeLoopService:
             "runtime_iteration_seconds": (
                 self._last_runtime_iteration_duration_seconds
                 if self._last_loop_iteration_started_at > 0.0
+                else None
+            ),
+            "runtime_main_thread_drain_seconds": (
+                self._last_main_thread_drain_duration_seconds
+                if self._last_loop_iteration_started_at > 0.0
+                or self._main_thread_drain_recorded
                 else None
             ),
             "voip_schedule_delay_seconds": (

--- a/yoyopod/core/loop.py
+++ b/yoyopod/core/loop.py
@@ -633,6 +633,10 @@ class RuntimeLoopService:
                 self._process_pending_main_thread_actions_for_iteration,
             )
             self._measure_blocking_span(
+                "worker_poll",
+                self.app.worker_supervisor.poll,
+            )
+            self._measure_blocking_span(
                 "manager_recovery",
                 lambda: self.app.recovery_service.attempt_manager_recovery(now=monotonic_now),
             )
@@ -849,6 +853,7 @@ class RuntimeLoopService:
                 or self._main_thread_drain_recorded
                 else None
             ),
+            "runtime_worker_count": len(self.app.worker_supervisor.snapshot()),
             "voip_schedule_delay_seconds": (
                 self._last_voip_schedule_delay_seconds
                 if self._last_voip_iterate_started_at > 0.0

--- a/yoyopod/core/loop.py
+++ b/yoyopod/core/loop.py
@@ -688,11 +688,12 @@ class RuntimeLoopService:
                 if screen_manager is None:
                     return current_time
 
-                self._measure_blocking_span(
+                refreshed_visible_screen = self._measure_blocking_span(
                     "visible_screen_refresh",
                     screen_manager.refresh_current_screen_for_visible_tick,
                 )
-                self.app.note_visible_refresh(refreshed_at=time.monotonic())
+                if refreshed_visible_screen:
+                    self.app.note_visible_refresh(refreshed_at=time.monotonic())
                 return current_time
 
             return last_screen_update

--- a/yoyopod/core/loop.py
+++ b/yoyopod/core/loop.py
@@ -196,6 +196,12 @@ class RuntimeLoopService:
             and getattr(self.app.voip_manager, "background_iterate_enabled", False)
         )
 
+    @property
+    def configured_voip_iterate_interval_seconds(self) -> float:
+        """Return the configured VoIP iterate cadence before runtime adaptation."""
+
+        return float(self.app._voip_iterate_interval_seconds)
+
     def _sync_background_voip_timing_sample(self) -> None:
         """Pull the latest background iterate sample into runtime timing snapshots."""
 

--- a/yoyopod/core/status.py
+++ b/yoyopod/core/status.py
@@ -60,12 +60,13 @@ class RuntimeMetricsStore:
 
         self.last_input_activity_at = time.monotonic() if captured_at is None else captured_at
         self.last_input_activity_action_name = getattr(action, "value", None)
-        self._pending_input_activities.append(
-            _InputActivityMarker(
-                action_name=self.last_input_activity_action_name,
-                captured_at=self.last_input_activity_at,
+        if self.last_input_activity_action_name is not None:
+            self._pending_input_activities.append(
+                _InputActivityMarker(
+                    action_name=self.last_input_activity_action_name,
+                    captured_at=self.last_input_activity_at,
+                )
             )
-        )
 
     def note_handled_input(
         self,
@@ -82,6 +83,8 @@ class RuntimeMetricsStore:
         if self._pending_input_activities:
             input_marker = self._pending_input_activities.popleft()
             input_activity_at = input_marker.captured_at
+        elif self.last_input_activity_action_name is None:
+            input_activity_at = 0.0
         else:
             input_activity_at = self.last_input_activity_at
         if input_activity_at <= 0.0:

--- a/yoyopod/core/status.py
+++ b/yoyopod/core/status.py
@@ -157,7 +157,10 @@ class RuntimeStatusService:
     def get_status(self, *, refresh_output_volume: bool = False) -> dict[str, Any]:
         """Return the current application status."""
 
+        from yoyopod.core.diagnostics.memory import collect_process_memory
+
         monotonic_now = time.monotonic()
+        process_memory = collect_process_memory()
         runtime_metrics = self.app.runtime_metrics
         pending_shutdown_in_seconds = None
         if self.app._pending_shutdown is not None:
@@ -277,6 +280,11 @@ class RuntimeStatusService:
                 if self.app._last_lvgl_pump_at > 0.0
                 else None
             ),
+            "process_memory_pid": process_memory.pid,
+            "process_memory_rss_kb": process_memory.rss_kb,
+            "process_memory_pss_kb": process_memory.pss_kb,
+            "process_memory_private_dirty_kb": process_memory.private_dirty_kb,
+            "process_memory_source": process_memory.source,
             "loop_heartbeat_age_seconds": (
                 max(0.0, monotonic_now - self.app._last_loop_heartbeat_at)
                 if self.app._last_loop_heartbeat_at > 0.0

--- a/yoyopod/core/status.py
+++ b/yoyopod/core/status.py
@@ -80,8 +80,8 @@ class RuntimeMetricsStore:
         self.last_input_handled_action_name = action_name
         self._last_handled_input_for_refresh_at = handled_at
         self._last_handled_input_for_refresh_action_name = action_name
-        if self._pending_input_activities:
-            input_marker = self._pending_input_activities.popleft()
+        input_marker = self._pop_matching_input_activity(action_name)
+        if input_marker is not None:
             input_activity_at = input_marker.captured_at
         elif self.last_input_activity_action_name is None:
             input_activity_at = 0.0
@@ -167,6 +167,19 @@ class RuntimeMetricsStore:
         self.last_responsiveness_capture_scope = suspected_scope
         self.last_responsiveness_capture_summary = summary
         self.last_responsiveness_capture_artifacts = dict(artifacts or {})
+
+    def _pop_matching_input_activity(
+        self,
+        action_name: str | None,
+    ) -> _InputActivityMarker | None:
+        if action_name is None:
+            return self._pending_input_activities.popleft() if self._pending_input_activities else None
+
+        while self._pending_input_activities:
+            input_marker = self._pending_input_activities.popleft()
+            if input_marker.action_name == action_name:
+                return input_marker
+        return None
 
 
 class RuntimeStatusService:

--- a/yoyopod/core/status.py
+++ b/yoyopod/core/status.py
@@ -356,6 +356,7 @@ class RuntimeStatusService:
             "responsiveness_last_capture_artifacts": dict(
                 runtime_metrics.last_responsiveness_capture_artifacts
             ),
+            **runtime_metrics.responsiveness_snapshot(now=monotonic_now),
             **self.app.runtime_loop.timing_snapshot(now=monotonic_now),
         }
 

--- a/yoyopod/core/status.py
+++ b/yoyopod/core/status.py
@@ -285,6 +285,7 @@ class RuntimeStatusService:
             "process_memory_pss_kb": process_memory.pss_kb,
             "process_memory_private_dirty_kb": process_memory.private_dirty_kb,
             "process_memory_source": process_memory.source,
+            "workers": self.app.worker_supervisor.snapshot(),
             "loop_heartbeat_age_seconds": (
                 max(0.0, monotonic_now - self.app._last_loop_heartbeat_at)
                 if self.app._last_loop_heartbeat_at > 0.0

--- a/yoyopod/core/status.py
+++ b/yoyopod/core/status.py
@@ -3,10 +3,25 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any
+from collections import deque
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from yoyopod.core.application import YoyoPodApp
+
+
+LatencyKind = Literal["input_to_action", "action_to_visible"]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeLatencySample:
+    """One user-visible responsiveness measurement."""
+
+    kind: LatencyKind
+    action_name: str | None
+    duration_seconds: float
+    recorded_at: float
 
 
 class RuntimeMetricsStore:
@@ -22,6 +37,10 @@ class RuntimeMetricsStore:
         self.last_responsiveness_capture_scope: str | None = None
         self.last_responsiveness_capture_summary: str | None = None
         self.last_responsiveness_capture_artifacts: dict[str, str] = {}
+        self._input_to_action_samples: deque[RuntimeLatencySample] = deque(maxlen=256)
+        self._action_to_visible_samples: deque[RuntimeLatencySample] = deque(maxlen=256)
+        self._last_handled_input_for_refresh_at = 0.0
+        self._last_handled_input_for_refresh_action_name: str | None = None
 
     def note_input_activity(
         self,
@@ -45,6 +64,71 @@ class RuntimeMetricsStore:
 
         self.last_input_handled_at = handled_at
         self.last_input_handled_action_name = action_name
+        self._last_handled_input_for_refresh_at = handled_at
+        self._last_handled_input_for_refresh_action_name = action_name
+        if self.last_input_activity_at <= 0.0:
+            return
+
+        duration_seconds = max(0.0, handled_at - self.last_input_activity_at)
+        self._input_to_action_samples.append(
+            RuntimeLatencySample(
+                kind="input_to_action",
+                action_name=action_name,
+                duration_seconds=duration_seconds,
+                recorded_at=handled_at,
+            )
+        )
+
+    def note_visible_refresh(self, *, refreshed_at: float) -> None:
+        """Record the first visible refresh after the latest handled input."""
+
+        if self._last_handled_input_for_refresh_at <= 0.0:
+            return
+
+        duration_seconds = max(0.0, refreshed_at - self._last_handled_input_for_refresh_at)
+        self._action_to_visible_samples.append(
+            RuntimeLatencySample(
+                kind="action_to_visible",
+                action_name=self._last_handled_input_for_refresh_action_name,
+                duration_seconds=duration_seconds,
+                recorded_at=refreshed_at,
+            )
+        )
+        self._last_handled_input_for_refresh_at = 0.0
+        self._last_handled_input_for_refresh_action_name = None
+
+    def responsiveness_snapshot(self, *, now: float) -> dict[str, float | int | str | None]:
+        """Return compact responsiveness metrics for status and diagnostics."""
+
+        input_samples = list(self._input_to_action_samples)
+        visible_samples = list(self._action_to_visible_samples)
+        last_input = input_samples[-1] if input_samples else None
+        last_visible = visible_samples[-1] if visible_samples else None
+        return {
+            "responsiveness_input_to_action_count": len(input_samples),
+            "responsiveness_input_to_action_p50_ms": _percentile_ms(input_samples, 0.50),
+            "responsiveness_input_to_action_p95_ms": _percentile_ms(input_samples, 0.95),
+            "responsiveness_input_to_action_max_ms": _max_ms(input_samples),
+            "responsiveness_input_to_action_last_ms": _sample_ms(last_input),
+            "responsiveness_last_input_to_action_name": (
+                last_input.action_name if last_input is not None else None
+            ),
+            "responsiveness_action_to_visible_count": len(visible_samples),
+            "responsiveness_action_to_visible_p50_ms": _percentile_ms(
+                visible_samples,
+                0.50,
+            ),
+            "responsiveness_action_to_visible_p95_ms": _percentile_ms(
+                visible_samples,
+                0.95,
+            ),
+            "responsiveness_action_to_visible_max_ms": _max_ms(visible_samples),
+            "responsiveness_action_to_visible_last_ms": _sample_ms(last_visible),
+            "responsiveness_last_visible_action_name": (
+                last_visible.action_name if last_visible is not None else None
+            ),
+            "responsiveness_snapshot_age_seconds": 0.0 if now > 0.0 else None,
+        }
 
     def record_responsiveness_capture(
         self,
@@ -292,6 +376,26 @@ def build_runtime_status(app: Any) -> dict[str, object]:
         "services": [f"{domain}.{service}" for domain, service in app.services.registered()],
         "tick_stats_last_100": app.tick_stats_snapshot(),
     }
+
+
+def _sample_ms(sample: RuntimeLatencySample | None) -> float | None:
+    if sample is None:
+        return None
+    return round(sample.duration_seconds * 1000.0, 3)
+
+
+def _max_ms(samples: list[RuntimeLatencySample]) -> float | None:
+    if not samples:
+        return None
+    return round(max(sample.duration_seconds for sample in samples) * 1000.0, 3)
+
+
+def _percentile_ms(samples: list[RuntimeLatencySample], ratio: float) -> float | None:
+    if not samples:
+        return None
+    ordered = sorted(sample.duration_seconds for sample in samples)
+    index = int(round((len(ordered) - 1) * ratio))
+    return round(ordered[index] * 1000.0, 3)
 
 
 def _jsonify(value: object) -> object:

--- a/yoyopod/core/status.py
+++ b/yoyopod/core/status.py
@@ -404,7 +404,8 @@ def _percentile_ms(samples: list[RuntimeLatencySample], ratio: float) -> float |
     if not samples:
         return None
     ordered = sorted(sample.duration_seconds for sample in samples)
-    index = int(round((len(ordered) - 1) * ratio))
+    position = (len(ordered) - 1) * min(1.0, max(0.0, ratio))
+    index = int(position + 0.5)
     return round(ordered[index] * 1000.0, 3)
 
 

--- a/yoyopod/core/status.py
+++ b/yoyopod/core/status.py
@@ -24,6 +24,12 @@ class RuntimeLatencySample:
     recorded_at: float
 
 
+@dataclass(frozen=True, slots=True)
+class _InputActivityMarker:
+    action_name: str | None
+    captured_at: float
+
+
 class RuntimeMetricsStore:
     """Track small runtime markers that status and diagnostics need to read."""
 
@@ -39,6 +45,7 @@ class RuntimeMetricsStore:
         self.last_responsiveness_capture_artifacts: dict[str, str] = {}
         self._input_to_action_samples: deque[RuntimeLatencySample] = deque(maxlen=256)
         self._action_to_visible_samples: deque[RuntimeLatencySample] = deque(maxlen=256)
+        self._pending_input_activities: deque[_InputActivityMarker] = deque(maxlen=256)
         self._last_handled_input_for_refresh_at = 0.0
         self._last_handled_input_for_refresh_action_name: str | None = None
 
@@ -53,6 +60,12 @@ class RuntimeMetricsStore:
 
         self.last_input_activity_at = time.monotonic() if captured_at is None else captured_at
         self.last_input_activity_action_name = getattr(action, "value", None)
+        self._pending_input_activities.append(
+            _InputActivityMarker(
+                action_name=self.last_input_activity_action_name,
+                captured_at=self.last_input_activity_at,
+            )
+        )
 
     def note_handled_input(
         self,
@@ -66,10 +79,15 @@ class RuntimeMetricsStore:
         self.last_input_handled_action_name = action_name
         self._last_handled_input_for_refresh_at = handled_at
         self._last_handled_input_for_refresh_action_name = action_name
-        if self.last_input_activity_at <= 0.0:
+        if self._pending_input_activities:
+            input_marker = self._pending_input_activities.popleft()
+            input_activity_at = input_marker.captured_at
+        else:
+            input_activity_at = self.last_input_activity_at
+        if input_activity_at <= 0.0:
             return
 
-        duration_seconds = max(0.0, handled_at - self.last_input_activity_at)
+        duration_seconds = max(0.0, handled_at - input_activity_at)
         self._input_to_action_samples.append(
             RuntimeLatencySample(
                 kind="input_to_action",

--- a/yoyopod/core/workers/__init__.py
+++ b/yoyopod/core/workers/__init__.py
@@ -16,6 +16,7 @@ from yoyopod.core.workers.protocol import (
     make_envelope,
     parse_envelope_line,
 )
+from yoyopod.core.workers.supervisor import WorkerSupervisor
 
 __all__ = [
     "SUPPORTED_SCHEMA_VERSION",
@@ -25,6 +26,7 @@ __all__ = [
     "WorkerProcessRuntime",
     "WorkerProcessSnapshot",
     "WorkerProtocolError",
+    "WorkerSupervisor",
     "encode_envelope",
     "make_envelope",
     "parse_envelope_line",

--- a/yoyopod/core/workers/__init__.py
+++ b/yoyopod/core/workers/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from yoyopod.core.workers.process import (
+    WorkerProcessConfig,
+    WorkerProcessRuntime,
+    WorkerProcessSnapshot,
+)
 from yoyopod.core.workers.protocol import (
     SUPPORTED_SCHEMA_VERSION,
     VALID_KINDS,
@@ -16,6 +21,9 @@ __all__ = [
     "SUPPORTED_SCHEMA_VERSION",
     "VALID_KINDS",
     "WorkerEnvelope",
+    "WorkerProcessConfig",
+    "WorkerProcessRuntime",
+    "WorkerProcessSnapshot",
     "WorkerProtocolError",
     "encode_envelope",
     "make_envelope",

--- a/yoyopod/core/workers/__init__.py
+++ b/yoyopod/core/workers/__init__.py
@@ -1,0 +1,23 @@
+"""Worker runtime primitives for YoYoPod."""
+
+from __future__ import annotations
+
+from yoyopod.core.workers.protocol import (
+    SUPPORTED_SCHEMA_VERSION,
+    VALID_KINDS,
+    WorkerEnvelope,
+    WorkerProtocolError,
+    encode_envelope,
+    make_envelope,
+    parse_envelope_line,
+)
+
+__all__ = [
+    "SUPPORTED_SCHEMA_VERSION",
+    "VALID_KINDS",
+    "WorkerEnvelope",
+    "WorkerProtocolError",
+    "encode_envelope",
+    "make_envelope",
+    "parse_envelope_line",
+]

--- a/yoyopod/core/workers/process.py
+++ b/yoyopod/core/workers/process.py
@@ -57,7 +57,7 @@ class WorkerProcessRuntime:
 
     def __init__(self, config: WorkerProcessConfig) -> None:
         self.config = config
-        self._process: subprocess.Popen[str] | None = None
+        self._process: subprocess.Popen[bytes] | None = None
         self._messages: Queue[WorkerEnvelope] = Queue(maxsize=max(1, config.receive_queue_size))
         self._outbound: Queue[WorkerEnvelope | None] = Queue(
             maxsize=max(1, config.send_queue_size)
@@ -95,8 +95,8 @@ class WorkerProcessRuntime:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,
+            text=False,
+            bufsize=-1,
         )
         assert self._process.stdout is not None
         assert self._process.stderr is not None
@@ -246,7 +246,7 @@ class WorkerProcessRuntime:
             if process.poll() is not None:
                 return False
             try:
-                process.stdin.write(encode_envelope(envelope))
+                process.stdin.write(encode_envelope(envelope).encode("utf-8"))
                 process.stdin.flush()
             except (BrokenPipeError, OSError, TypeError, ValueError):
                 return False
@@ -283,7 +283,7 @@ class WorkerProcessRuntime:
             killed=self._killed,
         )
 
-    def _start_reader(self, stream_name: str, stream: IO[str]) -> threading.Thread:
+    def _start_reader(self, stream_name: str, stream: IO[bytes]) -> threading.Thread:
         thread = threading.Thread(
             target=self._read_stream,
             args=(stream_name, stream),
@@ -293,11 +293,15 @@ class WorkerProcessRuntime:
         thread.start()
         return thread
 
-    def _read_stream(self, stream_name: str, stream: IO[str]) -> None:
+    def _read_stream(self, stream_name: str, stream: IO[bytes]) -> None:
         for line in stream:
             if stream_name == "stderr":
                 self._stderr_lines += 1
-                logger.info("worker {} stderr: {}", self.config.name, line.rstrip())
+                logger.info(
+                    "worker {} stderr: {}",
+                    self.config.name,
+                    line.decode("utf-8", errors="replace").rstrip(),
+                )
                 continue
             try:
                 envelope = parse_envelope_line(line)

--- a/yoyopod/core/workers/process.py
+++ b/yoyopod/core/workers/process.py
@@ -1,0 +1,242 @@
+"""One child-process runtime for NDJSON worker sidecars."""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from queue import Empty, Full, Queue
+from typing import IO
+
+from loguru import logger
+
+from yoyopod.core.workers.protocol import (
+    WorkerEnvelope,
+    WorkerProtocolError,
+    encode_envelope,
+    make_envelope,
+    parse_envelope_line,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerProcessConfig:
+    """Configuration for one managed worker process."""
+
+    name: str
+    argv: list[str]
+    cwd: str | None = None
+    env: dict[str, str] | None = None
+    receive_queue_size: int = 64
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerProcessSnapshot:
+    """Observable state for one worker process."""
+
+    name: str
+    running: bool
+    pid: int | None
+    returncode: int | None
+    received_messages: int
+    protocol_errors: int
+    dropped_messages: int
+    stderr_lines: int
+    terminated: bool
+    killed: bool
+
+
+class WorkerProcessRuntime:
+    """Manage stdio for one worker child process without blocking the UI loop."""
+
+    def __init__(self, config: WorkerProcessConfig) -> None:
+        self.config = config
+        self._process: subprocess.Popen[str] | None = None
+        self._messages: Queue[WorkerEnvelope] = Queue(maxsize=max(1, config.receive_queue_size))
+        self._stdin_lock = threading.Lock()
+        self._reader_threads: list[threading.Thread] = []
+        self._received_messages = 0
+        self._protocol_errors = 0
+        self._dropped_messages = 0
+        self._stderr_lines = 0
+        self._terminated = False
+        self._killed = False
+
+    @property
+    def running(self) -> bool:
+        """Return whether the child process is still alive."""
+
+        return self._process is not None and self._process.poll() is None
+
+    def start(self) -> None:
+        """Start the child process and stdout/stderr reader threads."""
+
+        if self.running:
+            return
+        self._process = subprocess.Popen(
+            self.config.argv,
+            cwd=self.config.cwd,
+            env=self.config.env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        assert self._process.stdout is not None
+        assert self._process.stderr is not None
+        self._reader_threads = [
+            self._start_reader("stdout", self._process.stdout),
+            self._start_reader("stderr", self._process.stderr),
+        ]
+
+    def send_command(
+        self,
+        *,
+        type: str,
+        payload: dict[str, object] | None = None,
+        request_id: str | None = None,
+        timestamp_ms: int = 0,
+        deadline_ms: int = 0,
+    ) -> bool:
+        """Write one command envelope to worker stdin."""
+
+        envelope = make_envelope(
+            kind="command",
+            type=type,
+            payload=payload,
+            request_id=request_id,
+            timestamp_ms=timestamp_ms,
+            deadline_ms=deadline_ms,
+        )
+        return self.send(envelope)
+
+    def send(self, envelope: WorkerEnvelope) -> bool:
+        """Write one envelope to worker stdin and report whether it was accepted."""
+
+        process = self._process
+        if process is None or process.stdin is None or process.poll() is not None:
+            return False
+        with self._stdin_lock:
+            try:
+                process.stdin.write(encode_envelope(envelope))
+                process.stdin.flush()
+            except (BrokenPipeError, OSError, ValueError):
+                return False
+        return True
+
+    def drain_messages(self, limit: int | None = None) -> list[WorkerEnvelope]:
+        """Return available worker messages without blocking."""
+
+        messages: list[WorkerEnvelope] = []
+        while limit is None or len(messages) < limit:
+            try:
+                messages.append(self._messages.get_nowait())
+            except Empty:
+                break
+        return messages
+
+    def wait_for_messages(
+        self,
+        *,
+        count: int,
+        timeout_seconds: float,
+    ) -> list[WorkerEnvelope]:
+        """Testing helper that waits for a small number of messages."""
+
+        deadline = time.monotonic() + timeout_seconds
+        messages: list[WorkerEnvelope] = []
+        while len(messages) < count and time.monotonic() < deadline:
+            messages.extend(self.drain_messages(limit=count - len(messages)))
+            if len(messages) >= count:
+                break
+            time.sleep(0.01)
+        return messages
+
+    def wait_until_exited(self, *, timeout_seconds: float) -> bool:
+        """Testing helper that waits for process exit."""
+
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            if self._process is None or self._process.poll() is not None:
+                return True
+            time.sleep(0.01)
+        return False
+
+    def stop(self, *, grace_seconds: float = 1.0) -> None:
+        """Stop the worker with bounded terminate/kill behavior."""
+
+        process = self._process
+        if process is None:
+            return
+        if process.poll() is None:
+            try:
+                self.send_command(
+                    type="worker.stop",
+                    payload={},
+                    deadline_ms=int(grace_seconds * 1000),
+                )
+            except Exception as exc:
+                logger.debug("worker {} graceful stop send failed: {}", self.config.name, exc)
+            deadline = time.monotonic() + max(0.0, grace_seconds)
+            while process.poll() is None and time.monotonic() < deadline:
+                time.sleep(0.01)
+        if process.poll() is None:
+            process.terminate()
+            self._terminated = True
+            try:
+                process.wait(timeout=max(0.05, grace_seconds))
+            except subprocess.TimeoutExpired:
+                process.kill()
+                self._killed = True
+                process.wait(timeout=1.0)
+        self._join_readers(timeout_seconds=0.2)
+
+    def snapshot(self) -> WorkerProcessSnapshot:
+        """Return the observable process state."""
+
+        process = self._process
+        return WorkerProcessSnapshot(
+            name=self.config.name,
+            running=self.running,
+            pid=process.pid if process is not None else None,
+            returncode=process.poll() if process is not None else None,
+            received_messages=self._received_messages,
+            protocol_errors=self._protocol_errors,
+            dropped_messages=self._dropped_messages,
+            stderr_lines=self._stderr_lines,
+            terminated=self._terminated,
+            killed=self._killed,
+        )
+
+    def _start_reader(self, stream_name: str, stream: IO[str]) -> threading.Thread:
+        thread = threading.Thread(
+            target=self._read_stream,
+            args=(stream_name, stream),
+            name=f"yoyopod-worker-{self.config.name}-{stream_name}",
+            daemon=True,
+        )
+        thread.start()
+        return thread
+
+    def _read_stream(self, stream_name: str, stream: IO[str]) -> None:
+        for line in stream:
+            if stream_name == "stderr":
+                self._stderr_lines += 1
+                logger.info("worker {} stderr: {}", self.config.name, line.rstrip())
+                continue
+            try:
+                envelope = parse_envelope_line(line)
+            except WorkerProtocolError:
+                self._protocol_errors += 1
+                continue
+            try:
+                self._messages.put_nowait(envelope)
+                self._received_messages += 1
+            except Full:
+                self._dropped_messages += 1
+
+    def _join_readers(self, *, timeout_seconds: float) -> None:
+        for thread in self._reader_threads:
+            thread.join(timeout=timeout_seconds)

--- a/yoyopod/core/workers/process.py
+++ b/yoyopod/core/workers/process.py
@@ -29,6 +29,7 @@ class WorkerProcessConfig:
     cwd: str | None = None
     env: dict[str, str] | None = None
     receive_queue_size: int = 64
+    send_queue_size: int = 64
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,6 +43,10 @@ class WorkerProcessSnapshot:
     received_messages: int
     protocol_errors: int
     dropped_messages: int
+    sent_messages: int
+    queued_sends: int
+    dropped_sends: int
+    send_failures: int
     stderr_lines: int
     terminated: bool
     killed: bool
@@ -54,11 +59,19 @@ class WorkerProcessRuntime:
         self.config = config
         self._process: subprocess.Popen[str] | None = None
         self._messages: Queue[WorkerEnvelope] = Queue(maxsize=max(1, config.receive_queue_size))
+        self._outbound: Queue[WorkerEnvelope | None] = Queue(
+            maxsize=max(1, config.send_queue_size)
+        )
         self._stdin_lock = threading.Lock()
         self._reader_threads: list[threading.Thread] = []
+        self._writer_thread: threading.Thread | None = None
+        self._writer_stop_requested = threading.Event()
         self._received_messages = 0
         self._protocol_errors = 0
         self._dropped_messages = 0
+        self._sent_messages = 0
+        self._dropped_sends = 0
+        self._send_failures = 0
         self._stderr_lines = 0
         self._terminated = False
         self._killed = False
@@ -74,6 +87,7 @@ class WorkerProcessRuntime:
 
         if self.running:
             return
+        self._writer_stop_requested.clear()
         self._process = subprocess.Popen(
             self.config.argv,
             cwd=self.config.cwd,
@@ -90,6 +104,7 @@ class WorkerProcessRuntime:
             self._start_reader("stdout", self._process.stdout),
             self._start_reader("stderr", self._process.stderr),
         ]
+        self._start_writer()
 
     def send_command(
         self,
@@ -113,17 +128,16 @@ class WorkerProcessRuntime:
         return self.send(envelope)
 
     def send(self, envelope: WorkerEnvelope) -> bool:
-        """Write one envelope to worker stdin and report whether it was accepted."""
+        """Queue one envelope for worker stdin and report whether it was accepted."""
 
         process = self._process
         if process is None or process.stdin is None or process.poll() is not None:
             return False
-        with self._stdin_lock:
-            try:
-                process.stdin.write(encode_envelope(envelope))
-                process.stdin.flush()
-            except (BrokenPipeError, OSError, ValueError):
-                return False
+        try:
+            self._outbound.put_nowait(envelope)
+        except Full:
+            self._dropped_sends += 1
+            return False
         return True
 
     def drain_messages(self, limit: int | None = None) -> list[WorkerEnvelope]:
@@ -177,10 +191,9 @@ class WorkerProcessRuntime:
                 payload={},
                 deadline_ms=int(grace_seconds * 1000),
             )
-            self._send_graceful_stop_async(
-                envelope,
-                lock_timeout_seconds=min(0.05, grace_seconds),
-            )
+            if self._writer_thread is None:
+                self._start_writer()
+            self.send(envelope)
             deadline = time.monotonic() + max(0.0, grace_seconds)
             while process.poll() is None and time.monotonic() < deadline:
                 time.sleep(0.01)
@@ -196,37 +209,40 @@ class WorkerProcessRuntime:
                     process.wait(timeout=1.0)
                 except subprocess.TimeoutExpired:
                     logger.warning("worker {} did not exit after kill", self.config.name)
+        self._request_writer_shutdown()
         self._join_readers(timeout_seconds=0.2)
+        self._join_writer(timeout_seconds=0.2)
 
-    def _send_graceful_stop_async(
-        self,
-        envelope: WorkerEnvelope,
-        *,
-        lock_timeout_seconds: float,
-    ) -> None:
+    def _start_writer(self) -> None:
+        if self._writer_thread is not None and self._writer_thread.is_alive():
+            return
         thread = threading.Thread(
-            target=self._send_with_lock_timeout,
-            args=(envelope,),
-            kwargs={"timeout_seconds": lock_timeout_seconds},
-            name=f"yoyopod-worker-{self.config.name}-graceful-stop",
+            target=self._write_outbound,
+            name=f"yoyopod-worker-{self.config.name}-stdin",
             daemon=True,
         )
         thread.start()
+        self._writer_thread = thread
 
-    def _send_with_lock_timeout(
-        self,
-        envelope: WorkerEnvelope,
-        *,
-        timeout_seconds: float,
-    ) -> bool:
+    def _write_outbound(self) -> None:
+        while not self._writer_stop_requested.is_set() or not self._outbound.empty():
+            try:
+                envelope = self._outbound.get(timeout=0.05)
+            except Empty:
+                process = self._process
+                if process is None or process.poll() is not None:
+                    return
+                continue
+            if envelope is None:
+                return
+            if not self._write_envelope(envelope):
+                self._send_failures += 1
+
+    def _write_envelope(self, envelope: WorkerEnvelope) -> bool:
         process = self._process
         if process is None or process.stdin is None or process.poll() is not None:
             return False
-        acquired = self._stdin_lock.acquire(timeout=max(0.0, timeout_seconds))
-        if not acquired:
-            logger.debug("worker {} graceful stop skipped; stdin lock busy", self.config.name)
-            return False
-        try:
+        with self._stdin_lock:
             if process.poll() is not None:
                 return False
             try:
@@ -234,9 +250,17 @@ class WorkerProcessRuntime:
                 process.stdin.flush()
             except (BrokenPipeError, OSError, ValueError):
                 return False
-        finally:
-            self._stdin_lock.release()
+        self._sent_messages += 1
         return True
+
+    def _request_writer_shutdown(self) -> None:
+        if self._writer_thread is None:
+            return
+        self._writer_stop_requested.set()
+        try:
+            self._outbound.put_nowait(None)
+        except Full:
+            return
 
     def snapshot(self) -> WorkerProcessSnapshot:
         """Return the observable process state."""
@@ -250,6 +274,10 @@ class WorkerProcessRuntime:
             received_messages=self._received_messages,
             protocol_errors=self._protocol_errors,
             dropped_messages=self._dropped_messages,
+            sent_messages=self._sent_messages,
+            queued_sends=self._outbound.qsize(),
+            dropped_sends=self._dropped_sends,
+            send_failures=self._send_failures,
             stderr_lines=self._stderr_lines,
             terminated=self._terminated,
             killed=self._killed,
@@ -285,3 +313,7 @@ class WorkerProcessRuntime:
     def _join_readers(self, *, timeout_seconds: float) -> None:
         for thread in self._reader_threads:
             thread.join(timeout=timeout_seconds)
+
+    def _join_writer(self, *, timeout_seconds: float) -> None:
+        if self._writer_thread is not None:
+            self._writer_thread.join(timeout=timeout_seconds)

--- a/yoyopod/core/workers/process.py
+++ b/yoyopod/core/workers/process.py
@@ -171,14 +171,13 @@ class WorkerProcessRuntime:
         if process is None:
             return
         if process.poll() is None:
-            try:
-                self.send_command(
-                    type="worker.stop",
-                    payload={},
-                    deadline_ms=int(grace_seconds * 1000),
-                )
-            except Exception as exc:
-                logger.debug("worker {} graceful stop send failed: {}", self.config.name, exc)
+            envelope = make_envelope(
+                kind="command",
+                type="worker.stop",
+                payload={},
+                deadline_ms=int(grace_seconds * 1000),
+            )
+            self._send_with_lock_timeout(envelope, timeout_seconds=min(0.05, grace_seconds))
             deadline = time.monotonic() + max(0.0, grace_seconds)
             while process.poll() is None and time.monotonic() < deadline:
                 time.sleep(0.01)
@@ -190,8 +189,36 @@ class WorkerProcessRuntime:
             except subprocess.TimeoutExpired:
                 process.kill()
                 self._killed = True
-                process.wait(timeout=1.0)
+                try:
+                    process.wait(timeout=1.0)
+                except subprocess.TimeoutExpired:
+                    logger.warning("worker {} did not exit after kill", self.config.name)
         self._join_readers(timeout_seconds=0.2)
+
+    def _send_with_lock_timeout(
+        self,
+        envelope: WorkerEnvelope,
+        *,
+        timeout_seconds: float,
+    ) -> bool:
+        process = self._process
+        if process is None or process.stdin is None or process.poll() is not None:
+            return False
+        acquired = self._stdin_lock.acquire(timeout=max(0.0, timeout_seconds))
+        if not acquired:
+            logger.debug("worker {} graceful stop skipped; stdin lock busy", self.config.name)
+            return False
+        try:
+            if process.poll() is not None:
+                return False
+            try:
+                process.stdin.write(encode_envelope(envelope))
+                process.stdin.flush()
+            except (BrokenPipeError, OSError, ValueError):
+                return False
+        finally:
+            self._stdin_lock.release()
+        return True
 
     def snapshot(self) -> WorkerProcessSnapshot:
         """Return the observable process state."""

--- a/yoyopod/core/workers/process.py
+++ b/yoyopod/core/workers/process.py
@@ -177,7 +177,10 @@ class WorkerProcessRuntime:
                 payload={},
                 deadline_ms=int(grace_seconds * 1000),
             )
-            self._send_with_lock_timeout(envelope, timeout_seconds=min(0.05, grace_seconds))
+            self._send_graceful_stop_async(
+                envelope,
+                lock_timeout_seconds=min(0.05, grace_seconds),
+            )
             deadline = time.monotonic() + max(0.0, grace_seconds)
             while process.poll() is None and time.monotonic() < deadline:
                 time.sleep(0.01)
@@ -194,6 +197,21 @@ class WorkerProcessRuntime:
                 except subprocess.TimeoutExpired:
                     logger.warning("worker {} did not exit after kill", self.config.name)
         self._join_readers(timeout_seconds=0.2)
+
+    def _send_graceful_stop_async(
+        self,
+        envelope: WorkerEnvelope,
+        *,
+        lock_timeout_seconds: float,
+    ) -> None:
+        thread = threading.Thread(
+            target=self._send_with_lock_timeout,
+            args=(envelope,),
+            kwargs={"timeout_seconds": lock_timeout_seconds},
+            name=f"yoyopod-worker-{self.config.name}-graceful-stop",
+            daemon=True,
+        )
+        thread.start()
 
     def _send_with_lock_timeout(
         self,

--- a/yoyopod/core/workers/process.py
+++ b/yoyopod/core/workers/process.py
@@ -248,7 +248,7 @@ class WorkerProcessRuntime:
             try:
                 process.stdin.write(encode_envelope(envelope))
                 process.stdin.flush()
-            except (BrokenPipeError, OSError, ValueError):
+            except (BrokenPipeError, OSError, TypeError, ValueError):
                 return False
         self._sent_messages += 1
         return True

--- a/yoyopod/core/workers/protocol.py
+++ b/yoyopod/core/workers/protocol.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 SUPPORTED_SCHEMA_VERSION = 1
-VALID_KINDS = {"command", "event", "result", "error", "heartbeat"}
+VALID_KINDS = frozenset({"command", "event", "result", "error", "heartbeat"})
 
 
 class WorkerProtocolError(ValueError):
@@ -62,7 +62,7 @@ def parse_envelope_line(line: str | bytes) -> WorkerEnvelope:
     try:
         data = json.loads(decoded)
     except json.JSONDecodeError as exc:
-        raise WorkerProtocolError("invalid JSON worker envelope") from exc
+        raise WorkerProtocolError(f"invalid JSON worker envelope: {exc.msg}") from exc
 
     if not isinstance(data, dict):
         raise WorkerProtocolError("worker envelope must be a JSON object")
@@ -135,7 +135,7 @@ def _validate_envelope_data(data: dict[str, Any]) -> WorkerEnvelope:
         request_id=request_id,
         timestamp_ms=timestamp_ms,
         deadline_ms=deadline_ms,
-        payload=payload,
+        payload=dict(payload),
     )
 
 

--- a/yoyopod/core/workers/protocol.py
+++ b/yoyopod/core/workers/protocol.py
@@ -1,0 +1,147 @@
+"""NDJSON envelope helpers for YoYoPod worker processes."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+SUPPORTED_SCHEMA_VERSION = 1
+VALID_KINDS = {"command", "event", "result", "error", "heartbeat"}
+
+
+class WorkerProtocolError(ValueError):
+    """Raised when a worker protocol envelope is malformed or unsupported."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerEnvelope:
+    """One validated worker protocol message envelope."""
+
+    schema_version: int
+    kind: str
+    type: str
+    request_id: str | None = None
+    timestamp_ms: int = 0
+    deadline_ms: int = 0
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+def make_envelope(
+    *,
+    kind: str,
+    type: str,
+    request_id: str | None = None,
+    timestamp_ms: int = 0,
+    deadline_ms: int = 0,
+    payload: dict[str, Any] | None = None,
+) -> WorkerEnvelope:
+    """Create a schema-version-1 worker envelope after validating fields."""
+
+    return _validate_envelope_data(
+        {
+            "schema_version": SUPPORTED_SCHEMA_VERSION,
+            "kind": kind,
+            "type": type,
+            "request_id": request_id,
+            "timestamp_ms": timestamp_ms,
+            "deadline_ms": deadline_ms,
+            "payload": {} if payload is None else payload,
+        }
+    )
+
+
+def parse_envelope_line(line: str | bytes) -> WorkerEnvelope:
+    """Parse one NDJSON worker envelope line and validate its object shape."""
+
+    try:
+        decoded = line.decode("utf-8") if isinstance(line, bytes) else line
+    except UnicodeDecodeError as exc:
+        raise WorkerProtocolError("worker envelope line is not valid UTF-8") from exc
+
+    try:
+        data = json.loads(decoded)
+    except json.JSONDecodeError as exc:
+        raise WorkerProtocolError("invalid JSON worker envelope") from exc
+
+    if not isinstance(data, dict):
+        raise WorkerProtocolError("worker envelope must be a JSON object")
+
+    return _validate_envelope_data(data)
+
+
+def encode_envelope(envelope: WorkerEnvelope) -> str:
+    """Return stable compact newline-terminated JSON for one envelope."""
+
+    validated = _validate_envelope_data(
+        {
+            "schema_version": envelope.schema_version,
+            "kind": envelope.kind,
+            "type": envelope.type,
+            "request_id": envelope.request_id,
+            "timestamp_ms": envelope.timestamp_ms,
+            "deadline_ms": envelope.deadline_ms,
+            "payload": envelope.payload,
+        }
+    )
+    data = {
+        "schema_version": validated.schema_version,
+        "kind": validated.kind,
+        "type": validated.type,
+        "request_id": validated.request_id,
+        "timestamp_ms": validated.timestamp_ms,
+        "deadline_ms": validated.deadline_ms,
+        "payload": validated.payload,
+    }
+    return json.dumps(data, separators=(",", ":"), ensure_ascii=True) + "\n"
+
+
+def _validate_envelope_data(data: dict[str, Any]) -> WorkerEnvelope:
+    schema_version = data.get("schema_version")
+    if not _is_non_bool_int(schema_version) or schema_version != SUPPORTED_SCHEMA_VERSION:
+        raise WorkerProtocolError(
+            f"unsupported worker schema_version {schema_version!r}; "
+            f"expected {SUPPORTED_SCHEMA_VERSION}"
+        )
+
+    kind = data.get("kind")
+    if not isinstance(kind, str) or kind not in VALID_KINDS:
+        raise WorkerProtocolError(f"invalid worker envelope kind {kind!r}")
+
+    type_value = data.get("type")
+    if not isinstance(type_value, str) or not type_value.strip():
+        raise WorkerProtocolError("worker envelope type must be a non-empty string")
+
+    request_id = data.get("request_id")
+    if request_id is not None and not isinstance(request_id, str):
+        raise WorkerProtocolError("worker envelope request_id must be a string or null")
+
+    timestamp_ms = data.get("timestamp_ms", 0)
+    if not _is_non_negative_int(timestamp_ms):
+        raise WorkerProtocolError("worker envelope timestamp_ms must be a non-negative integer")
+
+    deadline_ms = data.get("deadline_ms", 0)
+    if not _is_non_negative_int(deadline_ms):
+        raise WorkerProtocolError("worker envelope deadline_ms must be a non-negative integer")
+
+    payload = data.get("payload", {})
+    if not isinstance(payload, dict):
+        raise WorkerProtocolError("worker envelope payload must be a JSON object")
+
+    return WorkerEnvelope(
+        schema_version=schema_version,
+        kind=kind,
+        type=type_value,
+        request_id=request_id,
+        timestamp_ms=timestamp_ms,
+        deadline_ms=deadline_ms,
+        payload=payload,
+    )
+
+
+def _is_non_negative_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _is_non_bool_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -313,6 +313,8 @@ class WorkerSupervisor:
         ]
         for request_id in expired_stale_ids:
             slot.stale_request_ids.pop(request_id, None)
+            if request_id not in slot.request_deadlines:
+                slot.request_attempts.pop(request_id, None)
 
     def _is_timeout_cancel_ack(self, domain: str, message: WorkerEnvelope) -> bool:
         return message.type == f"{domain}.cancelled"

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -1,0 +1,219 @@
+"""Supervisor for named YoYoPod worker processes."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from yoyopod.core.bus import Bus
+from yoyopod.core.events import (
+    WorkerDomainStateChangedEvent,
+    WorkerMessageReceivedEvent,
+)
+from yoyopod.core.scheduler import MainThreadScheduler
+from yoyopod.core.workers.process import WorkerProcessConfig, WorkerProcessRuntime
+from yoyopod.core.workers.protocol import WorkerEnvelope
+
+
+@dataclass(slots=True)
+class _WorkerSlot:
+    config: WorkerProcessConfig
+    runtime: WorkerProcessRuntime | None = None
+    state: str = "stopped"
+    restart_count: int = 0
+    next_restart_at: float = 0.0
+    request_deadlines: dict[str, float] = field(default_factory=dict)
+    request_timeouts: int = 0
+    last_reason: str = ""
+
+
+class WorkerSupervisor:
+    """Own worker lifecycle while publishing only on the supervisor main thread."""
+
+    def __init__(
+        self,
+        *,
+        scheduler: MainThreadScheduler,
+        bus: Bus,
+        restart_backoff_seconds: float = 1.0,
+        max_restarts: int = 3,
+    ) -> None:
+        self._scheduler = scheduler
+        self._bus = bus
+        self._restart_backoff_seconds = max(0.0, restart_backoff_seconds)
+        self._max_restarts = max(0, max_restarts)
+        self._workers: dict[str, _WorkerSlot] = {}
+
+    def register(self, domain: str, config: WorkerProcessConfig) -> None:
+        """Register one worker domain before it is started."""
+
+        if domain in self._workers:
+            raise ValueError(f"worker domain {domain!r} is already registered")
+        self._workers[domain] = _WorkerSlot(config=config)
+
+    def start(self, domain: str) -> None:
+        """Start one worker domain."""
+
+        slot = self._workers[domain]
+        runtime = WorkerProcessRuntime(slot.config)
+        runtime.start()
+        slot.runtime = runtime
+        slot.next_restart_at = 0.0
+        self._set_state(domain, slot, "running", "started")
+
+    def stop_all(self, *, grace_seconds: float = 1.0) -> None:
+        """Stop all registered workers with bounded waits."""
+
+        for domain, slot in self._workers.items():
+            if slot.runtime is not None:
+                slot.runtime.stop(grace_seconds=grace_seconds)
+            slot.request_deadlines.clear()
+            slot.next_restart_at = 0.0
+            self._set_state(domain, slot, "stopped", "stop_all")
+
+    def poll(self, *, monotonic_now: float | None = None) -> int:
+        """Advance worker state without blocking."""
+
+        now = time.monotonic() if monotonic_now is None else monotonic_now
+        processed = 0
+        for domain, slot in self._workers.items():
+            runtime = slot.runtime
+            if runtime is None:
+                continue
+            messages = runtime.drain_messages()
+            processed += len(messages)
+            for message in messages:
+                self._publish_message(domain, slot, message)
+            self._expire_requests(domain, slot, now=now)
+            if not runtime.running and slot.state == "running":
+                self._handle_exit(domain, slot, now=now)
+            if (
+                slot.state == "degraded"
+                and slot.next_restart_at > 0.0
+                and now >= slot.next_restart_at
+            ):
+                self._restart_if_allowed(domain, slot)
+        return processed
+
+    def send_request(
+        self,
+        domain: str,
+        *,
+        type: str,
+        payload: dict[str, Any],
+        request_id: str,
+        timeout_seconds: float,
+    ) -> bool:
+        """Send one request and remember its timeout."""
+
+        slot = self._workers[domain]
+        runtime = slot.runtime
+        if runtime is None:
+            return False
+        timeout_seconds = max(0.0, timeout_seconds)
+        sent = runtime.send_command(
+            type=type,
+            payload=payload,
+            request_id=request_id,
+            timestamp_ms=int(time.time() * 1000),
+            deadline_ms=int(timeout_seconds * 1000),
+        )
+        if sent:
+            slot.request_deadlines[request_id] = time.monotonic() + timeout_seconds
+        return sent
+
+    def drain_worker_messages(self, domain: str) -> list[WorkerEnvelope]:
+        """Testing helper for messages that have not yet been consumed by poll."""
+
+        runtime = self._workers[domain].runtime
+        return [] if runtime is None else runtime.drain_messages()
+
+    def wait_until_exited(self, domain: str, timeout_seconds: float) -> bool:
+        """Testing helper that waits for one worker process to exit."""
+
+        runtime = self._workers[domain].runtime
+        return (
+            True if runtime is None else runtime.wait_until_exited(timeout_seconds=timeout_seconds)
+        )
+
+    def snapshot(self) -> dict[str, dict[str, object]]:
+        """Return status-ready worker health data."""
+
+        result: dict[str, dict[str, object]] = {}
+        for domain, slot in self._workers.items():
+            process_snapshot = slot.runtime.snapshot() if slot.runtime is not None else None
+            result[domain] = {
+                "state": slot.state,
+                "restart_count": slot.restart_count,
+                "next_restart_at": slot.next_restart_at,
+                "last_reason": slot.last_reason,
+                "pending_requests": len(slot.request_deadlines),
+                "request_timeouts": slot.request_timeouts,
+                "running": process_snapshot.running if process_snapshot is not None else False,
+                "pid": process_snapshot.pid if process_snapshot is not None else None,
+                "received_messages": (
+                    process_snapshot.received_messages if process_snapshot is not None else 0
+                ),
+                "protocol_errors": (
+                    process_snapshot.protocol_errors if process_snapshot is not None else 0
+                ),
+                "dropped_messages": (
+                    process_snapshot.dropped_messages if process_snapshot is not None else 0
+                ),
+            }
+        return result
+
+    def _publish_message(
+        self,
+        domain: str,
+        slot: _WorkerSlot,
+        message: WorkerEnvelope,
+    ) -> None:
+        if message.request_id is not None:
+            slot.request_deadlines.pop(message.request_id, None)
+        self._bus.publish(
+            WorkerMessageReceivedEvent(
+                domain=domain,
+                kind=message.kind,
+                type=message.type,
+                request_id=message.request_id,
+                payload=message.payload,
+            )
+        )
+
+    def _expire_requests(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
+        expired = [
+            request_id for request_id, deadline in slot.request_deadlines.items() if deadline <= now
+        ]
+        for request_id in expired:
+            slot.request_deadlines.pop(request_id, None)
+            slot.request_timeouts += 1
+            if slot.runtime is not None:
+                slot.runtime.send_command(
+                    type=f"{domain}.cancel",
+                    payload={"request_id": request_id},
+                    request_id=request_id,
+                    timestamp_ms=int(time.time() * 1000),
+                    deadline_ms=1000,
+                )
+
+    def _handle_exit(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
+        slot.request_deadlines.clear()
+        slot.next_restart_at = now + self._restart_backoff_seconds
+        self._set_state(domain, slot, "degraded", "process_exited")
+
+    def _restart_if_allowed(self, domain: str, slot: _WorkerSlot) -> None:
+        if slot.restart_count >= self._max_restarts:
+            slot.next_restart_at = 0.0
+            self._set_state(domain, slot, "disabled", "max_restarts_exceeded")
+            return
+        slot.restart_count += 1
+        self.start(domain)
+
+    def _set_state(self, domain: str, slot: _WorkerSlot, state: str, reason: str) -> None:
+        if slot.state == state and slot.last_reason == reason:
+            return
+        slot.state = state
+        slot.last_reason = reason
+        self._bus.publish(WorkerDomainStateChangedEvent(domain=domain, state=state, reason=reason))

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -135,22 +135,31 @@ class WorkerSupervisor:
 
         remaining_message_budget = self._max_messages_per_poll
         ordered_worker_items = self._rotate_worker_items(worker_items)
-        remaining_runtime_count = sum(
-            1 for _domain, slot in ordered_worker_items if slot.runtime is not None
-        )
-        for domain, slot in ordered_worker_items:
-            runtime = slot.runtime
-            if runtime is None:
-                continue
-            if remaining_message_budget <= 0:
+        candidate_worker_items = [
+            (domain, slot) for domain, slot in ordered_worker_items if slot.runtime is not None
+        ]
+        while remaining_message_budget > 0 and candidate_worker_items:
+            next_candidate_worker_items: list[tuple[str, _WorkerSlot]] = []
+            drained_in_round = False
+            remaining_runtime_count = len(candidate_worker_items)
+            for index, (domain, slot) in enumerate(candidate_worker_items):
+                runtime = slot.runtime
+                if runtime is None or remaining_message_budget <= 0:
+                    continue
+                share = max(1, remaining_message_budget // (remaining_runtime_count - index))
+                messages = runtime.drain_messages(limit=share)
+                if not messages:
+                    continue
+                drained_in_round = True
+                processed += len(messages)
+                remaining_message_budget -= len(messages)
+                for message in messages:
+                    self._publish_message(domain, slot, message)
+                if len(messages) == share and remaining_message_budget > 0:
+                    next_candidate_worker_items.append((domain, slot))
+            if not drained_in_round:
                 break
-            share = max(1, remaining_message_budget // remaining_runtime_count)
-            messages = runtime.drain_messages(limit=share)
-            processed += len(messages)
-            remaining_message_budget -= len(messages)
-            for message in messages:
-                self._publish_message(domain, slot, message)
-            remaining_runtime_count -= 1
+            candidate_worker_items = next_candidate_worker_items
 
         self._poll_start_index = (self._poll_start_index + 1) % len(worker_items)
 

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -24,6 +24,7 @@ class _WorkerSlot:
     restart_count: int = 0
     next_restart_at: float = 0.0
     request_deadlines: dict[str, float] = field(default_factory=dict)
+    stale_request_ids: dict[str, float] = field(default_factory=dict)
     request_timeouts: int = 0
     last_reason: str = ""
 
@@ -34,6 +35,8 @@ class WorkerSupervisor:
     The scheduler is retained for the Task 7 app/loop integration seam; this
     phase publishes directly because the supervisor itself is main-thread owned.
     """
+
+    _STALE_REQUEST_RETENTION_SECONDS = 30.0
 
     def __init__(
         self,
@@ -56,13 +59,13 @@ class WorkerSupervisor:
             raise ValueError(f"worker domain {domain!r} is already registered")
         self._workers[domain] = _WorkerSlot(config=config)
 
-    def start(self, domain: str) -> None:
+    def start(self, domain: str) -> bool:
         """Start one worker domain."""
 
         slot = self._workers[domain]
         if slot.runtime is not None and slot.runtime.running:
             raise RuntimeError(f"worker domain {domain!r} is already running")
-        self._start_runtime(
+        return self._start_runtime(
             domain,
             slot,
             state_reason="started",
@@ -76,17 +79,20 @@ class WorkerSupervisor:
         *,
         state_reason: str,
         failure_reason: str,
-    ) -> None:
+    ) -> bool:
         runtime = WorkerProcessRuntime(slot.config)
         try:
             runtime.start()
         except Exception:
             slot.next_restart_at = 0.0
+            slot.stale_request_ids.clear()
             self._set_state(domain, slot, "degraded", failure_reason)
-            raise
+            return False
         slot.runtime = runtime
         slot.next_restart_at = 0.0
+        slot.stale_request_ids.clear()
         self._set_state(domain, slot, "running", state_reason)
+        return True
 
     def stop_all(self, *, grace_seconds: float = 1.0) -> None:
         """Stop all registered workers with bounded waits."""
@@ -95,6 +101,7 @@ class WorkerSupervisor:
             if slot.runtime is not None:
                 slot.runtime.stop(grace_seconds=grace_seconds)
             slot.request_deadlines.clear()
+            slot.stale_request_ids.clear()
             slot.next_restart_at = 0.0
             self._set_state(domain, slot, "stopped", "stop_all")
 
@@ -187,6 +194,18 @@ class WorkerSupervisor:
                 "dropped_messages": (
                     process_snapshot.dropped_messages if process_snapshot is not None else 0
                 ),
+                "sent_messages": (
+                    process_snapshot.sent_messages if process_snapshot is not None else 0
+                ),
+                "queued_sends": (
+                    process_snapshot.queued_sends if process_snapshot is not None else 0
+                ),
+                "dropped_sends": (
+                    process_snapshot.dropped_sends if process_snapshot is not None else 0
+                ),
+                "send_failures": (
+                    process_snapshot.send_failures if process_snapshot is not None else 0
+                ),
             }
         return result
 
@@ -196,6 +215,9 @@ class WorkerSupervisor:
         slot: _WorkerSlot,
         message: WorkerEnvelope,
     ) -> None:
+        if message.request_id is not None and message.request_id in slot.stale_request_ids:
+            if not self._is_timeout_cancel_ack(domain, message):
+                return
         if message.request_id is not None:
             slot.request_deadlines.pop(message.request_id, None)
         self._bus.publish(
@@ -209,12 +231,14 @@ class WorkerSupervisor:
         )
 
     def _expire_requests(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
+        self._prune_stale_request_ids(slot, now=now)
         expired = [
             request_id for request_id, deadline in slot.request_deadlines.items() if deadline <= now
         ]
         for request_id in expired:
             slot.request_deadlines.pop(request_id, None)
             slot.request_timeouts += 1
+            slot.stale_request_ids[request_id] = now + self._STALE_REQUEST_RETENTION_SECONDS
             if slot.runtime is not None:
                 slot.runtime.send_command(
                     type=f"{domain}.cancel",
@@ -226,8 +250,23 @@ class WorkerSupervisor:
 
     def _handle_exit(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
         slot.request_deadlines.clear()
+        slot.stale_request_ids.clear()
         slot.next_restart_at = now + self._restart_backoff_seconds
         self._set_state(domain, slot, "degraded", "process_exited")
+
+    def _prune_stale_request_ids(self, slot: _WorkerSlot, *, now: float) -> None:
+        expired_stale_ids = [
+            request_id
+            for request_id, stale_until in slot.stale_request_ids.items()
+            if stale_until <= now
+        ]
+        for request_id in expired_stale_ids:
+            slot.stale_request_ids.pop(request_id, None)
+
+    def _is_timeout_cancel_ack(self, domain: str, message: WorkerEnvelope) -> bool:
+        if message.type == f"{domain}.cancelled":
+            return True
+        return bool(message.payload.get("cancelled"))
 
     def _restart_if_allowed(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
         if slot.restart_count >= self._max_restarts:
@@ -235,14 +274,13 @@ class WorkerSupervisor:
             self._set_state(domain, slot, "disabled", "max_restarts_exceeded")
             return
         slot.restart_count += 1
-        try:
-            self._start_runtime(
-                domain,
-                slot,
-                state_reason="started",
-                failure_reason="restart_failed",
-            )
-        except Exception:
+        started = self._start_runtime(
+            domain,
+            slot,
+            state_reason="started",
+            failure_reason="restart_failed",
+        )
+        if not started:
             if slot.restart_count >= self._max_restarts:
                 slot.next_restart_at = 0.0
             else:

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -37,6 +37,7 @@ class WorkerSupervisor:
     """
 
     _STALE_REQUEST_RETENTION_SECONDS = 30.0
+    _DEFAULT_MAX_MESSAGES_PER_POLL = 8
 
     def __init__(
         self,
@@ -45,11 +46,13 @@ class WorkerSupervisor:
         bus: Bus,
         restart_backoff_seconds: float = 1.0,
         max_restarts: int = 3,
+        max_messages_per_poll: int = _DEFAULT_MAX_MESSAGES_PER_POLL,
     ) -> None:
         self._scheduler = scheduler
         self._bus = bus
         self._restart_backoff_seconds = max(0.0, restart_backoff_seconds)
         self._max_restarts = max(0, max_restarts)
+        self._max_messages_per_poll = max(1, int(max_messages_per_poll))
         self._workers: dict[str, _WorkerSlot] = {}
 
     def register(self, domain: str, config: WorkerProcessConfig) -> None:
@@ -110,13 +113,17 @@ class WorkerSupervisor:
 
         now = time.monotonic() if monotonic_now is None else monotonic_now
         processed = 0
+        remaining_message_budget = self._max_messages_per_poll
         for domain, slot in self._workers.items():
             runtime = slot.runtime
             if runtime is None:
                 continue
             self._expire_requests(domain, slot, now=now)
-            messages = runtime.drain_messages()
+            if remaining_message_budget <= 0:
+                continue
+            messages = runtime.drain_messages(limit=remaining_message_budget)
             processed += len(messages)
+            remaining_message_budget -= len(messages)
             for message in messages:
                 self._publish_message(domain, slot, message)
             if not runtime.running and slot.state == "running":

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -193,6 +193,10 @@ class WorkerSupervisor:
         if runtime is None:
             return False
         timeout_seconds = max(0.0, timeout_seconds)
+        now = time.monotonic()
+        existing_deadline = slot.request_deadlines.get(request_id)
+        if existing_deadline is not None and existing_deadline <= now:
+            self._expire_request(domain, slot, request_id, now=now)
         request_attempt = slot.request_attempts.get(request_id, 0) + 1
         command_payload = dict(payload)
         command_payload[self._REQUEST_ATTEMPT_PAYLOAD_KEY] = request_attempt
@@ -207,7 +211,7 @@ class WorkerSupervisor:
             slot.request_types[request_id] = type
             slot.request_attempts[request_id] = request_attempt
             slot.stale_request_ids.pop(request_id, None)
-            slot.request_deadlines[request_id] = time.monotonic() + timeout_seconds
+            slot.request_deadlines[request_id] = now + timeout_seconds
         return sent
 
     def drain_worker_messages(self, domain: str) -> list[WorkerEnvelope]:
@@ -296,17 +300,27 @@ class WorkerSupervisor:
             request_id for request_id, deadline in slot.request_deadlines.items() if deadline <= now
         ]
         for request_id in expired:
-            slot.request_deadlines.pop(request_id, None)
-            slot.request_timeouts += 1
-            slot.stale_request_ids[request_id] = now + self._STALE_REQUEST_RETENTION_SECONDS
-            if slot.runtime is not None:
-                slot.runtime.send_command(
-                    type=f"{domain}.cancel",
-                    payload={"request_id": request_id},
-                    request_id=request_id,
-                    timestamp_ms=int(time.time() * 1000),
-                    deadline_ms=1000,
-                )
+            self._expire_request(domain, slot, request_id, now=now)
+
+    def _expire_request(
+        self,
+        domain: str,
+        slot: _WorkerSlot,
+        request_id: str,
+        *,
+        now: float,
+    ) -> None:
+        slot.request_deadlines.pop(request_id, None)
+        slot.request_timeouts += 1
+        slot.stale_request_ids[request_id] = now + self._STALE_REQUEST_RETENTION_SECONDS
+        if slot.runtime is not None:
+            slot.runtime.send_command(
+                type=f"{domain}.cancel",
+                payload={"request_id": request_id},
+                request_id=request_id,
+                timestamp_ms=int(time.time() * 1000),
+                deadline_ms=1000,
+            )
 
     def _handle_exit(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
         slot.request_types.clear()

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -29,7 +29,11 @@ class _WorkerSlot:
 
 
 class WorkerSupervisor:
-    """Own worker lifecycle while publishing only on the supervisor main thread."""
+    """Own worker lifecycle from the main-thread runtime loop.
+
+    The scheduler is retained for the Task 7 app/loop integration seam; this
+    phase publishes directly because the supervisor itself is main-thread owned.
+    """
 
     def __init__(
         self,
@@ -56,11 +60,33 @@ class WorkerSupervisor:
         """Start one worker domain."""
 
         slot = self._workers[domain]
+        if slot.runtime is not None and slot.runtime.running:
+            raise RuntimeError(f"worker domain {domain!r} is already running")
+        self._start_runtime(
+            domain,
+            slot,
+            state_reason="started",
+            failure_reason="start_failed",
+        )
+
+    def _start_runtime(
+        self,
+        domain: str,
+        slot: _WorkerSlot,
+        *,
+        state_reason: str,
+        failure_reason: str,
+    ) -> None:
         runtime = WorkerProcessRuntime(slot.config)
-        runtime.start()
+        try:
+            runtime.start()
+        except Exception:
+            slot.next_restart_at = 0.0
+            self._set_state(domain, slot, "degraded", failure_reason)
+            raise
         slot.runtime = runtime
         slot.next_restart_at = 0.0
-        self._set_state(domain, slot, "running", "started")
+        self._set_state(domain, slot, "running", state_reason)
 
     def stop_all(self, *, grace_seconds: float = 1.0) -> None:
         """Stop all registered workers with bounded waits."""
@@ -93,7 +119,7 @@ class WorkerSupervisor:
                 and slot.next_restart_at > 0.0
                 and now >= slot.next_restart_at
             ):
-                self._restart_if_allowed(domain, slot)
+                self._restart_if_allowed(domain, slot, now=now)
         return processed
 
     def send_request(
@@ -203,13 +229,24 @@ class WorkerSupervisor:
         slot.next_restart_at = now + self._restart_backoff_seconds
         self._set_state(domain, slot, "degraded", "process_exited")
 
-    def _restart_if_allowed(self, domain: str, slot: _WorkerSlot) -> None:
+    def _restart_if_allowed(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
         if slot.restart_count >= self._max_restarts:
             slot.next_restart_at = 0.0
             self._set_state(domain, slot, "disabled", "max_restarts_exceeded")
             return
         slot.restart_count += 1
-        self.start(domain)
+        try:
+            self._start_runtime(
+                domain,
+                slot,
+                state_reason="started",
+                failure_reason="restart_failed",
+            )
+        except Exception:
+            if slot.restart_count >= self._max_restarts:
+                slot.next_restart_at = 0.0
+            else:
+                slot.next_restart_at = now + self._restart_backoff_seconds
 
     def _set_state(self, domain: str, slot: _WorkerSlot, state: str, reason: str) -> None:
         if slot.state == state and slot.last_reason == reason:

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -24,6 +24,7 @@ class _WorkerSlot:
     restart_count: int = 0
     next_restart_at: float = 0.0
     request_deadlines: dict[str, float] = field(default_factory=dict)
+    request_attempts: dict[str, int] = field(default_factory=dict)
     stale_request_ids: dict[str, float] = field(default_factory=dict)
     request_timeouts: int = 0
     last_reason: str = ""
@@ -38,6 +39,7 @@ class WorkerSupervisor:
 
     _STALE_REQUEST_RETENTION_SECONDS = 30.0
     _DEFAULT_MAX_MESSAGES_PER_POLL = 8
+    _REQUEST_ATTEMPT_PAYLOAD_KEY = "_yoyopod_request_attempt"
 
     def __init__(
         self,
@@ -54,6 +56,7 @@ class WorkerSupervisor:
         self._max_restarts = max(0, max_restarts)
         self._max_messages_per_poll = max(1, int(max_messages_per_poll))
         self._workers: dict[str, _WorkerSlot] = {}
+        self._poll_start_index = 0
 
     def register(self, domain: str, config: WorkerProcessConfig) -> None:
         """Register one worker domain before it is started."""
@@ -88,11 +91,13 @@ class WorkerSupervisor:
             runtime.start()
         except Exception:
             slot.next_restart_at = 0.0
+            slot.request_attempts.clear()
             slot.stale_request_ids.clear()
             self._set_state(domain, slot, "degraded", failure_reason)
             return False
         slot.runtime = runtime
         slot.next_restart_at = 0.0
+        slot.request_attempts.clear()
         slot.stale_request_ids.clear()
         self._set_state(domain, slot, "running", state_reason)
         return True
@@ -104,6 +109,7 @@ class WorkerSupervisor:
             if slot.runtime is not None:
                 slot.runtime.stop(grace_seconds=grace_seconds)
             slot.request_deadlines.clear()
+            slot.request_attempts.clear()
             slot.stale_request_ids.clear()
             slot.next_restart_at = 0.0
             self._set_state(domain, slot, "stopped", "stop_all")
@@ -113,18 +119,41 @@ class WorkerSupervisor:
 
         now = time.monotonic() if monotonic_now is None else monotonic_now
         processed = 0
-        remaining_message_budget = self._max_messages_per_poll
-        for domain, slot in self._workers.items():
+        worker_items = list(self._workers.items())
+        if not worker_items:
+            return 0
+
+        for domain, slot in worker_items:
             runtime = slot.runtime
             if runtime is None:
                 continue
             self._expire_requests(domain, slot, now=now)
-            if remaining_message_budget > 0:
-                messages = runtime.drain_messages(limit=remaining_message_budget)
-                processed += len(messages)
-                remaining_message_budget -= len(messages)
-                for message in messages:
-                    self._publish_message(domain, slot, message)
+
+        remaining_message_budget = self._max_messages_per_poll
+        ordered_worker_items = self._rotate_worker_items(worker_items)
+        remaining_runtime_count = sum(
+            1 for _domain, slot in ordered_worker_items if slot.runtime is not None
+        )
+        for domain, slot in ordered_worker_items:
+            runtime = slot.runtime
+            if runtime is None:
+                continue
+            if remaining_message_budget <= 0:
+                break
+            share = max(1, remaining_message_budget // remaining_runtime_count)
+            messages = runtime.drain_messages(limit=share)
+            processed += len(messages)
+            remaining_message_budget -= len(messages)
+            for message in messages:
+                self._publish_message(domain, slot, message)
+            remaining_runtime_count -= 1
+
+        self._poll_start_index = (self._poll_start_index + 1) % len(worker_items)
+
+        for domain, slot in worker_items:
+            runtime = slot.runtime
+            if runtime is None:
+                continue
             if not runtime.running and slot.state == "running":
                 self._handle_exit(domain, slot, now=now)
             if (
@@ -151,14 +180,18 @@ class WorkerSupervisor:
         if runtime is None:
             return False
         timeout_seconds = max(0.0, timeout_seconds)
+        request_attempt = slot.request_attempts.get(request_id, 0) + 1
+        command_payload = dict(payload)
+        command_payload[self._REQUEST_ATTEMPT_PAYLOAD_KEY] = request_attempt
         sent = runtime.send_command(
             type=type,
-            payload=payload,
+            payload=command_payload,
             request_id=request_id,
             timestamp_ms=int(time.time() * 1000),
             deadline_ms=int(timeout_seconds * 1000),
         )
         if sent:
+            slot.request_attempts[request_id] = request_attempt
             slot.stale_request_ids.pop(request_id, None)
             slot.request_deadlines[request_id] = time.monotonic() + timeout_seconds
         return sent
@@ -222,6 +255,8 @@ class WorkerSupervisor:
         slot: _WorkerSlot,
         message: WorkerEnvelope,
     ) -> None:
+        if not self._matches_active_request_attempt(slot, message):
+            return
         if (
             message.request_id is not None
             and self._is_timeout_cancel_ack(domain, message)
@@ -234,13 +269,14 @@ class WorkerSupervisor:
                 return
         if message.request_id is not None:
             slot.request_deadlines.pop(message.request_id, None)
+            slot.request_attempts.pop(message.request_id, None)
         self._bus.publish(
             WorkerMessageReceivedEvent(
                 domain=domain,
                 kind=message.kind,
                 type=message.type,
                 request_id=message.request_id,
-                payload=message.payload,
+                payload=self._public_payload(message),
             )
         )
 
@@ -264,6 +300,7 @@ class WorkerSupervisor:
 
     def _handle_exit(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
         slot.request_deadlines.clear()
+        slot.request_attempts.clear()
         slot.stale_request_ids.clear()
         slot.next_restart_at = now + self._restart_backoff_seconds
         self._set_state(domain, slot, "degraded", "process_exited")
@@ -279,6 +316,35 @@ class WorkerSupervisor:
 
     def _is_timeout_cancel_ack(self, domain: str, message: WorkerEnvelope) -> bool:
         return message.type == f"{domain}.cancelled"
+
+    def _rotate_worker_items(
+        self, worker_items: list[tuple[str, _WorkerSlot]]
+    ) -> list[tuple[str, _WorkerSlot]]:
+        if not worker_items:
+            return []
+        start_index = self._poll_start_index % len(worker_items)
+        return worker_items[start_index:] + worker_items[:start_index]
+
+    def _matches_active_request_attempt(
+        self,
+        slot: _WorkerSlot,
+        message: WorkerEnvelope,
+    ) -> bool:
+        request_id = message.request_id
+        if request_id is None:
+            return True
+        active_attempt = slot.request_attempts.get(request_id)
+        if active_attempt is None:
+            return True
+        message_attempt = message.payload.get(self._REQUEST_ATTEMPT_PAYLOAD_KEY)
+        if active_attempt <= 1:
+            return message_attempt is None or message_attempt == active_attempt
+        return message_attempt == active_attempt
+
+    def _public_payload(self, message: WorkerEnvelope) -> dict[str, Any]:
+        payload = dict(message.payload)
+        payload.pop(self._REQUEST_ATTEMPT_PAYLOAD_KEY, None)
+        return payload
 
     def _restart_if_allowed(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
         if slot.restart_count >= self._max_restarts:

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -265,9 +265,7 @@ class WorkerSupervisor:
             slot.stale_request_ids.pop(request_id, None)
 
     def _is_timeout_cancel_ack(self, domain: str, message: WorkerEnvelope) -> bool:
-        if message.type == f"{domain}.cancelled":
-            return True
-        return bool(message.payload.get("cancelled"))
+        return message.type == f"{domain}.cancelled"
 
     def _restart_if_allowed(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
         if slot.restart_count >= self._max_restarts:

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -267,7 +267,7 @@ class WorkerSupervisor:
         if message.request_id is not None and message.request_id in slot.stale_request_ids:
             if not self._is_timeout_cancel_ack(domain, message):
                 return
-        if message.request_id is not None:
+        if message.request_id is not None and self._is_terminal_request_reply(domain, message):
             slot.request_deadlines.pop(message.request_id, None)
             slot.request_attempts.pop(message.request_id, None)
         self._bus.publish(
@@ -318,6 +318,11 @@ class WorkerSupervisor:
 
     def _is_timeout_cancel_ack(self, domain: str, message: WorkerEnvelope) -> bool:
         return message.type == f"{domain}.cancelled"
+
+    def _is_terminal_request_reply(self, domain: str, message: WorkerEnvelope) -> bool:
+        if self._is_timeout_cancel_ack(domain, message):
+            return True
+        return message.kind in {"result", "error"}
 
     def _rotate_worker_items(
         self, worker_items: list[tuple[str, _WorkerSlot]]

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -114,11 +114,11 @@ class WorkerSupervisor:
             runtime = slot.runtime
             if runtime is None:
                 continue
+            self._expire_requests(domain, slot, now=now)
             messages = runtime.drain_messages()
             processed += len(messages)
             for message in messages:
                 self._publish_message(domain, slot, message)
-            self._expire_requests(domain, slot, now=now)
             if not runtime.running and slot.state == "running":
                 self._handle_exit(domain, slot, now=now)
             if (

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -216,6 +216,13 @@ class WorkerSupervisor:
         slot: _WorkerSlot,
         message: WorkerEnvelope,
     ) -> None:
+        if (
+            message.request_id is not None
+            and self._is_timeout_cancel_ack(domain, message)
+            and message.request_id in slot.request_deadlines
+            and message.request_id not in slot.stale_request_ids
+        ):
+            return
         if message.request_id is not None and message.request_id in slot.stale_request_ids:
             if not self._is_timeout_cancel_ack(domain, message):
                 return

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -153,6 +153,7 @@ class WorkerSupervisor:
             deadline_ms=int(timeout_seconds * 1000),
         )
         if sent:
+            slot.stale_request_ids.pop(request_id, None)
             slot.request_deadlines[request_id] = time.monotonic() + timeout_seconds
         return sent
 

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -23,6 +23,7 @@ class _WorkerSlot:
     state: str = "stopped"
     restart_count: int = 0
     next_restart_at: float = 0.0
+    request_types: dict[str, str] = field(default_factory=dict)
     request_deadlines: dict[str, float] = field(default_factory=dict)
     request_attempts: dict[str, int] = field(default_factory=dict)
     stale_request_ids: dict[str, float] = field(default_factory=dict)
@@ -91,12 +92,14 @@ class WorkerSupervisor:
             runtime.start()
         except Exception:
             slot.next_restart_at = 0.0
+            slot.request_types.clear()
             slot.request_attempts.clear()
             slot.stale_request_ids.clear()
             self._set_state(domain, slot, "degraded", failure_reason)
             return False
         slot.runtime = runtime
         slot.next_restart_at = 0.0
+        slot.request_types.clear()
         slot.request_attempts.clear()
         slot.stale_request_ids.clear()
         self._set_state(domain, slot, "running", state_reason)
@@ -108,6 +111,7 @@ class WorkerSupervisor:
         for domain, slot in self._workers.items():
             if slot.runtime is not None:
                 slot.runtime.stop(grace_seconds=grace_seconds)
+            slot.request_types.clear()
             slot.request_deadlines.clear()
             slot.request_attempts.clear()
             slot.stale_request_ids.clear()
@@ -191,6 +195,7 @@ class WorkerSupervisor:
             deadline_ms=int(timeout_seconds * 1000),
         )
         if sent:
+            slot.request_types[request_id] = type
             slot.request_attempts[request_id] = request_attempt
             slot.stale_request_ids.pop(request_id, None)
             slot.request_deadlines[request_id] = time.monotonic() + timeout_seconds
@@ -257,17 +262,13 @@ class WorkerSupervisor:
     ) -> None:
         if not self._matches_active_request_attempt(slot, message):
             return
-        if (
-            message.request_id is not None
-            and self._is_timeout_cancel_ack(domain, message)
-            and message.request_id in slot.request_deadlines
-            and message.request_id not in slot.stale_request_ids
-        ):
+        if self._should_drop_active_cancel_ack(domain, slot, message):
             return
         if message.request_id is not None and message.request_id in slot.stale_request_ids:
             if not self._is_timeout_cancel_ack(domain, message):
                 return
         if message.request_id is not None and self._is_terminal_request_reply(domain, message):
+            slot.request_types.pop(message.request_id, None)
             slot.request_deadlines.pop(message.request_id, None)
             slot.request_attempts.pop(message.request_id, None)
         self._bus.publish(
@@ -299,6 +300,7 @@ class WorkerSupervisor:
                 )
 
     def _handle_exit(self, domain: str, slot: _WorkerSlot, *, now: float) -> None:
+        slot.request_types.clear()
         slot.request_deadlines.clear()
         slot.request_attempts.clear()
         slot.stale_request_ids.clear()
@@ -314,6 +316,7 @@ class WorkerSupervisor:
         for request_id in expired_stale_ids:
             slot.stale_request_ids.pop(request_id, None)
             if request_id not in slot.request_deadlines:
+                slot.request_types.pop(request_id, None)
                 slot.request_attempts.pop(request_id, None)
 
     def _is_timeout_cancel_ack(self, domain: str, message: WorkerEnvelope) -> bool:
@@ -323,6 +326,19 @@ class WorkerSupervisor:
         if self._is_timeout_cancel_ack(domain, message):
             return True
         return message.kind in {"result", "error"}
+
+    def _should_drop_active_cancel_ack(
+        self,
+        domain: str,
+        slot: _WorkerSlot,
+        message: WorkerEnvelope,
+    ) -> bool:
+        request_id = message.request_id
+        if request_id is None or not self._is_timeout_cancel_ack(domain, message):
+            return False
+        if request_id not in slot.request_deadlines or request_id in slot.stale_request_ids:
+            return False
+        return slot.request_types.get(request_id) != f"{domain}.cancel"
 
     def _rotate_worker_items(
         self, worker_items: list[tuple[str, _WorkerSlot]]
@@ -344,8 +360,8 @@ class WorkerSupervisor:
         if active_attempt is None:
             return True
         message_attempt = message.payload.get(self._REQUEST_ATTEMPT_PAYLOAD_KEY)
-        if active_attempt <= 1:
-            return message_attempt is None or message_attempt == active_attempt
+        if message_attempt is None:
+            return True
         return message_attempt == active_attempt
 
     def _public_payload(self, message: WorkerEnvelope) -> dict[str, Any]:

--- a/yoyopod/core/workers/supervisor.py
+++ b/yoyopod/core/workers/supervisor.py
@@ -119,13 +119,12 @@ class WorkerSupervisor:
             if runtime is None:
                 continue
             self._expire_requests(domain, slot, now=now)
-            if remaining_message_budget <= 0:
-                continue
-            messages = runtime.drain_messages(limit=remaining_message_budget)
-            processed += len(messages)
-            remaining_message_budget -= len(messages)
-            for message in messages:
-                self._publish_message(domain, slot, message)
+            if remaining_message_budget > 0:
+                messages = runtime.drain_messages(limit=remaining_message_budget)
+                processed += len(messages)
+                remaining_message_budget -= len(messages)
+                for message in messages:
+                    self._publish_message(domain, slot, message)
             if not runtime.running and slot.state == "running":
                 self._handle_exit(domain, slot, now=now)
             if (

--- a/yoyopod/integrations/display/service.py
+++ b/yoyopod/integrations/display/service.py
@@ -79,10 +79,6 @@ class ScreenPowerService:
         """Wake the display and reset the inactivity timer on user activity."""
         logger.debug(f"User activity received: {event.action_name or 'unknown'}")
         handled_now = time.monotonic()
-        self.app.note_handled_input(
-            action_name=event.action_name,
-            handled_at=handled_now,
-        )
         self.mark_user_activity(
             now=handled_now,
             render_on_wake=event.action_name is not None,

--- a/yoyopod/ui/screens/manager.py
+++ b/yoyopod/ui/screens/manager.py
@@ -213,34 +213,19 @@ class ScreenManager:
     def refresh_current_screen(self) -> None:
         """Re-render the current screen."""
         self._navigation_refresh_pending = False
-        if self.current_screen:
-            started_at = time.monotonic()
-            refresh_for_visible_tick = getattr(
-                self.current_screen, "refresh_for_visible_tick", None
-            )
-            if callable(refresh_for_visible_tick):
-                refresh_for_visible_tick()
-            self.current_screen.render()
-            if self.on_visible_refresh is not None and self._is_screen_visible():
-                self.on_visible_refresh(refreshed_at=time.monotonic())
-            self._warn_if_slow(
-                "refresh_current_screen",
-                started_at=started_at,
-                threshold_seconds=self._SLOW_RENDER_WARNING_SECONDS,
-                detail=f"screen={self.current_screen.route_name or self.current_screen.name}",
-            )
-        if self.current_screen is None:
+        screen = self.current_screen
+        if screen is None:
             return
 
         started_at = time.monotonic()
         refresh_for_visible_tick = getattr(
-            self.current_screen,
+            screen,
             "refresh_for_visible_tick",
             None,
         )
         if callable(refresh_for_visible_tick):
             refresh_for_visible_tick()
-        self._render_screen(self.current_screen, started_at=started_at)
+        self._render_screen(screen, started_at=started_at)
 
     def refresh_current_screen_for_visible_tick(self) -> VisibleTickRefreshResult:
         """Refresh the current screen when it opts into periodic visible ticks.
@@ -510,6 +495,8 @@ class ScreenManager:
         render_started_at = time.monotonic() if started_at is None else started_at
         screen.render()
         screen.clear_dirty()
+        if self.on_visible_refresh is not None and self._is_screen_visible():
+            self.on_visible_refresh(refreshed_at=time.monotonic())
         self._warn_if_slow(
             "refresh_current_screen",
             started_at=render_started_at,

--- a/yoyopod/ui/screens/manager.py
+++ b/yoyopod/ui/screens/manager.py
@@ -64,6 +64,8 @@ class ScreenManager:
         router: Optional[ScreenRouter] = None,
         on_screen_changed: Optional[Callable[[Optional[str]], None]] = None,
         action_scheduler: Optional[Callable[[Callable[[], None]], None]] = None,
+        on_action_handled: Optional[Callable[[Optional[str], float], None]] = None,
+        on_visible_refresh: Optional[Callable[[float], None]] = None,
     ) -> None:
         """
         Initialize the screen manager.
@@ -80,6 +82,8 @@ class ScreenManager:
         self.router = router or ScreenRouter()
         self.on_screen_changed = on_screen_changed
         self.action_scheduler = action_scheduler
+        self.on_action_handled = on_action_handled
+        self.on_visible_refresh = on_visible_refresh
         self._navigation_refresh_pending = False
         self._input_dispatch_registered = False
 
@@ -207,6 +211,22 @@ class ScreenManager:
     def refresh_current_screen(self) -> None:
         """Re-render the current screen."""
         self._navigation_refresh_pending = False
+        if self.current_screen:
+            started_at = time.monotonic()
+            refresh_for_visible_tick = getattr(
+                self.current_screen, "refresh_for_visible_tick", None
+            )
+            if callable(refresh_for_visible_tick):
+                refresh_for_visible_tick()
+            self.current_screen.render()
+            if self.on_visible_refresh is not None:
+                self.on_visible_refresh(refreshed_at=time.monotonic())
+            self._warn_if_slow(
+                "refresh_current_screen",
+                started_at=started_at,
+                threshold_seconds=self._SLOW_RENDER_WARNING_SECONDS,
+                detail=f"screen={self.current_screen.route_name or self.current_screen.name}",
+            )
         if self.current_screen is None:
             return
 
@@ -425,6 +445,9 @@ class ScreenManager:
             return
 
         previous_screen.handle_action(action, data)
+        handled_at = time.monotonic()
+        if self.on_action_handled is not None:
+            self.on_action_handled(action_name=action.value, handled_at=handled_at)
         navigation_request = previous_screen.consume_navigation_request()
         if navigation_request is not None:
             self.apply_navigation_request(navigation_request, source_screen=previous_screen)

--- a/yoyopod/ui/screens/manager.py
+++ b/yoyopod/ui/screens/manager.py
@@ -66,6 +66,7 @@ class ScreenManager:
         action_scheduler: Optional[Callable[[Callable[[], None]], None]] = None,
         on_action_handled: Optional[Callable[[Optional[str], float], None]] = None,
         on_visible_refresh: Optional[Callable[[float], None]] = None,
+        is_screen_visible: Optional[Callable[[], bool]] = None,
     ) -> None:
         """
         Initialize the screen manager.
@@ -84,6 +85,7 @@ class ScreenManager:
         self.action_scheduler = action_scheduler
         self.on_action_handled = on_action_handled
         self.on_visible_refresh = on_visible_refresh
+        self.is_screen_visible = is_screen_visible
         self._navigation_refresh_pending = False
         self._input_dispatch_registered = False
 
@@ -219,7 +221,7 @@ class ScreenManager:
             if callable(refresh_for_visible_tick):
                 refresh_for_visible_tick()
             self.current_screen.render()
-            if self.on_visible_refresh is not None:
+            if self.on_visible_refresh is not None and self._is_screen_visible():
                 self.on_visible_refresh(refreshed_at=time.monotonic())
             self._warn_if_slow(
                 "refresh_current_screen",
@@ -367,6 +369,12 @@ class ScreenManager:
             return
         route_name = self.current_screen.route_name if self.current_screen else None
         self.on_screen_changed(route_name)
+
+    def _is_screen_visible(self) -> bool:
+        """Return whether a refresh can be counted as visible to the user."""
+        if self.is_screen_visible is None:
+            return True
+        return self.is_screen_visible()
 
     def _refresh_after_navigation(self) -> None:
         """Refresh immediately or defer to the LVGL pump after a navigation change."""


### PR DESCRIPTION
﻿## Summary

This PR implements the Runtime Hybrid Phase 0/1 foundation for YoYoPod, now rebased on top of merged PR #376 (`BackgroundExecutor`).

- Adds the runtime hybrid architecture spec and Phase 0/1 implementation plan.
- Adds responsiveness and memory instrumentation for baseline profiling on the Pi.
- Adds a stdio NDJSON worker foundation with bounded receive/send queues, restart/backoff, request timeout handling, and worker status snapshots.
- Integrates the worker supervisor into the app loop/status path without splitting production subsystems yet.
- Adds the Pi profiling workflow for capturing baseline RAM and responsiveness data.

## Design Direction

The branch keeps the Python coordinator as the owner of LVGL/UI, app state, scheduler, bus, music/call coordination, and VoIP for now. It prepares for a future cloud-first Go voice worker and Python network worker, but does not introduce the 7-process/ZeroMQ design in this phase.

PR #376 now provides the in-process blocking-I/O threading layer underneath this work; this PR adds the process-worker protocol/supervisor and Phase 0 observability layer above it.

## Review Findings Addressed

Codex review findings are addressed with regression tests:

- `748052581c92fb4f668021dcd42ed01b6a4f8060`
  - Worker writer treats JSON encoding `TypeError` as a send failure instead of letting the stdin writer thread die.
  - Runtime percentile indexing no longer uses Python bankers rounding.
  - Retried worker requests that reuse a timed-out `request_id` clear the stale marker after the new send succeeds.
- `beb955e244f3c64aadd885ab483f53592a1444a5`
  - Worker request deadlines expire before drained messages are published, so late responses are not accepted as successful after loop stalls.
- `6c862da4cb10475e696db8ce27d60f0365a584b0`
  - Input-to-action metrics correlate handled actions with their FIFO input activity timestamp instead of the latest global input timestamp.
  - Visible refresh metrics are recorded only when the screen is awake/visible, so wake-from-sleep renders do not consume the marker too early.
  - Timed-out worker responses only bypass stale-message dropping when the envelope type is the explicit `{domain}.cancelled` ACK.
- `fdd5239f0216aa12af039912cd37c93bf6565953`
  - Raw adapter activity still updates last-activity state, but only semantic input activity is queued for input-to-action latency correlation.
- `219cd1b10d0a30dd43fde3ff6f13214636ba92b3`
  - Late timeout cancel ACKs are ignored when the same `request_id` has already been retried and has a live deadline, preserving timeout enforcement for the retry.
- `07e491e1e53506a4407cbb073cf82b12344b1413`
  - Worker poll publishes at most eight worker messages per poll across all domains, matching the coordinator bus-drain budget and leaving burst excess in bounded worker queues.
- `cda59b4f686f2fd16382439df5af3b8b22bcf4ae`
  - Worker lifecycle checks now still run after poll message budget exhaustion, so exited or degraded later domains can still transition and restart under sustained load.

## Validation

Local validation after the latest review findings:

- `uv run python scripts/quality.py gate` passed
- `uv run pytest -q` passed: 1282 passed, 21 skipped

Hardware dev-lane validation after the latest review findings:

- Host: `rpi-zero`
- Branch/SHA: `codex/runtime-hybrid-phase-0-1` at `cda59b4f686f2fd16382439df5af3b8b22bcf4ae`
- Command: `uv run yoyopod remote --branch codex/runtime-hybrid-phase-0-1 validate --sha cda59b4`
- Result: passed deploy, smoke, and stability validation
- Stability soak: 2 cycles, 32 actions, 24 transitions, final screen `hub`, sleep/wake OK
- Dev lane is active after validation: `yoyopod-dev.service` running on the same SHA

Notes: the soak still surfaces non-fatal slow-loop/power-refresh signals and repeated MQTT reconnects on the dev board. Those are useful baseline signals for Phase 0 instrumentation; they did not fail validation.
