### PR TITLE
feat(voip): add SupervisorBackedBackend (opt-in sidecar VoIP)

### DIFF
--- a/tests/backends/test_supervisor_backed_voip.py
+++ b/tests/backends/test_supervisor_backed_voip.py
@@ -1,0 +1,395 @@
+"""Unit + loopback-integration tests for :class:`SupervisorBackedBackend`.
+
+Two layers of coverage:
+
+1. **Unit tests** with a fake supervisor verify the protocol-event ->
+   :class:`VoIPEvent` translation and the command dispatch decisions
+   without spawning anything.
+2. **Loopback integration test** wires a real :class:`SidecarSupervisor`
+   in loopback mode against a :class:`MockVoIPBackend` factory and
+   exercises the full ``start -> register -> dial -> hangup`` round trip
+   end-to-end. This is the harness that proves the protocol/event
+   plumbing is wired correctly without paying the spawn cost or
+   depending on real liblinphone.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import threading
+import time
+from collections.abc import Callable
+from multiprocessing.connection import Connection
+from typing import Any
+
+import pytest
+
+from yoyopod.backends.voip.mock_backend import MockVoIPBackend
+from yoyopod.backends.voip.supervisor_backed import SupervisorBackedBackend
+from yoyopod.integrations.call.models import (
+    BackendStopped,
+    CallState,
+    CallStateChanged as BackendCallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged as BackendRegistrationStateChanged,
+    VoIPConfig,
+    VoIPEvent,
+)
+from yoyopod.integrations.call.sidecar_main import run_sidecar
+from yoyopod.integrations.call.sidecar_protocol import (
+    Accept,
+    Configure,
+    Dial,
+    Error as ProtocolError,
+    Hangup,
+    Hello,
+    IncomingCall,
+    Log as ProtocolLog,
+    MediaStateChanged,
+    Pong,
+    Ready,
+    Register,
+    RegistrationStateChanged as ProtocolRegistrationStateChanged,
+    SetMute,
+    Unregister,
+    CallStateChanged as ProtocolCallStateChanged,
+)
+from yoyopod.integrations.call.sidecar_supervisor import SidecarSupervisor
+
+LOOPBACK_BUDGET_SECONDS = 2.0
+
+
+def _config() -> VoIPConfig:
+    return VoIPConfig(sip_server="sip.example.com", sip_identity="sip:alice@example.com")
+
+
+# ---------------------------------------------------------------------------
+# Fake supervisor for unit tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeSupervisor:
+    """Minimal stand-in that records sent commands and exposes ``_on_event``."""
+
+    def __init__(self) -> None:
+        self.sent: list[Any] = []
+        self.started = False
+        self.stopped = False
+        self.send_should_raise: Exception | None = None
+        self.start_should_raise: Exception | None = None
+        # Set after attachment by the backend constructor.
+        self._on_event: Callable[[Any], None] | None = None
+
+    def start(self) -> None:
+        if self.start_should_raise is not None:
+            raise self.start_should_raise
+        self.started = True
+
+    def stop(self, *, timeout_seconds: float = 2.0) -> None:
+        self.stopped = True
+
+    def send(self, command: Any) -> None:
+        if self.send_should_raise is not None:
+            raise self.send_should_raise
+        self.sent.append(command)
+
+    # ``_on_event`` mimics the supervisor's internal handler attribute the
+    # backend reaches for in __init__; nothing on this fake actually calls it.
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: command dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_start_sends_configure_then_register_in_order() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+
+    assert backend.start() is True
+    assert fake.started is True
+    assert backend.running is True
+    assert [type(cmd).__name__ for cmd in fake.sent] == ["Configure", "Register"]
+    cfg_cmd: Configure = fake.sent[0]
+    assert cfg_cmd.config == dataclasses.asdict(_config())
+
+
+def test_start_returns_false_when_supervisor_refuses() -> None:
+    fake = _FakeSupervisor()
+    fake.start_should_raise = RuntimeError("permanently failed")
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    assert backend.start() is False
+    assert backend.running is False
+
+
+def test_start_returns_false_when_configure_send_fails() -> None:
+    fake = _FakeSupervisor()
+    fake.send_should_raise = RuntimeError("not running")
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    assert backend.start() is False
+    assert backend.running is False
+
+
+def test_make_call_sends_dial_command() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    backend.start()
+    fake.sent.clear()
+
+    assert backend.make_call("sip:bob@example.com") is True
+    assert isinstance(fake.sent[-1], Dial)
+    assert fake.sent[-1].uri == "sip:bob@example.com"
+
+
+def test_answer_call_without_tracked_call_returns_false() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    assert backend.answer_call() is False
+    assert not any(type(cmd).__name__ == "Accept" for cmd in fake.sent)
+
+
+def test_answer_call_with_tracked_call_sends_accept() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    backend._set_current_call_id("call-7")
+    assert backend.answer_call() is True
+    assert isinstance(fake.sent[-1], Accept)
+    assert fake.sent[-1].call_id == "call-7"
+
+
+def test_hangup_with_tracked_call_sends_hangup() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    backend._set_current_call_id("call-3")
+    assert backend.hangup() is True
+    assert isinstance(fake.sent[-1], Hangup)
+    assert fake.sent[-1].call_id == "call-3"
+
+
+def test_mute_unmute_send_correct_set_mute_commands() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    backend._set_current_call_id("call-1")
+
+    assert backend.mute() is True
+    assert isinstance(fake.sent[-1], SetMute)
+    assert fake.sent[-1].on is True
+
+    assert backend.unmute() is True
+    assert fake.sent[-1].on is False
+
+
+def test_iterate_returns_zero_and_get_iterate_metrics_returns_none() -> None:
+    backend = SupervisorBackedBackend(_config(), supervisor=_FakeSupervisor())
+    assert backend.iterate() == 0
+    assert backend.get_iterate_metrics() is None
+
+
+@pytest.mark.parametrize(
+    "method, args",
+    [
+        ("send_text_message", ("sip:bob", "hi")),
+        ("start_voice_note_recording", ("/tmp/note.wav",)),
+        ("stop_voice_note_recording", ()),
+        ("cancel_voice_note_recording", ()),
+    ],
+)
+def test_messaging_methods_raise_not_implemented(method: str, args: tuple) -> None:
+    backend = SupervisorBackedBackend(_config(), supervisor=_FakeSupervisor())
+    with pytest.raises(NotImplementedError, match="Messaging and voice notes"):
+        getattr(backend, method)(*args)
+
+
+def test_send_voice_note_raises_not_implemented() -> None:
+    backend = SupervisorBackedBackend(_config(), supervisor=_FakeSupervisor())
+    with pytest.raises(NotImplementedError, match="Messaging and voice notes"):
+        backend.send_voice_note(
+            "sip:bob", file_path="/tmp/note.wav", duration_ms=1500, mime_type="audio/wav"
+        )
+
+
+def test_stop_sends_unregister_and_clears_call_state() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    backend.start()
+    backend._set_current_call_id("call-9")
+
+    backend.stop()
+
+    assert backend.running is False
+    assert fake.stopped is True
+    # The last command sent before stop() should be Unregister.
+    assert any(isinstance(cmd, Unregister) for cmd in fake.sent)
+    assert backend._read_current_call_id() is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: protocol -> VoIP event translation
+# ---------------------------------------------------------------------------
+
+
+def test_registration_state_event_translates_to_voip_event() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    received: list[VoIPEvent] = []
+    backend.on_event(received.append)
+
+    backend._on_protocol_event(ProtocolRegistrationStateChanged(state="ok", reason=None))
+    assert received and isinstance(received[-1], BackendRegistrationStateChanged)
+    assert received[-1].state == RegistrationState.OK
+
+
+def test_incoming_call_event_tracks_call_id_and_dispatches() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    received: list[VoIPEvent] = []
+    backend.on_event(received.append)
+
+    backend._on_protocol_event(
+        IncomingCall(call_id="call-42", from_uri="sip:bob@example.com", from_display=None)
+    )
+    assert backend._read_current_call_id() == "call-42"
+    assert any(
+        isinstance(event, IncomingCallDetected) and event.caller_address == "sip:bob@example.com"
+        for event in received
+    )
+
+
+def test_call_state_terminal_clears_call_id() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    backend._set_current_call_id("call-5")
+
+    backend._on_protocol_event(ProtocolCallStateChanged(call_id="call-5", state="released"))
+    assert backend._read_current_call_id() is None
+
+
+def test_call_state_non_terminal_tracks_call_id_for_outgoing_dial() -> None:
+    """Outgoing Dial flow: CallStateChanged with non-terminal state should populate _current_call_id."""
+
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+
+    backend._on_protocol_event(ProtocolCallStateChanged(call_id="call-99", state="connected"))
+    assert backend._read_current_call_id() == "call-99"
+
+
+def test_protocol_error_with_backend_stopped_dispatches_voip_event() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    backend._set_current_call_id("call-stuck")
+    received: list[VoIPEvent] = []
+    backend.on_event(received.append)
+
+    backend._on_protocol_event(
+        ProtocolError(code="backend_stopped", message="iterate failed", cmd_id=None)
+    )
+    assert backend._read_current_call_id() is None
+    assert any(
+        isinstance(event, BackendStopped) and "iterate failed" in event.reason for event in received
+    )
+
+
+def test_protocol_only_events_are_ignored() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    received: list[VoIPEvent] = []
+    backend.on_event(received.append)
+
+    for event in (
+        Hello(version=1),
+        Ready(),
+        Pong(cmd_id=1),
+        MediaStateChanged(call_id="x", mic_muted=False, speaker_volume=1.0),
+        ProtocolLog(level="DEBUG", message="hi"),
+    ):
+        backend._on_protocol_event(event)
+    assert received == []
+
+
+def test_unknown_registration_state_logs_and_drops() -> None:
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    received: list[VoIPEvent] = []
+    backend.on_event(received.append)
+
+    backend._on_protocol_event(ProtocolRegistrationStateChanged(state="bogus", reason=None))
+    assert received == []
+
+
+# ---------------------------------------------------------------------------
+# Loopback integration test
+# ---------------------------------------------------------------------------
+
+
+# Module-level so the loopback-mode sidecar target can resolve the shared
+# mock backend (loopback runs in-process so closures would also work, but
+# keeping symmetry with the spawn case is cheap).
+_TEST_BACKEND_HANDLE: dict[str, MockVoIPBackend] = {}
+
+
+def _shared_mock_backend_factory(_config: VoIPConfig) -> MockVoIPBackend:
+    return _TEST_BACKEND_HANDLE["backend"]
+
+
+def _sidecar_target(conn: Connection) -> None:
+    run_sidecar(conn, backend_factory=_shared_mock_backend_factory)
+
+
+def _wait_for(pred, *, timeout: float = LOOPBACK_BUDGET_SECONDS) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+def test_loopback_end_to_end_call_flow() -> None:
+    """End-to-end: backend.start -> sidecar Configure+Register, dial, accept, hangup."""
+
+    backend_inside_sidecar = MockVoIPBackend()
+    _TEST_BACKEND_HANDLE["backend"] = backend_inside_sidecar
+    try:
+        supervisor = SidecarSupervisor(
+            on_event=lambda _event: None,  # backend overrides this in __init__
+            sidecar_target=_sidecar_target,
+            use_loopback=True,
+            handshake_timeout_seconds=LOOPBACK_BUDGET_SECONDS,
+        )
+        backend = SupervisorBackedBackend(_config(), supervisor=supervisor)
+        received: list[VoIPEvent] = []
+        backend.on_event(received.append)
+
+        try:
+            assert backend.start() is True
+            assert _wait_for(lambda: backend_inside_sidecar.running)
+
+            # Drive a registration state change inside the sidecar — should
+            # surface as a VoIPEvent on the main side.
+            backend_inside_sidecar.emit(BackendRegistrationStateChanged(state=RegistrationState.OK))
+            assert _wait_for(
+                lambda: any(
+                    isinstance(event, BackendRegistrationStateChanged)
+                    and event.state == RegistrationState.OK
+                    for event in received
+                )
+            )
+
+            # Drive an incoming-call flow.
+            backend_inside_sidecar.emit(IncomingCallDetected(caller_address="sip:bob@example.com"))
+            assert _wait_for(
+                lambda: any(isinstance(event, IncomingCallDetected) for event in received)
+            )
+            assert _wait_for(lambda: backend._read_current_call_id() is not None)
+
+            assert backend.answer_call() is True
+            assert _wait_for(lambda: "answer" in backend_inside_sidecar.commands)
+
+            assert backend.hangup() is True
+            assert _wait_for(lambda: "terminate" in backend_inside_sidecar.commands)
+        finally:
+            backend.stop()
+    finally:
+        _TEST_BACKEND_HANDLE.clear()

--- a/tests/backends/test_supervisor_backed_voip.py
+++ b/tests/backends/test_supervisor_backed_voip.py
@@ -348,6 +348,109 @@ def test_call_in_progress_error_during_active_call_drops_to_error() -> None:
     assert backend._read_current_call_id() is None
 
 
+def test_call_fatal_error_dispatches_even_without_tracked_call() -> None:
+    """Call-fatal codes must always dispatch CallStateChanged(ERROR).
+
+    Codex follow-up review on #393 (P1 repeat): the previous guard
+    skipped dispatch when ``_current_call_id`` was None for codes other
+    than ``dial_failed``. That left the UI stranded if sidecar's
+    ``_current_call_id`` was set but main's tracker was not (e.g.,
+    back-to-back Dials, or stale ``unknown_call_id`` rejections).
+    """
+
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    received: list[VoIPEvent] = []
+    backend.on_event(received.append)
+
+    backend._on_protocol_event(ProtocolError(code="call_in_progress", message="busy", cmd_id=1))
+    assert any(
+        isinstance(event, BackendCallStateChanged) and event.state == CallState.ERROR
+        for event in received
+    )
+
+    received.clear()
+    backend._on_protocol_event(ProtocolError(code="unknown_call_id", message="stale", cmd_id=2))
+    assert any(
+        isinstance(event, BackendCallStateChanged) and event.state == CallState.ERROR
+        for event in received
+    )
+
+
+def test_on_ready_during_initial_start_does_not_resend_configure() -> None:
+    """The very first handshake fires on_ready while ``running`` is still False.
+
+    During ``start()`` the supervisor invokes ``on_ready`` between handshake
+    success and ``start()``'s own Configure+Register sends. The handler
+    must not duplicate the Configure that ``start()`` is about to issue.
+    """
+
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    # Running is False before start(); on_ready should be a no-op.
+    assert backend.running is False
+    backend._on_supervisor_ready()
+    assert fake.sent == []
+
+
+def test_on_ready_after_restart_resends_configure_and_register() -> None:
+    """After a transparent supervisor restart, the new sidecar is blank.
+
+    Codex follow-up review on #393 (P1 new): the previous backend only
+    sent Configure + Register inside ``start()``. A pipe-death triggered
+    a transparent supervisor restart; the new sidecar came up with no
+    backend configured and rejected later commands as ``not_configured``,
+    while ``make_call`` still returned True from the optimistic pipe send.
+
+    The fix adds an ``on_ready`` callback the supervisor fires after
+    every successful handshake, and the backend re-issues Configure +
+    Register against the freshly handshaked sidecar.
+    """
+
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    received: list[VoIPEvent] = []
+    backend.on_event(received.append)
+
+    # Initial start — sends Configure + Register.
+    assert backend.start() is True
+    initial_sends = list(fake.sent)
+    assert [type(cmd).__name__ for cmd in initial_sends] == ["Configure", "Register"]
+
+    # Track a call to verify the ready handler clears stale state.
+    backend._set_current_call_id("call-77")
+    fake.sent.clear()
+    received.clear()
+
+    # Simulate the supervisor calling on_ready after a transparent restart.
+    backend._on_supervisor_ready()
+
+    # Configure + Register were re-sent against the new sidecar.
+    assert [type(cmd).__name__ for cmd in fake.sent] == ["Configure", "Register"]
+    # The stale call id was cleared so a fresh dial is not blocked.
+    assert backend._read_current_call_id() is None
+    # Listeners got a registration-progress event so the UI knows we're
+    # re-registering against the fresh sidecar.
+    assert any(
+        isinstance(event, BackendRegistrationStateChanged)
+        and event.state == RegistrationState.PROGRESS
+        for event in received
+    )
+
+
+def test_on_ready_after_restart_logs_when_resend_fails() -> None:
+    """If the supervisor cannot accept the re-Configure, the backend logs and continues."""
+
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    backend.start()
+    fake.send_should_raise = RuntimeError("sidecar pipe closed mid-restart")
+    fake.sent.clear()
+
+    # Should not raise — error is logged and swallowed.
+    backend._on_supervisor_ready()
+
+
 def test_register_failed_error_dispatches_registration_failed() -> None:
     """``register_failed`` must surface as RegistrationStateChanged(FAILED)."""
 

--- a/tests/backends/test_supervisor_backed_voip.py
+++ b/tests/backends/test_supervisor_backed_voip.py
@@ -123,6 +123,22 @@ def test_start_returns_false_when_supervisor_refuses() -> None:
     assert backend.running is False
 
 
+def test_start_returns_false_on_spawn_oserror_instead_of_crashing() -> None:
+    """Process spawn failures (OSError) must degrade to ``start() == False``.
+
+    Codex review on #393 (P2): the original ``except RuntimeError`` was
+    too narrow — ``multiprocessing.Process.start()`` can raise OSError
+    (Windows path issues, Linux fork limits, etc.) and that would have
+    escaped this method and crashed ``ManagersBoot.init_managers``.
+    """
+
+    fake = _FakeSupervisor()
+    fake.start_should_raise = OSError("simulated spawn failure")
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    assert backend.start() is False
+    assert backend.running is False
+
+
 def test_start_returns_false_when_configure_send_fails() -> None:
     fake = _FakeSupervisor()
     fake.send_should_raise = RuntimeError("not running")
@@ -289,6 +305,77 @@ def test_protocol_error_with_backend_stopped_dispatches_voip_event() -> None:
     assert any(
         isinstance(event, BackendStopped) and "iterate failed" in event.reason for event in received
     )
+
+
+def test_dial_failed_error_drops_call_state_to_error() -> None:
+    """``dial_failed`` must surface as CallStateChanged(ERROR) so optimistic UI drops back to idle.
+
+    Codex review on #393 (P1): previously ``make_call`` returned True from
+    the optimistic pipe-send, but a sidecar-side rejection (``dial_failed``,
+    ``call_in_progress``, ...) only got logged. Without a corrective event
+    the UI/runtime stayed in "dialing" state forever.
+    """
+
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    received: list[VoIPEvent] = []
+    backend.on_event(received.append)
+
+    backend._on_protocol_event(
+        ProtocolError(code="dial_failed", message="backend.make_call returned False", cmd_id=3)
+    )
+    assert any(
+        isinstance(event, BackendCallStateChanged) and event.state == CallState.ERROR
+        for event in received
+    )
+    assert backend._read_current_call_id() is None
+
+
+def test_call_in_progress_error_during_active_call_drops_to_error() -> None:
+    """``call_in_progress`` while a call id is tracked must trigger the error transition."""
+
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    backend._set_current_call_id("call-12")
+    received: list[VoIPEvent] = []
+    backend.on_event(received.append)
+
+    backend._on_protocol_event(ProtocolError(code="call_in_progress", message="...", cmd_id=4))
+    assert any(
+        isinstance(event, BackendCallStateChanged) and event.state == CallState.ERROR
+        for event in received
+    )
+    assert backend._read_current_call_id() is None
+
+
+def test_register_failed_error_dispatches_registration_failed() -> None:
+    """``register_failed`` must surface as RegistrationStateChanged(FAILED)."""
+
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    received: list[VoIPEvent] = []
+    backend.on_event(received.append)
+
+    backend._on_protocol_event(ProtocolError(code="register_failed", message="bad creds", cmd_id=2))
+    assert any(
+        isinstance(event, BackendRegistrationStateChanged)
+        and event.state == RegistrationState.FAILED
+        for event in received
+    )
+
+
+def test_unrelated_error_codes_do_not_dispatch_voip_event() -> None:
+    """Errors that are neither call-fatal nor registration-fatal stay log-only."""
+
+    fake = _FakeSupervisor()
+    backend = SupervisorBackedBackend(_config(), supervisor=fake)
+    received: list[VoIPEvent] = []
+    backend.on_event(received.append)
+
+    backend._on_protocol_event(
+        ProtocolError(code="invalid_config", message="bogus field", cmd_id=1)
+    )
+    assert received == []
 
 
 def test_protocol_only_events_are_ignored() -> None:

--- a/yoyopod/backends/voip/supervisor_backed.py
+++ b/yoyopod/backends/voip/supervisor_backed.py
@@ -1,0 +1,352 @@
+"""VoIPBackend implementation that delegates to a sidecar process.
+
+Production wires this backend up when ``YOYOPOD_VOIP_SIDECAR=1`` is set.
+The :class:`SidecarSupervisor` owns the sidecar process; this backend
+adapts the synchronous :class:`yoyopod.backends.voip.protocol.VoIPBackend`
+surface that :class:`VoIPManager` already consumes onto the asynchronous
+command/event protocol the sidecar speaks.
+
+Translation responsibilities:
+
+* :meth:`start` / :meth:`stop` drive ``supervisor.start()`` /
+  ``supervisor.stop()`` and send ``Configure`` / ``Register`` /
+  ``Unregister`` commands at the right moments.
+* Per-call methods (:meth:`make_call`, :meth:`answer_call`,
+  :meth:`hangup`, :meth:`mute`, :meth:`unmute`, ...) translate to
+  ``Dial`` / ``Accept`` / ``Reject`` / ``Hangup`` / ``SetMute`` commands.
+* Backend events emitted by the sidecar are translated back to
+  :class:`yoyopod.integrations.call.models.VoIPEvent` instances and fired
+  to the callbacks registered via :meth:`on_event` so callers do not
+  need to know whether the backend is in-process or sidecar-backed.
+
+Phase 2B.3 ships the call surface only. Messaging and voice-note
+methods raise :class:`NotImplementedError` so callers fail loud rather
+than silently dropping IM frames; Phase 2B.4 will extend the protocol
+and wire those through.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.backends.voip.protocol import VoIPIterateMetrics
+from yoyopod.integrations.call.models import (
+    BackendStopped,
+    CallState,
+    CallStateChanged as BackendCallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged as BackendRegistrationStateChanged,
+    VoIPConfig,
+    VoIPEvent,
+)
+from yoyopod.integrations.call.sidecar_protocol import (
+    Accept,
+    CallStateChanged as ProtocolCallStateChanged,
+    Configure,
+    Dial,
+    Error as ProtocolError,
+    Hangup,
+    Hello,
+    IncomingCall,
+    Log as ProtocolLog,
+    MediaStateChanged,
+    Pong,
+    Ready,
+    Register,
+    RegistrationStateChanged as ProtocolRegistrationStateChanged,
+    Reject,
+    SetMute,
+    Unregister,
+)
+from yoyopod.integrations.call.sidecar_supervisor import SidecarSupervisor
+
+_NOT_SUPPORTED_MESSAGE = (
+    "Messaging and voice notes are not yet wired through the VoIP sidecar; "
+    "Phase 2B.4 will extend the protocol. Disable YOYOPOD_VOIP_SIDECAR to "
+    "fall back to the in-process backend if you need them now."
+)
+
+
+# States that mean the call has fully ended and the tracked id should be cleared.
+_TERMINAL_CALL_STATES = frozenset(
+    {
+        CallState.RELEASED,
+        CallState.END,
+        CallState.ERROR,
+        CallState.IDLE,
+    }
+)
+
+
+# Liblinphone log levels arrive as strings; map to loguru levels.
+_LOG_LEVEL_MAP = {
+    "DEBUG": "DEBUG",
+    "INFO": "INFO",
+    "WARNING": "WARNING",
+    "ERROR": "ERROR",
+    "CRITICAL": "CRITICAL",
+}
+
+
+class SupervisorBackedBackend:
+    """``VoIPBackend`` adapter on top of a :class:`SidecarSupervisor`."""
+
+    def __init__(
+        self,
+        config: VoIPConfig,
+        *,
+        supervisor: SidecarSupervisor | None = None,
+    ) -> None:
+        self.config = config
+        self.running = False
+        self.event_callbacks: list[Callable[[VoIPEvent], None]] = []
+
+        self._supervisor = supervisor or SidecarSupervisor(on_event=self._on_protocol_event)
+        # If the caller passed in a pre-built supervisor, rewire its event
+        # handler to ours so events from the sidecar reach this backend.
+        if supervisor is not None:
+            self._supervisor._on_event = self._on_protocol_event  # type: ignore[attr-defined]
+
+        self._call_lock = threading.Lock()
+        self._current_call_id: str | None = None
+
+    # ------------------------------------------------------------------
+    # VoIPBackend surface
+    # ------------------------------------------------------------------
+
+    def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
+        """Register a callback for translated VoIP events."""
+
+        self.event_callbacks.append(callback)
+
+    def start(self) -> bool:
+        """Spawn the sidecar (if needed), Configure it, and Register."""
+
+        try:
+            self._supervisor.start()
+        except RuntimeError as exc:
+            logger.error("VoIP sidecar supervisor refused to start: {}", exc)
+            return False
+
+        config_dict = dataclasses.asdict(self.config)
+        try:
+            self._supervisor.send(Configure(config=config_dict))
+            self._supervisor.send(Register())
+        except RuntimeError as exc:
+            logger.error("VoIP sidecar refused configure/register command: {}", exc)
+            return False
+
+        self.running = True
+        return True
+
+    def stop(self) -> None:
+        """Send Unregister and stop the sidecar supervisor."""
+
+        # Best-effort Unregister; if the supervisor is already in a non-running
+        # state ``send`` raises and we proceed straight to stop().
+        try:
+            self._supervisor.send(Unregister())
+        except RuntimeError:
+            pass
+        self._supervisor.stop()
+        self.running = False
+        self._reset_call_state()
+
+    def iterate(self) -> int:
+        """No-op: the sidecar drives its own iterate cadence."""
+
+        return 0
+
+    def get_iterate_metrics(self) -> VoIPIterateMetrics | None:
+        """The sidecar owns iterate metrics; the main process does not see them."""
+
+        return None
+
+    def make_call(self, sip_address: str) -> bool:
+        """Send a Dial command. Backend events surface call progress."""
+
+        return self._send_or_log(Dial(uri=sip_address), label="Dial")
+
+    def answer_call(self) -> bool:
+        """Accept the currently-tracked incoming call."""
+
+        call_id = self._read_current_call_id()
+        if call_id is None:
+            logger.warning("answer_call called with no tracked call")
+            return False
+        return self._send_or_log(Accept(call_id=call_id), label="Accept")
+
+    def reject_call(self) -> bool:
+        """Reject the currently-tracked incoming call."""
+
+        call_id = self._read_current_call_id()
+        if call_id is None:
+            logger.warning("reject_call called with no tracked call")
+            return False
+        return self._send_or_log(Reject(call_id=call_id), label="Reject")
+
+    def hangup(self) -> bool:
+        """Terminate the currently-tracked active call."""
+
+        call_id = self._read_current_call_id()
+        if call_id is None:
+            logger.warning("hangup called with no tracked call")
+            return False
+        return self._send_or_log(Hangup(call_id=call_id), label="Hangup")
+
+    def mute(self) -> bool:
+        """Mute the local microphone for the currently-tracked call."""
+
+        call_id = self._read_current_call_id()
+        if call_id is None:
+            logger.warning("mute called with no tracked call")
+            return False
+        return self._send_or_log(SetMute(call_id=call_id, on=True), label="SetMute(on)")
+
+    def unmute(self) -> bool:
+        """Unmute the local microphone for the currently-tracked call."""
+
+        call_id = self._read_current_call_id()
+        if call_id is None:
+            logger.warning("unmute called with no tracked call")
+            return False
+        return self._send_or_log(SetMute(call_id=call_id, on=False), label="SetMute(off)")
+
+    def send_text_message(self, sip_address: str, text: str) -> str | None:
+        """Not yet supported in sidecar mode."""
+
+        raise NotImplementedError(_NOT_SUPPORTED_MESSAGE)
+
+    def start_voice_note_recording(self, file_path: str) -> bool:
+        """Not yet supported in sidecar mode."""
+
+        raise NotImplementedError(_NOT_SUPPORTED_MESSAGE)
+
+    def stop_voice_note_recording(self) -> int | None:
+        """Not yet supported in sidecar mode."""
+
+        raise NotImplementedError(_NOT_SUPPORTED_MESSAGE)
+
+    def cancel_voice_note_recording(self) -> bool:
+        """Not yet supported in sidecar mode."""
+
+        raise NotImplementedError(_NOT_SUPPORTED_MESSAGE)
+
+    def send_voice_note(
+        self,
+        sip_address: str,
+        *,
+        file_path: str,
+        duration_ms: int,
+        mime_type: str,
+    ) -> str | None:
+        """Not yet supported in sidecar mode."""
+
+        raise NotImplementedError(_NOT_SUPPORTED_MESSAGE)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _send_or_log(self, command: Any, *, label: str) -> bool:
+        """Send a command and return ``False`` on supervisor errors."""
+
+        try:
+            self._supervisor.send(command)
+            return True
+        except RuntimeError as exc:
+            logger.error("VoIP sidecar refused {} command: {}", label, exc)
+            return False
+
+    def _read_current_call_id(self) -> str | None:
+        with self._call_lock:
+            return self._current_call_id
+
+    def _set_current_call_id(self, call_id: str | None) -> None:
+        with self._call_lock:
+            self._current_call_id = call_id
+
+    def _reset_call_state(self) -> None:
+        self._set_current_call_id(None)
+
+    def _on_protocol_event(self, event: Any) -> None:
+        """Translate a protocol event from the sidecar into a ``VoIPEvent``."""
+
+        # Protocol-only events that don't surface to the call layer.
+        if isinstance(event, (Hello, Ready, Pong, MediaStateChanged)):
+            return
+
+        if isinstance(event, ProtocolLog):
+            self._forward_log(event)
+            return
+
+        if isinstance(event, ProtocolError):
+            logger.warning(
+                "VoIP sidecar reported error: code={!r} message={!r} cmd_id={}",
+                event.code,
+                event.message,
+                event.cmd_id,
+            )
+            # ``backend_stopped`` is the supervisor's signal that the sidecar's
+            # backend is gone — surface as a BackendStopped event so existing
+            # recovery paths can react.
+            if event.code == "backend_stopped":
+                self._reset_call_state()
+                self._dispatch(BackendStopped(reason=event.message))
+            return
+
+        if isinstance(event, ProtocolRegistrationStateChanged):
+            try:
+                state = RegistrationState(event.state)
+            except ValueError:
+                logger.warning("Sidecar emitted unknown registration state {!r}", event.state)
+                return
+            self._dispatch(BackendRegistrationStateChanged(state=state))
+            return
+
+        if isinstance(event, IncomingCall):
+            self._set_current_call_id(event.call_id)
+            self._dispatch(IncomingCallDetected(caller_address=event.from_uri))
+            return
+
+        if isinstance(event, ProtocolCallStateChanged):
+            try:
+                state = CallState(event.state)
+            except ValueError:
+                logger.warning("Sidecar emitted unknown call state {!r}", event.state)
+                return
+            # Track the call id whenever a non-terminal state arrives so
+            # outgoing-call flows (Dial -> CallStateChanged) populate it
+            # without an IncomingCall ever firing.
+            if state not in _TERMINAL_CALL_STATES:
+                self._set_current_call_id(event.call_id)
+            else:
+                self._reset_call_state()
+            self._dispatch(BackendCallStateChanged(state=state))
+            return
+
+        # Anything else (DTMFReceived, etc.) — log and drop. Future events get
+        # explicit handling here as they're added.
+        logger.debug(
+            "SupervisorBackedBackend dropping unhandled event {}",
+            type(event).__name__,
+        )
+
+    def _dispatch(self, event: VoIPEvent) -> None:
+        """Fire a translated VoIP event to all registered callbacks."""
+
+        for callback in list(self.event_callbacks):
+            try:
+                callback(event)
+            except Exception:
+                logger.exception("VoIP event callback raised for {}", type(event).__name__)
+
+    def _forward_log(self, event: ProtocolLog) -> None:
+        level = _LOG_LEVEL_MAP.get(event.level.upper(), "INFO")
+        logger.bind(subsystem="comm").log(level, "[voip-sidecar] {}", event.message)

