### PR TITLE
[codex] Introduce a first-class cross-screen overlay runtime

### DIFF
--- a/docs/CROSS_SCREEN_OVERLAYS.md
+++ b/docs/CROSS_SCREEN_OVERLAYS.md
@@ -21,11 +21,15 @@ to either duplicate rendering in many screens or add more bespoke manager APIs.
 Cross-screen concerns should implement one shared contract:
 
 1. Long-lived instance: created once at boot by its owning subsystem.
-2. Activation check: `is_active(now: float) -> bool`.
+2. Pure activation check: `is_active(now: float) -> bool` decides visibility
+   without mutating overlay-owned state.
 3. Rendering hook: `render(now: float) -> None`.
-4. Ordering: each overlay provides `priority: int`; higher values render first.
-5. Runtime ownership: overlays are registered in a shared overlay runtime that
-   evaluates all overlays and renders only the highest-priority active overlay.
+4. Deactivation hook: `on_deactivate(now: float) -> None` owns cleanup that
+   should happen only when an overlay stops being active.
+5. Ordering: each overlay provides `priority: int`; higher values render first.
+6. Runtime ownership: overlays are registered in a shared overlay runtime that
+   evaluates overlays once per coordinator tick, stops at the first active
+   overlay, and renders only that winner.
 
 ## Loop Placement
 
@@ -41,8 +45,7 @@ avoids standalone special-cases in the outer coordinator iteration.
   internal state.
 - Overlays must be self-deactivating: once the condition is gone,
   `is_active()` returns `False` and the runtime naturally stops rendering it.
-- Overlay owners can trigger one-time cleanup actions (for example, refreshing
-  the previously visible screen) when transitioning to inactive.
+- One-time cleanup actions belong in `on_deactivate()`, not in `is_active()`.
 
 ## Current Migration Plan
 

--- a/docs/CROSS_SCREEN_OVERLAYS.md
+++ b/docs/CROSS_SCREEN_OVERLAYS.md
@@ -24,8 +24,8 @@ Cross-screen concerns should implement one shared contract:
 2. Pure activation check: `is_active(now: float) -> bool` decides visibility
    without mutating overlay-owned state.
 3. Rendering hook: `render(now: float) -> None`.
-4. Deactivation hook: `on_deactivate(now: float) -> None` owns cleanup that
-   should happen only when an overlay stops being active.
+4. Deactivation hook: `on_deactivate(now: float) -> None` owns idempotent
+   cleanup that may run while an overlay is not the active winner.
 5. Ordering: each overlay provides `priority: int`; higher values render first.
 6. Runtime ownership: overlays are registered in a shared overlay runtime that
    evaluates overlays once per coordinator tick, stops at the first active
@@ -45,7 +45,7 @@ avoids standalone special-cases in the outer coordinator iteration.
   internal state.
 - Overlays must be self-deactivating: once the condition is gone,
   `is_active()` returns `False` and the runtime naturally stops rendering it.
-- One-time cleanup actions belong in `on_deactivate()`, not in `is_active()`.
+- Inactive cleanup belongs in `on_deactivate()`, not in `is_active()`.
 
 ## Current Migration Plan
 

--- a/docs/CROSS_SCREEN_OVERLAYS.md
+++ b/docs/CROSS_SCREEN_OVERLAYS.md
@@ -1,0 +1,54 @@
+# Cross-Screen Overlay Contract
+
+**Last updated:** 2026-04-25  
+**Status:** active design contract for runtime overlay refactors
+
+## Problem
+
+YoYoPod has multiple UI concerns that can appear regardless of the current route
+(power alerts, call state, future HUD/toast flows), but runtime ownership has
+historically been split across:
+
+- ad-hoc `ScreenManager` helper methods
+- route-stack push/pop side effects
+- one-off rendering hooks in the coordinator loop
+
+That coupling makes cross-screen behavior hard to extend and forces new concerns
+to either duplicate rendering in many screens or add more bespoke manager APIs.
+
+## Overlay Runtime Contract
+
+Cross-screen concerns should implement one shared contract:
+
+1. Long-lived instance: created once at boot by its owning subsystem.
+2. Activation check: `is_active(now: float) -> bool`.
+3. Rendering hook: `render(now: float) -> None`.
+4. Ordering: each overlay provides `priority: int`; higher values render first.
+5. Runtime ownership: overlays are registered in a shared overlay runtime that
+   evaluates all overlays and renders only the highest-priority active overlay.
+
+## Loop Placement
+
+Overlay evaluation/rendering runs during LVGL pump in `RuntimeLoopService`,
+between deferred navigation refresh and `backend.pump(delta_ms)`.
+
+This keeps overlay rendering in the same frame pipeline as screen refreshes and
+avoids standalone special-cases in the outer coordinator iteration.
+
+## Lifecycle Expectations
+
+- Overlay owners subscribe to bus/domain events as needed and update their own
+  internal state.
+- Overlays must be self-deactivating: once the condition is gone,
+  `is_active()` returns `False` and the runtime naturally stops rendering it.
+- Overlay owners can trigger one-time cleanup actions (for example, refreshing
+  the previously visible screen) when transitioning to inactive.
+
+## Current Migration Plan
+
+1. Phase 1 (this change): power overlay moved to the shared overlay contract
+   while preserving behavior.
+2. Phase 2: move call-presenter UI concerns to overlay implementations and
+   remove call-specific `ScreenManager` helpers.
+3. Phase 3: onboard new cross-screen concerns (volume HUD, voice feedback,
+   network degradation indicator) onto the same contract.

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Plan docs are useful, but they are not automatically the current implementation 
 ### Core runtime architecture
 
 - [`SYSTEM_ARCHITECTURE.md`](SYSTEM_ARCHITECTURE.md), top-level runtime topology plus startup/bootstrap flow
