### PR TITLE
feat(voip): make sidecar the production default (Phase 2B.5)

### DIFF
--- a/tests/core/test_bootstrap.py
+++ b/tests/core/test_bootstrap.py
@@ -1137,3 +1137,37 @@ def test_managers_boot_starts_network_and_syncs_context_without_event_wiring() -
     assert app.network_manager.started is False
     assert app.network_manager.started_in_background is True
     assert sync_calls == ["synced"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 2B.5: VoIP sidecar default-on
+# ---------------------------------------------------------------------------
+
+
+def test_voip_sidecar_enabled_by_default(monkeypatch) -> None:
+    """Sidecar is the production default; missing env var enables it."""
+
+    from yoyopod.core.bootstrap.managers_boot import _voip_sidecar_enabled
+
+    monkeypatch.delenv("YOYOPOD_VOIP_SIDECAR", raising=False)
+    assert _voip_sidecar_enabled() is True
+
+
+def test_voip_sidecar_opt_out_via_env_var(monkeypatch) -> None:
+    """Operators can fall back to the in-process backend with an opt-out env var."""
+
+    from yoyopod.core.bootstrap.managers_boot import _voip_sidecar_enabled
+
+    for value in ("0", "false", "no", "off", "FALSE", "Off"):
+        monkeypatch.setenv("YOYOPOD_VOIP_SIDECAR", value)
+        assert _voip_sidecar_enabled() is False, f"value {value!r} should opt out"
+
+
+def test_voip_sidecar_remains_enabled_for_other_values(monkeypatch) -> None:
+    """Anything other than the explicit opt-out keeps the sidecar default."""
+
+    from yoyopod.core.bootstrap.managers_boot import _voip_sidecar_enabled
+
+    for value in ("1", "true", "yes", "on", "", "  ", "anything-else"):
+        monkeypatch.setenv("YOYOPOD_VOIP_SIDECAR", value)
+        assert _voip_sidecar_enabled() is True, f"value {value!r} should keep sidecar on"

--- a/yoyopod/backends/voip/supervisor_backed.py
+++ b/yoyopod/backends/voip/supervisor_backed.py
@@ -1,8 +1,10 @@
 """VoIPBackend implementation that delegates to a sidecar process.
 
-Production wires this backend up when ``YOYOPOD_VOIP_SIDECAR=1`` is set.
-The :class:`SidecarSupervisor` owns the sidecar process; this backend
-adapts the synchronous :class:`yoyopod.backends.voip.protocol.VoIPBackend`
+Phase 2B.5 made this the production default. Set
+``YOYOPOD_VOIP_SIDECAR=0`` (or ``false``/``no``/``off``) to opt out and
+fall back to the in-process :class:`LiblinphoneBackend`. The
+:class:`SidecarSupervisor` owns the sidecar process; this backend adapts
+the synchronous :class:`yoyopod.backends.voip.protocol.VoIPBackend`
 surface that :class:`VoIPManager` already consumes onto the asynchronous
 command/event protocol the sidecar speaks.
 

--- a/yoyopod/core/bootstrap/managers_boot.py
+++ b/yoyopod/core/bootstrap/managers_boot.py
@@ -12,15 +12,25 @@ if TYPE_CHECKING:
 def _voip_sidecar_enabled() -> bool:
     """Return whether the VoIP sidecar process should back the manager.
 
-    Off by default; opt in via the ``YOYOPOD_VOIP_SIDECAR`` env var. Phase
-    2B.3 ships the sidecar path as opt-in so production keeps using the
-    in-process :class:`LiblinphoneBackend` until the call surface has been
-    smoke-tested on the Pi. Phase 2B.4 will extend the sidecar protocol to
-    cover messaging / voice notes; Phase 2B.5 will flip the default.
+    Phase 2B.5: sidecar is now the production default. Set
+    ``YOYOPOD_VOIP_SIDECAR=0`` (or ``false``/``no``/``off``) to opt out
+    and fall back to the in-process :class:`LiblinphoneBackend`. Any
+    other value (including unset) keeps the sidecar path active.
+
+    The opt-out exists for two reasons:
+
+    1. **Hardware regression escape hatch.** If a Pi-specific issue
+       surfaces post-rollout, operators can flip a single env var in
+       ``yoyopod-prod.service`` and restart instead of waiting for a
+       revert PR.
+    2. **Local dev shortcut.** In-process is easier to attach a
+       debugger to and skips the spawn/forkserver cost.
     """
 
     raw = os.environ.get("YOYOPOD_VOIP_SIDECAR", "").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return True
 
 
 class ManagersBoot:
@@ -68,7 +78,7 @@ class ManagersBoot:
             sidecar_backed_backend = None
             background_iterate_enabled = True
             if _voip_sidecar_enabled():
-                self.logger.info("    YOYOPOD_VOIP_SIDECAR=1 — using sidecar-backed VoIP backend")
+                self.logger.info("    using sidecar-backed VoIP backend (default)")
                 from yoyopod.backends.voip.supervisor_backed import (
                     SupervisorBackedBackend,
                 )
@@ -78,6 +88,10 @@ class ManagersBoot:
                 # background-iterate worker would do nothing useful here and
                 # would just add noise to the loop instrumentation.
                 background_iterate_enabled = False
+            else:
+                self.logger.info(
+                    "    YOYOPOD_VOIP_SIDECAR opt-out detected — using in-process LiblinphoneBackend"
+                )
             self.app.voip_manager = self.voip_manager_cls(
                 voip_config,
                 people_directory=self.app.people_directory,


### PR DESCRIPTION
## Summary

Phase 2B.5 of the VoIP-sidecar plan: flip the default from opt-in to opt-out so the sidecar is the production VoIP path. The sidecar surface has shipped through:

- Phase 2A (#377) — protocol + supervisor scaffolding
- Phase 2B.1/2 (#378, #389) — loopback runner + adapter
- Phase 2B.3 (#393) — `SupervisorBackedBackend` behind `YOYOPOD_VOIP_SIDECAR=1`
- Phase 2B.4 (#394) — text messaging through sidecar
- Phase 2B.4b (#396) — voice notes through sidecar

Full unit + loopback E2E coverage exists for every command and event.

### Behavior change

| Env var value                          | Before (opt-in)        | After (opt-out)        |
|----------------------------------------|------------------------|------------------------|
| unset                                  | in-process backend     | **sidecar backend**    |
| `1` / `true` / `yes` / `on`            | sidecar backend        | sidecar backend        |
| `0` / `false` / `no` / `off`           | in-process backend     | **in-process backend** |
| any other value                        | in-process backend     | **sidecar backend**    |

### Why opt-out instead of removing the env var

- **Hardware regression escape hatch.** If a Pi-specific issue surfaces post-rollout, operators can flip a single env var in `yoyopod-prod.service` and restart, instead of waiting for a revert PR to land.
- **Local dev shortcut.** In-process is easier to attach a debugger to and skips the spawn/forkserver cost; useful when iterating on call/messaging logic.

### Rollback

If hardware testing reveals a regression: add `Environment=YOYOPOD_VOIP_SIDECAR=0` to `deploy/systemd/yoyopod-prod.service` and `systemctl restart yoyopod-prod`. No code revert needed.

## Test plan

- [x] `uv run python scripts/quality.py gate` — passes
- [x] `uv run pytest -q` — 1773 passed, 22 skipped
- New regression tests pin the env-var semantics:
  - default (env var unset) returns `True` (sidecar on)
  - explicit opt-out values (`0`, `false`, `no`, `off`, case-insensitive) return `False`
  - any other value (`1`, `true`, empty, garbage) keeps sidecar on
- Manual Pi smoke-test still pending — see plan doc for the checklist (register success, register failure restart, incoming call accept/hangup, sidecar crash → restart → re-register, text + voice-note round-trip, ALSA not held by zombie sidecar after `systemctl restart`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)