--- a/yoyopod/backends/voip/supervisor_backed.py
+++ b/yoyopod/backends/voip/supervisor_backed.py
@@ -94,6 +94,30 @@ _LOG_LEVEL_MAP = {
 }
 
 
+# Sidecar error codes emitted by ``SidecarBackendAdapter`` that mean the
+# active call is finished or the attempted dial was refused. Surfacing
+# them as ``BackendCallStateChanged(ERROR)`` lets the existing
+# ``VoIPManager`` state machine retreat to idle instead of leaving the UI
+# stuck in "dialing" / "connecting" after an optimistic make_call.
+_CALL_FATAL_ERROR_CODES = frozenset(
+    {
+        "dial_failed",
+        "call_in_progress",
+        "accept_failed",
+        "reject_failed",
+        "hangup_failed",
+        "mute_failed",
+        "unknown_call_id",
+    }
+)
+
+
+# Sidecar error codes that mean SIP registration cannot proceed. Translate
+# to ``BackendRegistrationStateChanged(FAILED)`` so the manager can
+# surface a "registration failed" status to the UI.
+_REGISTRATION_FATAL_ERROR_CODES = frozenset({"register_failed"})
+
+
 class SupervisorBackedBackend:
     """``VoIPBackend`` adapter on top of a :class:`SidecarSupervisor`."""
 