+- [`CROSS_SCREEN_OVERLAYS.md`](CROSS_SCREEN_OVERLAYS.md), first-class contract for cross-screen overlay ownership and ordering
 - [`CANONICAL_STRUCTURE.md`](CANONICAL_STRUCTURE.md), canonical config topology and domain package ownership
 - [`CLOUD_PROVISIONING_AND_BACKEND.md`](CLOUD_PROVISIONING_AND_BACKEND.md), claimed-device auth, config sync, cache/status files, MQTT telemetry, and current backend-integration status
 - [`RUNTIME_EVENT_FLOW.md`](RUNTIME_EVENT_FLOW.md), current event pipeline and coordinator ownership

--- a/docs/SYSTEM_ARCHITECTURE.md
+++ b/docs/SYSTEM_ARCHITECTURE.md
@@ -59,7 +59,7 @@ This is the startup sequence that exists on `main` today.
    - `--simulate` is parsed before the app is constructed.
 3. `main()` constructs `YoyoPodApp(config_dir="config", simulate=simulate)`.
    - The constructor does not start hardware or backend processes yet.
-  - It allocates the typed `Bus`, the shared `MainThreadScheduler`, the core bootstrap service (`RuntimeBootService` from `yoyopod/core/bootstrap/`), the canonical main-thread loop (`RuntimeLoopService` from `yoyopod/core/loop.py`), the remaining live services (`RuntimeRecoveryService` from `yoyopod/core/recovery.py`, `PowerRuntimeService` from `yoyopod/integrations/power/service.py`, `ShutdownLifecycleService` from `yoyopod/core/shutdown.py`), the canonical display-power helper (`ScreenPowerService` from `yoyopod/integrations/display/service.py`), and the long-lived placeholder fields for managers, screens, and shared context.
+  - It allocates the typed `Bus`, the shared `MainThreadScheduler`, the core bootstrap service (`RuntimeBootService` from `yoyopod/core/bootstrap/`), the canonical main-thread loop (`RuntimeLoopService` from `yoyopod/core/loop.py`), the shared cross-screen overlay runtime (`CrossScreenOverlayRuntime` from `yoyopod/core/overlays.py`), the remaining live services (`RuntimeRecoveryService` from `yoyopod/core/recovery.py`, `PowerRuntimeService` from `yoyopod/integrations/power/service.py`, `ShutdownLifecycleService` from `yoyopod/core/shutdown.py`), the canonical display-power helper (`ScreenPowerService` from `yoyopod/integrations/display/service.py`), and the long-lived placeholder fields for managers, screens, and shared context.
 - `RuntimeRecoveryService` now keeps VoIP/music/network recovery while `yoyopod.integrations.power.service.PowerRuntimeService` owns PiSugar polling and watchdog cadence.
 - It also registers app-level event subscriptions on the `Bus` so later boot stages can publish typed events back onto the main thread.
 4. `main()` calls `app.setup()`, which delegates to `RuntimeBootService.setup()` in `yoyopod/core/bootstrap/`.
@@ -129,6 +129,7 @@ yoyopod.py / yoyopod.main
      -> RuntimeLoopService
      -> RuntimeRecoveryService
      -> PowerRuntimeService
+     -> CrossScreenOverlayRuntime
      -> integrations.display.ScreenPowerService
      -> core.shutdown.ShutdownLifecycleService
      -> MainThreadScheduler
@@ -183,8 +184,9 @@ yoyopod.py / yoyopod.main
 - `yoyopod/core/app_context.py`: `AppContext` plus the focused runtime state objects it owns
 - `yoyopod/core/bootstrap/`: boot-time composition and manager wiring
 - `yoyopod/core/loop.py`: main-thread loop scheduling and queued main-thread work
