### PR TITLE
[codex] Add dirty gating for visible-tick screen refresh

### DIFF
--- a/tests/e2e/test_app_orchestration.py
+++ b/tests/e2e/test_app_orchestration.py
@@ -56,6 +56,10 @@ class RenderableScreen(Protocol):
 
     def refresh_for_visible_tick(self) -> None: ...
 
+    def clear_dirty(self) -> None: ...
+
+    def should_render_for_visible_tick(self) -> bool: ...
+
 
 class IncomingCallScreenLike(RenderableScreen, Protocol):
     """Extra incoming-call fields used by the screen coordinator."""
@@ -73,15 +77,25 @@ class FakeScreen:
         self.refresh_for_visible_tick_calls = 0
         self.route_name: str | None = None
         self.visible_tick_refresh_enabled = False
+        self.keep_visible_tick_dirty = False
+        self._dirty = True
 
     def render(self) -> None:
         self.render_calls += 1
 
     def refresh_for_visible_tick(self) -> None:
         self.refresh_for_visible_tick_calls += 1
+        if self.keep_visible_tick_dirty:
+            self._dirty = True
 
     def wants_visible_tick_refresh(self) -> bool:
         return self.visible_tick_refresh_enabled
+
+    def clear_dirty(self) -> None:
+        self._dirty = False
+
+    def should_render_for_visible_tick(self) -> bool:
+        return self.keep_visible_tick_dirty or self._dirty
 
 
 class FakeIncomingCallScreen(FakeScreen):
@@ -159,6 +173,7 @@ class FakeScreenManager:
             return
         self.current_screen.refresh_for_visible_tick()
         self.current_screen.render()
+        self.current_screen.clear_dirty()
 
     def refresh_current_screen_for_visible_tick(self) -> bool:
         if self.current_screen is None:
@@ -178,7 +193,17 @@ class FakeScreenManager:
                 return False
         elif not callable(refresh_for_visible_tick):
             return False
-        self.refresh_current_screen()
+        if callable(refresh_for_visible_tick):
+            refresh_for_visible_tick()
+        should_render_for_visible_tick = getattr(
+            self.current_screen,
+            "should_render_for_visible_tick",
+            None,
+        )
+        if callable(should_render_for_visible_tick) and not should_render_for_visible_tick():
+            return False
+        self.current_screen.render()
+        self.current_screen.clear_dirty()
         return True
 
     def pop_call_screens(self) -> None:
@@ -192,11 +217,13 @@ class FakeScreenManager:
         if self.current_screen is None or self.current_screen.route_name != "now_playing":
             return
         self.current_screen.render()
+        self.current_screen.clear_dirty()
 
     def refresh_call_screen_if_visible(self) -> None:
         if self.current_screen is None or self.current_screen.route_name != "call":
             return
         self.current_screen.render()
+        self.current_screen.clear_dirty()
 
     def show_incoming_call(self, caller_address: str, caller_name: str) -> None:
         screen = self.screen_lookup["incoming_call"]
@@ -619,6 +646,8 @@ class OrchestrationHarness:
         screens.power.visible_tick_refresh_enabled = True
         screens.now_playing.visible_tick_refresh_enabled = True
         screens.in_call.visible_tick_refresh_enabled = True
+        screens.now_playing.keep_visible_tick_dirty = True
+        screens.in_call.keep_visible_tick_dirty = True
         app.menu_screen = screens.menu
         app.power_screen = screens.power
         app.now_playing_screen = screens.now_playing

--- a/tests/e2e/test_app_orchestration.py
+++ b/tests/e2e/test_app_orchestration.py
@@ -43,6 +43,7 @@ from yoyopod.core import UserActivityEvent
 from yoyopod.integrations.power import PowerAlert
 from yoyopod.integrations.network.models import ModemPhase, ModemState, SignalInfo
 from yoyopod.ui.input import InputManager, InteractionProfile
+from yoyopod.ui.screens.manager import VisibleTickRefreshResult
 
 
 class RenderableScreen(Protocol):