@@ -130,7 +154,13 @@ class SupervisorBackedBackend:
 
         try:
             self._supervisor.start()
-        except RuntimeError as exc:
+        except Exception as exc:
+            # ``SidecarSupervisor.start()`` propagates whatever
+            # ``multiprocessing.Process.start()`` raises (typically
+            # ``OSError`` on spawn / fork failure) in addition to its own
+            # ``RuntimeError`` for permanent-failure state. A spawn failure
+            # at boot must not crash ``ManagersBoot.init_managers``;
+            # ``VoIPManager.start()`` treats ``False`` as music-only mode.
             logger.error("VoIP sidecar supervisor refused to start: {}", exc)
             return False
 
@@ -138,7 +168,7 @@ class SupervisorBackedBackend:
         try:
             self._supervisor.send(Configure(config=config_dict))
             self._supervisor.send(Register())
-        except RuntimeError as exc:
+        except Exception as exc:
             logger.error("VoIP sidecar refused configure/register command: {}", exc)
             return False
 
@@ -299,6 +329,24 @@ class SupervisorBackedBackend:
             if event.code == "backend_stopped":
                 self._reset_call_state()
                 self._dispatch(BackendStopped(reason=event.message))
+                return
+            # Non-terminal sidecar errors that nonetheless mean the call did
+            # not / cannot proceed: synthesize a CallStateChanged(ERROR) so
+            # ``VoIPManager``'s existing terminal-state handling drops the
+            # UI back to idle rather than leaving an optimistic "dialing"
+            # state in place. Only fires when there is something call-side
+            # to retreat from.
+            if event.code in _CALL_FATAL_ERROR_CODES:
+                if self._read_current_call_id() is not None or event.code == "dial_failed":
+                    self._reset_call_state()
+                    self._dispatch(BackendCallStateChanged(state=CallState.ERROR))
+                return
+            # SIP registration cannot proceed — surface as a registration
+            # state change so the manager flips to FAILED instead of staying
+            # in PROGRESS forever.
+            if event.code in _REGISTRATION_FATAL_ERROR_CODES:
+                self._dispatch(BackendRegistrationStateChanged(state=RegistrationState.FAILED))
+                return
             return
 
         if isinstance(event, ProtocolRegistrationStateChanged):