+- `yoyopod/core/overlays.py`: cross-screen overlay contract and ordering runtime
 - `yoyopod/core/recovery.py`: backend recovery supervision and retry services
-- `yoyopod/integrations/display/service.py`: screen wake/sleep policy and power overlays
+- `yoyopod/integrations/display/service.py`: screen wake/sleep policy and power-overlay implementation
 - `yoyopod/core/shutdown.py`: shutdown countdowns, hooks, and lifecycle cleanup
 - `yoyopod/integrations/power/service.py`: power polling and watchdog cadence
 
@@ -193,6 +195,7 @@ yoyopod.py / yoyopod.main
 - `yoyopod/integrations/call/runtime.py`: call-flow orchestration and screen transitions
 - `yoyopod/integrations/music/runtime.py`: playback-flow orchestration and now-playing refreshes
 - `yoyopod/integrations/power/service.py`: power polling, power snapshot application, watchdog cadence, and safety-policy event emission
+- `yoyopod/core/overlays.py`: priority-ordered cross-screen overlay activation and rendering
 - `yoyopod/ui/screens/manager.py`: screen refresh helpers and call-screen stack updates
 - `yoyopod/core/app_state.py`: derived runtime state and shared runtime references
 

--- a/tests/core/test_overlays.py
+++ b/tests/core/test_overlays.py
@@ -18,6 +18,7 @@ class _OverlayStub:
     active: bool = False
     is_active_calls: list[float] = field(default_factory=list)
     render_calls: list[float] = field(default_factory=list)
+    deactivation_calls: list[float] = field(default_factory=list)
 
     def is_active(self, now: float) -> bool:
         self.is_active_calls.append(now)
@@ -25,6 +26,9 @@ class _OverlayStub:
 
     def render(self, now: float) -> None:
         self.render_calls.append(now)
+
+    def on_deactivate(self, now: float) -> None:
+        self.deactivation_calls.append(now)
 
 
 def test_overlay_runtime_renders_highest_priority_active_overlay() -> None:
@@ -39,8 +43,8 @@ def test_overlay_runtime_renders_highest_priority_active_overlay() -> None:
     handled = runtime.update(now=5.0, render=True)
 
     assert handled is True
-    assert lower.is_active_calls == [5.0]
     assert higher.is_active_calls == [5.0]
+    assert lower.is_active_calls == []
     assert lower.render_calls == []
     assert higher.render_calls == [5.0]
     assert runtime.last_active_overlay_name == "higher"
@@ -59,6 +63,34 @@ def test_overlay_runtime_can_evaluate_without_rendering() -> None:
     assert overlay.is_active_calls == [8.0]
     assert overlay.render_calls == []
     assert runtime.last_active_overlay_name == "power"
+
+
+def test_overlay_runtime_reuses_cached_overlay_decision_for_same_tick() -> None:
+    """Evaluating and rendering the same tick should call `is_active()` only once."""
+
+    runtime = CrossScreenOverlayRuntime()
+    overlay = _OverlayStub(name="power", priority=100, active=True)
+    runtime.register(overlay)
+
+    assert runtime.evaluate(now=8.0) is True
+    assert runtime.render_active(now=8.0) is True
+
+    assert overlay.is_active_calls == [8.0]
+    assert overlay.render_calls == [8.0]
+
+
+def test_overlay_runtime_calls_deactivate_hook_once_on_transition_to_inactive() -> None:
+    """Overlay cleanup should run only when a previously active overlay turns off."""
+
+    runtime = CrossScreenOverlayRuntime()
+    overlay = _OverlayStub(name="power", priority=100, active=True)
+    runtime.register(overlay)
+
+    assert runtime.evaluate(now=1.0) is True
+    overlay.active = False
+
+    assert runtime.evaluate(now=2.0) is False
+    assert overlay.deactivation_calls == [2.0]
 
 
 def test_overlay_runtime_clears_active_name_when_no_overlays_are_active() -> None:

--- a/tests/core/test_overlays.py
+++ b/tests/core/test_overlays.py
@@ -1,0 +1,86 @@
+"""Focused tests for the cross-screen overlay runtime contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from yoyopod.core.overlays import CrossScreenOverlayRuntime
+
+
+@dataclass(slots=True)
+class _OverlayStub:
+    """Minimal overlay double with configurable active state."""
+
+    name: str
+    priority: int
+    active: bool = False
+    is_active_calls: list[float] = field(default_factory=list)
+    render_calls: list[float] = field(default_factory=list)
+
+    def is_active(self, now: float) -> bool:
+        self.is_active_calls.append(now)
+        return self.active
+
+    def render(self, now: float) -> None:
+        self.render_calls.append(now)
+
+
+def test_overlay_runtime_renders_highest_priority_active_overlay() -> None:
+    """Only the highest-priority active overlay should render on each update."""
+
+    runtime = CrossScreenOverlayRuntime()
+    lower = _OverlayStub(name="lower", priority=10, active=True)
+    higher = _OverlayStub(name="higher", priority=20, active=True)
+    runtime.register(lower)
+    runtime.register(higher)
+
+    handled = runtime.update(now=5.0, render=True)
+
+    assert handled is True
+    assert lower.is_active_calls == [5.0]
+    assert higher.is_active_calls == [5.0]
+    assert lower.render_calls == []
+    assert higher.render_calls == [5.0]
+    assert runtime.last_active_overlay_name == "higher"
+
+
+def test_overlay_runtime_can_evaluate_without_rendering() -> None:
+    """State-only updates should not render even when an overlay is active."""
+
+    runtime = CrossScreenOverlayRuntime()
+    overlay = _OverlayStub(name="power", priority=100, active=True)
+    runtime.register(overlay)
+
+    handled = runtime.update(now=8.0, render=False)
+
+    assert handled is True
+    assert overlay.is_active_calls == [8.0]
+    assert overlay.render_calls == []
+    assert runtime.last_active_overlay_name == "power"
+
+
+def test_overlay_runtime_clears_active_name_when_no_overlays_are_active() -> None:
+    """The runtime should clear the active overlay marker when nothing is active."""
+
+    runtime = CrossScreenOverlayRuntime()
+    overlay = _OverlayStub(name="power", priority=100, active=True)
+    runtime.register(overlay)
+    runtime.update(now=1.0, render=False)
+
+    overlay.active = False
+    handled = runtime.update(now=2.0, render=False)
+
+    assert handled is False
+    assert runtime.last_active_overlay_name is None
+
+
+def test_overlay_runtime_rejects_duplicate_overlay_names() -> None:
+    """Overlay names must be unique so runtime diagnostics stay deterministic."""
+
+    runtime = CrossScreenOverlayRuntime()
+    runtime.register(_OverlayStub(name="power", priority=100))
+
+    with pytest.raises(ValueError, match="Duplicate overlay registration"):
+        runtime.register(_OverlayStub(name="power", priority=50))

--- a/tests/core/test_overlays.py
+++ b/tests/core/test_overlays.py
@@ -93,6 +93,32 @@ def test_overlay_runtime_calls_deactivate_hook_once_on_transition_to_inactive() 
     assert overlay.deactivation_calls == [2.0]
 
 
+def test_overlay_runtime_deactivates_inactive_overlay_on_first_evaluation() -> None:
+    """Stale inactive overlays should clean up even if they were never the active winner."""
+
+    runtime = CrossScreenOverlayRuntime()
+    overlay = _OverlayStub(name="power", priority=100, active=False)
+    runtime.register(overlay)
+
+    assert runtime.evaluate(now=3.0) is False
+    assert overlay.deactivation_calls == [3.0]
+
+
+def test_overlay_runtime_deactivates_hidden_lower_priority_overlay_without_evaluating_it() -> None:
+    """A hidden lower-priority overlay should still reconcile stale inactive state."""
+
+    runtime = CrossScreenOverlayRuntime()
+    higher = _OverlayStub(name="higher", priority=20, active=True)
+    lower = _OverlayStub(name="lower", priority=10, active=False)
+    runtime.register(lower)
+    runtime.register(higher)
+
+    assert runtime.evaluate(now=4.0) is True
+    assert higher.is_active_calls == [4.0]
+    assert lower.is_active_calls == []
+    assert lower.deactivation_calls == [4.0]
+
+
 def test_overlay_runtime_clears_active_name_when_no_overlays_are_active() -> None:
     """The runtime should clear the active overlay marker when nothing is active."""
 

--- a/tests/ui/test_screen_routing.py
+++ b/tests/ui/test_screen_routing.py
@@ -355,9 +355,8 @@ def test_lvgl_pump_runs_overlay_runtime_between_navigation_flush_and_backend_pum
             super().render()
 
     class _OverlayRuntimeStub:
-        def update(self, now: float, *, render: bool) -> bool:
-            if render:
-                events.append("overlay")
+        def render_active(self, now: float) -> bool:
+            events.append("overlay")
             return False
 
     class _OrderedBackend(FakeLvglPumpBackend):

--- a/tests/ui/test_screen_routing.py
+++ b/tests/ui/test_screen_routing.py
@@ -74,12 +74,19 @@ class FakeLvglPumpBackend:
 class FakeLvglPumpApp:
     """Small app double that exposes only the LVGL pump dependencies."""
 
-    def __init__(self, *, screen_manager: ScreenManager, backend: FakeLvglPumpBackend) -> None:
+    def __init__(
+        self,
+        *,
+        screen_manager: ScreenManager,
+        backend: FakeLvglPumpBackend,
+        overlay_runtime: object | None = None,
+    ) -> None:
         self.screen_manager = screen_manager
         self._lvgl_backend = backend
         self._lvgl_input_bridge = None
         self._last_lvgl_pump_at = 0.0
         self._voip_iterate_interval_seconds = 0.02
+        self.cross_screen_overlays = overlay_runtime
         self.app_state_runtime = None
         self.bus = SimpleNamespace(pending_count=lambda: 0)
         self.scheduler = SimpleNamespace(pending_count=lambda: 0)
@@ -335,6 +342,45 @@ def test_lvgl_navigation_burst_coalesces_to_one_render_on_runtime_pump() -> None
     assert len(backend.pump_calls) == 2
     assert backend.pump_calls[0] == 0
     assert backend.pump_calls[1] > 0
+
+
+def test_lvgl_pump_runs_overlay_runtime_between_navigation_flush_and_backend_pump() -> None:
+    """Cross-screen overlays should render in the LVGL pump before backend timer work."""
+
+    events: list[str] = []
+
+    class _OrderedScreen(HookAwareStubScreen):
+        def render(self) -> None:
+            events.append("screen")
+            super().render()
+
+    class _OverlayRuntimeStub:
+        def update(self, now: float, *, render: bool) -> bool:
+            if render:
+                events.append("overlay")
+            return False
+
+    class _OrderedBackend(FakeLvglPumpBackend):
+        def pump(self, delta_ms: int) -> None:
+            events.append("backend")
+            super().pump(delta_ms)
+
+    display = SimpleNamespace(backend_kind="lvgl")
+    screen_manager = ScreenManager(display, input_manager=None)
+    screen = _OrderedScreen(display, AppContext())
+    screen_manager.register_screen("power", screen)
+    screen_manager.replace_screen("power")
+
+    runtime_loop = RuntimeLoopService(
+        FakeLvglPumpApp(
+            screen_manager=screen_manager,
+            backend=_OrderedBackend(),
+            overlay_runtime=_OverlayRuntimeStub(),
+        )
+    )
+    runtime_loop.pump_lvgl_backend(now=10.0)
+
+    assert events[:3] == ["screen", "overlay", "backend"]
 
 
 def test_screen_manager_routes_whisplay_hub_cards_through_stack(display: Display) -> None:

--- a/yoyopod/core/__init__.py
+++ b/yoyopod/core/__init__.py
@@ -17,6 +17,7 @@ _PUBLIC_EXPORTS = {
     "BackgroundExecutor": ("yoyopod.core.background", "BackgroundExecutor"),
     "BackgroundPool": ("yoyopod.core.background", "BackgroundPool"),
     "Bus": ("yoyopod.core.bus", "Bus"),
+    "CrossScreenOverlayRuntime": ("yoyopod.core.overlays", "CrossScreenOverlayRuntime"),
     "DiagnosticsRuntime": ("yoyopod.core.diagnostics", "DiagnosticsRuntime"),
     "EventLogWriter": ("yoyopod.core.diagnostics", "EventLogWriter"),
     "FocusController": ("yoyopod.core.focus", "FocusController"),

--- a/yoyopod/core/application.py
+++ b/yoyopod/core/application.py
@@ -21,6 +21,7 @@ from yoyopod.core.audio_volume import OutputVolumeController
 from yoyopod.core.events import LifecycleEvent
 from yoyopod.core.hardware import AudioDeviceCatalog
 from yoyopod.core.logbuffer import LogBuffer
+from yoyopod.core.overlays import CrossScreenOverlayRuntime
 from yoyopod.core.scheduler import MainThreadScheduler
 from yoyopod.core.services import Services
 from yoyopod.core.states import States
@@ -214,9 +215,11 @@ class YoyoPodApp:
         self._voip_iterate_interval_seconds = 0.02
 
         self.runtime_metrics = RuntimeMetricsStore()
+        self.cross_screen_overlays = CrossScreenOverlayRuntime()
 
         # Runtime services
         self.screen_power_service = ScreenPowerService(self)
+        self.cross_screen_overlays.register(self.screen_power_service)
         self.recovery_service = RuntimeRecoveryService(self)
         self.power_runtime = PowerRuntimeService(self)
         self.shutdown_service = ShutdownLifecycleService(self)

--- a/yoyopod/core/loop.py
+++ b/yoyopod/core/loop.py
@@ -447,7 +447,7 @@ class RuntimeLoopService:
             self.app._lvgl_input_bridge.process_pending()
         overlay_runtime = getattr(self.app, "cross_screen_overlays", None)
         if overlay_runtime is not None:
-            overlay_runtime.update(monotonic_now, render=True)
+            overlay_runtime.render_active(monotonic_now)
         self.app._lvgl_backend.pump(delta_ms)
         self._warn_if_slow(
             "lvgl pump",
@@ -635,10 +635,6 @@ class RuntimeLoopService:
                     lambda: cloud_manager.tick(monotonic_now),
                 )
             self._measure_blocking_span(
-                "lvgl_pump",
-                lambda: self.pump_lvgl_backend(monotonic_now),
-            )
-            self._measure_blocking_span(
                 "watchdog_feed",
                 lambda: self.app.power_runtime.feed_watchdog_if_due(monotonic_now),
             )
@@ -653,14 +649,24 @@ class RuntimeLoopService:
                 "screen_power",
                 lambda: self.app.screen_power_service.update_screen_power(monotonic_now),
             )
+            overlay_active = False
             overlay_runtime = getattr(self.app, "cross_screen_overlays", None)
             if overlay_runtime is not None:
                 overlay_active = self._measure_blocking_span(
                     "cross_screen_overlay_state",
-                    lambda: overlay_runtime.update(monotonic_now, render=False),
+                    lambda: overlay_runtime.evaluate(monotonic_now),
                 )
-                if overlay_active:
-                    return current_time
+
+            self._measure_blocking_span(
+                "lvgl_pump",
+                lambda: self.pump_lvgl_backend(monotonic_now),
+            )
+
+            if self.app._shutdown_completed:
+                return last_screen_update
+
+            if overlay_active:
+                return current_time
 
             if not self.app._screen_awake:
                 return current_time

--- a/yoyopod/core/loop.py
+++ b/yoyopod/core/loop.py
@@ -445,6 +445,9 @@ class RuntimeLoopService:
 
         if self.app._lvgl_input_bridge is not None:
             self.app._lvgl_input_bridge.process_pending()
+        overlay_runtime = getattr(self.app, "cross_screen_overlays", None)
+        if overlay_runtime is not None:
+            overlay_runtime.update(monotonic_now, render=True)
         self.app._lvgl_backend.pump(delta_ms)
         self._warn_if_slow(
             "lvgl pump",
@@ -650,12 +653,14 @@ class RuntimeLoopService:
                 "screen_power",
                 lambda: self.app.screen_power_service.update_screen_power(monotonic_now),
             )
-            overlay_active = self._measure_blocking_span(
-                "power_overlay",
-                lambda: self.app.screen_power_service.update_power_overlays(monotonic_now),
-            )
-            if overlay_active:
-                return current_time
+            overlay_runtime = getattr(self.app, "cross_screen_overlays", None)
+            if overlay_runtime is not None:
+                overlay_active = self._measure_blocking_span(
+                    "cross_screen_overlay_state",
+                    lambda: overlay_runtime.update(monotonic_now, render=False),
+                )
+                if overlay_active:
+                    return current_time
 
             if not self.app._screen_awake:
                 return current_time

--- a/yoyopod/core/overlays.py
+++ b/yoyopod/core/overlays.py
@@ -13,20 +13,26 @@ class CrossScreenOverlay(Protocol):
     priority: int
 
     def is_active(self, now: float) -> bool:
-        """Return whether this overlay should be active at the given timestamp."""
+        """Return whether this overlay should be active without mutating overlay state."""
         ...
 
     def render(self, now: float) -> None:
         """Render this overlay on top of the currently active screen."""
         ...
 
+    def on_deactivate(self, now: float) -> None:
+        """Clean up overlay-owned state after this overlay stops being active."""
+        ...
+
 
 @dataclass(slots=True)
 class CrossScreenOverlayRuntime:
-    """Evaluate registered overlays and render the highest-priority active one."""
+    """Evaluate registered overlays once per tick and render the active winner."""
 
     _overlays: list[CrossScreenOverlay] = field(default_factory=list)
+    _active_overlay: CrossScreenOverlay | None = None
     _last_active_overlay_name: str | None = None
+    _last_evaluated_at: float | None = None
 
     def register(self, overlay: CrossScreenOverlay) -> None:
         """Register a long-lived overlay implementation."""
@@ -37,18 +43,41 @@ class CrossScreenOverlayRuntime:
         self._overlays.append(overlay)
         self._overlays.sort(key=lambda entry: entry.priority, reverse=True)
 
-    def update(self, now: float, *, render: bool) -> bool:
-        """Refresh active overlay state and optionally render the top active overlay."""
+    def evaluate(self, now: float) -> bool:
+        """Evaluate active overlay state once for the current runtime tick."""
 
-        active_overlay: CrossScreenOverlay | None = None
-        for overlay in self._overlays:
-            if overlay.is_active(now) and active_overlay is None:
-                active_overlay = overlay
+        if self._last_evaluated_at == now:
+            return self._active_overlay is not None
 
+        active_overlay = next(
+            (overlay for overlay in self._overlays if overlay.is_active(now)),
+            None,
+        )
+        previous_overlay = self._active_overlay
+        if previous_overlay is not None and previous_overlay is not active_overlay:
+            previous_overlay.on_deactivate(now)
+
+        self._active_overlay = active_overlay
         self._last_active_overlay_name = active_overlay.name if active_overlay else None
-        if active_overlay is not None and render:
-            active_overlay.render(now)
+        self._last_evaluated_at = now
         return active_overlay is not None
+
+    def render_active(self, now: float) -> bool:
+        """Render the cached active overlay, evaluating once when needed."""
+
+        if not self.evaluate(now):
+            return False
+
+        assert self._active_overlay is not None
+        self._active_overlay.render(now)
+        return True
+
+    def update(self, now: float, *, render: bool) -> bool:
+        """Compatibility wrapper for older callers using the combined update API."""
+
+        if render:
+            return self.render_active(now)
+        return self.evaluate(now)
 
     @property
     def last_active_overlay_name(self) -> str | None:

--- a/yoyopod/core/overlays.py
+++ b/yoyopod/core/overlays.py
@@ -1,0 +1,57 @@
+"""Cross-screen overlay contracts and runtime ordering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+class CrossScreenOverlay(Protocol):
+    """Protocol for one long-lived cross-screen overlay renderer."""
+
+    name: str
+    priority: int
+
+    def is_active(self, now: float) -> bool:
+        """Return whether this overlay should be active at the given timestamp."""
+        ...
+
+    def render(self, now: float) -> None:
+        """Render this overlay on top of the currently active screen."""
+        ...
+
+
+@dataclass(slots=True)
+class CrossScreenOverlayRuntime:
+    """Evaluate registered overlays and render the highest-priority active one."""
+
+    _overlays: list[CrossScreenOverlay] = field(default_factory=list)
+    _last_active_overlay_name: str | None = None
+
+    def register(self, overlay: CrossScreenOverlay) -> None:
+        """Register a long-lived overlay implementation."""
+
+        if any(existing.name == overlay.name for existing in self._overlays):
+            raise ValueError(f"Duplicate overlay registration: {overlay.name}")
+
+        self._overlays.append(overlay)
+        self._overlays.sort(key=lambda entry: entry.priority, reverse=True)
+
+    def update(self, now: float, *, render: bool) -> bool:
+        """Refresh active overlay state and optionally render the top active overlay."""
+
+        active_overlay: CrossScreenOverlay | None = None
+        for overlay in self._overlays:
+            if overlay.is_active(now) and active_overlay is None:
+                active_overlay = overlay
+
+        self._last_active_overlay_name = active_overlay.name if active_overlay else None
+        if active_overlay is not None and render:
+            active_overlay.render(now)
+        return active_overlay is not None
+
+    @property
+    def last_active_overlay_name(self) -> str | None:
+        """Return the most recent active overlay key, if any."""
+
+        return self._last_active_overlay_name