@@ -175,9 +176,9 @@ class FakeScreenManager:
         self.current_screen.render()
         self.current_screen.clear_dirty()
 
-    def refresh_current_screen_for_visible_tick(self) -> bool:
+    def refresh_current_screen_for_visible_tick(self) -> VisibleTickRefreshResult:
         if self.current_screen is None:
-            return False
+            return VisibleTickRefreshResult.NOT_ELIGIBLE
         wants_visible_tick_refresh = getattr(
             self.current_screen,
             "wants_visible_tick_refresh",
@@ -188,23 +189,26 @@ class FakeScreenManager:
             "refresh_for_visible_tick",
             None,
         )
+        refresh_for_visible_tick_callback = (
+            refresh_for_visible_tick if callable(refresh_for_visible_tick) else None
+        )
         if callable(wants_visible_tick_refresh):
             if not wants_visible_tick_refresh():
-                return False
-        elif not callable(refresh_for_visible_tick):
-            return False
-        if callable(refresh_for_visible_tick):
-            refresh_for_visible_tick()
+                return VisibleTickRefreshResult.NOT_ELIGIBLE
+        elif refresh_for_visible_tick_callback is None:
+            return VisibleTickRefreshResult.NOT_ELIGIBLE
+        if refresh_for_visible_tick_callback is not None:
+            refresh_for_visible_tick_callback()
         should_render_for_visible_tick = getattr(
             self.current_screen,
             "should_render_for_visible_tick",
             None,
         )
         if callable(should_render_for_visible_tick) and not should_render_for_visible_tick():
-            return False
+            return VisibleTickRefreshResult.CLEAN
         self.current_screen.render()
         self.current_screen.clear_dirty()
-        return True
+        return VisibleTickRefreshResult.RENDERED
 
     def pop_call_screens(self) -> None:
         call_route_names = {"in_call", "incoming_call", "outgoing_call"}
@@ -1189,15 +1193,24 @@ def test_periodic_in_call_refresh_only_renders_visible_call_screen() -> None:
     app, _, screen_manager = _build_app(playback_state="stopped")
 
     assert app.screen_manager is not None
-    assert app.screen_manager.refresh_current_screen_for_visible_tick() is False
+    assert (
+        app.screen_manager.refresh_current_screen_for_visible_tick()
+        is VisibleTickRefreshResult.NOT_ELIGIBLE
+    )
     assert app.in_call_screen.render_calls == 0
 
     screen_manager.push_screen("in_call")
-    assert app.screen_manager.refresh_current_screen_for_visible_tick() is True
+    assert (
+        app.screen_manager.refresh_current_screen_for_visible_tick()
+        is VisibleTickRefreshResult.RENDERED
+    )
     assert app.in_call_screen.render_calls == 1
 
     screen_manager.pop_screen()
-    assert app.screen_manager.refresh_current_screen_for_visible_tick() is False
+    assert (
+        app.screen_manager.refresh_current_screen_for_visible_tick()
+        is VisibleTickRefreshResult.NOT_ELIGIBLE
+    )
     assert app.in_call_screen.render_calls == 1
 
 
@@ -1206,11 +1219,17 @@ def test_periodic_visible_tick_refreshes_visible_now_playing_screen() -> None:
     harness = OrchestrationHarness.build(playback_state="playing")
 
     assert harness.app.screen_manager is not None
-    assert harness.app.screen_manager.refresh_current_screen_for_visible_tick() is False
+    assert (
+        harness.app.screen_manager.refresh_current_screen_for_visible_tick()
+        is VisibleTickRefreshResult.NOT_ELIGIBLE
+    )
     assert harness.screens.now_playing.render_calls == 0
 
     harness.show_now_playing()
-    assert harness.app.screen_manager.refresh_current_screen_for_visible_tick() is True
+    assert (
+        harness.app.screen_manager.refresh_current_screen_for_visible_tick()
+        is VisibleTickRefreshResult.RENDERED
+    )
     assert harness.screens.now_playing.render_calls == 1
     assert harness.screens.now_playing.refresh_for_visible_tick_calls == 1
 