--- a/yoyopod/backends/voip/supervisor_backed.py
+++ b/yoyopod/backends/voip/supervisor_backed.py
@@ -131,11 +131,16 @@ class SupervisorBackedBackend:
         self.running = False
         self.event_callbacks: list[Callable[[VoIPEvent], None]] = []
 
-        self._supervisor = supervisor or SidecarSupervisor(on_event=self._on_protocol_event)
+        self._supervisor = supervisor or SidecarSupervisor(
+            on_event=self._on_protocol_event,
+            on_ready=self._on_supervisor_ready,
+        )
         # If the caller passed in a pre-built supervisor, rewire its event
-        # handler to ours so events from the sidecar reach this backend.
+        # and ready handlers to ours so events from the sidecar reach this
+        # backend (including ``Ready`` callbacks fired after every restart).
         if supervisor is not None:
             self._supervisor._on_event = self._on_protocol_event  # type: ignore[attr-defined]
+            self._supervisor._on_ready = self._on_supervisor_ready  # type: ignore[attr-defined]
 
         self._call_lock = threading.Lock()
         self._current_call_id: str | None = None
@@ -187,6 +192,36 @@ class SupervisorBackedBackend:
         self._supervisor.stop()
         self.running = False
         self._reset_call_state()
+
+    def _on_supervisor_ready(self) -> None:
+        """Re-issue Configure + Register after the supervisor (re)starts the sidecar.
+
+        Called by :class:`SidecarSupervisor` after every successful
+        handshake, including the transparent restart that follows a
+        sidecar pipe-death. The first invocation happens during
+        :meth:`start`, before ``self.running`` is True; we skip it then
+        because the start path will send Configure + Register itself.
+
+        On every subsequent invocation the sidecar is fresh (no backend
+        configured), so we resend Configure + Register so the new sidecar
+        accepts subsequent call-control commands instead of rejecting
+        them as ``not_configured``.
+        """
+
+        if not self.running:
+            # Initial handshake — start() will Configure separately.
+            return
+        try:
+            self._supervisor.send(Configure(config=dataclasses.asdict(self.config)))
+            self._supervisor.send(Register())
+        except Exception as exc:
+            logger.error("VoIP sidecar re-Configure after restart failed: {}", exc)
+            return
+        # Surface a registration progress signal so the manager / UI know
+        # the sidecar bounced and we are re-registering.
+        self._dispatch(BackendRegistrationStateChanged(state=RegistrationState.PROGRESS))
+        self._reset_call_state()
+        logger.info("VoIP sidecar re-Configured after supervisor restart")
 
     def iterate(self) -> int:
         """No-op: the sidecar drives its own iterate cadence."""