--- a/yoyopod/core/overlays.py
+++ b/yoyopod/core/overlays.py
@@ -21,7 +21,7 @@ class CrossScreenOverlay(Protocol):
         ...
 
     def on_deactivate(self, now: float) -> None:
-        """Clean up overlay-owned state after this overlay stops being active."""
+        """Reconcile overlay-owned state while this overlay is not the active winner."""
         ...
 
 
@@ -53,9 +53,10 @@ class CrossScreenOverlayRuntime:
             (overlay for overlay in self._overlays if overlay.is_active(now)),
             None,
         )
-        previous_overlay = self._active_overlay
-        if previous_overlay is not None and previous_overlay is not active_overlay:
-            previous_overlay.on_deactivate(now)
+        for overlay in self._overlays:
+            if overlay is active_overlay:
+                continue
+            overlay.on_deactivate(now)
 
         self._active_overlay = active_overlay
         self._last_active_overlay_name = active_overlay.name if active_overlay else None

--- a/yoyopod/integrations/display/service.py
+++ b/yoyopod/integrations/display/service.py
@@ -262,13 +262,7 @@ class ScreenPowerService:
         if self.app._power_alert is None:
             return False
 
-        if now >= self.app._power_alert.expires_at:
-            self.app._power_alert = None
-            if self.app.screen_manager is not None:
-                self.app.screen_manager.refresh_current_screen()
-            return False
-
-        return True
+        return now < self.app._power_alert.expires_at
 
     def render(self, now: float) -> None:
         """Render the current power overlay state when active."""