@@ -1658,12 +1677,18 @@ def test_periodic_power_refresh_only_renders_visible_power_screen() -> None:
     )
 
     assert app.screen_manager is not None
-    assert app.screen_manager.refresh_current_screen_for_visible_tick() is False
+    assert (
+        app.screen_manager.refresh_current_screen_for_visible_tick()
+        is VisibleTickRefreshResult.NOT_ELIGIBLE
+    )
     assert app.power_screen.render_calls == 0
     assert app.power_screen.refresh_for_visible_tick_calls == 0
 
     screen_manager.push_screen("power")
-    assert app.screen_manager.refresh_current_screen_for_visible_tick() is True
+    assert (
+        app.screen_manager.refresh_current_screen_for_visible_tick()
+        is VisibleTickRefreshResult.RENDERED
+    )
     assert app.power_screen.render_calls == 1
     assert app.power_screen.refresh_for_visible_tick_calls == 1
 

--- a/tests/ui/test_power_screen.py
+++ b/tests/ui/test_power_screen.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import fields
+from dataclasses import fields, replace
 from datetime import datetime
 import time
 from types import SimpleNamespace
@@ -539,16 +539,45 @@ def test_power_screen_visible_tick_stays_clean_when_prepared_state_is_unchanged(
 def test_power_screen_visible_tick_marks_dirty_when_prepared_state_changes() -> None:
     """Visible ticks should mark the screen dirty when the prepared state changes."""
 
+    first_snapshot = _snapshot()
+    second_snapshot = replace(
+        first_snapshot,
+        battery=replace(first_snapshot.battery, level_percent=42.0),
+    )
+
     states = iter(
         (
             PowerScreenState(
-                network_enabled=True,
-                network_rows=(("Status", "Online"),),
+                snapshot=first_snapshot,
             ),
             PowerScreenState(
-                network_enabled=True,
-                network_rows=(("Status", "Offline"),),
+                snapshot=second_snapshot,
             ),
+        )
+    )
+
+    display = Display(simulate=True)
+    try:
+        screen = PowerScreen(display, AppContext(), state_provider=lambda: next(states))
+        screen._visible_tick_refresh_grace_seconds = 0.0
+
+        screen.enter()
+        screen.in_detail = True
+        screen.clear_dirty()
+        screen.refresh_for_visible_tick()
+
+        assert screen.should_render_for_visible_tick() is True
+    finally:
+        display.cleanup()
+
+
+def test_power_screen_visible_tick_ignores_volatile_status_ages_for_dirty_flag() -> None:
+    """Visible ticks should ignore status-only age churn that does not change visible rows."""
+
+    states = iter(
+        (
+            PowerScreenState(status={"input_activity_age_seconds": 1.0}),
+            PowerScreenState(status={"input_activity_age_seconds": 2.0}),
         )
     )
 
@@ -561,7 +590,7 @@ def test_power_screen_visible_tick_marks_dirty_when_prepared_state_changes() -> 
         screen.clear_dirty()
         screen.refresh_for_visible_tick()
 
-        assert screen.should_render_for_visible_tick() is True
+        assert screen.should_render_for_visible_tick() is False
     finally:
         display.cleanup()
 

--- a/tests/ui/test_power_screen.py
+++ b/tests/ui/test_power_screen.py
@@ -514,6 +514,58 @@ def test_power_screen_visible_tick_waits_for_gps_page_dwell_before_query() -> No
         display.cleanup()
 
 
+def test_power_screen_visible_tick_stays_clean_when_prepared_state_is_unchanged() -> None:
+    """Visible ticks should not force a render when the prepared state is unchanged."""
+
+    state = PowerScreenState(
+        network_enabled=True,
+        network_rows=(("Status", "Online"),),
+    )
+
+    display = Display(simulate=True)
+    try:
+        screen = PowerScreen(display, AppContext(), state_provider=lambda: state)
+        screen._visible_tick_refresh_grace_seconds = 0.0
+
+        screen.enter()
+        screen.clear_dirty()
+        screen.refresh_for_visible_tick()
+
+        assert screen.should_render_for_visible_tick() is False
+    finally:
+        display.cleanup()
+
+
+def test_power_screen_visible_tick_marks_dirty_when_prepared_state_changes() -> None:
+    """Visible ticks should mark the screen dirty when the prepared state changes."""
+
+    states = iter(
+        (
+            PowerScreenState(
+                network_enabled=True,
+                network_rows=(("Status", "Online"),),
+            ),
+            PowerScreenState(
+                network_enabled=True,
+                network_rows=(("Status", "Offline"),),
+            ),
+        )
+    )
+
+    display = Display(simulate=True)
+    try:
+        screen = PowerScreen(display, AppContext(), state_provider=lambda: next(states))
+        screen._visible_tick_refresh_grace_seconds = 0.0
+
+        screen.enter()
+        screen.clear_dirty()
+        screen.refresh_for_visible_tick()
+
+        assert screen.should_render_for_visible_tick() is True
+    finally:
+        display.cleanup()
+
+
 def test_power_screen_copies_provider_status_on_refresh() -> None:
     """Prepared state should not retain provider-owned mutable status mappings."""
 

--- a/tests/ui/test_screen_routing.py
+++ b/tests/ui/test_screen_routing.py
@@ -46,10 +46,17 @@ class RoutableStubScreen(Screen):
 class HookAwareStubScreen(Screen):
     """Minimal screen double that exposes refresh-hook counters."""
 
-    def __init__(self, display: Display, context: AppContext | None = None) -> None:
+    def __init__(
+        self,
+        display: Display,
+        context: AppContext | None = None,
+        *,
+        keep_visible_tick_dirty: bool = True,
+    ) -> None:
         super().__init__(display, context, "HookAwareStub")
         self.render_calls = 0
         self.refresh_for_visible_tick_calls = 0
+        self.keep_visible_tick_dirty = keep_visible_tick_dirty
 
     def render(self) -> None:
         """Count renders performed by the screen manager."""
@@ -58,6 +65,14 @@ class HookAwareStubScreen(Screen):
     def refresh_for_visible_tick(self) -> None:
         """Count visible-tick refreshes before render."""
         self.refresh_for_visible_tick_calls += 1
+        if self.keep_visible_tick_dirty:
+            self.mark_dirty()
+
+    @staticmethod
+    def wants_visible_tick_refresh() -> bool:
+        """Opt into the shared visible-tick refresh path."""
+
+        return True
 
 
 class FakeLvglPumpBackend:
@@ -279,6 +294,25 @@ def test_screen_manager_only_refreshes_visible_ticks_for_opted_in_screen(
     screen_manager.replace_screen("power")
     assert screen_manager.refresh_current_screen_for_visible_tick() is True
     assert power.render_calls == 2
+    assert power.refresh_for_visible_tick_calls == 2
+
+
+def test_screen_manager_skips_visible_tick_render_when_screen_stays_clean(
+    display: Display,
+) -> None:
+    """Visible ticks should skip opted-in screens that do not mark themselves dirty."""
+
+    context = AppContext()
+    screen_manager = ScreenManager(display, input_manager=None)
+    power = HookAwareStubScreen(display, context, keep_visible_tick_dirty=False)
+
+    screen_manager.register_screen("power", power)
+    screen_manager.replace_screen("power")
+
+    assert power.render_calls == 1
+    assert power.refresh_for_visible_tick_calls == 1
+    assert screen_manager.refresh_current_screen_for_visible_tick() is False
+    assert power.render_calls == 1
     assert power.refresh_for_visible_tick_calls == 2
 
 

--- a/tests/ui/test_screen_routing.py
+++ b/tests/ui/test_screen_routing.py
@@ -16,7 +16,7 @@ from yoyopod.core.loop import RuntimeLoopService
 from yoyopod.ui.display import Display
 from yoyopod.ui.input import InputAction, InputManager
 from yoyopod.ui.screens.base import Screen
-from yoyopod.ui.screens.manager import ScreenManager
+from yoyopod.ui.screens.manager import ScreenManager, VisibleTickRefreshResult
 from yoyopod.ui.screens.navigation.ask import AskScreen
 from yoyopod.ui.screens.navigation.home import HomeScreen
 from yoyopod.ui.screens.navigation.hub import HubScreen
@@ -289,10 +289,16 @@ def test_screen_manager_only_refreshes_visible_ticks_for_opted_in_screen(
     screen_manager.register_screen("power", power)
 
     screen_manager.replace_screen("menu")
-    assert screen_manager.refresh_current_screen_for_visible_tick() is False
+    assert (
+        screen_manager.refresh_current_screen_for_visible_tick()
+        is VisibleTickRefreshResult.NOT_ELIGIBLE
+    )
 
     screen_manager.replace_screen("power")
-    assert screen_manager.refresh_current_screen_for_visible_tick() is True
+    assert (
+        screen_manager.refresh_current_screen_for_visible_tick()
+        is VisibleTickRefreshResult.RENDERED
+    )
     assert power.render_calls == 2
     assert power.refresh_for_visible_tick_calls == 2
 
@@ -311,7 +317,10 @@ def test_screen_manager_skips_visible_tick_render_when_screen_stays_clean(
 
     assert power.render_calls == 1
     assert power.refresh_for_visible_tick_calls == 1
-    assert screen_manager.refresh_current_screen_for_visible_tick() is False
+    assert (
+        screen_manager.refresh_current_screen_for_visible_tick()
+        is VisibleTickRefreshResult.CLEAN
+    )
     assert power.render_calls == 1
     assert power.refresh_for_visible_tick_calls == 2
 

--- a/yoyopod/ui/screens/base.py
+++ b/yoyopod/ui/screens/base.py
@@ -53,6 +53,7 @@ class Screen(ABC):
         self.screen_manager: Optional["ScreenManager"] = None
         self.route_name: Optional[str] = None
         self._pending_navigation: Optional[NavigationRequest] = None
+        self._is_dirty = True
         logger.debug(f"Screen '{name}' initialized")
 
     def set_screen_manager(self, manager: "ScreenManager") -> None:
@@ -95,6 +96,23 @@ class Screen(ABC):
         request = self._pending_navigation
         self._pending_navigation = None
         return request
+
+    def mark_dirty(self) -> None:
+        """Declare that the current screen contents should be re-rendered."""
+        self._is_dirty = True
+
+    def clear_dirty(self) -> None:
+        """Declare that the current screen contents are up to date."""
+        self._is_dirty = False
+
+    @property
+    def is_dirty(self) -> bool:
+        """Return whether the screen has changed since its last render."""
+        return self._is_dirty
+
+    def should_render_for_visible_tick(self) -> bool:
+        """Return whether a periodic visible tick should trigger a render."""
+        return self.is_dirty
 
     def get_interaction_profile(self) -> InteractionProfile:
         """Return the current interaction profile for the active device."""

--- a/yoyopod/ui/screens/manager.py
+++ b/yoyopod/ui/screens/manager.py
@@ -186,34 +186,33 @@ class ScreenManager:
     def refresh_current_screen(self) -> None:
         """Re-render the current screen."""
         self._navigation_refresh_pending = False
-        if self.current_screen:
-            started_at = time.monotonic()
-            refresh_for_visible_tick = getattr(
-                self.current_screen, "refresh_for_visible_tick", None
-            )
-            if callable(refresh_for_visible_tick):
-                refresh_for_visible_tick()
-            self.current_screen.render()
-            self._warn_if_slow(
-                "refresh_current_screen",
-                started_at=started_at,
-                threshold_seconds=self._SLOW_RENDER_WARNING_SECONDS,
-                detail=f"screen={self.current_screen.route_name or self.current_screen.name}",
-            )
+        if self.current_screen is None:
+            return
+
+        started_at = time.monotonic()
+        refresh_for_visible_tick = getattr(
+            self.current_screen,
+            "refresh_for_visible_tick",
+            None,
+        )
+        if callable(refresh_for_visible_tick):
+            refresh_for_visible_tick()
+        self._render_screen(self.current_screen, started_at=started_at)
 
     def refresh_current_screen_for_visible_tick(self) -> bool:
         """Refresh the current screen when it opts into periodic visible ticks."""
 
-        if self.current_screen is None:
+        screen = self.current_screen
+        if screen is None:
             return False
 
         wants_visible_tick_refresh = getattr(
-            self.current_screen,
+            screen,
             "wants_visible_tick_refresh",
             None,
         )
         refresh_for_visible_tick = getattr(
-            self.current_screen,
+            screen,
             "refresh_for_visible_tick",
             None,
         )
@@ -223,7 +222,18 @@ class ScreenManager:
         elif not callable(refresh_for_visible_tick):
             return False
 
-        self.refresh_current_screen()
+        if callable(refresh_for_visible_tick):
+            refresh_for_visible_tick()
+
+        should_render_for_visible_tick = getattr(
+            screen,
+            "should_render_for_visible_tick",
+            None,
+        )
+        if callable(should_render_for_visible_tick) and not should_render_for_visible_tick():
+            return False
+
+        self._render_screen(screen)
         return True
 
     def pop_call_screens(self) -> None:
@@ -244,7 +254,7 @@ class ScreenManager:
 
         if self.current_screen is None or self.current_screen.route_name != "now_playing":
             return
-        self.current_screen.render()
+        self._render_screen(self.current_screen)
         logger.debug("  -> Now playing screen refreshed")
 
     def refresh_call_screen_if_visible(self) -> None:
@@ -252,7 +262,7 @@ class ScreenManager:
 
         if self.current_screen is None or self.current_screen.route_name != "call":
             return
-        self.current_screen.render()
+        self._render_screen(self.current_screen)
         logger.debug("  -> Call screen refreshed")
 
     def show_incoming_call(self, caller_address: str, caller_name: str) -> None:
@@ -434,6 +444,19 @@ class ScreenManager:
         if self.current_screen is None:
             return
         self._configure_screen_input_modes()
+
+    def _render_screen(self, screen: Screen, *, started_at: float | None = None) -> None:
+        """Render one screen and clear its dirty flag after a successful draw."""
+
+        render_started_at = time.monotonic() if started_at is None else started_at
+        screen.render()
+        screen.clear_dirty()
+        self._warn_if_slow(
+            "refresh_current_screen",
+            started_at=render_started_at,
+            threshold_seconds=self._SLOW_RENDER_WARNING_SECONDS,
+            detail=f"screen={screen.route_name or screen.name}",
+        )
 
     def _warn_if_slow(
         self,

--- a/yoyopod/ui/screens/manager.py
+++ b/yoyopod/ui/screens/manager.py
@@ -5,6 +5,7 @@ Handles screen transitions, route resolution, and the navigation stack.
 """
 
 import time
+from enum import Enum, auto
 from typing import Callable, Optional, Dict, TYPE_CHECKING
 from loguru import logger
 
@@ -22,6 +23,26 @@ else:
         # Fallback for gradual migration
         InputManager = None
         InputAction = None
+
+
+class VisibleTickRefreshResult(Enum):
+    """Outcome of one periodic visible-tick refresh attempt."""
+
+    NOT_ELIGIBLE = auto()
+    CLEAN = auto()
+    RENDERED = auto()
+
+    @property
+    def eligible(self) -> bool:
+        """Return True when the screen participates in visible-tick refreshes."""
+
+        return self is not VisibleTickRefreshResult.NOT_ELIGIBLE
+
+    @property
+    def rendered(self) -> bool:
+        """Return True when the visible-tick refresh produced a render."""
+
+        return self is VisibleTickRefreshResult.RENDERED
 
 
 class ScreenManager:
@@ -199,12 +220,16 @@ class ScreenManager:
             refresh_for_visible_tick()
         self._render_screen(self.current_screen, started_at=started_at)
 
-    def refresh_current_screen_for_visible_tick(self) -> bool:
-        """Refresh the current screen when it opts into periodic visible ticks."""
+    def refresh_current_screen_for_visible_tick(self) -> VisibleTickRefreshResult:
+        """Refresh the current screen when it opts into periodic visible ticks.
+
+        Returns a result that distinguishes ineligible screens from eligible
+        screens that stayed clean across the visible tick.
+        """
 
         screen = self.current_screen
         if screen is None:
-            return False
+            return VisibleTickRefreshResult.NOT_ELIGIBLE
 
         wants_visible_tick_refresh = getattr(
             screen,
@@ -216,14 +241,17 @@ class ScreenManager:
             "refresh_for_visible_tick",
             None,
         )
+        refresh_for_visible_tick_callback = (
+            refresh_for_visible_tick if callable(refresh_for_visible_tick) else None
+        )
         if callable(wants_visible_tick_refresh):
             if not wants_visible_tick_refresh():
-                return False
-        elif not callable(refresh_for_visible_tick):
-            return False
+                return VisibleTickRefreshResult.NOT_ELIGIBLE
+        elif refresh_for_visible_tick_callback is None:
+            return VisibleTickRefreshResult.NOT_ELIGIBLE
 
-        if callable(refresh_for_visible_tick):
-            refresh_for_visible_tick()
+        if refresh_for_visible_tick_callback is not None:
+            refresh_for_visible_tick_callback()
 
         should_render_for_visible_tick = getattr(
             screen,
@@ -231,10 +259,10 @@ class ScreenManager:
             None,
         )
         if callable(should_render_for_visible_tick) and not should_render_for_visible_tick():
-            return False
+            return VisibleTickRefreshResult.CLEAN
 
         self._render_screen(screen)
-        return True
+        return VisibleTickRefreshResult.RENDERED
 
     def pop_call_screens(self) -> None:
         """Pop all call-related screens from the stack."""

--- a/yoyopod/ui/screens/music/now_playing.py
+++ b/yoyopod/ui/screens/music/now_playing.py
@@ -351,6 +351,12 @@ class NowPlayingScreen(Screen):
 
         return None
 
+    @staticmethod
+    def should_render_for_visible_tick() -> bool:
+        """Keep rendering while playback progress remains time-driven."""
+
+        return True
+
     def get_footer_text(self, *, is_playing: bool, state_label: str | None = None) -> str:
         """Return the gesture hint for the active playback state."""
 

--- a/yoyopod/ui/screens/music/now_playing.py
+++ b/yoyopod/ui/screens/music/now_playing.py
@@ -353,7 +353,11 @@ class NowPlayingScreen(Screen):
 
     @staticmethod
     def should_render_for_visible_tick() -> bool:
-        """Keep rendering while playback progress remains time-driven."""
+        """Keep rendering while playback progress remains time-driven.
+
+        This intentionally bypasses dirty gating because progress advances even
+        when no state-change event fires.
+        """
 
         return True
 

--- a/yoyopod/ui/screens/system/power_screen.py
+++ b/yoyopod/ui/screens/system/power_screen.py
@@ -317,7 +317,9 @@ class PowerScreen(Screen):
         return pages
 
     def lvgl_payload(self) -> PowerScreenLvglPayload:
-        pages = self._prepared_pages()
+        return self._visible_payload_for_pages(self._prepared_pages())
+
+    def _visible_payload_for_pages(self, pages: list[PowerPage]) -> PowerScreenLvglPayload:
         if not pages:
             return PowerScreenLvglPayload(
                 title_text="Setup",
@@ -363,6 +365,13 @@ class PowerScreen(Screen):
             current_page_index=active_page_index,
             total_pages=len(pages),
         )
+
+    def _visible_payload_signature(
+        self,
+        state: PowerScreenState | None,
+    ) -> PowerScreenLvglPayload:
+        resolved_state = PowerScreenState() if state is None else state
+        return self._visible_payload_for_pages(self.build_pages(state=resolved_state))
 
     def _build_voice_rows(self, *, summary_mode: bool = False) -> list[tuple[str, str]]:
         return _build_voice_rows(
@@ -420,6 +429,7 @@ class PowerScreen(Screen):
         allow_gps_refresh: bool = False,
     ) -> PowerScreenState:
         previous_state = self._prepared_state
+        previous_payload = self._visible_payload_signature(previous_state)
         if allow_gps_refresh:
             self._refresh_gps_if_due()
         try:
@@ -427,7 +437,7 @@ class PowerScreen(Screen):
             self._last_prepared_refresh_at = time.monotonic()
         except Exception:
             self._prepared_state = PowerScreenState()
-        if previous_state != self._prepared_state:
+        if previous_payload != self._visible_payload_signature(self._prepared_state):
             self.mark_dirty()
         return self._prepared_state
 

--- a/yoyopod/ui/screens/system/power_screen.py
+++ b/yoyopod/ui/screens/system/power_screen.py
@@ -419,6 +419,7 @@ class PowerScreen(Screen):
         *,
         allow_gps_refresh: bool = False,
     ) -> PowerScreenState:
+        previous_state = self._prepared_state
         if allow_gps_refresh:
             self._refresh_gps_if_due()
         try:
@@ -426,6 +427,8 @@ class PowerScreen(Screen):
             self._last_prepared_refresh_at = time.monotonic()
         except Exception:
             self._prepared_state = PowerScreenState()
+        if previous_state != self._prepared_state:
+            self.mark_dirty()
         return self._prepared_state
 
     def refresh_for_visible_tick(self) -> None:

--- a/yoyopod/ui/screens/voip/in_call.py
+++ b/yoyopod/ui/screens/voip/in_call.py
@@ -137,6 +137,12 @@ class InCallScreen(Screen):
 
         return None
 
+    @staticmethod
+    def should_render_for_visible_tick() -> bool:
+        """Keep rendering while call duration remains time-driven."""
+
+        return True
+
     def _hangup_call(self) -> None:
         """End the current call."""
 

--- a/yoyopod/ui/screens/voip/in_call.py
+++ b/yoyopod/ui/screens/voip/in_call.py
@@ -139,7 +139,11 @@ class InCallScreen(Screen):
 
     @staticmethod
     def should_render_for_visible_tick() -> bool:
-        """Keep rendering while call duration remains time-driven."""
+        """Keep rendering while call duration remains time-driven.
+
+        This intentionally bypasses dirty gating because the visible timer can
+        advance without a matching state-change event.
+        """
 
         return True
 


### PR DESCRIPTION
## Summary
- add a screen-level dirty contract so visible-tick refreshes can skip screens with no new pixels to draw
- keep time-driven now-playing and in-call screens rendering on visible ticks while letting Setup/Power only redraw when prepared state changes
- clarify visible-tick refresh outcomes with explicit `NOT_ELIGIBLE`, `CLEAN`, and `RENDERED` results instead of an ambiguous boolean

## Why
Visible-tick refreshes were coupled to time alone, so any screen opting into periodic ticks had to re-render even when nothing changed. That created unnecessary render work on Pi Zero 2W and also made the refresh API ambiguous for future callers.

## Impact
- opted-in screens can now participate in render-on-change behavior instead of blind render-on-tick behavior
- future callers can distinguish "screen does not participate", "screen participated but stayed clean", and "screen rendered"
- time-driven screens keep the intended behavior for progress and call-duration updates

## Root Cause
`ScreenManager.refresh_current_screen_for_visible_tick()` only checked whether a screen opted into visible ticks, then always rendered. There was no shared dirty-signal primitive and no way to report whether a visible tick actually produced a render.

## Validation
- `uv run python scripts/quality.py ci`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`
- `uv run pytest -q tests/ui/test_screen_routing.py tests/ui/test_power_screen.py tests/e2e/test_app_orchestration.py`

Closes #330