@@ -331,15 +366,17 @@ class SupervisorBackedBackend:
                 self._dispatch(BackendStopped(reason=event.message))
                 return
             # Non-terminal sidecar errors that nonetheless mean the call did
-            # not / cannot proceed: synthesize a CallStateChanged(ERROR) so
-            # ``VoIPManager``'s existing terminal-state handling drops the
+            # not / cannot proceed: always synthesize a CallStateChanged(ERROR)
+            # so ``VoIPManager``'s existing terminal-state handling drops the
             # UI back to idle rather than leaving an optimistic "dialing"
-            # state in place. Only fires when there is something call-side
-            # to retreat from.
+            # state in place. Dispatching unconditionally is safe because
+            # the manager treats CallState.ERROR as a no-op when the call
+            # state machine is already idle, and missing the dispatch
+            # silently strands the UI when sidecar's _current_call_id is
+            # set but main's tracker is not (e.g., back-to-back Dials).
             if event.code in _CALL_FATAL_ERROR_CODES:
-                if self._read_current_call_id() is not None or event.code == "dial_failed":
-                    self._reset_call_state()
-                    self._dispatch(BackendCallStateChanged(state=CallState.ERROR))
+                self._reset_call_state()
+                self._dispatch(BackendCallStateChanged(state=CallState.ERROR))
                 return
             # SIP registration cannot proceed — surface as a registration
             # state change so the manager flips to FAILED instead of staying