@@ -293,9 +287,20 @@ class ScreenPowerService:
             self.app._power_alert.color,
         )
 
+    def on_deactivate(self, now: float) -> None:
+        """Clear expired alerts and restore the visible screen when needed."""
+
+        if self.app._power_alert is None or now < self.app._power_alert.expires_at:
+            return
+
+        self.app._power_alert = None
+        if self.app.screen_manager is not None:
+            self.app.screen_manager.refresh_current_screen()
+
     def update_power_overlays(self, now: float) -> bool:
         """Compatibility helper for callers still using the old power-overlay API."""
         if not self.is_active(now):
+            self.on_deactivate(now)
             return False
         self.render(now)
         return True

--- a/yoyopod/integrations/display/service.py
+++ b/yoyopod/integrations/display/service.py
@@ -1,4 +1,4 @@
-"""Live display wake/sleep policy and power overlay helpers."""
+"""Live display wake/sleep policy and power overlay integration."""
 
 from __future__ import annotations
 
@@ -17,7 +17,10 @@ if TYPE_CHECKING:
 
 
 class ScreenPowerService:
-    """Own screen-power policy and lightweight power overlay rendering."""
+    """Own screen-power policy and the canonical power overlay implementation."""
+
+    name = "power"
+    priority = 100
 
     def __init__(self, app: "YoyoPodApp") -> None:
         self.app = app
