### PR TITLE
feat(voip): wire VoIPBackend into sidecar via SidecarBackendAdapter

### DIFF
--- a/tests/integrations/call/test_sidecar_adapter.py
+++ b/tests/integrations/call/test_sidecar_adapter.py
@@ -674,6 +674,42 @@ def test_backend_stopped_emits_error_event(
     )
 
 
+def test_backend_stopped_clears_active_call_id(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    """``BackendStopped`` mid-call must clear the tracked call id.
+
+    Codex follow-up review on #389 (P1): if the backend dies during an
+    active call (e.g. liblinphone's ``iterate()`` raises and emits
+    ``BackendStopped``), the stale ``_current_call_id`` would otherwise
+    block subsequent ``Dial`` commands with ``call_in_progress`` even
+    after a recovery ``Configure`` swaps in a fresh backend.
+    """
+
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:bob@example.com"))
+    _drain(parent_conn)
+    assert adapter._current_call_id is not None
+
+    mock_backend.emit(BackendStopped(reason="iterate failed"))
+    _drain(parent_conn)
+    assert adapter._current_call_id is None
+
+    # And a fresh Configure + Register + Dial cycle is no longer blocked.
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=2))
+    _drain(parent_conn)
+    adapter.handle_command(Dial(uri="sip:carol@example.com", cmd_id=3))
+    events = _drain(parent_conn)
+    errors = [event for event in events if isinstance(event, Error)]
+    assert not any(error.code == "call_in_progress" for error in errors), errors
+
+
 # ---------------------------------------------------------------------------
 # Ping
 # ---------------------------------------------------------------------------

--- a/tests/integrations/call/test_sidecar_adapter.py
+++ b/tests/integrations/call/test_sidecar_adapter.py
@@ -347,6 +347,66 @@ def test_unregister_clears_current_call_id(
     ), f"call_in_progress leaked across unregister: {errors!r}"
 
 
