### PR TITLE
Add voice trace analyzer

### DIFF
--- a/tests/cli/test_yoyopod_cli_voice.py
+++ b/tests/cli/test_yoyopod_cli_voice.py
@@ -12,7 +12,6 @@ from typer.testing import CliRunner
 from yoyopod.integrations.voice.trace import VoiceTraceEntry, VoiceTraceStore
 from yoyopod_cli.main import app
 
-
 runner = CliRunner()
 
 
@@ -69,6 +68,36 @@ def test_voice_trace_last_uses_configured_default_path(
     assert result.exit_code == 0
     assert "turn-configured" in result.output
     assert "call mama" in result.output
+
+
+def test_voice_trace_analyze_prints_summary(tmp_path: Path) -> None:
+    trace_path = tmp_path / "turns.jsonl"
+    store = VoiceTraceStore(path=trace_path, max_turns=10)
+    store.append(_entry("turn-command", "call mama"))
+    store.append(
+        VoiceTraceEntry(
+            turn_id="turn-unknown",
+            started_at="2026-04-27T12:00:00.000Z",
+            completed_at="2026-04-27T12:00:01.000Z",
+            source="ask_screen",
+            mode="cloud",
+            route_kind="unknown",
+            outcome="not_recognized",
+            transcript_raw="call marmar",
+            transcript_normalized="call marmar",
+        )
+    )
+
+    result = runner.invoke(
+        app,
+        ["voice", "trace", "analyze", "--path", str(trace_path), "--limit", "10"],
+    )
+
+    assert result.exit_code == 0
+    assert "Voice trace analysis: 2 turn(s)" in result.output
+    assert "route_kind: command=1, unknown=1" in result.output
+    assert "recent failures:" in result.output
+    assert "turn-unknown unknown/not_recognized call marmar" in result.output
 
 
 def test_voice_trace_last_tolerates_missing_file(tmp_path: Path) -> None:

--- a/tests/integrations/test_voice_trace.py
+++ b/tests/integrations/test_voice_trace.py
@@ -13,17 +13,28 @@ from yoyopod.integrations.voice.trace import (
     new_turn_id,
     utc_now_iso,
 )
+from yoyopod.integrations.voice.trace_analysis import analyze_voice_trace
 
 
-def _entry(turn_id: str, transcript: str = "play music") -> VoiceTraceEntry:
+def _entry(
+    turn_id: str,
+    transcript: str = "play music",
+    *,
+    route_kind: str = "command",
+    outcome: str = "handled",
+    command_intent: str | None = None,
+    ask_fallback: bool | None = None,
+) -> VoiceTraceEntry:
     return VoiceTraceEntry(
         turn_id=turn_id,
         started_at="2026-04-27T12:00:00.000Z",
         completed_at="2026-04-27T12:00:01.000Z",
         source="ptt",
         mode="cloud",
-        route_kind="command",
-        outcome="handled",
+        route_kind=route_kind,
+        outcome=outcome,
+        command_intent=command_intent,
+        ask_fallback=ask_fallback,
         transcript_raw=transcript,
         transcript_normalized=transcript.lower(),
         assistant_body_preview="Starting local music now",
@@ -130,3 +141,49 @@ def test_voice_trace_helpers_make_trace_identifiers() -> None:
 
 def test_default_voice_trace_path_constant() -> None:
     assert DEFAULT_VOICE_TRACE_PATH == Path("logs/voice/turns.jsonl")
+
+
+def test_voice_trace_analysis_summarizes_routes_and_failures() -> None:
+    entries = [
+        _entry(
+            "turn-1",
+            "call mama",
+            route_kind="command",
+            outcome="handled",
+            command_intent="call_contact",
+        ).to_json_dict(),
+        _entry(
+            "turn-2",
+            "why is the sky blue",
+            route_kind="ask",
+            outcome="answered",
+            ask_fallback=True,
+        ).to_json_dict(),
+        _entry(
+            "turn-3",
+            "call marmar",
+            route_kind="unknown",
+            outcome="not_recognized",
+        ).to_json_dict(),
+        _entry(
+            "turn-4",
+            "",
+            route_kind="error",
+            outcome="stt_failed",
+        ).to_json_dict(),
+    ]
+
+    analysis = analyze_voice_trace(entries, failure_limit=5)
+
+    assert analysis.total_turns == 4
+    assert analysis.route_counts == {"ask": 1, "command": 1, "error": 1, "unknown": 1}
+    assert analysis.outcome_counts == {
+        "answered": 1,
+        "handled": 1,
+        "not_recognized": 1,
+        "stt_failed": 1,
+    }
+    assert analysis.command_counts == {"call_contact": 1}
+    assert analysis.ask_fallback_turns == 1
+    assert [failure.turn_id for failure in analysis.recent_failures] == ["turn-3", "turn-4"]
+    assert analysis.unknown_phrases == {"call marmar": 1}

--- a/yoyopod/integrations/voice/trace_analysis.py
+++ b/yoyopod/integrations/voice/trace_analysis.py
@@ -1,0 +1,113 @@
+"""Summaries for local voice trace entries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from collections import Counter
+from typing import Any
+
+_FAILURE_ROUTE_KINDS = frozenset({"error", "silence", "unknown"})
+_FAILURE_OUTCOME_TOKENS = ("fail", "error", "cancel", "unknown", "not_recognized", "no_match")
+
+
+@dataclass(slots=True, frozen=True)
+class VoiceTraceFailure:
+    """One recent failed voice turn extracted for diagnostics."""
+
+    turn_id: str
+    route_kind: str
+    outcome: str
+    text: str
+
+
+@dataclass(slots=True, frozen=True)
+class VoiceTraceAnalysis:
+    """Aggregate counters and failure samples for voice traces."""
+
+    total_turns: int = 0
+    route_counts: dict[str, int] = field(default_factory=dict)
+    outcome_counts: dict[str, int] = field(default_factory=dict)
+    command_counts: dict[str, int] = field(default_factory=dict)
+    ask_fallback_turns: int = 0
+    recent_failures: list[VoiceTraceFailure] = field(default_factory=list)
+    unknown_phrases: dict[str, int] = field(default_factory=dict)
+
+
+def analyze_voice_trace(
+    entries: list[dict[str, Any]],
+    *,
+    failure_limit: int = 5,
+) -> VoiceTraceAnalysis:
+    """Return aggregate diagnostics for voice trace entries."""
+
+    route_counts: Counter[str] = Counter()
+    outcome_counts: Counter[str] = Counter()
+    command_counts: Counter[str] = Counter()
+    unknown_phrases: Counter[str] = Counter()
+    failures: list[VoiceTraceFailure] = []
+    ask_fallback_turns = 0
+
+    for entry in entries:
+        route_kind = _clean_value(entry.get("route_kind")) or "unknown"
+        outcome = _clean_value(entry.get("outcome")) or "unknown"
+        route_counts[route_kind] += 1
+        outcome_counts[outcome] += 1
+
+        command_intent = _clean_value(entry.get("command_intent"))
+        if command_intent:
+            command_counts[command_intent] += 1
+        if entry.get("ask_fallback") is True:
+            ask_fallback_turns += 1
+
+        text = _trace_text(entry)
+        if route_kind == "unknown" and text:
+            unknown_phrases[text] += 1
+        if _is_failure(route_kind=route_kind, outcome=outcome):
+            failures.append(
+                VoiceTraceFailure(
+                    turn_id=_clean_value(entry.get("turn_id")) or "",
+                    route_kind=route_kind,
+                    outcome=outcome,
+                    text=text,
+                )
+            )
+
+    return VoiceTraceAnalysis(
+        total_turns=len(entries),
+        route_counts=_sorted_counts(route_counts),
+        outcome_counts=_sorted_counts(outcome_counts),
+        command_counts=_sorted_counts(command_counts),
+        ask_fallback_turns=ask_fallback_turns,
+        recent_failures=failures[-max(0, failure_limit) :] if failure_limit > 0 else [],
+        unknown_phrases=_sorted_counts(unknown_phrases),
+    )
+
+
+def _clean_value(value: object) -> str:
+    return " ".join(str(value or "").split())
+
+
+def _trace_text(entry: dict[str, Any]) -> str:
+    return (
+        _clean_value(entry.get("transcript_normalized"))
+        or _clean_value(entry.get("transcript_raw"))
+        or _clean_value(entry.get("assistant_body_preview"))
+    )
+
+
+def _is_failure(*, route_kind: str, outcome: str) -> bool:
+    if route_kind in _FAILURE_ROUTE_KINDS:
+        return True
+    lowered = outcome.lower()
+    return any(token in lowered for token in _FAILURE_OUTCOME_TOKENS)
+
+
+def _sorted_counts(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+__all__ = [
+    "VoiceTraceAnalysis",
+    "VoiceTraceFailure",
+    "analyze_voice_trace",
+]

--- a/yoyopod_cli/COMMANDS.md
+++ b/yoyopod_cli/COMMANDS.md
@@ -79,6 +79,7 @@ For live help, use `yoyopod <cmd> --help`.
 | Command | What it does |
 |---|---|
 | `yoyopod voice dictionary validate` | Validate a mutable voice command dictionary YAML file. |
+| `yoyopod voice trace analyze` | Summarize recent voice trace outcomes and failures. |
 | `yoyopod voice trace last` | Show the most recent local voice trace entries. |
 
 ## `yoyopod release`

--- a/yoyopod_cli/voice.py
+++ b/yoyopod_cli/voice.py
@@ -9,6 +9,7 @@ import typer
 
 from yoyopod.integrations.voice.dictionary_validator import validate_voice_command_dictionary
 from yoyopod.integrations.voice.trace import VoiceTraceStore
+from yoyopod.integrations.voice.trace_analysis import analyze_voice_trace
 
 app = typer.Typer(name="voice", help="Voice diagnostics and validation.", no_args_is_help=True)
 dictionary_app = typer.Typer(
@@ -47,6 +48,12 @@ def _row(payload: dict[str, Any]) -> str:
         text,
     )
     return " ".join(_cell(value) for value in values).rstrip()
+
+
+def _counts_text(counts: dict[str, int]) -> str:
+    if not counts:
+        return "none"
+    return ", ".join(f"{key}={value}" for key, value in counts.items())
 
 
 def _configured_dictionary_path() -> Path:
@@ -120,3 +127,42 @@ def trace_last(
     )
     for payload in rows:
         typer.echo(_row(payload))
+
+
+@trace_app.command(name="analyze")
+def trace_analyze(
+    limit: int = typer.Option(
+        50, "--limit", min=1, help="Number of recent trace entries to analyze."
+    ),
+    path: Path | None = typer.Option(
+        None,
+        "--path",
+        help="Path to the voice trace JSONL file.",
+    ),
+) -> None:
+    """Summarize recent voice trace outcomes and failures."""
+
+    trace_path = path or _configured_trace_path()
+    rows = VoiceTraceStore(path=trace_path, max_turns=max(1, limit)).read_recent(limit=limit)
+    if not rows:
+        typer.echo(f"No voice trace entries at {trace_path}")
+        return
+
+    analysis = analyze_voice_trace(rows)
+    typer.echo(f"Voice trace analysis: {analysis.total_turns} turn(s)")
+    typer.echo(f"route_kind: {_counts_text(analysis.route_counts)}")
+    typer.echo(f"outcome: {_counts_text(analysis.outcome_counts)}")
+    typer.echo(f"commands: {_counts_text(analysis.command_counts)}")
+    typer.echo(f"ask_fallback: {analysis.ask_fallback_turns}")
+
+    if analysis.unknown_phrases:
+        typer.echo("unknown phrases:")
+        for phrase, count in analysis.unknown_phrases.items():
+            typer.echo(f"- {phrase} ({count})")
+
+    if analysis.recent_failures:
+        typer.echo("recent failures:")
+        for failure in analysis.recent_failures:
+            typer.echo(
+                f"- {failure.turn_id} {failure.route_kind}/{failure.outcome} {failure.text}".rstrip()
+            )


### PR DESCRIPTION
## Summary
- Add `yoyopod voice trace analyze` to summarize recent trace route kinds, outcomes, commands, Ask fallback count, unknown phrases, and recent failures.
- Add a small reusable voice trace analysis module over existing JSONL trace entries.
- Update CLI command docs and focused tests for the new diagnostic output.

## Test Plan
- [x] `uv run pytest tests/integrations/test_voice_trace.py tests/cli/test_yoyopod_cli_voice.py -q`
- [x] `uv run python scripts/quality.py gate`
- [x] `uv run pytest -q`