@@ -251,18 +254,9 @@ class ScreenPowerService:
         )
         ui_backend.force_refresh()
 
-    def update_power_overlays(self, now: float) -> bool:
-        """Render pending power overlays and return True when one is active."""
+    def is_active(self, now: float) -> bool:
+        """Return whether the power overlay should be active."""
         if self.app._pending_shutdown is not None:
-            seconds_remaining = max(0, int(self.app._pending_shutdown.execute_at - now + 0.999))
-            subtitle = "Saving state and powering off"
-            if seconds_remaining > 0:
-                subtitle = f"Shutdown in {seconds_remaining}s"
-            self.render_power_overlay(
-                "Critical Battery",
-                subtitle,
-                self.app.display.COLOR_RED if self.app.display is not None else (255, 0, 0),
-            )
             return True
 
         if self.app._power_alert is None:
@@ -274,9 +268,34 @@ class ScreenPowerService:
                 self.app.screen_manager.refresh_current_screen()
             return False
 
+        return True
+
+    def render(self, now: float) -> None:
+        """Render the current power overlay state when active."""
+        if self.app._pending_shutdown is not None:
+            seconds_remaining = max(0, int(self.app._pending_shutdown.execute_at - now + 0.999))
+            subtitle = "Saving state and powering off"
+            if seconds_remaining > 0:
+                subtitle = f"Shutdown in {seconds_remaining}s"
+            self.render_power_overlay(
+                "Critical Battery",
+                subtitle,
+                self.app.display.COLOR_RED if self.app.display is not None else (255, 0, 0),
+            )
+            return
+
+        if self.app._power_alert is None:
+            return
+
         self.render_power_overlay(
             self.app._power_alert.title,
             self.app._power_alert.subtitle,
             self.app._power_alert.color,
         )
+
+    def update_power_overlays(self, now: float) -> bool:
+        """Compatibility helper for callers still using the old power-overlay API."""
+        if not self.is_active(now):
+            return False
+        self.render(now)
         return True


### PR DESCRIPTION
## Summary
- add a shared `CrossScreenOverlayRuntime` and document the cross-screen overlay contract
- move the existing power overlay onto that contract instead of a bespoke loop special-case
- cache overlay evaluation once per coordinator tick, add explicit deactivation cleanup, and short-circuit at the highest-priority active overlay
- add focused overlay and LVGL pump tests plus architecture/docs updates

## Root Cause
Cross-screen UI concerns had no first-class runtime home. The only generalized path was the power overlay, wired directly into the coordinator loop, while other cross-screen concerns depended on screen-manager special cases. The initial overlay extraction fixed the shape of the abstraction, but still re-evaluated overlay activation twice per tick and allowed cleanup side effects inside `is_active()`.

## Validation
- `uv run python scripts/quality.py ci`
- `uv run pytest -q tests/core/test_overlays.py tests/ui/test_screen_routing.py tests/e2e/test_app_orchestration.py::test_expired_power_alert_refreshes_visible_power_screen_through_shared_hook`

Closes #329.