+def test_register_with_stale_iterate_thread_returns_iterate_thread_busy() -> None:
+    """Register must not silently start a backend when a stale iterate thread blocks the start.
+
+    Codex follow-up review on #389 (P1): the round-1 fix retains the
+    iterate-thread handle when ``join`` times out, so
+    ``_start_iterate_thread`` silently returns to avoid racing two iterate
+    threads against the same backend. But callers also need that visibility:
+    a follow-up ``Configure + Register`` would otherwise start a fresh
+    backend with no iterate driver, registration/call events would stop
+    flowing, and the command path would still report success. The fixed
+    handler surfaces ``iterate_thread_busy`` and leaves the freshly created
+    backend untouched so ``main`` can retry once the stale thread exits.
+    """
+
+    parent, child = multiprocessing.Pipe(duplex=True)
+    try:
+        backend = MockVoIPBackend()
+        adapter = SidecarBackendAdapter(
+            conn=child,
+            backend_factory=lambda _config: backend,
+        )
+        # Plant a stuck stale iterate thread directly.
+        release = threading.Event()
+        stuck_thread = threading.Thread(
+            target=lambda: release.wait(timeout=10.0),
+            daemon=True,
+            name="voip-sidecar-iterate-stale-stub",
+        )
+        stuck_thread.start()
+        adapter._iterate_thread = stuck_thread
+
+        # Configure to install the backend, then attempt Register.
+        adapter.handle_command(Configure(config=_config_dict()))
+        _drain(parent)
+
+        adapter.handle_command(Register(cmd_id=99))
+        events = _drain(parent)
+        errors = [event for event in events if isinstance(event, Error)]
+        assert any(
+            error.code == "iterate_thread_busy" and error.cmd_id == 99 for error in errors
+        ), events
+        # backend.start() must NOT have been called — the stale-thread check
+        # short-circuits Register before the backend is touched.
+        assert (
+            backend.running is False
+        ), "Register must not start backend when iterate-thread is busy"
+
+        release.set()
+        stuck_thread.join(timeout=1.0)
+    finally:
+        try:
+            parent.close()
+        except OSError:
+            pass
+        try:
+            child.close()
+        except OSError:
+            pass
+
+
 def test_stop_iterate_thread_retains_handle_on_join_timeout() -> None:
     """A stuck iterate thread must not be silently forgotten.
 

--- a/tests/integrations/call/test_sidecar_adapter.py
+++ b/tests/integrations/call/test_sidecar_adapter.py
@@ -1,0 +1,472 @@
+"""Unit tests for :class:`SidecarBackendAdapter`.
+
+The adapter owns command->backend dispatch and backend->protocol event
+translation inside the sidecar process. These tests run the adapter in
+isolation (no supervisor, no subprocess) by feeding it commands directly
+and reading the events it writes onto a real ``multiprocessing.Pipe``.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import time
+from multiprocessing.connection import Connection
+from typing import Any
+
+import pytest
+
+from yoyopod.backends.voip.mock_backend import MockVoIPBackend
+from yoyopod.integrations.call.models import (
+    BackendStopped,
+    CallState,
+    CallStateChanged as BackendCallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged as BackendRegistrationStateChanged,
+    VoIPConfig,
+)
+from yoyopod.integrations.call.sidecar_adapter import SidecarBackendAdapter
+from yoyopod.integrations.call.sidecar_protocol import (
+    Accept,
+    CallStateChanged,
+    Configure,
+    Dial,
+    Error,
+    Hangup,
+    IncomingCall,
+    Log,
+    MediaStateChanged,
+    Ping,
+    Pong,
+    Register,
+    RegistrationStateChanged,
+    Reject,
+    SetMute,
+    SetVolume,
+    Unregister,
+    decode_event,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pipe() -> tuple[Connection, Connection]:
+    parent, child = multiprocessing.Pipe(duplex=True)
+    yield parent, child
+    try:
+        parent.close()
+    except OSError:
+        pass
+    try:
+        child.close()
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def parent_conn(pipe: tuple[Connection, Connection]) -> Connection:
+    return pipe[0]
+
+
+@pytest.fixture
+def child_conn(pipe: tuple[Connection, Connection]) -> Connection:
+    return pipe[1]
+
+
+@pytest.fixture
+def mock_backend() -> MockVoIPBackend:
+    return MockVoIPBackend()
+
+
+@pytest.fixture
+def adapter(child_conn: Connection, mock_backend: MockVoIPBackend) -> SidecarBackendAdapter:
+    captured: list[MockVoIPBackend] = []
+
+    def factory(_config: VoIPConfig) -> MockVoIPBackend:
+        captured.append(mock_backend)
+        return mock_backend
+
+    instance = SidecarBackendAdapter(conn=child_conn, backend_factory=factory)
+    instance.__test_factory_calls__ = captured  # type: ignore[attr-defined]
+    yield instance
+    instance.shutdown()
+
+
+def _drain(conn: Connection, *, timeout: float = 0.5) -> list[Any]:
+    """Read every event currently available on the pipe within ``timeout``."""
+
+    deadline = time.monotonic() + timeout
+    events: list[Any] = []
+    while time.monotonic() < deadline:
+        if conn.poll(timeout=0.05):
+            try:
+                events.append(decode_event(conn.recv_bytes()))
+            except (BrokenPipeError, EOFError, OSError):
+                break
+        elif events:
+            break
+    return events
+
+
+def _wait_for(predicate, *, timeout: float = 0.5) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+def _config_dict(**overrides: Any) -> dict[str, Any]:
+    base = VoIPConfig(sip_server="sip.example.com", sip_identity="sip:alice@example.com")
+    payload = {
+        f.name: getattr(base, f.name)
+        for f in [field for field in VoIPConfig.__dataclass_fields__.values()]
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Configure
+# ---------------------------------------------------------------------------
+
+
+def test_configure_creates_backend_and_logs_info(
+    adapter: SidecarBackendAdapter, parent_conn: Connection, mock_backend: MockVoIPBackend
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    events = _drain(parent_conn)
+
+    assert any(
+        isinstance(event, Log) and event.level == "INFO" and "configured backend" in event.message
+        for event in events
+    )
+    # Adapter should have asked the factory for one backend.
+    assert mock_backend.event_callbacks, "factory should have wired backend callbacks"
+
+
+def test_configure_with_unknown_field_returns_invalid_config_error(
+    adapter: SidecarBackendAdapter, parent_conn: Connection
+) -> None:
+    bogus = _config_dict()
+    bogus["not_a_real_field"] = "boom"
+    adapter.handle_command(Configure(config=bogus, cmd_id=42))
+    events = _drain(parent_conn)
+    errors = [event for event in events if isinstance(event, Error)]
+    assert any(error.code == "invalid_config" and error.cmd_id == 42 for error in errors), events
+
+
+# ---------------------------------------------------------------------------
+# Register / Unregister
+# ---------------------------------------------------------------------------
+
+
+def test_register_before_configure_returns_not_configured(
+    adapter: SidecarBackendAdapter, parent_conn: Connection
+) -> None:
+    adapter.handle_command(Register(cmd_id=7))
+    events = _drain(parent_conn)
+    assert any(
+        isinstance(event, Error) and event.code == "not_configured" and event.cmd_id == 7
+        for event in events
+    )
+
+
+def test_register_starts_backend_and_iterate_thread(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    _drain(parent_conn)
+
+    adapter.handle_command(Register(cmd_id=2))
+    assert _wait_for(lambda: mock_backend.running)
+    assert mock_backend.running is True
+    assert adapter._iterate_thread is not None
+    assert adapter._iterate_thread.is_alive()
+
+
+def test_register_when_backend_start_returns_false_emits_error(
+    parent_conn: Connection, child_conn: Connection
+) -> None:
+    failing_backend = MockVoIPBackend(start_result=False)
+
+    def factory(_config: VoIPConfig) -> MockVoIPBackend:
+        return failing_backend
+
+    adapter = SidecarBackendAdapter(conn=child_conn, backend_factory=factory)
+    try:
+        adapter.handle_command(Configure(config=_config_dict()))
+        _drain(parent_conn)
+        adapter.handle_command(Register(cmd_id=3))
+        events = _drain(parent_conn)
+        assert any(
+            isinstance(event, Error) and event.code == "register_failed" and event.cmd_id == 3
+            for event in events
+        )
+    finally:
+        adapter.shutdown()
+
+
+def test_unregister_stops_backend_and_iterate_thread(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+    assert _wait_for(lambda: mock_backend.running)
+
+    adapter.handle_command(Unregister())
+    assert _wait_for(lambda: not mock_backend.running)
+    assert adapter._wait_for_iterate_thread_to_exit(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Call control
+# ---------------------------------------------------------------------------
+
+
+def test_dial_assigns_call_id_and_calls_backend(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+
+    adapter.handle_command(Dial(uri="sip:bob@example.com", cmd_id=10))
+    assert mock_backend.commands[-1] == "call sip:bob@example.com"
+    assert adapter._current_call_id is not None
+
+
+def test_dial_when_call_in_progress_returns_call_in_progress_error(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+
+    adapter.handle_command(Dial(uri="sip:bob@example.com", cmd_id=10))
+    adapter.handle_command(Dial(uri="sip:carol@example.com", cmd_id=11))
+
+    events = _drain(parent_conn)
+    assert any(
+        isinstance(event, Error) and event.code == "call_in_progress" and event.cmd_id == 11
+        for event in events
+    )
+
+
+def test_accept_with_unknown_call_id_returns_error(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+
+    adapter.handle_command(Accept(call_id="call-bogus", cmd_id=20))
+    events = _drain(parent_conn)
+    assert any(
+        isinstance(event, Error) and event.code == "unknown_call_id" and event.cmd_id == 20
+        for event in events
+    )
+    assert "answer" not in mock_backend.commands
+
+
+def test_accept_with_correct_call_id_calls_backend(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:bob@example.com"))
+    events = _drain(parent_conn)
+    incoming = next(event for event in events if isinstance(event, IncomingCall))
+
+    adapter.handle_command(Accept(call_id=incoming.call_id, cmd_id=21))
+    assert "answer" in mock_backend.commands
+
+
+def test_hangup_with_correct_call_id_calls_backend(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:bob@example.com"))
+    events = _drain(parent_conn)
+    incoming = next(event for event in events if isinstance(event, IncomingCall))
+
+    adapter.handle_command(Hangup(call_id=incoming.call_id, cmd_id=22))
+    assert "terminate" in mock_backend.commands
+
+
+def test_set_mute_emits_media_state_changed(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:bob@example.com"))
+    events = _drain(parent_conn)
+    incoming = next(event for event in events if isinstance(event, IncomingCall))
+
+    adapter.handle_command(SetMute(call_id=incoming.call_id, on=True))
+    events = _drain(parent_conn)
+    assert "mute" in mock_backend.commands
+    assert any(
+        isinstance(event, MediaStateChanged)
+        and event.call_id == incoming.call_id
+        and event.mic_muted
+        for event in events
+    )
+
+
+def test_set_volume_does_not_call_backend_but_emits_media_state(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:bob@example.com"))
+    events = _drain(parent_conn)
+    incoming = next(event for event in events if isinstance(event, IncomingCall))
+
+    adapter.handle_command(SetVolume(call_id=incoming.call_id, level=0.4))
+    events = _drain(parent_conn)
+    media = [event for event in events if isinstance(event, MediaStateChanged)]
+    assert media and media[-1].speaker_volume == pytest.approx(0.4)
+
+
+# ---------------------------------------------------------------------------
+# Backend events -> protocol events
+# ---------------------------------------------------------------------------
+
+
+def test_backend_registration_state_propagates(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    _drain(parent_conn)
+
+    mock_backend.emit(BackendRegistrationStateChanged(state=RegistrationState.OK))
+    events = _drain(parent_conn)
+    assert any(
+        isinstance(event, RegistrationStateChanged) and event.state == "ok" for event in events
+    )
+
+
+def test_backend_call_state_propagates_with_call_id(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    _drain(parent_conn)
+
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:caller@example.com"))
+    events = _drain(parent_conn)
+    incoming = next(event for event in events if isinstance(event, IncomingCall))
+
+    mock_backend.emit(BackendCallStateChanged(state=CallState.CONNECTED))
+    events = _drain(parent_conn)
+    assert any(
+        isinstance(event, CallStateChanged)
+        and event.call_id == incoming.call_id
+        and event.state == "connected"
+        for event in events
+    )
+
+
+def test_call_released_clears_current_call_id(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    _drain(parent_conn)
+
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:caller@example.com"))
+    _drain(parent_conn)
+
+    mock_backend.emit(BackendCallStateChanged(state=CallState.RELEASED))
+    _drain(parent_conn)
+    assert adapter._current_call_id is None
+
+
+def test_backend_stopped_emits_error_event(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    _drain(parent_conn)
+
+    mock_backend.emit(BackendStopped(reason="link reset"))
+    events = _drain(parent_conn)
+    assert any(
+        isinstance(event, Error)
+        and event.code == "backend_stopped"
+        and "link reset" in event.message
+        for event in events
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ping
+# ---------------------------------------------------------------------------
+
+
+def test_ping_returns_pong_without_backend(
+    adapter: SidecarBackendAdapter, parent_conn: Connection
+) -> None:
+    adapter.handle_command(Ping(cmd_id=99))
+    events = _drain(parent_conn)
+    assert any(isinstance(event, Pong) and event.cmd_id == 99 for event in events)
+
+
+# ---------------------------------------------------------------------------
+# Reject path
+# ---------------------------------------------------------------------------
+
+
+def test_reject_with_correct_call_id_calls_backend(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:caller@example.com"))
+    events = _drain(parent_conn)
+    incoming = next(event for event in events if isinstance(event, IncomingCall))
+
+    adapter.handle_command(Reject(call_id=incoming.call_id, cmd_id=15))
+    assert "decline" in mock_backend.commands

--- a/tests/integrations/call/test_sidecar_adapter.py
+++ b/tests/integrations/call/test_sidecar_adapter.py
@@ -161,6 +161,50 @@ def test_configure_with_unknown_field_returns_invalid_config_error(
     assert any(error.code == "invalid_config" and error.cmd_id == 42 for error in errors), events
 
 
+def test_shutdown_stops_backend_even_when_not_running(
+    parent_conn: Connection, child_conn: Connection
+) -> None:
+    """``shutdown()`` must call ``backend.stop()`` regardless of ``backend.running``.
+
+    Codex follow-up review on #389 (P1): liblinphone flips ``running`` to
+    False when ``iterate()`` raises, but the native core/transports/audio
+    devices still need an explicit ``stop()`` to be released. Skipping the
+    call leaks native state into the next backend created by a follow-up
+    ``Configure``.
+    """
+
+    class _StopTrackingMockBackend(MockVoIPBackend):
+        def __init__(self) -> None:
+            super().__init__()
+            self.stop_called = 0
+
+        def stop(self) -> None:
+            self.stop_called += 1
+            super().stop()
+
+    backend = _StopTrackingMockBackend()
+    adapter = SidecarBackendAdapter(
+        conn=child_conn,
+        backend_factory=lambda _config: backend,
+    )
+    try:
+        adapter.handle_command(Configure(config=_config_dict()))
+        adapter.handle_command(Register(cmd_id=1))
+        _drain(parent_conn)
+        assert _wait_for(lambda: backend.running)
+
+        # Simulate the iterate-failure path: liblinphone flips ``running``
+        # to False internally without going through ``stop()``.
+        backend.running = False
+
+        adapter.shutdown()
+        assert (
+            backend.stop_called == 1
+        ), "shutdown() must call backend.stop() even when running is False"
+    finally:
+        adapter.shutdown()  # idempotent — must not double-stop
+
+
 def test_configure_clears_active_call_state(
     adapter: SidecarBackendAdapter,
     parent_conn: Connection,

--- a/tests/integrations/call/test_sidecar_adapter.py
+++ b/tests/integrations/call/test_sidecar_adapter.py
@@ -161,6 +161,41 @@ def test_configure_with_unknown_field_returns_invalid_config_error(
     assert any(error.code == "invalid_config" and error.cmd_id == 42 for error in errors), events
 
 
+def test_configure_clears_active_call_state(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    """A re-Configure during an active call must reset the tracked call id.
+
+    Codex follow-up review on #389 (P1): without this, a Configure issued
+    while a call is active leaves ``_current_call_id`` pinned to the old
+    backend's call. The subsequent Dial against the fresh backend is then
+    rejected with ``call_in_progress``.
+    """
+
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:caller@example.com"))
+    _drain(parent_conn)
+    assert adapter._current_call_id is not None
+
+    # Re-Configure: should drop the old backend, fresh-create, and clear call state.
+    adapter.handle_command(Configure(config=_config_dict()))
+    _drain(parent_conn)
+    assert adapter._current_call_id is None
+
+    # And a fresh Register + Dial cycle must succeed without ``call_in_progress``.
+    adapter.handle_command(Register(cmd_id=2))
+    _drain(parent_conn)
+    adapter.handle_command(Dial(uri="sip:carol@example.com", cmd_id=3))
+    events = _drain(parent_conn)
+    errors = [event for event in events if isinstance(event, Error)]
+    assert not any(error.code == "call_in_progress" for error in errors), errors
+
+
 # ---------------------------------------------------------------------------
 # Register / Unregister
 # ---------------------------------------------------------------------------
@@ -456,6 +491,43 @@ def test_set_volume_does_not_call_backend_but_emits_media_state(
     assert media and media[-1].speaker_volume == pytest.approx(0.4)
 
 
+def test_set_volume_with_unknown_call_id_returns_error(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    """A delayed SetVolume from a previous call must not mutate the current call.
+
+    Codex follow-up review on #389 (P2): without call-id validation, a stale
+    SetVolume frame can flip the adapter's tracked volume mid-call. Now the
+    handler validates the id like other call-scoped commands.
+    """
+
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:bob@example.com"))
+    _drain(parent_conn)
+
+    adapter.handle_command(SetVolume(call_id="call-bogus", level=0.5, cmd_id=77))
+    events = _drain(parent_conn)
+    errors = [event for event in events if isinstance(event, Error)]
+    assert any(error.code == "unknown_call_id" and error.cmd_id == 77 for error in errors), events
+    # Volume must not have changed.
+    assert adapter._speaker_volume == 1.0
+
+
+def test_set_volume_without_backend_returns_not_configured(
+    adapter: SidecarBackendAdapter, parent_conn: Connection
+) -> None:
+    """SetVolume before Configure surfaces ``not_configured`` like other commands."""
+
+    adapter.handle_command(SetVolume(call_id="call-1", level=0.5, cmd_id=88))
+    events = _drain(parent_conn)
+    errors = [event for event in events if isinstance(event, Error)]
+    assert any(error.code == "not_configured" and error.cmd_id == 88 for error in errors), events
+
+
 # ---------------------------------------------------------------------------
 # Backend events -> protocol events
 # ---------------------------------------------------------------------------
@@ -510,6 +582,32 @@ def test_call_released_clears_current_call_id(
     _drain(parent_conn)
 
     mock_backend.emit(BackendCallStateChanged(state=CallState.RELEASED))
+    _drain(parent_conn)
+    assert adapter._current_call_id is None
+
+
+def test_call_end_state_is_terminal(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    """``CallState.END`` must be treated as terminal alongside RELEASED.
+
+    Codex follow-up review on #389 (P1): liblinphone maps native state 13
+    to ``CallState.END`` and may emit it without a later ``RELEASED``
+    frame. The previous adapter only treated ``{RELEASED, ERROR, IDLE}``
+    as terminal, leaving the call id pinned and blocking subsequent Dials
+    with ``call_in_progress``.
+    """
+
+    adapter.handle_command(Configure(config=_config_dict()))
+    _drain(parent_conn)
+
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:caller@example.com"))
+    _drain(parent_conn)
+    assert adapter._current_call_id is not None
+
+    mock_backend.emit(BackendCallStateChanged(state=CallState.END))
     _drain(parent_conn)
     assert adapter._current_call_id is None
 

--- a/tests/integrations/call/test_sidecar_adapter.py
+++ b/tests/integrations/call/test_sidecar_adapter.py
@@ -9,6 +9,7 @@ and reading the events it writes onto a real ``multiprocessing.Pipe``.
 from __future__ import annotations
 
 import multiprocessing
+import threading
 import time
 from multiprocessing.connection import Connection
 from typing import Any
@@ -226,6 +227,100 @@ def test_unregister_stops_backend_and_iterate_thread(
     adapter.handle_command(Unregister())
     assert _wait_for(lambda: not mock_backend.running)
     assert adapter._wait_for_iterate_thread_to_exit(timeout=1.0)
+
+
+def test_unregister_clears_current_call_id(
+    adapter: SidecarBackendAdapter,
+    parent_conn: Connection,
+    mock_backend: MockVoIPBackend,
+) -> None:
+    """After Unregister, a follow-up Dial must not return ``call_in_progress``.
+
+    Codex review on #389 (P1): the iterate loop is stopped before
+    backend.stop(), so any terminal call-state event the backend would emit
+    on teardown is not guaranteed to flow through. _handle_unregister must
+    therefore reset the tracked call id explicitly.
+    """
+
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=1))
+    _drain(parent_conn)
+    mock_backend.emit(IncomingCallDetected(caller_address="sip:bob@example.com"))
+    events = _drain(parent_conn)
+    assert any(isinstance(event, IncomingCall) for event in events)
+    assert adapter._current_call_id is not None
+
+    adapter.handle_command(Unregister())
+    assert _wait_for(lambda: not mock_backend.running)
+    assert adapter._current_call_id is None
+
+    # A follow-up re-register + dial must succeed instead of being blocked by
+    # the stale call id from the previous registration.
+    mock_backend.start_result = True  # default already, but make it explicit
+    adapter.handle_command(Configure(config=_config_dict()))
+    adapter.handle_command(Register(cmd_id=2))
+    _drain(parent_conn)
+    adapter.handle_command(Dial(uri="sip:carol@example.com", cmd_id=3))
+    events = _drain(parent_conn)
+    errors = [event for event in events if isinstance(event, Error)]
+    assert not any(
+        error.code == "call_in_progress" for error in errors
+    ), f"call_in_progress leaked across unregister: {errors!r}"
+
+
+def test_stop_iterate_thread_retains_handle_on_join_timeout() -> None:
+    """A stuck iterate thread must not be silently forgotten.
+
+    Codex review on #389 (P1): if ``_stop_iterate_thread`` cleared
+    ``_iterate_thread = None`` even when ``join`` timed out, a follow-up
+    ``Register`` would happily spawn a second iterate thread alongside the
+    still-running one. Both would race ``backend.iterate()``. This test
+    drives the stuck case directly and asserts the handle is retained, so
+    ``_start_iterate_thread`` short-circuits on ``is_alive()``.
+    """
+
+    parent, child = multiprocessing.Pipe(duplex=True)
+    try:
+        adapter = SidecarBackendAdapter(
+            conn=child,
+            backend_factory=lambda _config: MockVoIPBackend(),
+        )
+        # Plant a synthetic stuck thread directly into the adapter so the
+        # test does not rely on a misbehaving backend.
+        release = threading.Event()
+        stuck_thread = threading.Thread(
+            target=lambda: release.wait(timeout=10.0),
+            daemon=True,
+            name="voip-sidecar-iterate-test-stub",
+        )
+        stuck_thread.start()
+        adapter._iterate_thread = stuck_thread
+
+        # Tighten the join timeout so the test runs quickly.
+        adapter._ITERATE_JOIN_TIMEOUT_SECONDS = 0.05  # type: ignore[misc]
+
+        adapter._stop_iterate_thread()
+
+        # Handle must still reference the alive thread.
+        assert adapter._iterate_thread is stuck_thread
+        assert adapter._iterate_thread.is_alive()
+
+        # And the start path must refuse to spawn a parallel iterate thread
+        # while the old one is still alive.
+        adapter._start_iterate_thread()
+        assert adapter._iterate_thread is stuck_thread
+
+        release.set()
+        stuck_thread.join(timeout=1.0)
+    finally:
+        try:
+            parent.close()
+        except OSError:
+            pass
+        try:
+            child.close()
+        except OSError:
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integrations/call/test_sidecar_loopback_with_backend.py
+++ b/tests/integrations/call/test_sidecar_loopback_with_backend.py
@@ -1,0 +1,232 @@
+"""End-to-end loopback tests that wire ``SidecarSupervisor`` -> sidecar_main ->
+``SidecarBackendAdapter`` -> ``MockVoIPBackend`` together.
+
+These tests exercise the full Phase 2B.2 stack inside one Python process via
+loopback mode (#378) — the supervisor runs the real ``run_sidecar`` entry
+point on a daemon thread, which constructs the adapter and routes commands
+through a mock backend that we control from the test.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+from collections.abc import Callable
+from multiprocessing.connection import Connection
+from typing import Any
+
+import pytest
+
+from yoyopod.backends.voip.mock_backend import MockVoIPBackend
+from yoyopod.integrations.call.models import (
+    CallState,
+    CallStateChanged as BackendCallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged as BackendRegistrationStateChanged,
+    VoIPConfig,
+)
+from yoyopod.integrations.call.sidecar_main import run_sidecar
+from yoyopod.integrations.call.sidecar_protocol import (
+    Accept,
+    CallStateChanged,
+    Configure,
+    Dial,
+    Hangup,
+    IncomingCall,
+    Ping,
+    Pong,
+    Register,
+    RegistrationStateChanged,
+    Unregister,
+)
+from yoyopod.integrations.call.sidecar_supervisor import SidecarSupervisor
+
+LOOPBACK_BUDGET_SECONDS = 2.0
+
+
+# Module-level so loopback (and a future spawn variant) can both pickle/find it.
+_TEST_BACKEND_HANDLE: dict[str, MockVoIPBackend] = {}
+
+
+def _shared_mock_backend_factory(_config: VoIPConfig) -> MockVoIPBackend:
+    """Hand back the test-shared :class:`MockVoIPBackend` so the test can drive it."""
+
+    return _TEST_BACKEND_HANDLE["backend"]
+
+
+def _sidecar_target_with_mock_backend(conn: Connection) -> None:
+    """Loopback sidecar target that wires a shared mock backend into ``run_sidecar``."""
+
+    run_sidecar(conn, backend_factory=_shared_mock_backend_factory)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def collected_events() -> list[Any]:
+    return []
+
+
+@pytest.fixture
+def event_handler(collected_events: list[Any]) -> Callable[[Any], None]:
+    return collected_events.append
+
+
+@pytest.fixture
+def shared_mock_backend() -> MockVoIPBackend:
+    backend = MockVoIPBackend()
+    _TEST_BACKEND_HANDLE["backend"] = backend
+    yield backend
+    _TEST_BACKEND_HANDLE.clear()
+
+
+@pytest.fixture
+def supervisor(
+    event_handler: Callable[[Any], None], shared_mock_backend: MockVoIPBackend
+) -> SidecarSupervisor:
+    sup = SidecarSupervisor(
+        on_event=event_handler,
+        sidecar_target=_sidecar_target_with_mock_backend,
+        use_loopback=True,
+        handshake_timeout_seconds=LOOPBACK_BUDGET_SECONDS,
+    )
+    sup.start()
+    assert sup.wait_for_state("running", timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+    yield sup
+    sup.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)
+
+
+def _wait_for(predicate, *, timeout: float = LOOPBACK_BUDGET_SECONDS) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+def _serialized_config() -> dict[str, Any]:
+    return dataclasses.asdict(
+        VoIPConfig(sip_server="sip.example.com", sip_identity="sip:alice@example.com")
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end flows
+# ---------------------------------------------------------------------------
+
+
+def test_configure_and_register_starts_mock_backend(
+    supervisor: SidecarSupervisor,
+    shared_mock_backend: MockVoIPBackend,
+    collected_events: list[Any],
+) -> None:
+    supervisor.send(Configure(config=_serialized_config(), cmd_id=1))
+    supervisor.send(Register(cmd_id=2))
+    assert _wait_for(lambda: shared_mock_backend.running)
+    assert shared_mock_backend.running
+
+
+def test_backend_event_round_trips_to_main(
+    supervisor: SidecarSupervisor,
+    shared_mock_backend: MockVoIPBackend,
+    collected_events: list[Any],
+) -> None:
+    supervisor.send(Configure(config=_serialized_config(), cmd_id=1))
+    supervisor.send(Register(cmd_id=2))
+    assert _wait_for(lambda: shared_mock_backend.running)
+
+    shared_mock_backend.emit(BackendRegistrationStateChanged(state=RegistrationState.OK))
+    assert _wait_for(
+        lambda: any(
+            isinstance(event, RegistrationStateChanged) and event.state == "ok"
+            for event in collected_events
+        )
+    )
+
+
+def test_incoming_call_then_accept_drives_backend(
+    supervisor: SidecarSupervisor,
+    shared_mock_backend: MockVoIPBackend,
+    collected_events: list[Any],
+) -> None:
+    supervisor.send(Configure(config=_serialized_config(), cmd_id=1))
+    supervisor.send(Register(cmd_id=2))
+    assert _wait_for(lambda: shared_mock_backend.running)
+
+    shared_mock_backend.emit(IncomingCallDetected(caller_address="sip:bob@example.com"))
+    assert _wait_for(lambda: any(isinstance(event, IncomingCall) for event in collected_events))
+    incoming = next(event for event in collected_events if isinstance(event, IncomingCall))
+
+    supervisor.send(Accept(call_id=incoming.call_id, cmd_id=3))
+    assert _wait_for(lambda: "answer" in shared_mock_backend.commands)
+
+
+def test_call_state_change_flows_back_with_call_id(
+    supervisor: SidecarSupervisor,
+    shared_mock_backend: MockVoIPBackend,
+    collected_events: list[Any],
+) -> None:
+    supervisor.send(Configure(config=_serialized_config(), cmd_id=1))
+    supervisor.send(Register(cmd_id=2))
+    assert _wait_for(lambda: shared_mock_backend.running)
+
+    shared_mock_backend.emit(IncomingCallDetected(caller_address="sip:bob@example.com"))
+    assert _wait_for(lambda: any(isinstance(event, IncomingCall) for event in collected_events))
+    incoming = next(event for event in collected_events if isinstance(event, IncomingCall))
+
+    shared_mock_backend.emit(BackendCallStateChanged(state=CallState.CONNECTED))
+    assert _wait_for(
+        lambda: any(
+            isinstance(event, CallStateChanged)
+            and event.call_id == incoming.call_id
+            and event.state == "connected"
+            for event in collected_events
+        )
+    )
+
+
+def test_dial_then_hangup_round_trips(
+    supervisor: SidecarSupervisor,
+    shared_mock_backend: MockVoIPBackend,
+    collected_events: list[Any],
+) -> None:
+    supervisor.send(Configure(config=_serialized_config(), cmd_id=1))
+    supervisor.send(Register(cmd_id=2))
+    assert _wait_for(lambda: shared_mock_backend.running)
+
+    supervisor.send(Dial(uri="sip:bob@example.com", cmd_id=3))
+    assert _wait_for(lambda: "call sip:bob@example.com" in shared_mock_backend.commands)
+
+    # Adapter assigned a call_id; main can hang up using the same id.
+    # Simulate that by reading the call id off the adapter via the backend's
+    # callback registration: the adapter mints call-1 the first time it sees
+    # a dial succeed, so we just send Hangup with that label.
+    supervisor.send(Hangup(call_id="call-1", cmd_id=4))
+    assert _wait_for(lambda: "terminate" in shared_mock_backend.commands)
+
+
+def test_unregister_stops_mock_backend(
+    supervisor: SidecarSupervisor,
+    shared_mock_backend: MockVoIPBackend,
+    collected_events: list[Any],
+) -> None:
+    supervisor.send(Configure(config=_serialized_config(), cmd_id=1))
+    supervisor.send(Register(cmd_id=2))
+    assert _wait_for(lambda: shared_mock_backend.running)
+
+    supervisor.send(Unregister())
+    assert _wait_for(lambda: not shared_mock_backend.running)
+
+
+def test_ping_works_without_configure(
+    supervisor: SidecarSupervisor, collected_events: list[Any]
+) -> None:
+    supervisor.send(Ping(cmd_id=77))
+    assert _wait_for(
+        lambda: any(isinstance(event, Pong) and event.cmd_id == 77 for event in collected_events)
+    )

--- a/tests/integrations/call/test_sidecar_protocol.py
+++ b/tests/integrations/call/test_sidecar_protocol.py
@@ -10,6 +10,7 @@ import pytest
 from yoyopod.integrations.call.sidecar_protocol import (
     Accept,
     CallStateChanged,
+    Configure,
     Dial,
     Error,
     Hangup,
@@ -46,7 +47,16 @@ def test_protocol_version_is_pinned() -> None:
     "message",
     [
         Hello(version=1, capabilities=("voip", "messaging")),
-        Register(server="sip.example.com", user="alice", password="hunter2", cmd_id=7),
+        Configure(
+            config={
+                "sip_server": "sip.example.com",
+                "sip_username": "alice",
+                "sip_password": "hunter2",
+                "transport": "tcp",
+            },
+            cmd_id=5,
+        ),
+        Register(cmd_id=7),
         Unregister(),
         Dial(uri="sip:bob@example.com", cmd_id=42),
         Accept(call_id="c-1", cmd_id=8),
@@ -90,7 +100,7 @@ def test_unknown_command_type_raises() -> None:
 
 
 def test_unknown_event_type_raises() -> None:
-    payload = encode(Register(server="x", user="y", password="z"))
+    payload = encode(Register(cmd_id=1))
     with pytest.raises(ProtocolError, match="Unknown event type"):
         decode_event(payload)
 
@@ -108,13 +118,13 @@ def test_send_and_recv_command_over_pipe() -> None:
     child_conn: Connection
     parent_conn, child_conn = multiprocessing.Pipe(duplex=True)
     try:
-        send_message(parent_conn, Register(server="s", user="u", password="p", cmd_id=1))
+        send_message(parent_conn, Register(cmd_id=1))
         send_message(parent_conn, Dial(uri="sip:peer@s", cmd_id=2))
 
         first = recv_command(child_conn)
         second = recv_command(child_conn)
 
-        assert first == Register(server="s", user="u", password="p", cmd_id=1)
+        assert first == Register(cmd_id=1)
         assert second == Dial(uri="sip:peer@s", cmd_id=2)
     finally:
         parent_conn.close()

--- a/tests/integrations/call/test_sidecar_supervisor_loopback.py
+++ b/tests/integrations/call/test_sidecar_supervisor_loopback.py
@@ -122,10 +122,12 @@ def test_loopback_send_ping_round_trips_to_pong(
         supervisor.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)
 
 
-def test_loopback_register_command_flows_to_log_event(
+def test_loopback_register_before_configure_returns_not_configured_error(
     collected_events: list[Any], event_handler: Callable[[Any], None]
 ) -> None:
-    """Verify the scaffold ack-as-Log path works through the loopback runner."""
+    """Sending Register before Configure should produce a not_configured Error."""
+
+    from yoyopod.integrations.call.sidecar_protocol import Error
 
     supervisor = SidecarSupervisor(
         on_event=event_handler,
@@ -136,19 +138,19 @@ def test_loopback_register_command_flows_to_log_event(
     try:
         supervisor.start()
         assert supervisor.wait_for_state("running", timeout_seconds=LOOPBACK_BUDGET_SECONDS)
-        supervisor.send(Register(server="sip.example.com", user="alice", password="x", cmd_id=1))
+        supervisor.send(Register(cmd_id=11))
 
         deadline = time.monotonic() + LOOPBACK_BUDGET_SECONDS
         while time.monotonic() < deadline:
-            log_events = [event for event in collected_events if type(event).__name__ == "Log"]
-            if any("alice" in event.message for event in log_events):
+            errors = [event for event in collected_events if isinstance(event, Error)]
+            if any(error.code == "not_configured" and error.cmd_id == 11 for error in errors):
                 break
             time.sleep(0.01)
 
-        log_events = [event for event in collected_events if type(event).__name__ == "Log"]
+        errors = [event for event in collected_events if isinstance(event, Error)]
         assert any(
-            "alice" in event.message for event in log_events
-        ), f"never saw Register ack log; collected {collected_events!r}"
+            error.code == "not_configured" and error.cmd_id == 11 for error in errors
+        ), f"never saw not_configured error; collected {collected_events!r}"
     finally:
         supervisor.stop(timeout_seconds=LOOPBACK_BUDGET_SECONDS)
 

--- a/yoyopod/integrations/call/sidecar_adapter.py
+++ b/yoyopod/integrations/call/sidecar_adapter.py
@@ -431,6 +431,12 @@ class SidecarBackendAdapter:
                 return
 
             if isinstance(event, BackendStopped):
+                # Treat as terminal for any in-flight call: the backend has
+                # gone down (typically because ``iterate()`` failed and the
+                # native shim is gone), so the tracked ``_current_call_id``
+                # would otherwise block future ``Dial`` commands with
+                # ``call_in_progress`` even after a recovery Configure.
+                self._reset_call_state()
                 self._safe_send(
                     Error(
                         code="backend_stopped",

--- a/yoyopod/integrations/call/sidecar_adapter.py
+++ b/yoyopod/integrations/call/sidecar_adapter.py
@@ -214,6 +214,29 @@ class SidecarBackendAdapter:
         backend = self._require_backend(command.cmd_id)
         if backend is None:
             return
+
+        # The iterate thread from a prior backend may still be alive — e.g.
+        # ``_stop_iterate_thread`` retained the handle when its join timed
+        # out (round-1 fix). ``_start_iterate_thread`` silently short-circuits
+        # in that case to avoid racing two iterate threads against the same
+        # backend, but that means a fresh backend would have no iterate
+        # driver and the SIP keep-alives / event drains would not flow even
+        # though Register reported success. Surface the situation as a
+        # caller-visible error instead of starting the backend in a
+        # half-broken state. ``main`` can retry once the stale thread exits.
+        if self._iterate_thread is not None and self._iterate_thread.is_alive():
+            self._safe_send(
+                Error(
+                    code="iterate_thread_busy",
+                    message=(
+                        "cannot register: previous iterate thread is still alive; "
+                        "retry once it exits"
+                    ),
+                    cmd_id=command.cmd_id,
+                )
+            )
+            return
+
         try:
             started = backend.start()
         except Exception as exc:

--- a/yoyopod/integrations/call/sidecar_adapter.py
+++ b/yoyopod/integrations/call/sidecar_adapter.py
@@ -150,7 +150,13 @@ class SidecarBackendAdapter:
         self._stop_iterate_thread()
         backend = self._backend
         self._backend = None
-        if backend is not None and backend.running:
+        # Always stop the backend if one exists. ``backend.running`` is not a
+        # reliable cleanup signal: ``LiblinphoneBackend`` flips ``running``
+        # to False when ``iterate()`` raises, but the native core, transports,
+        # and audio device claims still need ``stop()``/``shutdown()`` to
+        # release them. Skipping the call would leak native state into the
+        # next backend created by a follow-up Configure.
+        if backend is not None:
             try:
                 backend.stop()
             except Exception:

--- a/yoyopod/integrations/call/sidecar_adapter.py
+++ b/yoyopod/integrations/call/sidecar_adapter.py
@@ -1,0 +1,590 @@
+"""Translate protocol commands to ``VoIPBackend`` calls and back.
+
+The adapter is owned by the sidecar process. It receives decoded protocol
+commands from :func:`yoyopod.integrations.call.sidecar_main.run_sidecar`
+and dispatches them to the backend, runs the iterate loop on a dedicated
+thread, and emits backend events as protocol events through the pipe.
+
+Pipe writes happen from two threads — the command-handling thread when
+sending acks/errors, and the iterate thread when forwarding backend events.
+:class:`SidecarBackendAdapter` serializes pipe writes through ``_send_lock``
+so frames never interleave.
+
+The :class:`yoyopod.backends.voip.protocol.VoIPBackend` API is implicitly
+single-call (no ``call_id`` parameters). The sidecar mints a ``call_id``
+the first time it sees an :class:`IncomingCallDetected` or after
+:class:`Dial` succeeds; it tracks that id until the call releases. When
+main sends :class:`Accept`/:class:`Hangup`/:class:`SetMute` with a
+``call_id``, the adapter validates it matches the current call before
+calling the backend.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from multiprocessing.connection import Connection
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.backends.voip.protocol import VoIPBackend
+from yoyopod.integrations.call.models import (
+    BackendStopped,
+    CallState,
+    CallStateChanged as BackendCallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged as BackendRegistrationStateChanged,
+    VoIPConfig,
+    VoIPEvent,
+)
+from yoyopod.integrations.call.sidecar_protocol import (
+    Accept,
+    CallStateChanged,
+    Configure,
+    Dial,
+    Error,
+    Hangup,
+    IncomingCall,
+    Log,
+    MediaStateChanged,
+    Ping,
+    Pong,
+    Register,
+    RegistrationStateChanged,
+    Reject,
+    SetMute,
+    SetVolume,
+    Unregister,
+    send_message,
+)
+
+BackendFactory = Callable[[VoIPConfig], VoIPBackend]
+
+
+class SidecarBackendAdapter:
+    """Stateful adapter between the wire protocol and a ``VoIPBackend`` instance."""
+
+    _ITERATE_INTERVAL_FALLBACK_SECONDS = 0.02
+    _ITERATE_JOIN_TIMEOUT_SECONDS = 1.0
+
+    def __init__(
+        self,
+        *,
+        conn: Connection,
+        backend_factory: BackendFactory,
+    ) -> None:
+        self._conn = conn
+        self._backend_factory = backend_factory
+        self._backend: VoIPBackend | None = None
+        self._send_lock = threading.Lock()
+        self._iterate_thread: threading.Thread | None = None
+        self._iterate_stop = threading.Event()
+        self._iterate_interval_seconds = self._ITERATE_INTERVAL_FALLBACK_SECONDS
+
+        self._call_lock = threading.Lock()
+        self._next_call_id = 0
+        self._current_call_id: str | None = None
+        self._is_muted = False
+        self._speaker_volume = 1.0
+
+    # ------------------------------------------------------------------
+    # Public command dispatch
+    # ------------------------------------------------------------------
+
+    def handle_command(self, command: Any) -> None:
+        """Dispatch one decoded command to the appropriate backend operation."""
+
+        if isinstance(command, Ping):
+            self._safe_send(Pong(cmd_id=command.cmd_id))
+            return
+
+        if isinstance(command, Configure):
+            self._handle_configure(command)
+            return
+
+        if isinstance(command, Register):
+            self._handle_register(command)
+            return
+
+        if isinstance(command, Unregister):
+            self._handle_unregister(command)
+            return
+
+        if isinstance(command, Dial):
+            self._handle_dial(command)
+            return
+
+        if isinstance(command, Accept):
+            self._handle_accept(command)
+            return
+
+        if isinstance(command, Reject):
+            self._handle_reject(command)
+            return
+
+        if isinstance(command, Hangup):
+            self._handle_hangup(command)
+            return
+
+        if isinstance(command, SetMute):
+            self._handle_set_mute(command)
+            return
+
+        if isinstance(command, SetVolume):
+            self._handle_set_volume(command)
+            return
+
+        self._safe_send(
+            Log(
+                level="WARNING",
+                message=f"sidecar adapter: ignored unknown command {type(command).__name__}",
+            )
+        )
+
+    def shutdown(self) -> None:
+        """Tear down the iterate thread and stop the backend, if any."""
+
+        self._stop_iterate_thread()
+        backend = self._backend
+        self._backend = None
+        if backend is not None and backend.running:
+            try:
+                backend.stop()
+            except Exception:
+                logger.exception("Sidecar adapter: backend.stop() raised during shutdown")
+
+    # ------------------------------------------------------------------
+    # Command handlers
+    # ------------------------------------------------------------------
+
+    def _handle_configure(self, command: Configure) -> None:
+        try:
+            config = VoIPConfig(**command.config)
+        except TypeError as exc:
+            self._safe_send(
+                Error(
+                    code="invalid_config",
+                    message=f"VoIPConfig construction failed: {exc}",
+                    cmd_id=command.cmd_id,
+                )
+            )
+            return
+
+        # Replace any prior backend cleanly.
+        self.shutdown()
+        try:
+            backend = self._backend_factory(config)
+        except Exception as exc:
+            self._safe_send(
+                Error(
+                    code="backend_factory_failed",
+                    message=f"backend factory raised: {exc}",
+                    cmd_id=command.cmd_id,
+                )
+            )
+            return
+
+        backend.on_event(self._on_backend_event)
+        self._backend = backend
+        self._iterate_interval_seconds = max(0.001, float(config.iterate_interval_ms) / 1000.0)
+        self._safe_send(
+            Log(
+                level="INFO",
+                message=f"sidecar adapter: configured backend for {config.sip_server!r}",
+            )
+        )
+
+    def _handle_register(self, command: Register) -> None:
+        backend = self._require_backend(command.cmd_id)
+        if backend is None:
+            return
+        try:
+            started = backend.start()
+        except Exception as exc:
+            self._safe_send(
+                Error(
+                    code="register_failed",
+                    message=f"backend.start() raised: {exc}",
+                    cmd_id=command.cmd_id,
+                )
+            )
+            return
+
+        if not started:
+            self._safe_send(
+                Error(
+                    code="register_failed",
+                    message="backend.start() returned False",
+                    cmd_id=command.cmd_id,
+                )
+            )
+            return
+
+        self._start_iterate_thread()
+
+    def _handle_unregister(self, command: Unregister) -> None:
+        backend = self._backend
+        if backend is None:
+            self._safe_send(
+                Error(
+                    code="not_configured",
+                    message="cannot unregister; no backend configured",
+                    cmd_id=command.cmd_id,
+                )
+            )
+            return
+
+        self._stop_iterate_thread()
+        try:
+            backend.stop()
+        except Exception as exc:
+            self._safe_send(
+                Error(
+                    code="unregister_failed",
+                    message=f"backend.stop() raised: {exc}",
+                    cmd_id=command.cmd_id,
+                )
+            )
+
+    def _handle_dial(self, command: Dial) -> None:
+        backend = self._require_backend(command.cmd_id)
+        if backend is None:
+            return
+        with self._call_lock:
+            if self._current_call_id is not None:
+                self._safe_send(
+                    Error(
+                        code="call_in_progress",
+                        message=f"refusing to dial; current call {self._current_call_id!r}",
+                        cmd_id=command.cmd_id,
+                    )
+                )
+                return
+            call_id = self._mint_call_id_locked()
+
+        try:
+            success = backend.make_call(command.uri)
+        except Exception as exc:
+            self._clear_call_id(call_id)
+            self._safe_send(
+                Error(
+                    code="dial_failed",
+                    message=f"backend.make_call raised: {exc}",
+                    cmd_id=command.cmd_id,
+                )
+            )
+            return
+
+        if not success:
+            self._clear_call_id(call_id)
+            self._safe_send(
+                Error(
+                    code="dial_failed",
+                    message="backend.make_call returned False",
+                    cmd_id=command.cmd_id,
+                )
+            )
+
+    def _handle_accept(self, command: Accept) -> None:
+        backend = self._require_backend(command.cmd_id)
+        if backend is None:
+            return
+        if not self._verify_call_id(command.call_id, command.cmd_id):
+            return
+        self._invoke_simple_action(
+            backend.answer_call,
+            cmd_id=command.cmd_id,
+            failure_code="accept_failed",
+            label="answer_call",
+        )
+
+    def _handle_reject(self, command: Reject) -> None:
+        backend = self._require_backend(command.cmd_id)
+        if backend is None:
+            return
+        if not self._verify_call_id(command.call_id, command.cmd_id):
+            return
+        self._invoke_simple_action(
+            backend.reject_call,
+            cmd_id=command.cmd_id,
+            failure_code="reject_failed",
+            label="reject_call",
+        )
+
+    def _handle_hangup(self, command: Hangup) -> None:
+        backend = self._require_backend(command.cmd_id)
+        if backend is None:
+            return
+        if not self._verify_call_id(command.call_id, command.cmd_id):
+            return
+        self._invoke_simple_action(
+            backend.hangup,
+            cmd_id=command.cmd_id,
+            failure_code="hangup_failed",
+            label="hangup",
+        )
+
+    def _handle_set_mute(self, command: SetMute) -> None:
+        backend = self._require_backend(command.cmd_id)
+        if backend is None:
+            return
+        if not self._verify_call_id(command.call_id, command.cmd_id):
+            return
+        try:
+            success = backend.mute() if command.on else backend.unmute()
+        except Exception as exc:
+            self._safe_send(
+                Error(
+                    code="mute_failed",
+                    message=f"backend mute/unmute raised: {exc}",
+                    cmd_id=command.cmd_id,
+                )
+            )
+            return
+        if not success:
+            self._safe_send(
+                Error(
+                    code="mute_failed",
+                    message="backend mute/unmute returned False",
+                    cmd_id=command.cmd_id,
+                )
+            )
+            return
+        self._is_muted = bool(command.on)
+        self._emit_media_state_locked()
+
+    def _handle_set_volume(self, command: SetVolume) -> None:
+        # The current ``VoIPBackend`` protocol has no volume control; track
+        # the requested value and surface it via :class:`MediaStateChanged`
+        # so the main process keeps an accurate view of intended state.
+        self._speaker_volume = max(0.0, min(1.0, float(command.level)))
+        self._emit_media_state_locked()
+
+    # ------------------------------------------------------------------
+    # Backend event translation
+    # ------------------------------------------------------------------
+
+    def _on_backend_event(self, event: VoIPEvent) -> None:
+        """Translate one backend event to a protocol event and send it."""
+
+        try:
+            if isinstance(event, BackendRegistrationStateChanged):
+                self._safe_send(
+                    RegistrationStateChanged(
+                        state=_registration_state_value(event.state), reason=None
+                    )
+                )
+                return
+
+            if isinstance(event, IncomingCallDetected):
+                with self._call_lock:
+                    if self._current_call_id is None:
+                        call_id = self._mint_call_id_locked()
+                    else:
+                        call_id = self._current_call_id
+                self._safe_send(
+                    IncomingCall(
+                        call_id=call_id,
+                        from_uri=event.caller_address,
+                        from_display=None,
+                    )
+                )
+                return
+
+            if isinstance(event, BackendCallStateChanged):
+                call_id = self._current_call_id
+                state_value = _call_state_value(event.state)
+                if call_id is not None:
+                    self._safe_send(CallStateChanged(call_id=call_id, state=state_value))
+                if event.state in _CALL_TERMINAL_STATES:
+                    self._reset_call_state()
+                return
+
+            if isinstance(event, BackendStopped):
+                self._safe_send(
+                    Error(
+                        code="backend_stopped",
+                        message=event.reason or "backend stopped",
+                    )
+                )
+                return
+
+            # Messaging and voice-note events are out of scope for Phase 2B.2;
+            # forward them as a debug log so callers can see them in flight.
+            self._safe_send(
+                Log(
+                    level="DEBUG",
+                    message=f"sidecar adapter: forwarded {type(event).__name__}",
+                )
+            )
+        except Exception:
+            logger.exception(
+                "Sidecar adapter: failed to translate backend event {}",
+                type(event).__name__,
+            )
+
+    # ------------------------------------------------------------------
+    # Iterate thread
+    # ------------------------------------------------------------------
+
+    def _start_iterate_thread(self) -> None:
+        if self._iterate_thread is not None and self._iterate_thread.is_alive():
+            return
+        self._iterate_stop.clear()
+        thread = threading.Thread(
+            target=self._run_iterate_loop,
+            daemon=True,
+            name="voip-sidecar-iterate",
+        )
+        self._iterate_thread = thread
+        thread.start()
+
+    def _stop_iterate_thread(self) -> None:
+        thread = self._iterate_thread
+        if thread is None:
+            return
+        self._iterate_stop.set()
+        thread.join(timeout=self._ITERATE_JOIN_TIMEOUT_SECONDS)
+        if thread.is_alive():
+            logger.warning("Sidecar adapter: iterate thread did not exit within join timeout")
+        self._iterate_thread = None
+
+    def _run_iterate_loop(self) -> None:
+        backend = self._backend
+        if backend is None:
+            return
+        while not self._iterate_stop.is_set():
+            try:
+                if backend.running:
+                    backend.iterate()
+            except Exception:
+                logger.exception("Sidecar adapter: backend.iterate raised; continuing")
+            self._iterate_stop.wait(timeout=self._iterate_interval_seconds)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _require_backend(self, cmd_id: int | None) -> VoIPBackend | None:
+        backend = self._backend
+        if backend is None:
+            self._safe_send(
+                Error(
+                    code="not_configured",
+                    message="sidecar received command before Configure",
+                    cmd_id=cmd_id,
+                )
+            )
+        return backend
+
+    def _verify_call_id(self, call_id: str, cmd_id: int | None) -> bool:
+        with self._call_lock:
+            current = self._current_call_id
+        if current != call_id:
+            self._safe_send(
+                Error(
+                    code="unknown_call_id",
+                    message=f"command targets {call_id!r} but current call is {current!r}",
+                    cmd_id=cmd_id,
+                )
+            )
+            return False
+        return True
+
+    def _invoke_simple_action(
+        self,
+        action: Callable[[], bool],
+        *,
+        cmd_id: int | None,
+        failure_code: str,
+        label: str,
+    ) -> None:
+        try:
+            success = action()
+        except Exception as exc:
+            self._safe_send(
+                Error(
+                    code=failure_code,
+                    message=f"backend.{label} raised: {exc}",
+                    cmd_id=cmd_id,
+                )
+            )
+            return
+        if not success:
+            self._safe_send(
+                Error(
+                    code=failure_code,
+                    message=f"backend.{label} returned False",
+                    cmd_id=cmd_id,
+                )
+            )
+
+    def _mint_call_id_locked(self) -> str:
+        """Caller must hold ``self._call_lock``."""
+
+        self._next_call_id += 1
+        call_id = f"call-{self._next_call_id}"
+        self._current_call_id = call_id
+        self._is_muted = False
+        self._speaker_volume = 1.0
+        return call_id
+
+    def _clear_call_id(self, call_id: str) -> None:
+        with self._call_lock:
+            if self._current_call_id == call_id:
+                self._current_call_id = None
+                self._is_muted = False
+                self._speaker_volume = 1.0
+
+    def _reset_call_state(self) -> None:
+        with self._call_lock:
+            self._current_call_id = None
+            self._is_muted = False
+            self._speaker_volume = 1.0
+
+    def _emit_media_state_locked(self) -> None:
+        with self._call_lock:
+            call_id = self._current_call_id
+            mic_muted = self._is_muted
+            volume = self._speaker_volume
+        if call_id is None:
+            return
+        self._safe_send(
+            MediaStateChanged(call_id=call_id, mic_muted=mic_muted, speaker_volume=volume)
+        )
+
+    def _safe_send(self, message: Any) -> None:
+        with self._send_lock:
+            try:
+                send_message(self._conn, message)
+            except (BrokenPipeError, EOFError, OSError):
+                pass
+
+    # ------------------------------------------------------------------
+    # Test seams
+    # ------------------------------------------------------------------
+
+    def _wait_for_iterate_thread_to_exit(self, *, timeout: float = 1.0) -> bool:
+        """Block until the iterate thread has exited. Returns True on success."""
+
+        thread = self._iterate_thread
+        if thread is None:
+            return True
+        deadline = time.monotonic() + timeout
+        while thread.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.005)
+        return not thread.is_alive()
+
+
+_CALL_TERMINAL_STATES = frozenset({CallState.RELEASED, CallState.ERROR, CallState.IDLE})
+
+
+def _registration_state_value(state: RegistrationState) -> str:
+    return state.value if isinstance(state, RegistrationState) else str(state)
+
+
+def _call_state_value(state: CallState) -> str:
+    return state.value if isinstance(state, CallState) else str(state)

--- a/yoyopod/integrations/call/sidecar_adapter.py
+++ b/yoyopod/integrations/call/sidecar_adapter.py
@@ -248,6 +248,12 @@ class SidecarBackendAdapter:
                     cmd_id=command.cmd_id,
                 )
             )
+        # Stopping the iterate loop happens before backend.stop(), so any
+        # terminal call-state event the backend would have emitted on
+        # teardown is no longer guaranteed to flow through. Reset the
+        # tracked call id explicitly so a follow-up Configure/Register/Dial
+        # cycle is not stuck on a stale ``call_in_progress``.
+        self._reset_call_state()
 
     def _handle_dial(self, command: Dial) -> None:
         backend = self._require_backend(command.cmd_id)
@@ -449,7 +455,17 @@ class SidecarBackendAdapter:
         self._iterate_stop.set()
         thread.join(timeout=self._ITERATE_JOIN_TIMEOUT_SECONDS)
         if thread.is_alive():
-            logger.warning("Sidecar adapter: iterate thread did not exit within join timeout")
+            # Keep the handle so we never let a fresh start spawn a second
+            # iterate thread alongside the one that is still alive: two
+            # threads racing ``backend.iterate()`` would corrupt liblinphone
+            # state and double up on event emission. ``_start_iterate_thread``
+            # checks ``is_alive()`` and returns without spawning if the old
+            # thread is still here.
+            logger.warning(
+                "Sidecar adapter: iterate thread did not exit within join timeout; "
+                "retaining handle so a restart cannot race a second iterate thread"
+            )
+            return
         self._iterate_thread = None
 
     def _run_iterate_loop(self) -> None:

--- a/yoyopod/integrations/call/sidecar_adapter.py
+++ b/yoyopod/integrations/call/sidecar_adapter.py
@@ -173,8 +173,15 @@ class SidecarBackendAdapter:
             )
             return
 
-        # Replace any prior backend cleanly.
+        # Replace any prior backend cleanly. ``shutdown()`` joins the iterate
+        # thread and stops the old backend, but it does not clear tracked
+        # call state — a Configure issued during an active call would leave
+        # the adapter believing the call is still in progress and reject
+        # subsequent Dials with ``call_in_progress``. Reset explicitly so
+        # backend replacement is truly idempotent (matches the behaviour
+        # added to ``_handle_unregister``).
         self.shutdown()
+        self._reset_call_state()
         try:
             backend = self._backend_factory(config)
         except Exception as exc:
@@ -366,6 +373,14 @@ class SidecarBackendAdapter:
         # The current ``VoIPBackend`` protocol has no volume control; track
         # the requested value and surface it via :class:`MediaStateChanged`
         # so the main process keeps an accurate view of intended state.
+        # Validate the call id like the other call-scoped commands so a
+        # delayed SetVolume from a previous call cannot mutate the current
+        # call's media state. ``_require_backend`` and ``_verify_call_id``
+        # both emit Error events on rejection.
+        if self._require_backend(command.cmd_id) is None:
+            return
+        if not self._verify_call_id(command.call_id, command.cmd_id):
+            return
         self._speaker_volume = max(0.0, min(1.0, float(command.level)))
         self._emit_media_state_locked()
 
@@ -595,7 +610,20 @@ class SidecarBackendAdapter:
         return not thread.is_alive()
 
 
-_CALL_TERMINAL_STATES = frozenset({CallState.RELEASED, CallState.ERROR, CallState.IDLE})
+_CALL_TERMINAL_STATES = frozenset(
+    {
+        CallState.RELEASED,
+        CallState.END,
+        CallState.ERROR,
+        CallState.IDLE,
+    }
+)
+"""Liblinphone emits a native terminal that maps to ``CallState.END`` (state 13;
+see :file:`yoyopod/backends/voip/liblinphone.py`). Treat it as terminal here
+so a hangup that lands as END (with no later RELEASED) still clears the
+tracked ``_current_call_id`` instead of blocking subsequent Dials with
+``call_in_progress``. Mirrors the existing ``_TERMINAL_STATES`` set in
+:mod:`yoyopod.integrations.call.handlers`."""
 
 
 def _registration_state_value(state: RegistrationState) -> str:

--- a/yoyopod/integrations/call/sidecar_main.py
+++ b/yoyopod/integrations/call/sidecar_main.py
@@ -1,54 +1,49 @@
 """VoIP sidecar process entry point.
 
-Phase 2A ships a scaffold sidecar: it completes the protocol handshake,
-echoes :class:`Ping` to :class:`Pong`, and emits a :class:`Log` event
-acknowledging each accepted command without performing any liblinphone
-work. Phase 2B replaces :func:`_dispatch_command` with the real
-:class:`LiblinphoneBackend` integration.
+The sidecar runs the protocol handshake, owns a :class:`VoIPBackend`
+instance, and routes incoming commands and outgoing events through a
+:class:`SidecarBackendAdapter`. The default backend factory lazily imports
+:class:`yoyopod.backends.voip.LiblinphoneBackend` so the import chain is
+only paid in the sidecar process; tests inject a mock-backend factory
+instead.
 
 The function :func:`run_sidecar` is what
-``yoyopod.integrations.call.sidecar_supervisor.SidecarSupervisor`` passes to
-``multiprocessing.Process(target=...)``, so it must remain importable at
-module level for both ``spawn`` and ``forkserver`` start methods.
+:class:`yoyopod.integrations.call.sidecar_supervisor.SidecarSupervisor`
+passes to ``multiprocessing.Process(target=...)`` (or to the loopback
+thread runner), so it must remain importable at module level for
+``spawn`` and ``forkserver`` start methods.
 """
 
 from __future__ import annotations
 
 import sys
 from multiprocessing.connection import Connection
-from typing import Any
 
+from yoyopod.integrations.call.sidecar_adapter import (
+    BackendFactory,
+    SidecarBackendAdapter,
+)
 from yoyopod.integrations.call.sidecar_protocol import (
-    Accept,
-    CallStateChanged,
-    Dial,
     Error,
-    Hangup,
     Hello,
-    Log,
     PROTOCOL_VERSION,
-    Ping,
-    Pong,
     ProtocolError,
     Ready,
-    Register,
-    Reject,
-    SetMute,
-    SetVolume,
     Shutdown,
-    Unregister,
     recv_command,
     send_message,
 )
 
 
-def run_sidecar(conn: Connection) -> None:
+def run_sidecar(conn: Connection, backend_factory: BackendFactory | None = None) -> None:
     """Run the sidecar command loop until :class:`Shutdown` or the pipe closes."""
 
     _set_parent_death_signal()
 
+    factory = backend_factory or _default_liblinphone_factory
+
     try:
-        send_message(conn, Hello(version=PROTOCOL_VERSION, capabilities=("scaffold",)))
+        send_message(conn, Hello(version=PROTOCOL_VERSION, capabilities=("voip",)))
     except (BrokenPipeError, EOFError, OSError):
         return
 
@@ -79,79 +74,27 @@ def run_sidecar(conn: Connection) -> None:
     if not _safe_send(conn, Ready()):
         return
 
-    while True:
-        try:
-            command = recv_command(conn)
-        except (BrokenPipeError, EOFError, OSError):
-            return
-        except ProtocolError as exc:
-            if not _safe_send(conn, Error(code="protocol_error", message=str(exc))):
+    adapter = SidecarBackendAdapter(conn=conn, backend_factory=factory)
+    try:
+        while True:
+            try:
+                command = recv_command(conn)
+            except (BrokenPipeError, EOFError, OSError):
                 return
-            continue
+            except ProtocolError as exc:
+                if not _safe_send(conn, Error(code="protocol_error", message=str(exc))):
+                    return
+                continue
 
-        if isinstance(command, Shutdown):
-            return
+            if isinstance(command, Shutdown):
+                return
 
-        if not _dispatch_command(conn, command):
-            return
-
-
-def _dispatch_command(conn: Connection, command: Any) -> bool:
-    """Handle one command in the Phase 2A scaffold mode. Returns False on pipe close."""
-
-    if isinstance(command, Ping):
-        return _safe_send(conn, Pong(cmd_id=command.cmd_id))
-
-    if isinstance(command, Register):
-        return _safe_send(
-            conn,
-            Log(
-                level="INFO",
-                message=f"scaffold sidecar: would register user={command.user!r}",
-            ),
-        )
-
-    if isinstance(command, Unregister):
-        return _safe_send(conn, Log(level="INFO", message="scaffold sidecar: would unregister"))
-
-    if isinstance(command, Dial):
-        return _safe_send(
-            conn,
-            Log(
-                level="INFO",
-                message=f"scaffold sidecar: would dial uri={command.uri!r}",
-            ),
-        )
-
-    if isinstance(command, (Accept, Reject, Hangup)):
-        action = type(command).__name__.lower()
-        return _safe_send(
-            conn,
-            CallStateChanged(call_id=command.call_id, state=f"scaffold_{action}"),
-        )
-
-    if isinstance(command, (SetMute, SetVolume)):
-        verb = "mute" if isinstance(command, SetMute) else "volume"
-        return _safe_send(
-            conn,
-            Log(
-                level="DEBUG",
-                message=(
-                    f"scaffold sidecar: ignored {verb} change for call_id={command.call_id!r}"
-                ),
-            ),
-        )
-
-    return _safe_send(
-        conn,
-        Log(
-            level="DEBUG",
-            message=f"scaffold sidecar: unhandled command type={type(command).__name__}",
-        ),
-    )
+            adapter.handle_command(command)
+    finally:
+        adapter.shutdown()
 
 
-def _safe_send(conn: Connection, message: Any) -> bool:
+def _safe_send(conn: Connection, message: object) -> bool:
     """Send one message, returning False if the parent has closed the pipe."""
 
     try:
@@ -178,3 +121,21 @@ def _set_parent_death_signal() -> None:
         # If prctl is unavailable the supervisor still detects death via the
         # closed pipe; this is a defense-in-depth signal, not a hard requirement.
         pass
+
+
+def _default_liblinphone_factory(config: object) -> object:
+    """Lazily construct a :class:`LiblinphoneBackend` from the supplied config.
+
+    The import happens here so the sidecar process pays it only once on first
+    :class:`Configure` and tests that inject a different factory never trigger
+    the native shim load.
+    """
+
+    from yoyopod.backends.voip import LiblinphoneBackend
+    from yoyopod.integrations.call.models import VoIPConfig
+
+    if not isinstance(config, VoIPConfig):
+        raise TypeError(
+            f"_default_liblinphone_factory expected VoIPConfig, got {type(config).__name__}"
+        )
+    return LiblinphoneBackend(config)

--- a/yoyopod/integrations/call/sidecar_protocol.py
+++ b/yoyopod/integrations/call/sidecar_protocol.py
@@ -39,12 +39,23 @@ class Hello:
 
 
 @dataclass(frozen=True, slots=True)
-class Register:
-    """Initiate SIP registration with the configured account."""
+class Configure:
+    """Send the serialized ``VoIPConfig`` to the sidecar before registration.
 
-    server: str
-    user: str
-    password: str
+    ``config`` carries a ``dataclasses.asdict``-style payload of
+    :class:`yoyopod.integrations.call.models.VoIPConfig`. The sidecar
+    reconstructs the dataclass and asks the backend factory for a fresh
+    backend; idempotent calls replace the prior backend cleanly.
+    """
+
+    config: dict[str, Any]
+    cmd_id: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Register:
+    """Initiate SIP registration with the previously :class:`Configure`-d account."""
+
     cmd_id: int | None = None
 
 
@@ -202,6 +213,7 @@ class Log:
 # can decode the handshake without special-casing.
 _COMMAND_REGISTRY: dict[str, type[Any]] = {
     "Hello": Hello,
+    "Configure": Configure,
     "Register": Register,
     "Unregister": Unregister,
     "Dial": Dial,

--- a/yoyopod/integrations/call/sidecar_supervisor.py
+++ b/yoyopod/integrations/call/sidecar_supervisor.py
@@ -315,8 +315,12 @@ class SidecarSupervisor:
 
         deadline = time.monotonic() + self._handshake_timeout_seconds
         while time.monotonic() < deadline:
-            if not conn.poll(timeout=0.1):
-                continue
+            try:
+                if not conn.poll(timeout=0.1):
+                    continue
+            except (BrokenPipeError, EOFError, OSError) as exc:
+                logger.warning("Sidecar handshake poll failed: {}", exc)
+                return False
             try:
                 event = recv_event(conn)
             except (BrokenPipeError, EOFError, OSError) as exc:


### PR DESCRIPTION
## Summary

Phase 2B.2 of the concurrency rework. Replaces the scaffold ack-as-Log dispatcher in `sidecar_main.py` with a real backend integration: the sidecar constructs a `VoIPBackend` on `Configure`, runs an iterate thread that drives the backend's keep-alive cadence, and translates backend `VoIPEvent`s to protocol events as they arrive.

**Stacked on top of #378** (which is itself stacked on #377). Will rebase to main once those land.

### Protocol changes (backward-incompatible vs Phase 2A scaffold)

- New `Configure(config: dict, cmd_id)` command — main sends a serialized `VoIPConfig` (`dataclasses.asdict`) so the sidecar can construct the backend.
- `Register` no longer takes `server`/`user`/`password`; it just calls `backend.start()` on the previously `Configure`-d account.

### New `SidecarBackendAdapter`

`yoyopod/integrations/call/sidecar_adapter.py` owns:
- **Command dispatch**: `Configure`/`Register`/`Unregister`/`Dial`/`Accept`/`Reject`/`Hangup`/`SetMute`/`SetVolume`/`Ping` → `VoIPBackend` methods.
- **Lazy backend construction** via injected factory. Default is `_default_liblinphone_factory` which lazy-imports `LiblinphoneBackend`. Tests inject `MockVoIPBackend` instead — never triggers the native shim load.
- **Iterate thread** — drives `backend.iterate()` at `config.iterate_interval_ms` (default 20ms), exits cleanly on shutdown.
- **Thread-safe pipe writes** — `_send_lock` serializes frames between the command-handler thread and the iterate thread so they never interleave.
- **Call ID minting** — `VoIPBackend` is implicitly single-call (no `call_id` parameter on its methods). The adapter mints `call-1`, `call-2`, ... and validates incoming `Accept`/`Hangup`/`SetMute` against the current call.
- **Backend → protocol event mapping**: `RegistrationStateChanged` → `RegistrationStateChanged(state)`, `IncomingCallDetected` → `IncomingCall(call_id, from_uri)`, `CallStateChanged` → `CallStateChanged(call_id, state)`, `BackendStopped` → `Error(code=\"backend_stopped\")`.

### `sidecar_main.run_sidecar` refactor

- Accepts optional `backend_factory` parameter; default lazy-imports `LiblinphoneBackend`.
- After handshake, constructs `SidecarBackendAdapter` and routes every non-`Shutdown` command through it. Adapter shutdown runs in the `finally` block so the iterate thread always joins.

### Supervisor robustness fix

`_await_handshake` now catches `BrokenPipeError` from `conn.poll()` on Windows when the child exits before responding. Was intermittently failing `test_start_after_permanent_failure_raises`.

## Test plan

- [x] `uv run pytest -q` — **1246 passed**, 21 skipped (vs 1219 baseline; +27 new tests)
- [x] `uv run python scripts/quality.py gate` — passed
- [x] **19 adapter unit tests** in `tests/integrations/call/test_sidecar_adapter.py`: Configure happy + invalid-config; Register before/after Configure; backend.start() returning False; Unregister; Dial assigns call_id; Dial-while-call-in-progress; Accept/Hangup/Reject with call-id validation; SetMute emits MediaStateChanged; SetVolume; backend events → protocol events; `Pong` without backend; Ping.
- [x] **7 end-to-end loopback tests** in `tests/integrations/call/test_sidecar_loopback_with_backend.py`: full `SidecarSupervisor` → `run_sidecar` → `SidecarBackendAdapter` → `MockVoIPBackend` flow inside one process via loopback (#378).
- [x] All 39 existing protocol/supervisor/loopback tests still green.
- Hardware verification on the Pi happens in Phase 2B.3 once `VoIPManager` is routed through the supervisor.

### What this is NOT

- No `VoIPManager` refactor — that's Phase 2B.3.
- No `RuntimeBootService` wiring — that's Phase 2B.3.
- No real-liblinphone tests — `_default_liblinphone_factory` is in place but only exercised on the Pi (gated by hardware availability of the native shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)