--- a/yoyopod/core/bootstrap/managers_boot.py
+++ b/yoyopod/core/bootstrap/managers_boot.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from yoyopod.core.application import YoyoPodApp
+
+
+def _voip_sidecar_enabled() -> bool:
+    """Return whether the VoIP sidecar process should back the manager.
+
+    Off by default; opt in via the ``YOYOPOD_VOIP_SIDECAR`` env var. Phase
+    2B.3 ships the sidecar path as opt-in so production keeps using the
+    in-process :class:`LiblinphoneBackend` until the call surface has been
+    smoke-tested on the Pi. Phase 2B.4 will extend the sidecar protocol to
+    cover messaging / voice notes; Phase 2B.5 will flip the default.
+    """
+
+    raw = os.environ.get("YOYOPOD_VOIP_SIDECAR", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
 
 
 class ManagersBoot:
@@ -50,11 +65,25 @@ class ManagersBoot:
         try:
             self.logger.info("  - VoIPManager")
             voip_config = self.voip_config_cls.from_config_manager(config_manager)
+            sidecar_backed_backend = None
+            background_iterate_enabled = True
+            if _voip_sidecar_enabled():
+                self.logger.info("    YOYOPOD_VOIP_SIDECAR=1 — using sidecar-backed VoIP backend")
+                from yoyopod.backends.voip.supervisor_backed import (
+                    SupervisorBackedBackend,
+                )
+
+                sidecar_backed_backend = SupervisorBackedBackend(voip_config)
+                # The sidecar drives its own iterate cadence; the manager's
+                # background-iterate worker would do nothing useful here and
+                # would just add noise to the loop instrumentation.
+                background_iterate_enabled = False
             self.app.voip_manager = self.voip_manager_cls(
                 voip_config,
                 people_directory=self.app.people_directory,
+                backend=sidecar_backed_backend,
                 event_scheduler=self.app.scheduler.run_on_main,
-                background_iterate_enabled=True,
+                background_iterate_enabled=background_iterate_enabled,
             )
             set_configured_interval = getattr(
                 self.app.runtime_loop,

--- a/yoyopod/integrations/call/sidecar_supervisor.py
+++ b/yoyopod/integrations/call/sidecar_supervisor.py
@@ -120,8 +120,10 @@ class SidecarSupervisor:
         sidecar_target: SidecarTarget = run_sidecar,
         handshake_timeout_seconds: float = 5.0,
         use_loopback: bool = False,
+        on_ready: Callable[[], None] | None = None,
     ) -> None:
         self._on_event = on_event
+        self._on_ready = on_ready
         self._restart_policy = restart_policy or RestartPolicy()
         self._start_method = start_method or _default_start_method()
         self._sidecar_target = sidecar_target
@@ -338,6 +340,17 @@ class SidecarSupervisor:
         reader.start()
 
         self._state = "running"
+
+        # Notify listeners that a (possibly fresh) sidecar is ready to
+        # receive commands. This fires on every successful handshake —
+        # the initial start AND every transparent restart driven by the
+        # restart timer — so consumers can re-issue setup commands like
+        # ``Configure`` / ``Register`` against the new sidecar.
+        if self._on_ready is not None:
+            try:
+                self._on_ready()
+            except Exception:
+                logger.exception("Sidecar on_ready callback raised")
 
     def _await_handshake(self, conn: Connection) -> bool:
         """Send our :class:`Hello`, wait for the sidecar's :class:`Ready`."""


### PR DESCRIPTION
## Summary

Phase 2B.3 of the concurrency rework. Wires the VoIP sidecar into production by way of a new `VoIPBackend` implementation that delegates to a `SidecarSupervisor` instead of running `LiblinphoneBackend` in-process. **`VoIPManager` itself does not change** — it just receives the new backend through its existing `backend=` constructor parameter.

**Off by default**. Opt in via `YOYOPOD_VOIP_SIDECAR=1`. Production keeps using `LiblinphoneBackend` until the call surface has been smoke-tested on the Pi. Phase 2B.4 will extend the sidecar protocol to cover messaging / voice notes; Phase 2B.5 will flip the default.

## What changed

### New backend: [`yoyopod/backends/voip/supervisor_backed.py`](yoyopod/backends/voip/supervisor_backed.py)

- `SupervisorBackedBackend` satisfies the `VoIPBackend` protocol. `VoIPManager` consumes it identically to `LiblinphoneBackend`.
- **Lifecycle**: `start()` → `supervisor.start()` then `Configure` (serialized `VoIPConfig`) + `Register`. `stop()` → `Unregister` + `supervisor.stop()`.
- **Per-call commands**: `make_call` / `answer_call` / `reject_call` / `hangup` / `mute` / `unmute` map to `Dial` / `Accept` / `Reject` / `Hangup` / `SetMute`. `iterate()` is a no-op because the sidecar drives its own iterate cadence.
- **Event translation**: protocol events from the sidecar (`RegistrationStateChanged`, `IncomingCall`, `CallStateChanged`, `BackendStopped`) are translated back to existing `VoIPEvent` types and dispatched to registered callbacks. Existing callback consumers don't need to know whether the backend is in-process or sidecar-backed.
- **Call-id tracking**: outgoing flows (`Dial` → `CallStateChanged`) and incoming flows (`IncomingCall`) both populate `_current_call_id`. Terminal states (`RELEASED` / `END` / `ERROR` / `IDLE`) and `BackendStopped` clear it.
- **Messaging / voice notes**: raise `NotImplementedError` with a clear "not yet supported in sidecar mode" message so callers fail loud instead of silently dropping IM frames.

### Feature flag: [`yoyopod/core/bootstrap/managers_boot.py`](yoyopod/core/bootstrap/managers_boot.py)

- New `_voip_sidecar_enabled()` reads `YOYOPOD_VOIP_SIDECAR` env var (`1` / `true` / `yes` / `on`).
- When enabled, `init_managers` constructs `SupervisorBackedBackend` with the resolved `VoIPConfig` and passes it as `backend=...` to `VoIPManager`. Also sets `background_iterate_enabled=False` because the sidecar drives its own iterate.
- When disabled (default), behavior is unchanged: `VoIPManager` constructs `LiblinphoneBackend` internally.

### Tests: [`tests/backends/test_supervisor_backed_voip.py`](tests/backends/test_supervisor_backed_voip.py)

| | |
|---|---|
| Unit tests with a fake supervisor (22) | command dispatch (start ordering, supervisor-refused / send-fail paths, per-call commands with and without tracked call id), call-id tracking for incoming/outgoing flows, protocol → `VoIPEvent` translation (registration / incoming / call-state / `BackendStopped` / unknown states / protocol-only events), NotImplementedError for messaging methods |
| Loopback integration test (1) | real `SidecarSupervisor` in loopback mode + `MockVoIPBackend` factory inside the sidecar, exercises `start → Configure → Register → IncomingCall → Accept → Hangup` end-to-end |

## What this is NOT

- **Not on by default.** Production paths keep `LiblinphoneBackend`. Phase 2B.5 flips the default after hardware validation.
- **Not messaging or voice notes.** Those raise `NotImplementedError` in sidecar mode. Phase 2B.4 will extend the sidecar protocol + adapter to cover them; this PR ships the call surface only.
- **Not a `VoIPManager` refactor.** `VoIPManager` keeps its constructor and behavior; only the injected backend changes.

## How to validate on the Pi

```bash
yoyopod remote mode activate dev
YOYOPOD_VOIP_SIDECAR=1 yoyopod remote sync --branch claude/voip-supervisor-backend --clean-native
yoyopod logs --follow
```

Watch for:
- `[INFO] YOYOPOD_VOIP_SIDECAR=1 — using sidecar-backed VoIP backend` at boot
- `ps aux | grep yoyopod` shows the `voip-sidecar` process spawned alongside main
- A real call goes register → ring → answer → talk → hangup
- `top` shows sidecar resident set in the projected ~40–60MB range (the user's earlier RAM question)
- `kill -9 <sidecar-pid>` triggers the supervisor's auto-restart and the UI reconnects

If the call path is solid for a few hours, we can ship Phase 2B.4 (messaging/voice-note protocol extension) and then Phase 2B.5 (flip default).

## Test plan
- [x] `uv run pytest -q` — **1656 passed, 22 skipped**
- [x] `uv run python scripts/quality.py gate` — passed
- [x] 22 unit tests + 1 loopback integration test, all green
- [x] Default off — boot without `YOYOPOD_VOIP_SIDECAR` continues to use `LiblinphoneBackend` (no behavior change)
- [ ] Pi smoke test with `YOYOPOD_VOIP_SIDECAR=1` (manual, after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)