### PR TITLE
Rust VoIP Host first slice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,21 @@ jobs:
           path: src/crates/ui-host/build/yoyopod-ui-host
           if-no-files-found: error
 
+      - name: Build Rust VoIP host
+        working-directory: src
+        run: |
+          set -euo pipefail
+          cargo build --release -p yoyopod-voip-host --locked
+          mkdir -p crates/voip-host/build
+          cp target/release/yoyopod-voip-host crates/voip-host/build/yoyopod-voip-host
+
+      - name: Upload Rust VoIP ARM64 host
+        uses: actions/upload-artifact@v4
+        with:
+          name: yoyopod-voip-host-${{ github.sha }}
+          path: src/crates/voip-host/build/yoyopod-voip-host
+          if-no-files-found: error
+
   slot-arm64:
     runs-on: ubuntu-latest
     needs: [changes, quality, test, voice-go, ui-rust]

--- a/docs/hardware/DEPLOYED_PI_DEPENDENCIES.md
+++ b/docs/hardware/DEPLOYED_PI_DEPENDENCIES.md
@@ -68,6 +68,7 @@ No separate Mopidy process or music daemon is part of the stack anymore.
 ### Native VoIP bridge
 
 - `libyoyopod_liblinphone_shim.so`
+- `src/crates/voip-host/build/yoyopod-voip-host` - Rust VoIP Host calls-only worker, installed from GitHub Actions artifact.
 
 ## Python-Level Dependencies Used By The App
 

--- a/docs/superpowers/plans/2026-04-28-rust-voip-host.md
+++ b/docs/superpowers/plans/2026-04-28-rust-voip-host.md
@@ -1,0 +1,2318 @@
+# Rust VoIP Host Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a calls-only Rust VoIP Host that owns liblinphone backend execution while Python keeps `VoIPManager`, `CallRuntime`, call/music coordination, contacts, history, and UI state.
+
+**Architecture:** The Rust VoIP Host is a supervised worker process that speaks the same NDJSON envelope style as the existing worker runtime. Python adds a `RustHostBackend` implementing the current `VoIPBackend` protocol, translates Python calls into worker commands, and translates worker events back into existing `VoIPEvent` dataclasses. Rust initially binds the existing C liblinphone shim through `libloading` instead of binding liblinphone directly.
+
+**Tech Stack:** Rust 2021 workspace under `src/`, `serde`, `serde_json`, `libloading`, `thiserror`, `anyhow`, Python 3.12, existing `WorkerSupervisor`, pytest, GitHub Actions ARM64 runner, Raspberry Pi Zero 2W.
+
+---
+
+## Scope Check
+
+This plan implements the first Rust VoIP slice only:
+
+- Rust host skeleton and worker protocol.
+- Rust liblinphone shim wrapper.
+- Rust call registration/control/event flow.
+- Python `RustHostBackend` adapter.
+- Opt-in runtime selection.
+- CI artifact and hardware validation path.
+
+This plan does not implement text messages, voice notes, contacts, call history, UI screens, `VoIPManager` in Rust, or direct liblinphone Rust bindings.
+
+## Required Execution Rules
+
+- New production Rust sources go under top-level `src/`.
+- Do not add `src/rust/`.
+- Do not build Rust binaries on the Raspberry Pi Zero 2W.
+- Pi validation uses the GitHub Actions artifact for the exact commit.
+- Before every commit and every push run:
+
+```bash
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+- For Rust changes also run:
+
+```bash
+cargo fmt --manifest-path src/Cargo.toml
+cargo test --manifest-path src/Cargo.toml --workspace --locked
+```
+
+## File Structure
+
+- Modify: `src/Cargo.toml` - add `crates/voip-host`.
+- Create: `src/crates/voip-host/Cargo.toml` - Rust VoIP Host crate manifest.
+- Create: `src/crates/voip-host/src/main.rs` - process entrypoint and stdin/stdout loop.
+- Create: `src/crates/voip-host/src/protocol.rs` - worker envelope, commands, events.
+- Create: `src/crates/voip-host/src/config.rs` - Rust config shape matching Python `VoIPConfig`.
+- Create: `src/crates/voip-host/src/shim.rs` - dynamic binding to `libyoyopod_liblinphone_shim.so`.
+- Create: `src/crates/voip-host/src/events.rs` - native numeric event mapping.
+- Create: `src/crates/voip-host/src/host.rs` - command handling, host state, iterate cadence.
+- Create: `yoyopod/backends/voip/rust_host.py` - Python `VoIPBackend` adapter over `WorkerSupervisor`.
+- Create: `tests/backends/test_rust_host_voip.py` - Python adapter tests.
+- Modify: `yoyopod/core/bootstrap/managers_boot.py` - choose Rust host backend by env flag.
+- Test: `tests/core/test_bootstrap.py` - backend selection and flag conflict.
+- Modify: `.github/workflows/ci.yml` - build/upload `yoyopod-voip-host-<sha>`.
+- Modify: `docs/hardware/DEPLOYED_PI_DEPENDENCIES.md` or `docs/RUST_UI_HOST.md` only if needed to mention the new artifact.
+
+## Task 1: Add Rust VoIP Host Crate Skeleton
+
+**Files:**
+- Modify: `src/Cargo.toml`
+- Create: `src/crates/voip-host/Cargo.toml`
+- Create: `src/crates/voip-host/src/main.rs`
+- Create: `src/crates/voip-host/src/protocol.rs`
+
+- [ ] **Step 1: Write failing protocol tests**
+
+Create `src/crates/voip-host/src/protocol.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use thiserror::Error;
+
+pub const SUPPORTED_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvelopeKind {
+    Command,
+    Event,
+    Result,
+    Error,
+    Heartbeat,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkerEnvelope {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u16,
+    pub kind: EnvelopeKind,
+    #[serde(rename = "type")]
+    pub message_type: String,
+    #[serde(default)]
+    pub request_id: Option<String>,
+    #[serde(default)]
+    pub timestamp_ms: u64,
+    #[serde(default)]
+    pub deadline_ms: u64,
+    #[serde(default = "empty_payload")]
+    pub payload: Value,
+}
+
+#[derive(Debug, Error)]
+pub enum ProtocolError {
+    #[error("invalid JSON worker envelope: {0}")]
+    InvalidJson(#[from] serde_json::Error),
+    #[error("unsupported schema_version {actual}; expected {expected}")]
+    UnsupportedSchema { actual: u16, expected: u16 },
+    #[error("invalid worker envelope: {0}")]
+    InvalidEnvelope(String),
+}
+
+fn default_schema_version() -> u16 {
+    SUPPORTED_SCHEMA_VERSION
+}
+
+fn empty_payload() -> Value {
+    json!({})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_accepts_voip_health_command() {
+        let raw = br#"{"schema_version":1,"kind":"command","type":"voip.health","request_id":"r1","payload":{}}"#;
+
+        let envelope = WorkerEnvelope::decode(raw).expect("decode");
+
+        assert_eq!(envelope.schema_version, SUPPORTED_SCHEMA_VERSION);
+        assert_eq!(envelope.kind, EnvelopeKind::Command);
+        assert_eq!(envelope.message_type, "voip.health");
+        assert_eq!(envelope.request_id.as_deref(), Some("r1"));
+    }
+
+    #[test]
+    fn encode_ready_event_has_newline() {
+        let encoded = WorkerEnvelope::event("voip.ready", json!({"capabilities":["calls"]}))
+            .encode()
+            .expect("encode");
+
+        assert!(encoded.ends_with(b"\n"));
+        assert!(std::str::from_utf8(&encoded).unwrap().contains("\"type\":\"voip.ready\""));
+    }
+
+    #[test]
+    fn rejects_array_payload() {
+        let err = WorkerEnvelope::decode(br#"{"schema_version":1,"kind":"command","type":"voip.health","payload":[]}"#)
+            .expect_err("payload must be rejected");
+
+        assert!(err.to_string().contains("payload must be an object"));
+    }
+}
+```
+
+Run:
+
+```bash
+cargo test --manifest-path src/Cargo.toml -p yoyopod-voip-host protocol
+```
+
+Expected: fails because the crate is not in the workspace yet.
+
+- [ ] **Step 2: Add the crate manifest**
+
+Append the crate to `src/Cargo.toml`:
+
+```toml
+[workspace]
+resolver = "2"
+members = [
+    "crates/ui-host",
+    "crates/voip-host",
+]
+```
+
+Create `src/crates/voip-host/Cargo.toml`:
+
+```toml
+[package]
+name = "yoyopod-voip-host"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[[bin]]
+name = "yoyopod-voip-host"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+libloading = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "2.0"
+```
+
+- [ ] **Step 3: Implement envelope methods**
+
+Add to `protocol.rs`:
+
+```rust
+impl WorkerEnvelope {
+    pub fn decode(line: &[u8]) -> Result<Self, ProtocolError> {
+        let envelope: WorkerEnvelope = serde_json::from_slice(line)?;
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, ProtocolError> {
+        self.validate()?;
+        let mut encoded = serde_json::to_vec(self)?;
+        encoded.push(b'\n');
+        Ok(encoded)
+    }
+
+    pub fn event(message_type: impl Into<String>, payload: Value) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Event,
+            message_type: message_type.into(),
+            request_id: None,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload,
+        }
+    }
+
+    pub fn result(
+        message_type: impl Into<String>,
+        request_id: Option<String>,
+        payload: Value,
+    ) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Result,
+            message_type: message_type.into(),
+            request_id,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload,
+        }
+    }
+
+    pub fn error(
+        message_type: impl Into<String>,
+        request_id: Option<String>,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Error,
+            message_type: message_type.into(),
+            request_id,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload: json!({
+                "code": code.into(),
+                "message": message.into(),
+            }),
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), ProtocolError> {
+        if self.schema_version != SUPPORTED_SCHEMA_VERSION {
+            return Err(ProtocolError::UnsupportedSchema {
+                actual: self.schema_version,
+                expected: SUPPORTED_SCHEMA_VERSION,
+            });
+        }
+        if self.message_type.trim().is_empty() {
+            return Err(ProtocolError::InvalidEnvelope(
+                "type must be a non-empty string".to_string(),
+            ));
+        }
+        if !self.payload.is_object() {
+            return Err(ProtocolError::InvalidEnvelope(
+                "payload must be an object".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 4: Add a minimal process entrypoint**
+
+Create `src/crates/voip-host/src/main.rs`:
+
+```rust
+use anyhow::Result;
+use clap::Parser;
+use serde_json::json;
+use std::io::{self, BufRead, Write};
+
+mod protocol;
+
+use protocol::WorkerEnvelope;
+
+#[derive(Debug, Parser)]
+#[command(name = "yoyopod-voip-host")]
+#[command(about = "YoYoPod Rust VoIP host")]
+struct Args {
+    #[arg(long, default_value = "")]
+    shim_path: String,
+}
+
+fn main() -> Result<()> {
+    let _args = Args::parse();
+    write_envelope(&WorkerEnvelope::event(
+        "voip.ready",
+        json!({"capabilities":["calls"]}),
+    ))?;
+
+    let stdin = io::stdin();
+    for line in stdin.lock().lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let envelope = match WorkerEnvelope::decode(line.as_bytes()) {
+            Ok(envelope) => envelope,
+            Err(error) => {
+                write_envelope(&WorkerEnvelope::error(
+                    "voip.error",
+                    None,
+                    "protocol_error",
+                    error.to_string(),
+                ))?;
+                continue;
+            }
+        };
+
+        if envelope.message_type == "voip.health" {
+            write_envelope(&WorkerEnvelope::result(
+                "voip.health",
+                envelope.request_id,
+                json!({"ready":true,"registered":false,"active_call_id":null}),
+            ))?;
+        } else if envelope.message_type == "voip.shutdown" {
+            break;
+        } else {
+            write_envelope(&WorkerEnvelope::error(
+                "voip.error",
+                envelope.request_id,
+                "unsupported_command",
+                format!("unsupported command {}", envelope.message_type),
+            ))?;
+        }
+    }
+    Ok(())
+}
+
+fn write_envelope(envelope: &WorkerEnvelope) -> Result<()> {
+    let encoded = envelope.encode()?;
+    let mut stdout = io::stdout().lock();
+    stdout.write_all(&encoded)?;
+    stdout.flush()?;
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Run Rust tests**
+
+Run:
+
+```bash
+cargo fmt --manifest-path src/Cargo.toml
+cargo test --manifest-path src/Cargo.toml -p yoyopod-voip-host --locked
+cargo test --manifest-path src/Cargo.toml --workspace --locked
+```
+
+Expected: new protocol tests pass and existing UI host tests still pass.
+
+- [ ] **Step 6: Run repo gates and commit**
+
+Run:
+
+```bash
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+Commit:
+
+```bash
+git add src
+git commit -m "feat(voip): add rust voip host skeleton"
+```
+
+Expected: first commit introduces a buildable `yoyopod-voip-host` with health/shutdown only.
+
+## Task 2: Add Rust Config, Event Mapping, And Host State
+
+**Files:**
+- Create: `src/crates/voip-host/src/config.rs`
+- Create: `src/crates/voip-host/src/events.rs`
+- Create: `src/crates/voip-host/src/host.rs`
+- Modify: `src/crates/voip-host/src/main.rs`
+
+- [ ] **Step 1: Add config mapping tests**
+
+Create `src/crates/voip-host/src/config.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VoipConfig {
+    #[serde(default = "default_sip_server")]
+    pub sip_server: String,
+    #[serde(default)]
+    pub sip_username: String,
+    #[serde(default)]
+    pub sip_password: String,
+    #[serde(default)]
+    pub sip_password_ha1: String,
+    #[serde(default)]
+    pub sip_identity: String,
+    #[serde(default)]
+    pub factory_config_path: String,
+    #[serde(default = "default_transport")]
+    pub transport: String,
+    #[serde(default)]
+    pub stun_server: String,
+    #[serde(default)]
+    pub conference_factory_uri: String,
+    #[serde(default)]
+    pub file_transfer_server_url: String,
+    #[serde(default)]
+    pub lime_server_url: String,
+    #[serde(default = "default_iterate_interval_ms")]
+    pub iterate_interval_ms: u64,
+    #[serde(default)]
+    pub voice_note_store_dir: String,
+    #[serde(default)]
+    pub auto_download_incoming_voice_recordings: bool,
+    #[serde(default = "default_audio_device")]
+    pub playback_dev_id: String,
+    #[serde(default = "default_audio_device")]
+    pub ringer_dev_id: String,
+    #[serde(default = "default_audio_device")]
+    pub capture_dev_id: String,
+    #[serde(default = "default_audio_device")]
+    pub media_dev_id: String,
+    #[serde(default = "default_mic_gain")]
+    pub mic_gain: i32,
+    #[serde(default = "default_output_volume")]
+    pub output_volume: i32,
+}
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("invalid voip config payload: {0}")]
+    InvalidPayload(#[from] serde_json::Error),
+    #[error("sip_identity is required for Rust VoIP host registration")]
+    MissingSipIdentity,
+    #[error("sip_server is required for Rust VoIP host registration")]
+    MissingSipServer,
+}
+
+fn default_sip_server() -> String {
+    "sip.linphone.org".to_string()
+}
+
+fn default_transport() -> String {
+    "tcp".to_string()
+}
+
+fn default_iterate_interval_ms() -> u64 {
+    20
+}
+
+fn default_audio_device() -> String {
+    "ALSA: wm8960-soundcard".to_string()
+}
+
+fn default_mic_gain() -> i32 {
+    80
+}
+
+fn default_output_volume() -> i32 {
+    100
+}
+
+impl VoipConfig {
+    pub fn from_payload(payload: &Value) -> Result<Self, ConfigError> {
+        let config: Self = serde_json::from_value(payload.clone())?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.sip_server.trim().is_empty() {
+            return Err(ConfigError::MissingSipServer);
+        }
+        if self.sip_identity.trim().is_empty() {
+            return Err(ConfigError::MissingSipIdentity);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn config_from_payload_accepts_python_voip_config_shape() {
+        let payload = json!({
+            "sip_server": "sip.example.com",
+            "sip_username": "alice",
+            "sip_password": "secret",
+            "sip_identity": "sip:alice@example.com",
+            "transport": "tcp",
+            "iterate_interval_ms": 20,
+            "playback_dev_id": "ALSA: wm8960-soundcard",
+            "ringer_dev_id": "ALSA: wm8960-soundcard",
+            "capture_dev_id": "ALSA: wm8960-soundcard",
+            "media_dev_id": "ALSA: wm8960-soundcard",
+            "mic_gain": 80,
+            "output_volume": 100
+        });
+
+        let config = VoipConfig::from_payload(&payload).expect("config");
+
+        assert_eq!(config.sip_server, "sip.example.com");
+        assert_eq!(config.sip_identity, "sip:alice@example.com");
+        assert_eq!(config.iterate_interval_ms, 20);
+    }
+
+    #[test]
+    fn config_rejects_missing_identity() {
+        let payload = json!({"sip_server":"sip.example.com"});
+
+        let error = VoipConfig::from_payload(&payload).expect_err("must reject");
+
+        assert!(error.to_string().contains("sip_identity"));
+    }
+}
+```
+
+Run:
+
+```bash
+cargo test --manifest-path src/Cargo.toml -p yoyopod-voip-host config
+```
+
+Expected: passes after `mod config;` is added in `main.rs`.
+
+- [ ] **Step 2: Add event mapping tests**
+
+Create `src/crates/voip-host/src/events.rs`:
+
+```rust
+use serde_json::{json, Value};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegistrationState {
+    None,
+    Progress,
+    Ok,
+    Cleared,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallState {
+    Idle,
+    Incoming,
+    OutgoingInit,
+    OutgoingProgress,
+    OutgoingRinging,
+    OutgoingEarlyMedia,
+    Connected,
+    StreamsRunning,
+    Paused,
+    PausedByRemote,
+    UpdatedByRemote,
+    Released,
+    Error,
+    End,
+}
+
+impl RegistrationState {
+    pub fn from_native(value: i32) -> Self {
+        match value {
+            1 => Self::Progress,
+            2 => Self::Ok,
+            3 => Self::Cleared,
+            4 => Self::Failed,
+            _ => Self::None,
+        }
+    }
+
+    pub fn as_protocol(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Progress => "progress",
+            Self::Ok => "ok",
+            Self::Cleared => "cleared",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl CallState {
+    pub fn from_native(value: i32) -> Self {
+        match value {
+            1 => Self::Incoming,
+            2 => Self::OutgoingInit,
+            3 => Self::OutgoingProgress,
+            4 => Self::OutgoingRinging,
+            5 => Self::OutgoingEarlyMedia,
+            6 => Self::Connected,
+            7 => Self::StreamsRunning,
+            8 => Self::Paused,
+            9 => Self::PausedByRemote,
+            10 => Self::UpdatedByRemote,
+            11 => Self::Released,
+            12 => Self::Error,
+            13 => Self::End,
+            _ => Self::Idle,
+        }
+    }
+
+    pub fn as_protocol(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Incoming => "incoming",
+            Self::OutgoingInit => "outgoing_init",
+            Self::OutgoingProgress => "outgoing_progress",
+            Self::OutgoingRinging => "outgoing_ringing",
+            Self::OutgoingEarlyMedia => "outgoing_early_media",
+            Self::Connected => "connected",
+            Self::StreamsRunning => "streams_running",
+            Self::Paused => "paused",
+            Self::PausedByRemote => "paused_by_remote",
+            Self::UpdatedByRemote => "updated_by_remote",
+            Self::Released => "released",
+            Self::Error => "error",
+            Self::End => "end",
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Idle | Self::Released | Self::Error | Self::End)
+    }
+}
+
+pub fn registration_payload(state: RegistrationState, reason: &str) -> Value {
+    json!({"state": state.as_protocol(), "reason": reason})
+}
+
+pub fn call_state_payload(call_id: &str, state: CallState) -> Value {
+    json!({"call_id": call_id, "state": state.as_protocol()})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_native_registration_values_to_python_values() {
+        assert_eq!(RegistrationState::from_native(1).as_protocol(), "progress");
+        assert_eq!(RegistrationState::from_native(2).as_protocol(), "ok");
+        assert_eq!(RegistrationState::from_native(4).as_protocol(), "failed");
+        assert_eq!(RegistrationState::from_native(99).as_protocol(), "none");
+    }
+
+    #[test]
+    fn maps_native_call_values_to_python_values() {
+        assert_eq!(CallState::from_native(1).as_protocol(), "incoming");
+        assert_eq!(CallState::from_native(7).as_protocol(), "streams_running");
+        assert_eq!(CallState::from_native(11).as_protocol(), "released");
+        assert_eq!(CallState::from_native(99).as_protocol(), "idle");
+    }
+
+    #[test]
+    fn released_error_end_are_terminal() {
+        assert!(CallState::Released.is_terminal());
+        assert!(CallState::Error.is_terminal());
+        assert!(CallState::End.is_terminal());
+        assert!(!CallState::Connected.is_terminal());
+    }
+}
+```
+
+Run:
+
+```bash
+cargo test --manifest-path src/Cargo.toml -p yoyopod-voip-host events
+```
+
+Expected: event mapping tests pass.
+
+- [ ] **Step 3: Add host state tests**
+
+Create `src/crates/voip-host/src/host.rs`:
+
+```rust
+use crate::config::VoipConfig;
+use serde_json::json;
+
+#[derive(Debug, Default)]
+pub struct VoipHost {
+    config: Option<VoipConfig>,
+    registered: bool,
+    active_call_id: Option<String>,
+}
+
+impl VoipHost {
+    pub fn configure(&mut self, config: VoipConfig) {
+        self.config = Some(config);
+        self.registered = false;
+        self.active_call_id = None;
+    }
+
+    pub fn mark_registered(&mut self, registered: bool) {
+        self.registered = registered;
+    }
+
+    pub fn set_active_call_id(&mut self, call_id: Option<String>) {
+        self.active_call_id = call_id;
+    }
+
+    pub fn health_payload(&self) -> serde_json::Value {
+        json!({
+            "configured": self.config.is_some(),
+            "registered": self.registered,
+            "active_call_id": self.active_call_id,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> VoipConfig {
+        VoipConfig {
+            sip_server: "sip.example.com".to_string(),
+            sip_identity: "sip:alice@example.com".to_string(),
+            ..serde_json::from_value(serde_json::json!({})).unwrap()
+        }
+    }
+
+    #[test]
+    fn health_reports_configured_registered_and_call_id() {
+        let mut host = VoipHost::default();
+        host.configure(config());
+        host.mark_registered(true);
+        host.set_active_call_id(Some("call-1".to_string()));
+
+        let payload = host.health_payload();
+
+        assert_eq!(payload["configured"], true);
+        assert_eq!(payload["registered"], true);
+        assert_eq!(payload["active_call_id"], "call-1");
+    }
+}
+```
+
+Run:
+
+```bash
+cargo test --manifest-path src/Cargo.toml -p yoyopod-voip-host host
+```
+
+Expected: host state test passes after adding `mod host;`.
+
+- [ ] **Step 4: Wire modules into `main.rs`**
+
+At the top of `main.rs`, use:
+
+```rust
+mod config;
+mod events;
+mod host;
+mod protocol;
+```
+
+Extend command handling:
+
+```rust
+let mut host = host::VoipHost::default();
+
+match envelope.message_type.as_str() {
+    "voip.configure" => {
+        let config = config::VoipConfig::from_payload(&envelope.payload)?;
+        host.configure(config);
+        write_envelope(&WorkerEnvelope::result(
+            "voip.configure",
+            envelope.request_id,
+            json!({"configured": true}),
+        ))?;
+    }
+    "voip.health" => {
+        write_envelope(&WorkerEnvelope::result(
+            "voip.health",
+            envelope.request_id,
+            host.health_payload(),
+        ))?;
+    }
+    "voip.shutdown" => break,
+    _ => {
+        write_envelope(&WorkerEnvelope::error(
+            "voip.error",
+            envelope.request_id,
+            "unsupported_command",
+            format!("unsupported command {}", envelope.message_type),
+        ))?;
+    }
+}
+```
+
+- [ ] **Step 5: Run Rust and repo gates, then commit**
+
+Run:
+
+```bash
+cargo fmt --manifest-path src/Cargo.toml
+cargo test --manifest-path src/Cargo.toml -p yoyopod-voip-host --locked
+cargo test --manifest-path src/Cargo.toml --workspace --locked
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+Commit:
+
+```bash
+git add src
+git commit -m "feat(voip): add rust voip host state model"
+```
+
+Expected: Rust host can accept configure/health/shutdown without liblinphone loaded.
+
+## Task 3: Bind The Existing Liblinphone Shim In Rust
+
+**Files:**
+- Create: `src/crates/voip-host/src/shim.rs`
+- Modify: `src/crates/voip-host/src/host.rs`
+- Modify: `src/crates/voip-host/src/main.rs`
+
+- [ ] **Step 1: Add shim path resolution tests**
+
+Create `src/crates/voip-host/src/shim.rs`:
+
+```rust
+use libloading::{Library, Symbol};
+use std::env;
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NativeEvent {
+    pub event_type: i32,
+    pub registration_state: i32,
+    pub call_state: i32,
+    pub message_kind: i32,
+    pub message_direction: i32,
+    pub message_delivery_state: i32,
+    pub duration_ms: i32,
+    pub unread: i32,
+    pub message_id: [c_char; 128],
+    pub peer_sip_address: [c_char; 256],
+    pub sender_sip_address: [c_char; 256],
+    pub recipient_sip_address: [c_char; 256],
+    pub local_file_path: [c_char; 512],
+    pub mime_type: [c_char; 128],
+    pub text: [c_char; 1024],
+    pub reason: [c_char; 256],
+}
+
+#[derive(Debug, Error)]
+pub enum ShimError {
+    #[error("liblinphone shim path could not be resolved")]
+    NotFound,
+    #[error("liblinphone shim load failed: {0}")]
+    Load(String),
+    #[error("liblinphone shim call failed: {0}")]
+    Call(String),
+    #[error("string contains interior NUL: {0}")]
+    InvalidCString(#[from] std::ffi::NulError),
+}
+
+pub fn resolve_shim_path(explicit_path: Option<&str>) -> Result<PathBuf, ShimError> {
+    if let Some(path) = explicit_path.filter(|value| !value.trim().is_empty()) {
+        return Ok(PathBuf::from(path));
+    }
+    if let Ok(path) = env::var("YOYOPOD_LIBLINPHONE_SHIM_PATH") {
+        if !path.trim().is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+    let repo_candidate = Path::new("yoyopod")
+        .join("backends")
+        .join("voip")
+        .join("shim_native")
+        .join("build")
+        .join("libyoyopod_liblinphone_shim.so");
+    if repo_candidate.exists() {
+        return Ok(repo_candidate);
+    }
+    Err(ShimError::NotFound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_path_wins() {
+        let path = resolve_shim_path(Some("/tmp/libshim.so")).expect("path");
+        assert_eq!(path, PathBuf::from("/tmp/libshim.so"));
+    }
+}
+```
+
+Run:
+
+```bash
+cargo test --manifest-path src/Cargo.toml -p yoyopod-voip-host shim
+```
+
+Expected: fails until `mod shim;` is added.
+
+- [ ] **Step 2: Add dynamic symbols**
+
+Add to `shim.rs`:
+
+```rust
+type InitFn = unsafe extern "C" fn() -> c_int;
+type ShutdownFn = unsafe extern "C" fn();
+type StopFn = unsafe extern "C" fn();
+type IterateFn = unsafe extern "C" fn();
+type PollEventFn = unsafe extern "C" fn(*mut NativeEvent) -> c_int;
+type StartFn = unsafe extern "C" fn(
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    i32,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    i32,
+    i32,
+    i32,
+    *const c_char,
+) -> c_int;
+type SimpleCallFn = unsafe extern "C" fn() -> c_int;
+type MakeCallFn = unsafe extern "C" fn(*const c_char) -> c_int;
+type SetMutedFn = unsafe extern "C" fn(i32) -> c_int;
+type LastErrorFn = unsafe extern "C" fn() -> *const c_char;
+
+pub struct LiblinphoneShim {
+    _library: Library,
+    init: InitFn,
+    shutdown: ShutdownFn,
+    start: StartFn,
+    stop: StopFn,
+    iterate: IterateFn,
+    poll_event: PollEventFn,
+    make_call: MakeCallFn,
+    answer_call: SimpleCallFn,
+    reject_call: SimpleCallFn,
+    hangup: SimpleCallFn,
+    set_muted: SetMutedFn,
+    last_error: LastErrorFn,
+}
+
+impl LiblinphoneShim {
+    pub unsafe fn load(path: &Path) -> Result<Self, ShimError> {
+        let library = Library::new(path).map_err(|error| ShimError::Load(error.to_string()))?;
+        unsafe fn symbol<T: Copy>(library: &Library, name: &[u8]) -> Result<T, ShimError> {
+            let symbol: Symbol<T> = library
+                .get(name)
+                .map_err(|error| ShimError::Load(error.to_string()))?;
+            Ok(*symbol)
+        }
+        Ok(Self {
+            init: symbol(&library, b"yoyopod_liblinphone_init\0")?,
+            shutdown: symbol(&library, b"yoyopod_liblinphone_shutdown\0")?,
+            start: symbol(&library, b"yoyopod_liblinphone_start\0")?,
+            stop: symbol(&library, b"yoyopod_liblinphone_stop\0")?,
+            iterate: symbol(&library, b"yoyopod_liblinphone_iterate\0")?,
+            poll_event: symbol(&library, b"yoyopod_liblinphone_poll_event\0")?,
+            make_call: symbol(&library, b"yoyopod_liblinphone_make_call\0")?,
+            answer_call: symbol(&library, b"yoyopod_liblinphone_answer_call\0")?,
+            reject_call: symbol(&library, b"yoyopod_liblinphone_reject_call\0")?,
+            hangup: symbol(&library, b"yoyopod_liblinphone_hangup\0")?,
+            set_muted: symbol(&library, b"yoyopod_liblinphone_set_muted\0")?,
+            last_error: symbol(&library, b"yoyopod_liblinphone_last_error\0")?,
+            _library: library,
+        })
+    }
+
+    fn last_error(&self) -> String {
+        unsafe {
+            let raw = (self.last_error)();
+            if raw.is_null() {
+                return "unknown liblinphone shim error".to_string();
+            }
+            CStr::from_ptr(raw).to_string_lossy().into_owned()
+        }
+    }
+
+    fn check(&self, code: c_int) -> Result<(), ShimError> {
+        if code == 0 {
+            Ok(())
+        } else {
+            Err(ShimError::Call(self.last_error()))
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add safe call methods**
+
+Add:
+
+```rust
+impl LiblinphoneShim {
+    pub fn init(&self) -> Result<(), ShimError> {
+        self.check(unsafe { (self.init)() })
+    }
+
+    pub fn shutdown(&self) {
+        unsafe { (self.shutdown)() }
+    }
+
+    pub fn stop(&self) {
+        unsafe { (self.stop)() }
+    }
+
+    pub fn iterate(&self) {
+        unsafe { (self.iterate)() }
+    }
+
+    pub fn make_call(&self, sip_address: &str) -> Result<(), ShimError> {
+        let sip_address = CString::new(sip_address)?;
+        self.check(unsafe { (self.make_call)(sip_address.as_ptr()) })
+    }
+
+    pub fn answer_call(&self) -> Result<(), ShimError> {
+        self.check(unsafe { (self.answer_call)() })
+    }
+
+    pub fn reject_call(&self) -> Result<(), ShimError> {
+        self.check(unsafe { (self.reject_call)() })
+    }
+
+    pub fn hangup(&self) -> Result<(), ShimError> {
+        self.check(unsafe { (self.hangup)() })
+    }
+
+    pub fn set_muted(&self, muted: bool) -> Result<(), ShimError> {
+        self.check(unsafe { (self.set_muted)(if muted { 1 } else { 0 }) })
+    }
+}
+```
+
+Do not implement text or voice-note shim calls in this slice.
+
+- [ ] **Step 4: Wire loading into CLI args**
+
+In `main.rs`, keep the `--shim-path` arg and load only when `voip.configure` is followed by `voip.register`. The skeleton must still allow health tests without a shim.
+
+Add:
+
+```rust
+let explicit_shim_path = if args.shim_path.trim().is_empty() {
+    None
+} else {
+    Some(args.shim_path.clone())
+};
+```
+
+Pass `explicit_shim_path.as_deref()` into host registration in Task 4.
+
+- [ ] **Step 5: Run Rust and repo gates, then commit**
+
+Run:
+
+```bash
+cargo fmt --manifest-path src/Cargo.toml
+cargo test --manifest-path src/Cargo.toml -p yoyopod-voip-host --locked
+cargo test --manifest-path src/Cargo.toml --workspace --locked
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+Commit:
+
+```bash
+git add src
+git commit -m "feat(voip): bind rust host to liblinphone shim"
+```
+
+Expected: Rust can compile the dynamic shim wrapper without requiring the shim at test time.
+
+## Task 4: Implement Rust Registration And Call Commands
+
+**Files:**
+- Modify: `src/crates/voip-host/src/host.rs`
+- Modify: `src/crates/voip-host/src/main.rs`
+- Modify: `src/crates/voip-host/src/shim.rs`
+
+- [ ] **Step 1: Add host command tests with a fake backend trait**
+
+In `host.rs`, introduce a small trait above `VoipHost`:
+
+```rust
+pub trait CallBackend {
+    fn start(&mut self, config: &VoipConfig) -> Result<(), String>;
+    fn stop(&mut self);
+    fn iterate(&mut self) -> Result<Vec<BackendEvent>, String>;
+    fn make_call(&mut self, sip_address: &str) -> Result<String, String>;
+    fn answer_call(&mut self) -> Result<(), String>;
+    fn reject_call(&mut self) -> Result<(), String>;
+    fn hangup(&mut self) -> Result<(), String>;
+    fn set_muted(&mut self, muted: bool) -> Result<(), String>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackendEvent {
+    RegistrationChanged { state: String, reason: String },
+    IncomingCall { call_id: String, from_uri: String },
+    CallStateChanged { call_id: String, state: String },
+    BackendStopped { reason: String },
+}
+```
+
+Add tests:
+
+```rust
+#[cfg(test)]
+mod command_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[derive(Default)]
+    struct FakeBackend {
+        calls: Vec<String>,
+    }
+
+    impl CallBackend for FakeBackend {
+        fn start(&mut self, _config: &VoipConfig) -> Result<(), String> {
+            self.calls.push("start".to_string());
+            Ok(())
+        }
+        fn stop(&mut self) {
+            self.calls.push("stop".to_string());
+        }
+        fn iterate(&mut self) -> Result<Vec<BackendEvent>, String> {
+            Ok(vec![])
+        }
+        fn make_call(&mut self, sip_address: &str) -> Result<String, String> {
+            self.calls.push(format!("dial:{sip_address}"));
+            Ok("call-outgoing".to_string())
+        }
+        fn answer_call(&mut self) -> Result<(), String> {
+            self.calls.push("answer".to_string());
+            Ok(())
+        }
+        fn reject_call(&mut self) -> Result<(), String> {
+            self.calls.push("reject".to_string());
+            Ok(())
+        }
+        fn hangup(&mut self) -> Result<(), String> {
+            self.calls.push("hangup".to_string());
+            Ok(())
+        }
+        fn set_muted(&mut self, muted: bool) -> Result<(), String> {
+            self.calls.push(format!("mute:{muted}"));
+            Ok(())
+        }
+    }
+
+    fn config() -> VoipConfig {
+        VoipConfig::from_payload(&json!({
+            "sip_server":"sip.example.com",
+            "sip_identity":"sip:alice@example.com"
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn register_starts_backend_and_health_reports_registered() {
+        let mut host = VoipHost::default();
+        let mut backend = FakeBackend::default();
+        host.configure(config());
+
+        host.register(&mut backend).expect("register");
+
+        assert_eq!(backend.calls, vec!["start"]);
+        assert_eq!(host.health_payload()["registered"], true);
+    }
+
+    #[test]
+    fn dial_sets_active_call_id() {
+        let mut host = VoipHost::default();
+        let mut backend = FakeBackend::default();
+        host.configure(config());
+        host.register(&mut backend).unwrap();
+
+        host.dial(&mut backend, "sip:bob@example.com").expect("dial");
+
+        assert_eq!(host.health_payload()["active_call_id"], "call-outgoing");
+    }
+}
+```
+
+Run:
+
+```bash
+cargo test --manifest-path src/Cargo.toml -p yoyopod-voip-host host::command_tests
+```
+
+Expected: fails until command methods exist.
+
+- [ ] **Step 2: Implement command methods on `VoipHost`**
+
+Add methods:
+
+```rust
+impl VoipHost {
+    pub fn register<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
+        let config = self
+            .config
+            .as_ref()
+            .ok_or_else(|| "voip host is not configured".to_string())?;
+        backend.start(config)?;
+        self.registered = true;
+        Ok(())
+    }
+
+    pub fn unregister<B: CallBackend>(&mut self, backend: &mut B) {
+        backend.stop();
+        self.registered = false;
+        self.active_call_id = None;
+    }
+
+    pub fn dial<B: CallBackend>(
+        &mut self,
+        backend: &mut B,
+        sip_address: &str,
+    ) -> Result<(), String> {
+        let call_id = backend.make_call(sip_address)?;
+        self.active_call_id = Some(call_id);
+        Ok(())
+    }
+
+    pub fn answer<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
+        backend.answer_call()
+    }
+
+    pub fn reject<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
+        backend.reject_call()?;
+        self.active_call_id = None;
+        Ok(())
+    }
+
+    pub fn hangup<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
+        backend.hangup()?;
+        self.active_call_id = None;
+        Ok(())
+    }
+
+    pub fn set_muted<B: CallBackend>(
+        &mut self,
+        backend: &mut B,
+        muted: bool,
+    ) -> Result<(), String> {
+        backend.set_muted(muted)
+    }
+}
+```
+
+- [ ] **Step 3: Implement `CallBackend` for the real shim**
+
+In `shim.rs`, add:
+
+```rust
+use crate::config::VoipConfig;
+use crate::host::{BackendEvent, CallBackend};
+
+pub struct ShimBackend {
+    shim: LiblinphoneShim,
+    next_outgoing_call_id: u64,
+}
+
+impl ShimBackend {
+    pub unsafe fn load(path: &Path) -> Result<Self, ShimError> {
+        Ok(Self {
+            shim: LiblinphoneShim::load(path)?,
+            next_outgoing_call_id: 1,
+        })
+    }
+}
+
+impl CallBackend for ShimBackend {
+    fn start(&mut self, config: &VoipConfig) -> Result<(), String> {
+        self.shim.init().map_err(|error| error.to_string())?;
+        self.shim
+            .start(config)
+            .map_err(|error| error.to_string())
+    }
+
+    fn stop(&mut self) {
+        self.shim.stop();
+        self.shim.shutdown();
+    }
+
+    fn iterate(&mut self) -> Result<Vec<BackendEvent>, String> {
+        self.shim.iterate();
+        self.shim.drain_events().map_err(|error| error.to_string())
+    }
+
+    fn make_call(&mut self, sip_address: &str) -> Result<String, String> {
+        self.shim.make_call(sip_address).map_err(|error| error.to_string())?;
+        let call_id = format!("outgoing-{}", self.next_outgoing_call_id);
+        self.next_outgoing_call_id += 1;
+        Ok(call_id)
+    }
+
+    fn answer_call(&mut self) -> Result<(), String> {
+        self.shim.answer_call().map_err(|error| error.to_string())
+    }
+
+    fn reject_call(&mut self) -> Result<(), String> {
+        self.shim.reject_call().map_err(|error| error.to_string())
+    }
+
+    fn hangup(&mut self) -> Result<(), String> {
+        self.shim.hangup().map_err(|error| error.to_string())
+    }
+
+    fn set_muted(&mut self, muted: bool) -> Result<(), String> {
+        self.shim.set_muted(muted).map_err(|error| error.to_string())
+    }
+}
+```
+
+Implement `LiblinphoneShim::start(config)` using the existing C function signature. Use `CString::new` for every string field and pass `0` for liblinphone software mic gain because Python currently returns neutral software gain.
+
+- [ ] **Step 4: Add event draining from the shim**
+
+In `shim.rs`, implement:
+
+```rust
+pub fn c_string<const N: usize>(buffer: &[c_char; N]) -> String {
+    unsafe { CStr::from_ptr(buffer.as_ptr()) }
+        .to_string_lossy()
+        .into_owned()
+}
+
+impl LiblinphoneShim {
+    pub fn drain_events(&self) -> Result<Vec<BackendEvent>, ShimError> {
+        let mut events = Vec::new();
+        loop {
+            let mut event = NativeEvent::default();
+            let has_event = unsafe { (self.poll_event)(&mut event as *mut NativeEvent) };
+            if has_event == 0 {
+                break;
+            }
+            match event.event_type {
+                1 => events.push(BackendEvent::RegistrationChanged {
+                    state: crate::events::RegistrationState::from_native(event.registration_state)
+                        .as_protocol()
+                        .to_string(),
+                    reason: c_string(&event.reason),
+                }),
+                2 => events.push(BackendEvent::CallStateChanged {
+                    call_id: c_string(&event.peer_sip_address),
+                    state: crate::events::CallState::from_native(event.call_state)
+                        .as_protocol()
+                        .to_string(),
+                }),
+                3 => events.push(BackendEvent::IncomingCall {
+                    call_id: c_string(&event.peer_sip_address),
+                    from_uri: c_string(&event.peer_sip_address),
+                }),
+                4 => events.push(BackendEvent::BackendStopped {
+                    reason: c_string(&event.reason),
+                }),
+                _ => {}
+            }
+        }
+        Ok(events)
+    }
+}
+```
+
+Derive default for `NativeEvent` manually:
+
+```rust
+impl Default for NativeEvent {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+```
+
+- [ ] **Step 5: Wire register/dial/call commands in `main.rs`**
+
+The command loop should create the backend lazily when `voip.register` arrives:
+
+```rust
+let mut backend: Option<shim::ShimBackend> = None;
+
+match envelope.message_type.as_str() {
+    "voip.register" => {
+        if backend.is_none() {
+            let path = shim::resolve_shim_path(explicit_shim_path.as_deref())?;
+            backend = Some(unsafe { shim::ShimBackend::load(&path)? });
+        }
+        let backend_ref = backend.as_mut().expect("backend was just created");
+        host.register(backend_ref)?;
+        write_envelope(&WorkerEnvelope::result(
+            "voip.register",
+            envelope.request_id,
+            json!({"registered": true}),
+        ))?;
+    }
+    "voip.unregister" => {
+        if let Some(backend_ref) = backend.as_mut() {
+            host.unregister(backend_ref);
+        }
+        write_envelope(&WorkerEnvelope::result(
+            "voip.unregister",
+            envelope.request_id,
+            json!({"registered": false}),
+        ))?;
+    }
+    "voip.dial" => {
+        let uri = envelope.payload["uri"].as_str().unwrap_or("").trim();
+        if uri.is_empty() {
+            write_envelope(&WorkerEnvelope::error("voip.error", envelope.request_id, "invalid_command", "voip.dial requires uri"))?;
+        } else if let Some(backend_ref) = backend.as_mut() {
+            host.dial(backend_ref, uri)?;
+            write_envelope(&WorkerEnvelope::result("voip.dial", envelope.request_id, host.health_payload()))?;
+        }
+    }
+    "voip.answer" => {
+        if let Some(backend_ref) = backend.as_mut() {
+            host.answer(backend_ref)?;
+            write_envelope(&WorkerEnvelope::result("voip.answer", envelope.request_id, json!({"accepted": true})))?;
+        }
+    }
+    "voip.reject" => {
+        if let Some(backend_ref) = backend.as_mut() {
+            host.reject(backend_ref)?;
+            write_envelope(&WorkerEnvelope::result("voip.reject", envelope.request_id, json!({"rejected": true})))?;
+        }
+    }
+    "voip.hangup" => {
+        if let Some(backend_ref) = backend.as_mut() {
+            host.hangup(backend_ref)?;
+            write_envelope(&WorkerEnvelope::result("voip.hangup", envelope.request_id, json!({"hung_up": true})))?;
+        }
+    }
+    "voip.set_mute" => {
+        let muted = envelope.payload["muted"].as_bool().unwrap_or(false);
+        if let Some(backend_ref) = backend.as_mut() {
+            host.set_muted(backend_ref, muted)?;
+            write_envelope(&WorkerEnvelope::result("voip.set_mute", envelope.request_id, json!({"muted": muted})))?;
+        }
+    }
+    _ => {}
+}
+```
+
+Use helper functions to keep `main.rs` readable if the match grows beyond one screen.
+
+- [ ] **Step 6: Add nonblocking iterate between stdin polls**
+
+Keep this simple for the first slice: after each handled command, call `backend.iterate()` and emit any pending events:
+
+```rust
+fn emit_backend_events(events: Vec<host::BackendEvent>) -> Result<()> {
+    for event in events {
+        match event {
+            host::BackendEvent::RegistrationChanged { state, reason } => {
+                write_envelope(&WorkerEnvelope::event(
+                    "voip.registration_changed",
+                    json!({"state": state, "reason": reason}),
+                ))?;
+            }
+            host::BackendEvent::IncomingCall { call_id, from_uri } => {
+                write_envelope(&WorkerEnvelope::event(
+                    "voip.incoming_call",
+                    json!({"call_id": call_id, "from_uri": from_uri}),
+                ))?;
+            }
+            host::BackendEvent::CallStateChanged { call_id, state } => {
+                write_envelope(&WorkerEnvelope::event(
+                    "voip.call_state_changed",
+                    json!({"call_id": call_id, "state": state}),
+                ))?;
+            }
+            host::BackendEvent::BackendStopped { reason } => {
+                write_envelope(&WorkerEnvelope::event(
+                    "voip.backend_stopped",
+                    json!({"reason": reason}),
+                ))?;
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+The implementation plan for the next slice can replace command-coupled iterate with a timed loop if hardware validation shows registration/call events need stricter cadence.
+
+- [ ] **Step 7: Run Rust and repo gates, then commit**
+
+Run:
+
+```bash
+cargo fmt --manifest-path src/Cargo.toml
+cargo test --manifest-path src/Cargo.toml -p yoyopod-voip-host --locked
+cargo test --manifest-path src/Cargo.toml --workspace --locked
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+Commit:
+
+```bash
+git add src
+git commit -m "feat(voip): handle rust call commands"
+```
+
+Expected: Rust host handles registration and call commands against the real shim API shape.
+
+## Task 5: Add Python `RustHostBackend`
+
+**Files:**
+- Create: `yoyopod/backends/voip/rust_host.py`
+- Create: `tests/backends/test_rust_host_voip.py`
+- Modify: `yoyopod/backends/voip/__init__.py`
+
+- [ ] **Step 1: Write failing adapter tests**
+
+Create `tests/backends/test_rust_host_voip.py`:
+
+```python
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from yoyopod.backends.voip.rust_host import RustHostBackend
+from yoyopod.integrations.call.models import (
+    BackendStopped,
+    CallState,
+    CallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged,
+    VoIPConfig,
+)
+
+
+class _FakeSupervisor:
+    def __init__(self) -> None:
+        self.registered: list[tuple[str, Any]] = []
+        self.started: list[str] = []
+        self.stopped: list[tuple[str, float]] = []
+        self.sent: list[tuple[str, str, dict[str, Any]]] = []
+        self.messages: list[Any] = []
+
+    def register(self, domain: str, config: Any) -> None:
+        self.registered.append((domain, config))
+
+    def start(self, domain: str) -> bool:
+        self.started.append(domain)
+        return True
+
+    def stop(self, domain: str, *, grace_seconds: float = 1.0) -> None:
+        self.stopped.append((domain, grace_seconds))
+
+    def drain_worker_messages(self, domain: str) -> list[Any]:
+        assert domain == "voip"
+        drained = list(self.messages)
+        self.messages.clear()
+        return drained
+
+    def send_command(
+        self,
+        domain: str,
+        *,
+        type: str,
+        payload: dict[str, Any] | None = None,
+        request_id: str | None = None,
+        timestamp_ms: int = 0,
+        deadline_ms: int = 0,
+    ) -> bool:
+        self.sent.append((domain, type, payload or {}))
+        return True
+
+
+def _config() -> VoIPConfig:
+    return VoIPConfig(sip_server="sip.example.com", sip_identity="sip:alice@example.com")
+
+
+def _event(message_type: str, payload: dict[str, Any]) -> Any:
+    return SimpleNamespace(kind="event", type=message_type, payload=payload)
+
+
+def test_start_registers_worker_and_sends_configure_register() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+
+    assert backend.start() is True
+
+    assert supervisor.registered[0][0] == "voip"
+    assert supervisor.started == ["voip"]
+    assert [item[1] for item in supervisor.sent] == ["voip.configure", "voip.register"]
+    assert backend.running is True
+
+
+def test_call_commands_send_worker_commands() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    backend.start()
+    supervisor.sent.clear()
+
+    assert backend.make_call("sip:bob@example.com") is True
+    assert backend.answer_call() is True
+    assert backend.reject_call() is True
+    assert backend.hangup() is True
+    assert backend.mute() is True
+    assert backend.unmute() is True
+
+    assert [item[1] for item in supervisor.sent] == [
+        "voip.dial",
+        "voip.answer",
+        "voip.reject",
+        "voip.hangup",
+        "voip.set_mute",
+        "voip.set_mute",
+    ]
+    assert supervisor.sent[0][2] == {"uri": "sip:bob@example.com"}
+    assert supervisor.sent[4][2] == {"muted": True}
+    assert supervisor.sent[5][2] == {"muted": False}
+
+
+def test_worker_events_translate_to_voip_events() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+
+    backend.handle_worker_message(
+        _event("voip.registration_changed", {"state": "ok", "reason": ""})
+    )
+    backend.handle_worker_message(
+        _event("voip.incoming_call", {"call_id": "call-1", "from_uri": "sip:bob@example.com"})
+    )
+    backend.handle_worker_message(
+        _event("voip.call_state_changed", {"call_id": "call-1", "state": "streams_running"})
+    )
+    backend.handle_worker_message(
+        _event("voip.backend_stopped", {"reason": "iterate failed"})
+    )
+
+    assert isinstance(received[0], RegistrationStateChanged)
+    assert received[0].state == RegistrationState.OK
+    assert isinstance(received[1], IncomingCallDetected)
+    assert received[1].caller_address == "sip:bob@example.com"
+    assert isinstance(received[2], CallStateChanged)
+    assert received[2].state == CallState.STREAMS_RUNNING
+    assert isinstance(received[3], BackendStopped)
+    assert received[3].reason == "iterate failed"
+
+
+def test_iterate_is_noop_and_unsupported_messaging_fails() -> None:
+    backend = RustHostBackend(_config(), worker_supervisor=_FakeSupervisor(), worker_path="/bin/voip")
+
+    assert backend.iterate() == 0
+    assert backend.get_iterate_metrics() is None
+    assert backend.send_text_message("sip:bob@example.com", "hi") is None
+    assert backend.start_voice_note_recording("/tmp/a.wav") is False
+    assert backend.stop_voice_note_recording() is None
+```
+
+Run:
+
+```bash
+uv run pytest -q tests/backends/test_rust_host_voip.py
+```
+
+Expected: fails because `RustHostBackend` does not exist.
+
+- [ ] **Step 2: Implement `RustHostBackend`**
+
+Create `yoyopod/backends/voip/rust_host.py`:
+
+```python
+"""VoIPBackend adapter backed by the Rust VoIP Host worker."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.backends.voip.protocol import VoIPIterateMetrics
+from yoyopod.core.workers import WorkerProcessConfig
+from yoyopod.integrations.call.models import (
+    BackendStopped,
+    CallState,
+    CallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged,
+    VoIPConfig,
+    VoIPEvent,
+)
+
+
+class RustHostBackend:
+    """Calls-only VoIPBackend adapter for the Rust VoIP Host."""
+
+    def __init__(
+        self,
+        config: VoIPConfig,
+        *,
+        worker_supervisor: Any,
+        worker_path: str,
+        domain: str = "voip",
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+    ) -> None:
+        self.config = config
+        self.worker_supervisor = worker_supervisor
+        self.worker_path = worker_path
+        self.domain = domain
+        self.env = env
+        self.cwd = cwd
+        self.running = False
+        self.event_callbacks: list[Callable[[VoIPEvent], None]] = []
+
+    def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
+        self.event_callbacks.append(callback)
+
+    def start(self) -> bool:
+        register = getattr(self.worker_supervisor, "register", None)
+        start = getattr(self.worker_supervisor, "start", None)
+        if not callable(register) or not callable(start):
+            logger.error("Rust VoIP Host supervisor is unavailable")
+            return False
+        register(
+            self.domain,
+            WorkerProcessConfig(
+                name=self.domain,
+                argv=[self.worker_path],
+                cwd=self.cwd,
+                env=self.env,
+            ),
+        )
+        if not bool(start(self.domain)):
+            return False
+        if not self._send("voip.configure", dataclasses.asdict(self.config)):
+            return False
+        if not self._send("voip.register", {}):
+            return False
+        self.running = True
+        return True
+
+    def stop(self) -> None:
+        self._send("voip.unregister", {})
+        stop = getattr(self.worker_supervisor, "stop", None)
+        if callable(stop):
+            stop(self.domain, grace_seconds=1.0)
+        self.running = False
+
+    def iterate(self) -> int:
+        return 0
+
+    def get_iterate_metrics(self) -> VoIPIterateMetrics | None:
+        return None
+
+    def make_call(self, sip_address: str) -> bool:
+        return self._send("voip.dial", {"uri": sip_address})
+
+    def answer_call(self) -> bool:
+        return self._send("voip.answer", {})
+
+    def reject_call(self) -> bool:
+        return self._send("voip.reject", {})
+
+    def hangup(self) -> bool:
+        return self._send("voip.hangup", {})
+
+    def mute(self) -> bool:
+        return self._send("voip.set_mute", {"muted": True})
+
+    def unmute(self) -> bool:
+        return self._send("voip.set_mute", {"muted": False})
+
+    def send_text_message(self, sip_address: str, text: str) -> str | None:
+        logger.warning("Rust VoIP Host does not support text messages in calls-only mode")
+        return None
+
+    def start_voice_note_recording(self, file_path: str) -> bool:
+        logger.warning("Rust VoIP Host does not support voice notes in calls-only mode")
+        return False
+
+    def stop_voice_note_recording(self) -> int | None:
+        return None
+
+    def cancel_voice_note_recording(self) -> bool:
+        return False
+
+    def send_voice_note(
+        self,
+        sip_address: str,
+        *,
+        file_path: str,
+        duration_ms: int,
+        mime_type: str,
+    ) -> str | None:
+        return None
+
+    def handle_worker_message(self, event: Any) -> None:
+        if getattr(event, "type", "") == "voip.registration_changed":
+            self._dispatch(
+                RegistrationStateChanged(
+                    state=_registration_state(str(event.payload.get("state", "none")))
+                )
+            )
+            return
+        if getattr(event, "type", "") == "voip.incoming_call":
+            self._dispatch(
+                IncomingCallDetected(
+                    caller_address=str(event.payload.get("from_uri", ""))
+                )
+            )
+            return
+        if getattr(event, "type", "") == "voip.call_state_changed":
+            self._dispatch(
+                CallStateChanged(state=_call_state(str(event.payload.get("state", "idle"))))
+            )
+            return
+        if getattr(event, "type", "") == "voip.backend_stopped":
+            self.running = False
+            self._dispatch(BackendStopped(reason=str(event.payload.get("reason", ""))))
+
+    def _send(self, message_type: str, payload: dict[str, Any]) -> bool:
+        send_command = getattr(self.worker_supervisor, "send_command", None)
+        if not callable(send_command):
+            return False
+        return bool(send_command(self.domain, type=message_type, payload=payload))
+
+    def _dispatch(self, event: VoIPEvent) -> None:
+        for callback in list(self.event_callbacks):
+            try:
+                callback(event)
+            except Exception:
+                logger.exception("Rust VoIP Host callback raised for {}", type(event).__name__)
+
+
+def _registration_state(value: str) -> RegistrationState:
+    try:
+        return RegistrationState(value)
+    except ValueError:
+        return RegistrationState.NONE
+
+
+def _call_state(value: str) -> CallState:
+    try:
+        return CallState(value)
+    except ValueError:
+        return CallState.IDLE
+```
+
+- [ ] **Step 3: Export the backend lazily**
+
+In `yoyopod/backends/voip/__init__.py`, add:
+
+```python
+if TYPE_CHECKING:
+    from yoyopod.backends.voip.rust_host import RustHostBackend
+```
+
+Add to `_EXPORTS`:
+
+```python
+"RustHostBackend": ("yoyopod.backends.voip.rust_host", "RustHostBackend"),
+```
+
+Add to `__all__`:
+
+```python
+"RustHostBackend",
+```
+
+- [ ] **Step 4: Make adapter tests pass**
+
+Run:
+
+```bash
+uv run pytest -q tests/backends/test_rust_host_voip.py
+```
+
+Expected: adapter tests pass.
+
+- [ ] **Step 5: Run repo gates and commit**
+
+Run:
+
+```bash
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+Commit:
+
+```bash
+git add yoyopod/backends/voip tests/backends/test_rust_host_voip.py
+git commit -m "feat(voip): add rust host backend adapter"
+```
+
+Expected: Python can use Rust-host-backed calls through the existing backend protocol.
+
+## Task 6: Add Runtime Selection, Conflict Handling, And Worker Event Subscription
+
+**Files:**
+- Modify: `yoyopod/core/bootstrap/managers_boot.py`
+- Modify: `yoyopod/core/bootstrap/callbacks_boot.py`
+- Modify: `tests/core/test_bootstrap.py`
+
+- [ ] **Step 1: Write failing boot selection tests**
+
+Add to `tests/core/test_bootstrap.py`:
+
+```python
+def test_voip_rust_host_and_python_sidecar_flags_conflict(monkeypatch: pytest.MonkeyPatch) -> None:
+    from yoyopod.core.bootstrap.managers_boot import _rust_voip_host_enabled, _voip_sidecar_enabled
+
+    monkeypatch.setenv("YOYOPOD_RUST_VOIP_HOST", "1")
+    monkeypatch.setenv("YOYOPOD_VOIP_SIDECAR", "1")
+
+    assert _rust_voip_host_enabled() is True
+    assert _voip_sidecar_enabled() is True
+
+
+def test_rust_host_backend_receives_worker_supervisor(monkeypatch: pytest.MonkeyPatch) -> None:
+    from yoyopod.core.bootstrap.managers_boot import _rust_voip_host_enabled
+
+    monkeypatch.setenv("YOYOPOD_RUST_VOIP_HOST", "true")
+
+    assert _rust_voip_host_enabled() is True
+```
+
+Run:
+
+```bash
+uv run pytest -q tests/core/test_bootstrap.py::test_voip_rust_host_and_python_sidecar_flags_conflict tests/core/test_bootstrap.py::test_rust_host_backend_receives_worker_supervisor
+```
+
+Expected: fails until `_rust_voip_host_enabled` exists.
+
+- [ ] **Step 2: Add Rust host env helpers**
+
+In `yoyopod/core/bootstrap/managers_boot.py`, add:
+
+```python
+def _rust_voip_host_enabled() -> bool:
+    raw = os.environ.get("YOYOPOD_RUST_VOIP_HOST", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _rust_voip_host_worker_path() -> str:
+    return os.environ.get(
+        "YOYOPOD_RUST_VOIP_HOST_WORKER",
+        "src/crates/voip-host/build/yoyopod-voip-host",
+    ).strip()
+```
+
+In `init_managers`, before backend selection:
+
+```python
+if _voip_sidecar_enabled() and _rust_voip_host_enabled():
+    raise RuntimeError(
+        "YOYOPOD_VOIP_SIDECAR and YOYOPOD_RUST_VOIP_HOST cannot both be enabled"
+    )
+```
+
+Then select the Rust backend:
+
+```python
+if _rust_voip_host_enabled():
+    self.logger.info("    YOYOPOD_RUST_VOIP_HOST=1 - using Rust VoIP Host backend")
+    from yoyopod.backends.voip.rust_host import RustHostBackend
+
+    sidecar_backed_backend = RustHostBackend(
+        voip_config,
+        worker_supervisor=self.app.worker_supervisor,
+        worker_path=_rust_voip_host_worker_path(),
+    )
+    background_iterate_enabled = False
+elif _voip_sidecar_enabled():
+    ...
+```
+
+- [ ] **Step 3: Subscribe Rust backend to worker messages**
+
+In `CallbacksBoot.setup_voip_callbacks`, after manager callback registration:
+
+```python
+backend = getattr(self.app.voip_manager, "backend", None)
+handle_worker_message = getattr(backend, "handle_worker_message", None)
+if callable(handle_worker_message):
+    from yoyopod.core.events import WorkerMessageReceivedEvent
+
+    self.app.bus.subscribe(WorkerMessageReceivedEvent, handle_worker_message)
+```
+
+`RustHostBackend.handle_worker_message` ignores non-`voip` domains by checking the event domain before processing:
+
+```python
+if getattr(event, "domain", self.domain) != self.domain:
+    return
+```
+
+- [ ] **Step 4: Add an explicit domain check to the backend**
+
+At the top of `RustHostBackend.handle_worker_message`:
+
+```python
+if getattr(event, "domain", self.domain) != self.domain:
+    return
+```
+
+Update the fake test events to include `domain="voip"`:
+
+```python
+return SimpleNamespace(domain="voip", kind="event", type=message_type, payload=payload)
+```
+
+- [ ] **Step 5: Run boot and backend tests**
+
+Run:
+
+```bash
+uv run pytest -q tests/backends/test_rust_host_voip.py tests/core/test_bootstrap.py
+```
+
+Expected: tests pass.
+
+- [ ] **Step 6: Run repo gates and commit**
+
+Run:
+
+```bash
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+Commit:
+
+```bash
+git add yoyopod/core/bootstrap yoyopod/backends/voip/rust_host.py tests
+git commit -m "feat(voip): wire rust voip host runtime selection"
+```
+
+Expected: Rust VoIP Host is opt-in and conflicts clearly with the old Python sidecar flag.
+
+## Task 7: CI Artifact For Rust VoIP Host
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `skills/yoyopod-rust-artifact/SKILL.md`
+- Modify: `docs/hardware/DEPLOYED_PI_DEPENDENCIES.md`
+
+- [ ] **Step 1: Add CI build step**
+
+In `.github/workflows/ci.yml`, extend the Rust job after UI host build:
+
+```yaml
+      - name: Build Rust VoIP host
+        working-directory: src
+        run: |
+          set -euo pipefail
+          cargo build --release -p yoyopod-voip-host --locked
+          mkdir -p crates/voip-host/build
+          cp target/release/yoyopod-voip-host crates/voip-host/build/yoyopod-voip-host
+
+      - name: Upload Rust VoIP ARM64 host
+        uses: actions/upload-artifact@v4
+        with:
+          name: yoyopod-voip-host-${{ github.sha }}
+          path: src/crates/voip-host/build/yoyopod-voip-host
+          if-no-files-found: error
+```
+
+Keep the existing UI artifact step unchanged.
+
+- [ ] **Step 2: Update Rust artifact skill**
+
+In `skills/yoyopod-rust-artifact/SKILL.md`, add this section:
+
+````markdown
+## Rust VoIP Host Artifact
+
+The Rust VoIP Host artifact is:
+
+```bash
+yoyopod-voip-host-<sha>
+```
+
+Install it at:
+
+```bash
+/opt/yoyopod-dev/checkout/src/crates/voip-host/build/yoyopod-voip-host
+```
+
+Do not build `yoyopod-voip-host` on the Raspberry Pi Zero 2W.
+````
+
+- [ ] **Step 3: Update deployed dependency note**
+
+In `docs/hardware/DEPLOYED_PI_DEPENDENCIES.md`, add a bullet under native/runtime artifacts:
+
+```markdown
+- `src/crates/voip-host/build/yoyopod-voip-host` - Rust VoIP Host calls-only worker, installed from GitHub Actions artifact.
+```
+
+- [ ] **Step 4: Run validation and commit**
+
+Run:
+
+```bash
+cargo fmt --manifest-path src/Cargo.toml
+cargo test --manifest-path src/Cargo.toml --workspace --locked
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+Commit:
+
+```bash
+git add .github/workflows/ci.yml skills/yoyopod-rust-artifact/SKILL.md docs/hardware/DEPLOYED_PI_DEPENDENCIES.md
+git commit -m "ci: upload rust voip host artifact"
+```
+
+Expected: CI will build and upload both UI and VoIP Rust host artifacts.
+
+## Task 8: Hardware Validation
+
+**Files:**
+- No production code changes unless validation finds a bug.
+- Update PR description with the validation record.
+
+- [ ] **Step 1: Run all local gates before push**
+
+Run:
+
+```bash
+cargo fmt --manifest-path src/Cargo.toml
+cargo test --manifest-path src/Cargo.toml --workspace --locked
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+Expected: all local checks pass.
+
+- [ ] **Step 2: Push the branch**
+
+Run:
+
+```bash
+git push -u origin codex/rust-voip-host
+```
+
+Expected: branch is available on GitHub.
+
+- [ ] **Step 3: Wait for the exact CI artifact**
+
+Use:
+
+```bash
+gh run list --workflow CI --branch codex/rust-voip-host --json databaseId,headSha,status,conclusion --limit 20
+```
+
+Expected: use only a successful run whose `headSha` equals local `git rev-parse HEAD`.
+
+- [ ] **Step 4: Download and install the artifact**
+
+Download:
+
+```bash
+mkdir -p .artifacts/rust-voip/<sha>
+gh run download <run-id> --name yoyopod-voip-host-<sha> --dir .artifacts/rust-voip/<sha>
+chmod +x .artifacts/rust-voip/<sha>/yoyopod-voip-host
+```
+
+Install on Pi:
+
+```bash
+ssh tifo@rpi-zero "mkdir -p /opt/yoyopod-dev/checkout/src/crates/voip-host/build"
+scp .artifacts/rust-voip/<sha>/yoyopod-voip-host tifo@rpi-zero:/opt/yoyopod-dev/checkout/src/crates/voip-host/build/yoyopod-voip-host
+ssh tifo@rpi-zero "chmod +x /opt/yoyopod-dev/checkout/src/crates/voip-host/build/yoyopod-voip-host"
+```
+
+- [ ] **Step 5: Sync Python checkout without target Rust build**
+
+Run:
+
+```bash
+yoyopod remote mode activate dev
+yoyopod remote sync --branch codex/rust-voip-host
+```
+
+Use `--clean-native` only if the liblinphone C shim or native build inputs changed.
+
+- [ ] **Step 6: Start the dev service with Rust VoIP Host enabled**
+
+On the Pi:
+
+```bash
+ssh tifo@rpi-zero "sudo systemctl stop yoyopod-dev.service || true"
+ssh tifo@rpi-zero "cd /opt/yoyopod-dev/checkout && YOYOPOD_RUST_VOIP_HOST=1 YOYOPOD_RUST_VOIP_HOST_WORKER=src/crates/voip-host/build/yoyopod-voip-host /opt/yoyopod-dev/venv/bin/python yoyopod.py"
+```
+
+Expected startup log:
+
+```text
+YOYOPOD_RUST_VOIP_HOST=1 - using Rust VoIP Host backend
+VoIP started successfully
+```
+
+- [ ] **Step 7: Validate registration and call flow**
+
+Use the existing Pi VoIP validation commands where possible:
+
+```bash
+yoyopod pi validate voip
+```
+
+Expected:
+
+- Rust host loads `libyoyopod_liblinphone_shim.so`.
+- SIP registration reaches `ok`.
+- Outgoing dial command reaches Rust.
+- Incoming call event reaches Python as `IncomingCallDetected`.
+- Answer, reject, hangup, mute, and unmute send worker commands.
+- UI snapshots still show call state through the Rust UI Host.
+
+- [ ] **Step 8: Record validation in PR body**
+
+Record:
+
+```text
+Rust VoIP Host hardware validation:
+- branch:
+- commit:
+- CI run:
+- artifact: yoyopod-voip-host-<sha>
+- Pi path: /opt/yoyopod-dev/checkout/src/crates/voip-host/build/yoyopod-voip-host
+- registration:
+- outgoing call:
+- incoming call:
+- answer/reject/hangup:
+- mute/unmute:
+- service shutdown:
+```
+
+Expected: reviewer can verify the exact Rust binary tested on hardware.
+
+## Final Verification Before PR Ready
+
+Run locally:
+
+```bash
+cargo fmt --manifest-path src/Cargo.toml
+cargo test --manifest-path src/Cargo.toml --workspace --locked
+uv run python scripts/quality.py gate
+uv run pytest -q
+```
+
+Check:
+
+```bash
+git status --short
+```
+
+Expected: clean tree, all gates green, CI artifact validated on `rpi-zero`.

--- a/docs/superpowers/specs/2026-04-28-rust-voip-host-design.md
+++ b/docs/superpowers/specs/2026-04-28-rust-voip-host-design.md
@@ -1,0 +1,398 @@
+# Rust VoIP Host - Design Spec
+
+## Problem
+
+YoYoPod is moving the runtime toward Rust. The UI host is now the first
+production Rust ownership boundary under the top-level `src/` workspace. The
+next candidate is VoIP because the current call stack already has a clean
+backend seam and an opt-in sidecar-shaped path:
+
+- Python `VoIPManager` owns the app-facing facade.
+- Python `CallRuntime` owns call/music coordination, call screens, history, and
+  registration state propagation.
+- `LiblinphoneBackend` owns the native liblinphone shim through cffi.
+- `SupervisorBackedBackend` proves a process boundary can sit behind the
+  existing `VoIPBackend` contract.
+
+The current sidecar path is still Python-owned. It isolates some liblinphone
+behavior from the supervisor process, but it does not move production runtime
+ownership toward Rust and it still pays for another Python process.
+
+## Goal
+
+Add a production-shaped Rust VoIP host that owns liblinphone backend execution
+while the Python app remains the runtime supervisor for this slice.
+
+Rust owns:
+
+- liblinphone shim loading
+- liblinphone init/start/stop/shutdown
+- SIP registration command execution
+- call commands: dial, answer, reject, hangup, mute, unmute
+- native iterate cadence
+- native event draining
+- translation from native shim events into protocol events
+- backend crash/degraded reporting
+
+Python keeps:
+
+- config loading
+- `VoIPManager`
+- `CallRuntime`
+- call/music interruption policy
+- contacts and caller display-name lookup
+- call history
+- UI state and Rust UI snapshot generation
+- app bus and scheduler ownership
+- message store and voice-note runtime for this first slice
+
+The first implementation slice is calls only. Text messaging and voice notes are
+deferred until registration and call control are stable on hardware.
+
+## Naming
+
+Use **Rust VoIP Host** as the system name.
+
+The production binary should be named:
+
+```text
+yoyopod-voip-host
+```
+
+The GitHub Actions artifact should be named:
+
+```text
+yoyopod-voip-host-<sha>
+```
+
+The Python adapter should be named around ownership rather than process shape:
+
+```text
+yoyopod/backends/voip/rust_host.py
+```
+
+The older Python sidecar can remain available during migration, but new Rust
+VoIP work should not extend the old multiprocessing/msgpack sidecar protocol
+unless needed for compatibility tests.
+
+## Repository Structure
+
+Production Rust sources stay under the top-level `src/` workspace.
+
+```text
+src/
+  Cargo.toml
+  Cargo.lock
+  crates/
+    ui-host/
+    voip-host/
+      Cargo.toml
+      src/
+        main.rs
+        protocol.rs
+        config.rs
+        host.rs
+        shim.rs
+        events.rs
+        calls.rs
+```
+
+If both UI and VoIP need the same worker envelope helpers, add a small shared
+crate:
+
+```text
+src/crates/worker-protocol/
+```
+
+Do not add a `src/rust/` intermediate layer.
+
+## Architecture
+
+```text
+Python runtime process
+  |- VoIPManager
+  |- RustHostBackend implements VoIPBackend
+  |- WorkerSupervisor domain "voip"
+  |- CallRuntime and app bus
+  `- Rust UI Host receives call state through normal runtime snapshots
+
+Rust VoIP host process
+  |- NDJSON worker protocol
+  |- command handler
+  |- liblinphone shim loader
+  |- native iterate loop
+  |- event translator
+  `- health/degraded reporting
+```
+
+Python continues to call the existing `VoIPBackend` methods:
+
+- `start`
+- `stop`
+- `make_call`
+- `answer_call`
+- `reject_call`
+- `hangup`
+- `mute`
+- `unmute`
+- `on_event`
+
+`RustHostBackend` translates those methods into worker commands and translates
+worker events back into the existing Python `VoIPEvent` dataclasses. The rest of
+the Python runtime should not know whether liblinphone is in-process, Python
+sidecar-backed, or Rust-host-backed.
+
+## Protocol
+
+Use the existing worker-supervisor NDJSON envelope style, aligned with the Rust
+UI Host and Go voice worker shape.
+
+Command examples:
+
+```text
+voip.configure
+voip.register
+voip.unregister
+voip.dial
+voip.answer
+voip.reject
+voip.hangup
+voip.set_mute
+voip.health
+voip.shutdown
+```
+
+Event examples:
+
+```text
+voip.ready
+voip.registration_changed
+voip.incoming_call
+voip.call_state_changed
+voip.backend_stopped
+voip.health
+voip.error
+```
+
+The first slice should not expose text or voice-note commands. If the Python
+adapter receives `send_text_message`, `start_voice_note_recording`, or
+`send_voice_note` while Rust-host mode is enabled, it should fail cleanly and
+surface unsupported behavior rather than silently falling back to another
+backend in the same runtime.
+
+## Native Binding Strategy
+
+Use the existing C liblinphone shim first. Rust should dynamically load the same
+shared library that Python currently loads:
+
+```text
+libyoyopod_liblinphone_shim.so
+```
+
+Resolution order:
+
+1. `YOYOPOD_LIBLINPHONE_SHIM_PATH`
+2. repo runtime path under `yoyopod/backends/voip/shim_native/build/`
+3. packaged slot path once prod slots include the Rust host
+
+This keeps the Rust slice focused on process ownership and typed translation,
+not on replacing the native liblinphone C boundary. Direct Rust bindings to
+liblinphone can be considered only after the Rust host is stable.
+
+## Runtime Ownership
+
+The Rust host owns the liblinphone iterate cadence. Python should not call
+`iterate()` for this backend.
+
+`RustHostBackend.iterate()` should return `0` and exist only to satisfy the
+current `VoIPBackend` protocol. Timing and health should come from worker
+events, not from Python polling native liblinphone directly.
+
+Startup flow:
+
+1. Python reads `VoIPConfig`.
+2. Python registers worker domain `voip`.
+3. Python starts `yoyopod-voip-host`.
+4. Rust emits `voip.ready`.
+5. Python sends `voip.configure`.
+6. Python sends `voip.register`.
+7. Rust emits registration events.
+
+Shutdown flow:
+
+1. Python sends `voip.unregister` or `voip.shutdown`.
+2. Rust stops liblinphone and releases the shim.
+3. Worker supervisor stops the process with a bounded grace period.
+
+## Configuration
+
+Keep Rust VoIP host opt-in for the first slice.
+
+Suggested activation:
+
+```text
+YOYOPOD_RUST_VOIP_HOST=1
+```
+
+If both the old Python VoIP sidecar flag and the Rust VoIP host flag are set,
+boot should fail fast with a clear configuration error. Running two VoIP owners
+in one app process is not supported.
+
+Longer term, replace separate booleans with one explicit backend selector:
+
+```text
+voip.backend = "in_process" | "python_sidecar" | "rust_host"
+```
+
+That selector does not need to land in the first implementation slice if an env
+flag is enough for hardware validation.
+
+## Audio
+
+For this slice, Rust passes through the configured liblinphone device IDs:
+
+- playback device
+- ringer device
+- capture device
+- media device
+- mic gain
+- output volume
+
+The current ALSA capture tuning lives in Python `LiblinphoneBackend`, not in
+the C shim itself. Rust-host mode must preserve that behavior explicitly before
+hardware validation. The preferred first step is to extract the existing tuning
+logic into a small shared Python helper that both in-process liblinphone and
+Rust-host mode can call before registration. Rust should not invent a separate
+ALSA policy layer.
+
+Moving mixer ownership behind a shared app audio facade remains a separate
+architecture task.
+
+## CI And Deploy
+
+Rust binaries for Pi validation must come from GitHub Actions artifacts for the
+exact commit being tested.
+
+Required CI additions:
+
+- `cargo fmt --manifest-path src/Cargo.toml`
+- `cargo test --manifest-path src/Cargo.toml --workspace --locked`
+- `cargo build --release -p yoyopod-voip-host --locked`
+- upload `yoyopod-voip-host-<sha>`
+
+The hardware deploy path is:
+
+1. Commit and push.
+2. Wait for the Rust CI job for the exact commit.
+3. Download `yoyopod-voip-host-<sha>`.
+4. Copy it to the Pi dev checkout.
+5. Start the Python app with Rust VoIP host mode enabled.
+
+Do not build `yoyopod-voip-host` on the Raspberry Pi Zero 2W unless the user
+explicitly overrides this rule.
+
+## Testing
+
+Rust tests:
+
+- protocol decode/encode
+- command validation
+- config mapping
+- native event translation
+- call-id tracking
+- unsupported messaging command behavior
+- backend stopped/error event behavior
+
+Python tests:
+
+- `RustHostBackend` implements the `VoIPBackend` contract
+- startup sends configure/register after ready
+- worker registration errors mark VoIP unavailable
+- registration/call worker events become existing Python `VoIPEvent` dataclasses
+- dial/answer/reject/hangup/mute/unmute send correct worker commands
+- `iterate()` is a no-op for Rust-host mode
+- old Python sidecar flag and Rust host flag conflict clearly
+
+Hardware validation:
+
+- Rust host starts from CI artifact on `rpi-zero`
+- Rust host loads the deployed liblinphone shim
+- SIP registration reaches `ok`
+- outgoing call can be dialed and hung up
+- incoming call emits incoming-call and call-state events
+- answer/reject/hangup behave through the existing Python call services
+- UI still updates through normal runtime snapshots
+- service shutdown releases liblinphone cleanly
+
+## Acceptance Criteria
+
+This design is accepted when:
+
+- production Rust VoIP source lives under top-level `src/crates/voip-host/`
+- the binary is named `yoyopod-voip-host`
+- Rust owns liblinphone lifecycle and iterate cadence in Rust-host mode
+- Python `VoIPManager` and `CallRuntime` remain the app-facing runtime owners
+- the Python adapter implements the existing `VoIPBackend` contract
+- call control works through dial, answer, reject, hangup, mute, and unmute
+- messaging and voice notes fail explicitly as unsupported in the first slice
+- CI builds and uploads an ARM64 Rust VoIP host artifact
+- hardware validation uses the CI-built artifact, not a target-side Rust build
+- code follows clean Rust and Python guidelines: small modules, readable names,
+  explicit errors, narrow ownership, `rustfmt`, Black, ruff, and mypy gates
+
+## Non-Goals
+
+- Do not move `VoIPManager` into Rust in the first VoIP slice.
+- Do not move `CallRuntime` or call/music interruption policy into Rust.
+- Do not move contacts, call history, or UI call screens into Rust.
+- Do not implement text messaging or voice notes in the first Rust VoIP slice.
+- Do not replace the C liblinphone shim with direct liblinphone Rust bindings.
+- Do not build Rust binaries on the Pi Zero 2W.
+
+## Migration Slices
+
+### Slice 1: Rust Host Skeleton
+
+- Add `src/crates/voip-host/`.
+- Add the NDJSON worker protocol.
+- Add `voip.ready`, `voip.health`, and graceful shutdown.
+- Build and upload the CI artifact.
+
+### Slice 2: Shim Binding And Registration
+
+- Dynamically load the existing liblinphone shim.
+- Map `VoIPConfig` into the Rust host config.
+- Implement configure/register/unregister.
+- Emit registration state events.
+
+### Slice 3: Call Control
+
+- Implement dial/answer/reject/hangup/mute/unmute.
+- Translate native incoming-call and call-state events.
+- Track active call id in Rust.
+- Translate backend stopped/errors into Python-compatible events.
+
+### Slice 4: Python Runtime Wiring
+
+- Add `RustHostBackend`.
+- Add opt-in boot selection.
+- Route worker events into existing `VoIPEvent` callbacks.
+- Add tests proving the rest of the call runtime is backend-agnostic.
+
+### Slice 5: Hardware Validation
+
+- Deploy the CI artifact to `rpi-zero`.
+- Validate registration, outgoing call, incoming call, answer, reject, hangup,
+  mute, and clean shutdown.
+- Capture logs and document exact provenance.
+
+## Deferred Decisions
+
+- Whether text messaging and voice notes should move into the Rust VoIP host in
+  the next slice or wait until the broader Rust runtime owns message storage.
+- Whether the old Python VoIP sidecar should be deleted immediately after Rust
+  host validation or kept for one release as fallback.
+- Whether a shared Rust `worker-protocol` crate should be created before or
+  after the first VoIP host skeleton.
+- Whether the long-term runtime is one Rust binary with internal services or
+  multiple Rust hosts supervised during the migration.

--- a/skills/yoyopod-rust-artifact/SKILL.md
+++ b/skills/yoyopod-rust-artifact/SKILL.md
@@ -41,6 +41,22 @@ It contains the ARM64 Linux binary that should be installed at:
 /opt/yoyopod-dev/checkout/workers/ui/rust/build/yoyopod-rust-ui-poc
 ```
 
+## Rust VoIP Host Artifact
+
+The Rust VoIP Host artifact is:
+
+```bash
+yoyopod-voip-host-<sha>
+```
+
+Install it at:
+
+```bash
+/opt/yoyopod-dev/checkout/src/crates/voip-host/build/yoyopod-voip-host
+```
+
+Do not build `yoyopod-voip-host` on the Raspberry Pi Zero 2W.
+
 ## Steps
 
 1. **Check local git status.** Run `git status --short`. If there are local

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -370,6 +370,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoyopod-voip-host"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "libloading",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -2,4 +2,5 @@
 resolver = "2"
 members = [
     "crates/ui-host",
+    "crates/voip-host",
 ]

--- a/src/crates/voip-host/Cargo.toml
+++ b/src/crates/voip-host/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "yoyopod-voip-host"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[[bin]]
+name = "yoyopod-voip-host"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+libloading = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "2.0"

--- a/src/crates/voip-host/src/config.rs
+++ b/src/crates/voip-host/src/config.rs
@@ -1,0 +1,139 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VoipConfig {
+    #[serde(default = "default_sip_server")]
+    pub sip_server: String,
+    #[serde(default)]
+    pub sip_username: String,
+    #[serde(default)]
+    pub sip_password: String,
+    #[serde(default)]
+    pub sip_password_ha1: String,
+    #[serde(default)]
+    pub sip_identity: String,
+    #[serde(default)]
+    pub factory_config_path: String,
+    #[serde(default = "default_transport")]
+    pub transport: String,
+    #[serde(default)]
+    pub stun_server: String,
+    #[serde(default)]
+    pub conference_factory_uri: String,
+    #[serde(default)]
+    pub file_transfer_server_url: String,
+    #[serde(default)]
+    pub lime_server_url: String,
+    #[serde(default = "default_iterate_interval_ms")]
+    pub iterate_interval_ms: u64,
+    #[serde(default)]
+    pub voice_note_store_dir: String,
+    #[serde(default)]
+    pub auto_download_incoming_voice_recordings: bool,
+    #[serde(default = "default_audio_device")]
+    pub playback_dev_id: String,
+    #[serde(default = "default_audio_device")]
+    pub ringer_dev_id: String,
+    #[serde(default = "default_audio_device")]
+    pub capture_dev_id: String,
+    #[serde(default = "default_audio_device")]
+    pub media_dev_id: String,
+    #[serde(default = "default_mic_gain")]
+    pub mic_gain: i32,
+    #[serde(default = "default_output_volume")]
+    pub output_volume: i32,
+}
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("invalid voip config payload: {0}")]
+    InvalidPayload(#[from] serde_json::Error),
+    #[error("sip_identity is required for Rust VoIP host registration")]
+    MissingSipIdentity,
+    #[error("sip_server is required for Rust VoIP host registration")]
+    MissingSipServer,
+}
+
+impl VoipConfig {
+    pub fn from_payload(payload: &Value) -> Result<Self, ConfigError> {
+        let config: Self = serde_json::from_value(payload.clone())?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.sip_server.trim().is_empty() {
+            return Err(ConfigError::MissingSipServer);
+        }
+        if self.sip_identity.trim().is_empty() {
+            return Err(ConfigError::MissingSipIdentity);
+        }
+        Ok(())
+    }
+}
+
+fn default_sip_server() -> String {
+    "sip.linphone.org".to_string()
+}
+
+fn default_transport() -> String {
+    "tcp".to_string()
+}
+
+fn default_iterate_interval_ms() -> u64 {
+    20
+}
+
+fn default_audio_device() -> String {
+    "ALSA: wm8960-soundcard".to_string()
+}
+
+fn default_mic_gain() -> i32 {
+    80
+}
+
+fn default_output_volume() -> i32 {
+    100
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn config_from_payload_accepts_python_voip_config_shape() {
+        let payload = json!({
+            "sip_server": "sip.example.com",
+            "sip_username": "alice",
+            "sip_password": "secret",
+            "sip_identity": "sip:alice@example.com",
+            "transport": "tcp",
+            "iterate_interval_ms": 20,
+            "playback_dev_id": "ALSA: wm8960-soundcard",
+            "ringer_dev_id": "ALSA: wm8960-soundcard",
+            "capture_dev_id": "ALSA: wm8960-soundcard",
+            "media_dev_id": "ALSA: wm8960-soundcard",
+            "mic_gain": 80,
+            "output_volume": 100
+        });
+
+        let config = VoipConfig::from_payload(&payload).expect("config");
+
+        assert_eq!(config.sip_server, "sip.example.com");
+        assert_eq!(config.sip_identity, "sip:alice@example.com");
+        assert_eq!(config.iterate_interval_ms, 20);
+        assert_eq!(config.transport, "tcp");
+    }
+
+    #[test]
+    fn config_rejects_missing_identity() {
+        let payload = json!({"sip_server":"sip.example.com"});
+
+        let error = VoipConfig::from_payload(&payload).expect_err("must reject");
+
+        assert!(error.to_string().contains("sip_identity"));
+    }
+}

--- a/src/crates/voip-host/src/events.rs
+++ b/src/crates/voip-host/src/events.rs
@@ -1,0 +1,143 @@
+use serde_json::{json, Value};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegistrationState {
+    None,
+    Progress,
+    Ok,
+    Cleared,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallState {
+    Idle,
+    Incoming,
+    OutgoingInit,
+    OutgoingProgress,
+    OutgoingRinging,
+    OutgoingEarlyMedia,
+    Connected,
+    StreamsRunning,
+    Paused,
+    PausedByRemote,
+    UpdatedByRemote,
+    Released,
+    Error,
+    End,
+}
+
+impl RegistrationState {
+    pub fn from_native(value: i32) -> Self {
+        match value {
+            1 => Self::Progress,
+            2 => Self::Ok,
+            3 => Self::Cleared,
+            4 => Self::Failed,
+            _ => Self::None,
+        }
+    }
+
+    pub fn as_protocol(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Progress => "progress",
+            Self::Ok => "ok",
+            Self::Cleared => "cleared",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl CallState {
+    pub fn from_native(value: i32) -> Self {
+        match value {
+            1 => Self::Incoming,
+            2 => Self::OutgoingInit,
+            3 => Self::OutgoingProgress,
+            4 => Self::OutgoingRinging,
+            5 => Self::OutgoingEarlyMedia,
+            6 => Self::Connected,
+            7 => Self::StreamsRunning,
+            8 => Self::Paused,
+            9 => Self::PausedByRemote,
+            10 => Self::UpdatedByRemote,
+            11 => Self::Released,
+            12 => Self::Error,
+            13 => Self::End,
+            _ => Self::Idle,
+        }
+    }
+
+    pub fn as_protocol(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Incoming => "incoming",
+            Self::OutgoingInit => "outgoing_init",
+            Self::OutgoingProgress => "outgoing_progress",
+            Self::OutgoingRinging => "outgoing_ringing",
+            Self::OutgoingEarlyMedia => "outgoing_early_media",
+            Self::Connected => "connected",
+            Self::StreamsRunning => "streams_running",
+            Self::Paused => "paused",
+            Self::PausedByRemote => "paused_by_remote",
+            Self::UpdatedByRemote => "updated_by_remote",
+            Self::Released => "released",
+            Self::Error => "error",
+            Self::End => "end",
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Idle | Self::Released | Self::Error | Self::End)
+    }
+}
+
+pub fn registration_payload(state: RegistrationState, reason: &str) -> Value {
+    json!({"state": state.as_protocol(), "reason": reason})
+}
+
+pub fn call_state_payload(call_id: &str, state: CallState) -> Value {
+    json!({"call_id": call_id, "state": state.as_protocol()})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_native_registration_values_to_python_values() {
+        assert_eq!(RegistrationState::from_native(1).as_protocol(), "progress");
+        assert_eq!(RegistrationState::from_native(2).as_protocol(), "ok");
+        assert_eq!(RegistrationState::from_native(4).as_protocol(), "failed");
+        assert_eq!(RegistrationState::from_native(99).as_protocol(), "none");
+    }
+
+    #[test]
+    fn maps_native_call_values_to_python_values() {
+        assert_eq!(CallState::from_native(1).as_protocol(), "incoming");
+        assert_eq!(CallState::from_native(7).as_protocol(), "streams_running");
+        assert_eq!(CallState::from_native(11).as_protocol(), "released");
+        assert_eq!(CallState::from_native(99).as_protocol(), "idle");
+    }
+
+    #[test]
+    fn released_error_end_are_terminal() {
+        assert!(CallState::Released.is_terminal());
+        assert!(CallState::Error.is_terminal());
+        assert!(CallState::End.is_terminal());
+        assert!(!CallState::Connected.is_terminal());
+    }
+
+    #[test]
+    fn event_payload_helpers_match_worker_protocol() {
+        assert_eq!(
+            registration_payload(RegistrationState::Ok, ""),
+            serde_json::json!({"state": "ok", "reason": ""})
+        );
+        assert_eq!(
+            call_state_payload("call-1", CallState::StreamsRunning),
+            serde_json::json!({"call_id": "call-1", "state": "streams_running"})
+        );
+    }
+}

--- a/src/crates/voip-host/src/host.rs
+++ b/src/crates/voip-host/src/host.rs
@@ -1,6 +1,25 @@
 use crate::config::VoipConfig;
 use serde_json::json;
 
+pub trait CallBackend {
+    fn start(&mut self, config: &VoipConfig) -> Result<(), String>;
+    fn stop(&mut self);
+    fn iterate(&mut self) -> Result<Vec<BackendEvent>, String>;
+    fn make_call(&mut self, sip_address: &str) -> Result<String, String>;
+    fn answer_call(&mut self) -> Result<(), String>;
+    fn reject_call(&mut self) -> Result<(), String>;
+    fn hangup(&mut self) -> Result<(), String>;
+    fn set_muted(&mut self, muted: bool) -> Result<(), String>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackendEvent {
+    RegistrationChanged { state: String, reason: String },
+    IncomingCall { call_id: String, from_uri: String },
+    CallStateChanged { call_id: String, state: String },
+    BackendStopped { reason: String },
+}
+
 #[derive(Debug, Default)]
 pub struct VoipHost {
     config: Option<VoipConfig>,
@@ -30,6 +49,56 @@ impl VoipHost {
             "active_call_id": self.active_call_id,
         })
     }
+
+    pub fn register<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
+        let config = self
+            .config
+            .as_ref()
+            .ok_or_else(|| "voip host is not configured".to_string())?;
+        backend.start(config)?;
+        self.registered = true;
+        Ok(())
+    }
+
+    pub fn unregister<B: CallBackend>(&mut self, backend: &mut B) {
+        backend.stop();
+        self.registered = false;
+        self.active_call_id = None;
+    }
+
+    pub fn dial<B: CallBackend>(
+        &mut self,
+        backend: &mut B,
+        sip_address: &str,
+    ) -> Result<(), String> {
+        let call_id = backend.make_call(sip_address)?;
+        self.active_call_id = Some(call_id);
+        Ok(())
+    }
+
+    pub fn answer<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
+        backend.answer_call()
+    }
+
+    pub fn reject<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
+        backend.reject_call()?;
+        self.active_call_id = None;
+        Ok(())
+    }
+
+    pub fn hangup<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
+        backend.hangup()?;
+        self.active_call_id = None;
+        Ok(())
+    }
+
+    pub fn set_muted<B: CallBackend>(
+        &mut self,
+        backend: &mut B,
+        muted: bool,
+    ) -> Result<(), String> {
+        backend.set_muted(muted)
+    }
 }
 
 #[cfg(test)]
@@ -57,5 +126,139 @@ mod tests {
         assert_eq!(payload["configured"], true);
         assert_eq!(payload["registered"], true);
         assert_eq!(payload["active_call_id"], "call-1");
+    }
+}
+
+#[cfg(test)]
+mod command_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[derive(Default)]
+    struct FakeBackend {
+        calls: Vec<String>,
+    }
+
+    impl CallBackend for FakeBackend {
+        fn start(&mut self, _config: &VoipConfig) -> Result<(), String> {
+            self.calls.push("start".to_string());
+            Ok(())
+        }
+
+        fn stop(&mut self) {
+            self.calls.push("stop".to_string());
+        }
+
+        fn iterate(&mut self) -> Result<Vec<BackendEvent>, String> {
+            Ok(vec![])
+        }
+
+        fn make_call(&mut self, sip_address: &str) -> Result<String, String> {
+            self.calls.push(format!("dial:{sip_address}"));
+            Ok("call-outgoing".to_string())
+        }
+
+        fn answer_call(&mut self) -> Result<(), String> {
+            self.calls.push("answer".to_string());
+            Ok(())
+        }
+
+        fn reject_call(&mut self) -> Result<(), String> {
+            self.calls.push("reject".to_string());
+            Ok(())
+        }
+
+        fn hangup(&mut self) -> Result<(), String> {
+            self.calls.push("hangup".to_string());
+            Ok(())
+        }
+
+        fn set_muted(&mut self, muted: bool) -> Result<(), String> {
+            self.calls.push(format!("mute:{muted}"));
+            Ok(())
+        }
+    }
+
+    fn config() -> VoipConfig {
+        VoipConfig::from_payload(&json!({
+            "sip_server":"sip.example.com",
+            "sip_identity":"sip:alice@example.com"
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn register_starts_backend_and_health_reports_registered() {
+        let mut host = VoipHost::default();
+        let mut backend = FakeBackend::default();
+        host.configure(config());
+
+        host.register(&mut backend).expect("register");
+
+        assert_eq!(backend.calls, vec!["start"]);
+        assert_eq!(host.health_payload()["registered"], true);
+    }
+
+    #[test]
+    fn dial_sets_active_call_id() {
+        let mut host = VoipHost::default();
+        let mut backend = FakeBackend::default();
+        host.configure(config());
+        host.register(&mut backend).unwrap();
+
+        host.dial(&mut backend, "sip:bob@example.com")
+            .expect("dial");
+
+        assert_eq!(host.health_payload()["active_call_id"], "call-outgoing");
+    }
+
+    #[test]
+    fn call_commands_forward_to_backend_and_clear_finished_call() {
+        let mut host = VoipHost::default();
+        let mut backend = FakeBackend::default();
+        host.configure(config());
+        host.register(&mut backend).unwrap();
+        host.dial(&mut backend, "sip:bob@example.com").unwrap();
+
+        host.answer(&mut backend).expect("answer");
+        host.set_muted(&mut backend, true).expect("mute");
+        host.hangup(&mut backend).expect("hangup");
+
+        assert_eq!(
+            backend.calls,
+            vec![
+                "start",
+                "dial:sip:bob@example.com",
+                "answer",
+                "mute:true",
+                "hangup"
+            ]
+        );
+        assert_eq!(
+            host.health_payload()["active_call_id"],
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    fn reject_and_unregister_clear_state() {
+        let mut host = VoipHost::default();
+        let mut backend = FakeBackend::default();
+        host.configure(config());
+        host.register(&mut backend).unwrap();
+        host.dial(&mut backend, "sip:bob@example.com").unwrap();
+
+        host.reject(&mut backend).expect("reject");
+        host.unregister(&mut backend);
+
+        assert_eq!(
+            backend.calls,
+            vec!["start", "dial:sip:bob@example.com", "reject", "stop"]
+        );
+        assert_eq!(host.health_payload()["registered"], false);
+        assert_eq!(
+            host.health_payload()["active_call_id"],
+            serde_json::Value::Null
+        );
     }
 }

--- a/src/crates/voip-host/src/host.rs
+++ b/src/crates/voip-host/src/host.rs
@@ -50,6 +50,13 @@ impl VoipHost {
         })
     }
 
+    pub fn iterate_interval_ms(&self) -> u64 {
+        self.config
+            .as_ref()
+            .map(|config| config.iterate_interval_ms.max(1))
+            .unwrap_or(20)
+    }
+
     pub fn register<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
         let config = self
             .config
@@ -98,6 +105,47 @@ impl VoipHost {
         muted: bool,
     ) -> Result<(), String> {
         backend.set_muted(muted)
+    }
+
+    pub fn poll_backend_events<B: CallBackend>(
+        &mut self,
+        backend: &mut B,
+    ) -> Result<Vec<BackendEvent>, String> {
+        let events = backend.iterate()?;
+        for event in &events {
+            self.apply_backend_event(event);
+        }
+        Ok(events)
+    }
+
+    fn apply_backend_event(&mut self, event: &BackendEvent) {
+        match event {
+            BackendEvent::RegistrationChanged { state, .. } => {
+                if state == "ok" {
+                    self.registered = true;
+                } else if matches!(state.as_str(), "failed" | "cleared" | "none") {
+                    self.registered = false;
+                }
+            }
+            BackendEvent::IncomingCall { call_id, .. } => {
+                self.active_call_id = Some(call_id.clone());
+            }
+            BackendEvent::CallStateChanged { call_id, state } => {
+                if matches!(state.as_str(), "idle" | "released" | "error" | "end") {
+                    if self.active_call_id.as_deref() == Some(call_id.as_str())
+                        || self.active_call_id.is_none()
+                    {
+                        self.active_call_id = None;
+                    }
+                } else {
+                    self.active_call_id = Some(call_id.clone());
+                }
+            }
+            BackendEvent::BackendStopped { .. } => {
+                self.registered = false;
+                self.active_call_id = None;
+            }
+        }
     }
 }
 
@@ -260,5 +308,87 @@ mod command_tests {
             host.health_payload()["active_call_id"],
             serde_json::Value::Null
         );
+    }
+
+    #[test]
+    fn poll_backend_events_updates_registration_and_call_state() {
+        struct EventBackend {
+            events: Vec<BackendEvent>,
+        }
+
+        impl CallBackend for EventBackend {
+            fn start(&mut self, _config: &VoipConfig) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn stop(&mut self) {}
+
+            fn iterate(&mut self) -> Result<Vec<BackendEvent>, String> {
+                Ok(std::mem::take(&mut self.events))
+            }
+
+            fn make_call(&mut self, _sip_address: &str) -> Result<String, String> {
+                Ok("call-outgoing".to_string())
+            }
+
+            fn answer_call(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn reject_call(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn hangup(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn set_muted(&mut self, _muted: bool) -> Result<(), String> {
+                Ok(())
+            }
+        }
+
+        let mut host = VoipHost::default();
+        host.configure(config());
+        let mut backend = EventBackend {
+            events: vec![
+                BackendEvent::RegistrationChanged {
+                    state: "ok".to_string(),
+                    reason: "".to_string(),
+                },
+                BackendEvent::IncomingCall {
+                    call_id: "call-1".to_string(),
+                    from_uri: "sip:bob@example.com".to_string(),
+                },
+                BackendEvent::CallStateChanged {
+                    call_id: "call-1".to_string(),
+                    state: "released".to_string(),
+                },
+            ],
+        };
+
+        let events = host.poll_backend_events(&mut backend).expect("poll");
+
+        assert_eq!(events.len(), 3);
+        assert_eq!(host.health_payload()["registered"], true);
+        assert_eq!(
+            host.health_payload()["active_call_id"],
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    fn iterate_interval_comes_from_config() {
+        let mut host = VoipHost::default();
+        host.configure(
+            VoipConfig::from_payload(&json!({
+                "sip_server":"sip.example.com",
+                "sip_identity":"sip:alice@example.com",
+                "iterate_interval_ms": 37
+            }))
+            .unwrap(),
+        );
+
+        assert_eq!(host.iterate_interval_ms(), 37);
     }
 }

--- a/src/crates/voip-host/src/host.rs
+++ b/src/crates/voip-host/src/host.rs
@@ -1,0 +1,61 @@
+use crate::config::VoipConfig;
+use serde_json::json;
+
+#[derive(Debug, Default)]
+pub struct VoipHost {
+    config: Option<VoipConfig>,
+    registered: bool,
+    active_call_id: Option<String>,
+}
+
+impl VoipHost {
+    pub fn configure(&mut self, config: VoipConfig) {
+        self.config = Some(config);
+        self.registered = false;
+        self.active_call_id = None;
+    }
+
+    pub fn mark_registered(&mut self, registered: bool) {
+        self.registered = registered;
+    }
+
+    pub fn set_active_call_id(&mut self, call_id: Option<String>) {
+        self.active_call_id = call_id;
+    }
+
+    pub fn health_payload(&self) -> serde_json::Value {
+        json!({
+            "configured": self.config.is_some(),
+            "registered": self.registered,
+            "active_call_id": self.active_call_id,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn config() -> VoipConfig {
+        VoipConfig::from_payload(&json!({
+            "sip_server": "sip.example.com",
+            "sip_identity": "sip:alice@example.com"
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn health_reports_configured_registered_and_call_id() {
+        let mut host = VoipHost::default();
+        host.configure(config());
+        host.mark_registered(true);
+        host.set_active_call_id(Some("call-1".to_string()));
+
+        let payload = host.health_payload();
+
+        assert_eq!(payload["configured"], true);
+        assert_eq!(payload["registered"], true);
+        assert_eq!(payload["active_call_id"], "call-1");
+    }
+}

--- a/src/crates/voip-host/src/main.rs
+++ b/src/crates/voip-host/src/main.rs
@@ -1,0 +1,70 @@
+use anyhow::Result;
+use clap::Parser;
+use serde_json::json;
+use std::io::{self, BufRead, Write};
+
+mod protocol;
+
+use protocol::WorkerEnvelope;
+
+#[derive(Debug, Parser)]
+#[command(name = "yoyopod-voip-host")]
+#[command(about = "YoYoPod Rust VoIP host")]
+struct Args {
+    #[arg(long, default_value = "")]
+    shim_path: String,
+}
+
+fn main() -> Result<()> {
+    let _args = Args::parse();
+    write_envelope(&WorkerEnvelope::event(
+        "voip.ready",
+        json!({"capabilities":["calls"]}),
+    ))?;
+
+    let stdin = io::stdin();
+    for line in stdin.lock().lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let envelope = match WorkerEnvelope::decode(line.as_bytes()) {
+            Ok(envelope) => envelope,
+            Err(error) => {
+                write_envelope(&WorkerEnvelope::error(
+                    "voip.error",
+                    None,
+                    "protocol_error",
+                    error.to_string(),
+                ))?;
+                continue;
+            }
+        };
+
+        if envelope.message_type == "voip.health" {
+            write_envelope(&WorkerEnvelope::result(
+                "voip.health",
+                envelope.request_id,
+                json!({"ready":true,"registered":false,"active_call_id":null}),
+            ))?;
+        } else if envelope.message_type == "voip.shutdown" {
+            break;
+        } else {
+            write_envelope(&WorkerEnvelope::error(
+                "voip.error",
+                envelope.request_id,
+                "unsupported_command",
+                format!("unsupported command {}", envelope.message_type),
+            ))?;
+        }
+    }
+    Ok(())
+}
+
+fn write_envelope(envelope: &WorkerEnvelope) -> Result<()> {
+    let encoded = envelope.encode()?;
+    let mut stdout = io::stdout().lock();
+    stdout.write_all(&encoded)?;
+    stdout.flush()?;
+    Ok(())
+}

--- a/src/crates/voip-host/src/main.rs
+++ b/src/crates/voip-host/src/main.rs
@@ -2,6 +2,8 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use serde_json::json;
 use std::io::{self, BufRead, Write};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::time::Duration;
 
 mod config;
 mod events;
@@ -10,7 +12,7 @@ mod protocol;
 mod shim;
 
 use config::VoipConfig;
-use host::{CallBackend, VoipHost};
+use host::VoipHost;
 use protocol::WorkerEnvelope;
 
 #[derive(Debug, Parser)]
@@ -36,42 +38,60 @@ fn main() -> Result<()> {
         json!({"capabilities":["calls"]}),
     ))?;
 
-    let stdin = io::stdin();
-    for line in stdin.lock().lines() {
-        let line = line?;
-        if line.trim().is_empty() {
-            continue;
+    let (stdin_tx, stdin_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let stdin = io::stdin();
+        for line in stdin.lock().lines() {
+            if stdin_tx.send(line).is_err() {
+                break;
+            }
         }
-        let envelope = match WorkerEnvelope::decode(line.as_bytes()) {
-            Ok(envelope) => envelope,
-            Err(error) => {
-                write_envelope(&WorkerEnvelope::error(
-                    "voip.error",
-                    None,
-                    "protocol_error",
-                    error.to_string(),
-                ))?;
-                continue;
-            }
-        };
+    });
 
-        let request_id = envelope.request_id.clone();
-        match handle_command(
-            envelope,
-            &mut host,
-            &mut backend,
-            explicit_shim_path.as_deref(),
-        ) {
-            Ok(LoopAction::Continue) => {}
-            Ok(LoopAction::Shutdown) => break,
-            Err(error) => {
-                write_envelope(&WorkerEnvelope::error(
-                    "voip.error",
-                    request_id,
-                    "command_failed",
-                    error.to_string(),
-                ))?;
+    loop {
+        match stdin_rx.recv_timeout(next_loop_timeout(&host, backend.is_some())) {
+            Ok(Ok(line)) => {
+                if !line.trim().is_empty() {
+                    let envelope = match WorkerEnvelope::decode(line.as_bytes()) {
+                        Ok(envelope) => envelope,
+                        Err(error) => {
+                            write_envelope(&WorkerEnvelope::error(
+                                "voip.error",
+                                None,
+                                "protocol_error",
+                                error.to_string(),
+                            ))?;
+                            poll_backend(&mut host, &mut backend)?;
+                            continue;
+                        }
+                    };
+
+                    let request_id = envelope.request_id.clone();
+                    match handle_command(
+                        envelope,
+                        &mut host,
+                        &mut backend,
+                        explicit_shim_path.as_deref(),
+                    ) {
+                        Ok(LoopAction::Continue) => {}
+                        Ok(LoopAction::Shutdown) => break,
+                        Err(error) => {
+                            write_envelope(&WorkerEnvelope::error(
+                                "voip.error",
+                                request_id,
+                                "command_failed",
+                                error.to_string(),
+                            ))?;
+                        }
+                    }
+                }
+                poll_backend(&mut host, &mut backend)?;
             }
+            Ok(Err(error)) => return Err(error.into()),
+            Err(RecvTimeoutError::Timeout) => {
+                poll_backend(&mut host, &mut backend)?;
+            }
+            Err(RecvTimeoutError::Disconnected) => break,
         }
     }
     Ok(())
@@ -219,10 +239,25 @@ fn handle_command(
         }
     }
 
-    if let Some(backend_ref) = backend.as_mut() {
-        emit_backend_events(backend_ref.iterate().map_err(|error| anyhow!(error))?)?;
-    }
     Ok(LoopAction::Continue)
+}
+
+fn next_loop_timeout(host: &VoipHost, backend_running: bool) -> Duration {
+    if backend_running {
+        Duration::from_millis(host.iterate_interval_ms())
+    } else {
+        Duration::from_secs(60)
+    }
+}
+
+fn poll_backend(host: &mut VoipHost, backend: &mut Option<shim::ShimBackend>) -> Result<()> {
+    if let Some(backend_ref) = backend.as_mut() {
+        emit_backend_events(
+            host.poll_backend_events(backend_ref)
+                .map_err(|error| anyhow!(error))?,
+        )?;
+    }
+    Ok(())
 }
 
 fn emit_backend_events(events: Vec<host::BackendEvent>) -> Result<()> {

--- a/src/crates/voip-host/src/main.rs
+++ b/src/crates/voip-host/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::Parser;
 use serde_json::json;
 use std::io::{self, BufRead, Write};
@@ -7,7 +7,10 @@ mod config;
 mod events;
 mod host;
 mod protocol;
+mod shim;
 
+use config::VoipConfig;
+use host::{CallBackend, VoipHost};
 use protocol::WorkerEnvelope;
 
 #[derive(Debug, Parser)]
@@ -19,7 +22,15 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    let _args = Args::parse();
+    let args = Args::parse();
+    let explicit_shim_path = if args.shim_path.trim().is_empty() {
+        None
+    } else {
+        Some(args.shim_path.clone())
+    };
+    let mut host = VoipHost::default();
+    let mut backend: Option<shim::ShimBackend> = None;
+
     write_envelope(&WorkerEnvelope::event(
         "voip.ready",
         json!({"capabilities":["calls"]}),
@@ -44,15 +55,161 @@ fn main() -> Result<()> {
             }
         };
 
-        if envelope.message_type == "voip.health" {
+        let request_id = envelope.request_id.clone();
+        match handle_command(
+            envelope,
+            &mut host,
+            &mut backend,
+            explicit_shim_path.as_deref(),
+        ) {
+            Ok(LoopAction::Continue) => {}
+            Ok(LoopAction::Shutdown) => break,
+            Err(error) => {
+                write_envelope(&WorkerEnvelope::error(
+                    "voip.error",
+                    request_id,
+                    "command_failed",
+                    error.to_string(),
+                ))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+enum LoopAction {
+    Continue,
+    Shutdown,
+}
+
+fn handle_command(
+    envelope: WorkerEnvelope,
+    host: &mut VoipHost,
+    backend: &mut Option<shim::ShimBackend>,
+    explicit_shim_path: Option<&str>,
+) -> Result<LoopAction> {
+    match envelope.message_type.as_str() {
+        "voip.configure" => {
+            let config = VoipConfig::from_payload(&envelope.payload)?;
+            host.configure(config);
+            write_envelope(&WorkerEnvelope::result(
+                "voip.configure",
+                envelope.request_id,
+                json!({"configured": true}),
+            ))?;
+        }
+        "voip.health" => {
+            let mut payload = host.health_payload();
+            payload["ready"] = json!(true);
             write_envelope(&WorkerEnvelope::result(
                 "voip.health",
                 envelope.request_id,
-                json!({"ready":true,"registered":false,"active_call_id":null}),
+                payload,
             ))?;
-        } else if envelope.message_type == "voip.shutdown" {
-            break;
-        } else {
+        }
+        "voip.register" => {
+            if backend.is_none() {
+                let path = shim::resolve_shim_path(explicit_shim_path)?;
+                *backend = Some(unsafe { shim::ShimBackend::load(&path) }?);
+            }
+            let backend_ref = backend.as_mut().expect("backend was just created");
+            host.register(backend_ref).map_err(|error| anyhow!(error))?;
+            write_envelope(&WorkerEnvelope::result(
+                "voip.register",
+                envelope.request_id,
+                json!({"registered": true}),
+            ))?;
+        }
+        "voip.unregister" => {
+            if let Some(mut backend_ref) = backend.take() {
+                host.unregister(&mut backend_ref);
+            }
+            write_envelope(&WorkerEnvelope::result(
+                "voip.unregister",
+                envelope.request_id,
+                json!({"registered": false}),
+            ))?;
+        }
+        "voip.dial" => {
+            let uri = envelope.payload["uri"].as_str().unwrap_or("").trim();
+            if uri.is_empty() {
+                write_envelope(&WorkerEnvelope::error(
+                    "voip.error",
+                    envelope.request_id,
+                    "invalid_command",
+                    "voip.dial requires uri",
+                ))?;
+            } else {
+                let backend_ref = backend
+                    .as_mut()
+                    .ok_or_else(|| anyhow!("voip host is not registered"))?;
+                host.dial(backend_ref, uri)
+                    .map_err(|error| anyhow!(error))?;
+                write_envelope(&WorkerEnvelope::result(
+                    "voip.dial",
+                    envelope.request_id,
+                    host.health_payload(),
+                ))?;
+            }
+        }
+        "voip.answer" => {
+            let backend_ref = backend
+                .as_mut()
+                .ok_or_else(|| anyhow!("voip host is not registered"))?;
+            host.answer(backend_ref).map_err(|error| anyhow!(error))?;
+            write_envelope(&WorkerEnvelope::result(
+                "voip.answer",
+                envelope.request_id,
+                json!({"accepted": true}),
+            ))?;
+        }
+        "voip.reject" => {
+            let backend_ref = backend
+                .as_mut()
+                .ok_or_else(|| anyhow!("voip host is not registered"))?;
+            host.reject(backend_ref).map_err(|error| anyhow!(error))?;
+            write_envelope(&WorkerEnvelope::result(
+                "voip.reject",
+                envelope.request_id,
+                json!({"rejected": true}),
+            ))?;
+        }
+        "voip.hangup" => {
+            let backend_ref = backend
+                .as_mut()
+                .ok_or_else(|| anyhow!("voip host is not registered"))?;
+            host.hangup(backend_ref).map_err(|error| anyhow!(error))?;
+            write_envelope(&WorkerEnvelope::result(
+                "voip.hangup",
+                envelope.request_id,
+                json!({"hung_up": true}),
+            ))?;
+        }
+        "voip.set_mute" => {
+            let muted = envelope.payload["muted"].as_bool().unwrap_or(false);
+            let backend_ref = backend
+                .as_mut()
+                .ok_or_else(|| anyhow!("voip host is not registered"))?;
+            host.set_muted(backend_ref, muted)
+                .map_err(|error| anyhow!(error))?;
+            write_envelope(&WorkerEnvelope::result(
+                "voip.set_mute",
+                envelope.request_id,
+                json!({"muted": muted}),
+            ))?;
+        }
+        "voip.shutdown" => {
+            if let Some(mut backend_ref) = backend.take() {
+                host.unregister(&mut backend_ref);
+            }
+            write_envelope(&WorkerEnvelope::result(
+                "voip.shutdown",
+                envelope.request_id,
+                json!({"shutdown": true}),
+            ))?;
+            return Ok(LoopAction::Shutdown);
+        }
+        _ => {
             write_envelope(&WorkerEnvelope::error(
                 "voip.error",
                 envelope.request_id,
@@ -61,7 +218,38 @@ fn main() -> Result<()> {
             ))?;
         }
     }
+
+    if let Some(backend_ref) = backend.as_mut() {
+        emit_backend_events(backend_ref.iterate().map_err(|error| anyhow!(error))?)?;
+    }
+    Ok(LoopAction::Continue)
+}
+
+fn emit_backend_events(events: Vec<host::BackendEvent>) -> Result<()> {
+    for event in events {
+        write_envelope(&backend_event_envelope(event))?;
+    }
     Ok(())
+}
+
+fn backend_event_envelope(event: host::BackendEvent) -> WorkerEnvelope {
+    match event {
+        host::BackendEvent::RegistrationChanged { state, reason } => WorkerEnvelope::event(
+            "voip.registration_changed",
+            json!({"state": state, "reason": reason}),
+        ),
+        host::BackendEvent::IncomingCall { call_id, from_uri } => WorkerEnvelope::event(
+            "voip.incoming_call",
+            json!({"call_id": call_id, "from_uri": from_uri}),
+        ),
+        host::BackendEvent::CallStateChanged { call_id, state } => WorkerEnvelope::event(
+            "voip.call_state_changed",
+            json!({"call_id": call_id, "state": state}),
+        ),
+        host::BackendEvent::BackendStopped { reason } => {
+            WorkerEnvelope::event("voip.backend_stopped", json!({"reason": reason}))
+        }
+    }
 }
 
 fn write_envelope(envelope: &WorkerEnvelope) -> Result<()> {
@@ -70,4 +258,21 @@ fn write_envelope(envelope: &WorkerEnvelope) -> Result<()> {
     stdout.write_all(&encoded)?;
     stdout.flush()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_events_map_to_worker_envelopes() {
+        let envelope = backend_event_envelope(host::BackendEvent::IncomingCall {
+            call_id: "call-1".to_string(),
+            from_uri: "sip:bob@example.com".to_string(),
+        });
+
+        assert_eq!(envelope.message_type, "voip.incoming_call");
+        assert_eq!(envelope.payload["call_id"], "call-1");
+        assert_eq!(envelope.payload["from_uri"], "sip:bob@example.com");
+    }
 }

--- a/src/crates/voip-host/src/main.rs
+++ b/src/crates/voip-host/src/main.rs
@@ -218,12 +218,12 @@ fn handle_command(
                 json!({"muted": muted}),
             ))?;
         }
-        "voip.shutdown" => {
+        "voip.shutdown" | "worker.stop" => {
             if let Some(mut backend_ref) = backend.take() {
                 host.unregister(&mut backend_ref);
             }
             write_envelope(&WorkerEnvelope::result(
-                "voip.shutdown",
+                envelope.message_type,
                 envelope.request_id,
                 json!({"shutdown": true}),
             ))?;
@@ -309,5 +309,28 @@ mod tests {
         assert_eq!(envelope.message_type, "voip.incoming_call");
         assert_eq!(envelope.payload["call_id"], "call-1");
         assert_eq!(envelope.payload["from_uri"], "sip:bob@example.com");
+    }
+
+    #[test]
+    fn worker_stop_uses_shutdown_path() {
+        let mut host = VoipHost::default();
+        let mut backend = None;
+        let action = handle_command(
+            WorkerEnvelope {
+                schema_version: protocol::SUPPORTED_SCHEMA_VERSION,
+                kind: protocol::EnvelopeKind::Command,
+                message_type: "worker.stop".to_string(),
+                request_id: Some("stop-1".to_string()),
+                timestamp_ms: 0,
+                deadline_ms: 0,
+                payload: json!({}),
+            },
+            &mut host,
+            &mut backend,
+            None,
+        )
+        .expect("worker.stop should be handled");
+
+        assert!(matches!(action, LoopAction::Shutdown));
     }
 }

--- a/src/crates/voip-host/src/main.rs
+++ b/src/crates/voip-host/src/main.rs
@@ -3,6 +3,9 @@ use clap::Parser;
 use serde_json::json;
 use std::io::{self, BufRead, Write};
 
+mod config;
+mod events;
+mod host;
 mod protocol;
 
 use protocol::WorkerEnvelope;

--- a/src/crates/voip-host/src/protocol.rs
+++ b/src/crates/voip-host/src/protocol.rs
@@ -1,0 +1,172 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use thiserror::Error;
+
+pub const SUPPORTED_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvelopeKind {
+    Command,
+    Event,
+    Result,
+    Error,
+    Heartbeat,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkerEnvelope {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u16,
+    pub kind: EnvelopeKind,
+    #[serde(rename = "type")]
+    pub message_type: String,
+    #[serde(default)]
+    pub request_id: Option<String>,
+    #[serde(default)]
+    pub timestamp_ms: u64,
+    #[serde(default)]
+    pub deadline_ms: u64,
+    #[serde(default = "empty_payload")]
+    pub payload: Value,
+}
+
+#[derive(Debug, Error)]
+pub enum ProtocolError {
+    #[error("invalid JSON worker envelope: {0}")]
+    InvalidJson(#[from] serde_json::Error),
+    #[error("unsupported schema_version {actual}; expected {expected}")]
+    UnsupportedSchema { actual: u16, expected: u16 },
+    #[error("invalid worker envelope: {0}")]
+    InvalidEnvelope(String),
+}
+
+fn default_schema_version() -> u16 {
+    SUPPORTED_SCHEMA_VERSION
+}
+
+fn empty_payload() -> Value {
+    json!({})
+}
+
+impl WorkerEnvelope {
+    pub fn decode(line: &[u8]) -> Result<Self, ProtocolError> {
+        let envelope: WorkerEnvelope = serde_json::from_slice(line)?;
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, ProtocolError> {
+        self.validate()?;
+        let mut encoded = serde_json::to_vec(self)?;
+        encoded.push(b'\n');
+        Ok(encoded)
+    }
+
+    pub fn event(message_type: impl Into<String>, payload: Value) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Event,
+            message_type: message_type.into(),
+            request_id: None,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload,
+        }
+    }
+
+    pub fn result(
+        message_type: impl Into<String>,
+        request_id: Option<String>,
+        payload: Value,
+    ) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Result,
+            message_type: message_type.into(),
+            request_id,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload,
+        }
+    }
+
+    pub fn error(
+        message_type: impl Into<String>,
+        request_id: Option<String>,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Error,
+            message_type: message_type.into(),
+            request_id,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload: json!({
+                "code": code.into(),
+                "message": message.into(),
+            }),
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), ProtocolError> {
+        if self.schema_version != SUPPORTED_SCHEMA_VERSION {
+            return Err(ProtocolError::UnsupportedSchema {
+                actual: self.schema_version,
+                expected: SUPPORTED_SCHEMA_VERSION,
+            });
+        }
+        if self.message_type.trim().is_empty() {
+            return Err(ProtocolError::InvalidEnvelope(
+                "type must be a non-empty string".to_string(),
+            ));
+        }
+        if !self.payload.is_object() {
+            return Err(ProtocolError::InvalidEnvelope(
+                "payload must be an object".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_accepts_voip_health_command() {
+        let raw = br#"{"schema_version":1,"kind":"command","type":"voip.health","request_id":"r1","payload":{}}"#;
+
+        let envelope = WorkerEnvelope::decode(raw).expect("decode");
+
+        assert_eq!(envelope.schema_version, SUPPORTED_SCHEMA_VERSION);
+        assert_eq!(envelope.kind, EnvelopeKind::Command);
+        assert_eq!(envelope.message_type, "voip.health");
+        assert_eq!(envelope.request_id.as_deref(), Some("r1"));
+    }
+
+    #[test]
+    fn encode_ready_event_has_newline() {
+        let encoded = WorkerEnvelope::event("voip.ready", json!({"capabilities":["calls"]}))
+            .encode()
+            .expect("encode");
+
+        assert!(encoded.ends_with(b"\n"));
+        assert!(std::str::from_utf8(&encoded)
+            .unwrap()
+            .contains("\"type\":\"voip.ready\""));
+    }
+
+    #[test]
+    fn rejects_array_payload() {
+        let err = WorkerEnvelope::decode(
+            br#"{"schema_version":1,"kind":"command","type":"voip.health","payload":[]}"#,
+        )
+        .expect_err("payload must be rejected");
+
+        assert!(err.to_string().contains("payload must be an object"));
+    }
+}

--- a/src/crates/voip-host/src/shim.rs
+++ b/src/crates/voip-host/src/shim.rs
@@ -1,0 +1,365 @@
+use crate::config::VoipConfig;
+use crate::host::{BackendEvent, CallBackend};
+use libloading::Library;
+use std::env;
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NativeEvent {
+    pub event_type: i32,
+    pub registration_state: i32,
+    pub call_state: i32,
+    pub message_kind: i32,
+    pub message_direction: i32,
+    pub message_delivery_state: i32,
+    pub duration_ms: i32,
+    pub unread: i32,
+    pub message_id: [c_char; 128],
+    pub peer_sip_address: [c_char; 256],
+    pub sender_sip_address: [c_char; 256],
+    pub recipient_sip_address: [c_char; 256],
+    pub local_file_path: [c_char; 512],
+    pub mime_type: [c_char; 128],
+    pub text: [c_char; 1024],
+    pub reason: [c_char; 256],
+}
+
+impl Default for NativeEvent {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ShimError {
+    #[error("liblinphone shim path could not be resolved")]
+    NotFound,
+    #[error("liblinphone shim load failed: {0}")]
+    Load(String),
+    #[error("liblinphone shim call failed: {0}")]
+    Call(String),
+    #[error("string contains interior NUL: {0}")]
+    InvalidCString(#[from] std::ffi::NulError),
+}
+
+type InitFn = unsafe extern "C" fn() -> c_int;
+type ShutdownFn = unsafe extern "C" fn();
+type StopFn = unsafe extern "C" fn();
+type IterateFn = unsafe extern "C" fn();
+type PollEventFn = unsafe extern "C" fn(*mut NativeEvent) -> c_int;
+type StartFn = unsafe extern "C" fn(
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    i32,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    i32,
+    i32,
+    i32,
+    *const c_char,
+) -> c_int;
+type SimpleCallFn = unsafe extern "C" fn() -> c_int;
+type MakeCallFn = unsafe extern "C" fn(*const c_char) -> c_int;
+type SetMutedFn = unsafe extern "C" fn(i32) -> c_int;
+type LastErrorFn = unsafe extern "C" fn() -> *const c_char;
+
+pub struct LiblinphoneShim {
+    _library: Library,
+    init: InitFn,
+    shutdown: ShutdownFn,
+    start: StartFn,
+    stop: StopFn,
+    iterate: IterateFn,
+    poll_event: PollEventFn,
+    make_call: MakeCallFn,
+    answer_call: SimpleCallFn,
+    reject_call: SimpleCallFn,
+    hangup: SimpleCallFn,
+    set_muted: SetMutedFn,
+    last_error: LastErrorFn,
+}
+
+pub struct ShimBackend {
+    shim: LiblinphoneShim,
+    next_outgoing_call_id: u64,
+}
+
+pub fn resolve_shim_path(explicit_path: Option<&str>) -> Result<PathBuf, ShimError> {
+    if let Some(path) = explicit_path.filter(|value| !value.trim().is_empty()) {
+        return Ok(PathBuf::from(path));
+    }
+    if let Ok(path) = env::var("YOYOPOD_LIBLINPHONE_SHIM_PATH") {
+        if !path.trim().is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+    let repo_candidate = Path::new("yoyopod")
+        .join("backends")
+        .join("voip")
+        .join("shim_native")
+        .join("build")
+        .join(shim_file_name());
+    if repo_candidate.exists() {
+        return Ok(repo_candidate);
+    }
+    Err(ShimError::NotFound)
+}
+
+fn shim_file_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "yoyopod_liblinphone_shim.dll"
+    } else if cfg!(target_os = "macos") {
+        "libyoyopod_liblinphone_shim.dylib"
+    } else {
+        "libyoyopod_liblinphone_shim.so"
+    }
+}
+
+impl LiblinphoneShim {
+    pub unsafe fn load(path: &Path) -> Result<Self, ShimError> {
+        let library =
+            unsafe { Library::new(path) }.map_err(|error| ShimError::Load(error.to_string()))?;
+        unsafe fn symbol<T: Copy>(library: &Library, name: &[u8]) -> Result<T, ShimError> {
+            let symbol = unsafe { library.get::<T>(name) }
+                .map_err(|error| ShimError::Load(error.to_string()))?;
+            Ok(*symbol)
+        }
+        Ok(Self {
+            init: unsafe { symbol(&library, b"yoyopod_liblinphone_init\0") }?,
+            shutdown: unsafe { symbol(&library, b"yoyopod_liblinphone_shutdown\0") }?,
+            start: unsafe { symbol(&library, b"yoyopod_liblinphone_start\0") }?,
+            stop: unsafe { symbol(&library, b"yoyopod_liblinphone_stop\0") }?,
+            iterate: unsafe { symbol(&library, b"yoyopod_liblinphone_iterate\0") }?,
+            poll_event: unsafe { symbol(&library, b"yoyopod_liblinphone_poll_event\0") }?,
+            make_call: unsafe { symbol(&library, b"yoyopod_liblinphone_make_call\0") }?,
+            answer_call: unsafe { symbol(&library, b"yoyopod_liblinphone_answer_call\0") }?,
+            reject_call: unsafe { symbol(&library, b"yoyopod_liblinphone_reject_call\0") }?,
+            hangup: unsafe { symbol(&library, b"yoyopod_liblinphone_hangup\0") }?,
+            set_muted: unsafe { symbol(&library, b"yoyopod_liblinphone_set_muted\0") }?,
+            last_error: unsafe { symbol(&library, b"yoyopod_liblinphone_last_error\0") }?,
+            _library: library,
+        })
+    }
+
+    pub fn init(&self) -> Result<(), ShimError> {
+        self.check(unsafe { (self.init)() })
+    }
+
+    pub fn start(&self, config: &VoipConfig) -> Result<(), ShimError> {
+        let sip_server = CString::new(config.sip_server.as_str())?;
+        let sip_username = CString::new(config.sip_username.as_str())?;
+        let sip_password = CString::new(config.sip_password.as_str())?;
+        let sip_password_ha1 = CString::new(config.sip_password_ha1.as_str())?;
+        let sip_identity = CString::new(config.sip_identity.as_str())?;
+        let factory_config_path = CString::new(config.factory_config_path.as_str())?;
+        let transport = CString::new(config.transport.as_str())?;
+        let stun_server = CString::new(config.stun_server.as_str())?;
+        let conference_factory_uri = CString::new(config.conference_factory_uri.as_str())?;
+        let file_transfer_server_url = CString::new(config.file_transfer_server_url.as_str())?;
+        let lime_server_url = CString::new(config.lime_server_url.as_str())?;
+        let playback_dev_id = CString::new(config.playback_dev_id.as_str())?;
+        let ringer_dev_id = CString::new(config.ringer_dev_id.as_str())?;
+        let capture_dev_id = CString::new(config.capture_dev_id.as_str())?;
+        let media_dev_id = CString::new(config.media_dev_id.as_str())?;
+        let voice_note_store_dir = CString::new(config.voice_note_store_dir.as_str())?;
+
+        self.check(unsafe {
+            (self.start)(
+                sip_server.as_ptr(),
+                sip_username.as_ptr(),
+                sip_password.as_ptr(),
+                sip_password_ha1.as_ptr(),
+                sip_identity.as_ptr(),
+                factory_config_path.as_ptr(),
+                transport.as_ptr(),
+                stun_server.as_ptr(),
+                conference_factory_uri.as_ptr(),
+                file_transfer_server_url.as_ptr(),
+                lime_server_url.as_ptr(),
+                if config.auto_download_incoming_voice_recordings {
+                    1
+                } else {
+                    0
+                },
+                playback_dev_id.as_ptr(),
+                ringer_dev_id.as_ptr(),
+                capture_dev_id.as_ptr(),
+                media_dev_id.as_ptr(),
+                1,
+                0,
+                config.output_volume,
+                voice_note_store_dir.as_ptr(),
+            )
+        })
+    }
+
+    pub fn shutdown(&self) {
+        unsafe { (self.shutdown)() }
+    }
+
+    pub fn stop(&self) {
+        unsafe { (self.stop)() }
+    }
+
+    pub fn iterate(&self) {
+        unsafe { (self.iterate)() }
+    }
+
+    pub fn make_call(&self, sip_address: &str) -> Result<(), ShimError> {
+        let sip_address = CString::new(sip_address)?;
+        self.check(unsafe { (self.make_call)(sip_address.as_ptr()) })
+    }
+
+    pub fn answer_call(&self) -> Result<(), ShimError> {
+        self.check(unsafe { (self.answer_call)() })
+    }
+
+    pub fn reject_call(&self) -> Result<(), ShimError> {
+        self.check(unsafe { (self.reject_call)() })
+    }
+
+    pub fn hangup(&self) -> Result<(), ShimError> {
+        self.check(unsafe { (self.hangup)() })
+    }
+
+    pub fn set_muted(&self, muted: bool) -> Result<(), ShimError> {
+        self.check(unsafe { (self.set_muted)(if muted { 1 } else { 0 }) })
+    }
+
+    fn last_error(&self) -> String {
+        unsafe {
+            let raw = (self.last_error)();
+            if raw.is_null() {
+                return "unknown liblinphone shim error".to_string();
+            }
+            CStr::from_ptr(raw).to_string_lossy().into_owned()
+        }
+    }
+
+    fn check(&self, code: c_int) -> Result<(), ShimError> {
+        if code == 0 {
+            Ok(())
+        } else {
+            Err(ShimError::Call(self.last_error()))
+        }
+    }
+
+    pub fn drain_events(&self) -> Result<Vec<BackendEvent>, ShimError> {
+        let mut events = Vec::new();
+        loop {
+            let mut event = NativeEvent::default();
+            let has_event = unsafe { (self.poll_event)(&mut event as *mut NativeEvent) };
+            if has_event == 0 {
+                break;
+            }
+            match event.event_type {
+                1 => events.push(BackendEvent::RegistrationChanged {
+                    state: crate::events::RegistrationState::from_native(event.registration_state)
+                        .as_protocol()
+                        .to_string(),
+                    reason: c_string(&event.reason),
+                }),
+                2 => events.push(BackendEvent::CallStateChanged {
+                    call_id: c_string(&event.peer_sip_address),
+                    state: crate::events::CallState::from_native(event.call_state)
+                        .as_protocol()
+                        .to_string(),
+                }),
+                3 => events.push(BackendEvent::IncomingCall {
+                    call_id: c_string(&event.peer_sip_address),
+                    from_uri: c_string(&event.peer_sip_address),
+                }),
+                4 => events.push(BackendEvent::BackendStopped {
+                    reason: c_string(&event.reason),
+                }),
+                _ => {}
+            }
+        }
+        Ok(events)
+    }
+}
+
+impl ShimBackend {
+    pub unsafe fn load(path: &Path) -> Result<Self, ShimError> {
+        Ok(Self {
+            shim: unsafe { LiblinphoneShim::load(path) }?,
+            next_outgoing_call_id: 1,
+        })
+    }
+}
+
+impl CallBackend for ShimBackend {
+    fn start(&mut self, config: &VoipConfig) -> Result<(), String> {
+        self.shim.init().map_err(|error| error.to_string())?;
+        self.shim.start(config).map_err(|error| error.to_string())
+    }
+
+    fn stop(&mut self) {
+        self.shim.stop();
+        self.shim.shutdown();
+    }
+
+    fn iterate(&mut self) -> Result<Vec<BackendEvent>, String> {
+        self.shim.iterate();
+        self.shim.drain_events().map_err(|error| error.to_string())
+    }
+
+    fn make_call(&mut self, sip_address: &str) -> Result<String, String> {
+        self.shim
+            .make_call(sip_address)
+            .map_err(|error| error.to_string())?;
+        let call_id = format!("outgoing-{}", self.next_outgoing_call_id);
+        self.next_outgoing_call_id += 1;
+        Ok(call_id)
+    }
+
+    fn answer_call(&mut self) -> Result<(), String> {
+        self.shim.answer_call().map_err(|error| error.to_string())
+    }
+
+    fn reject_call(&mut self) -> Result<(), String> {
+        self.shim.reject_call().map_err(|error| error.to_string())
+    }
+
+    fn hangup(&mut self) -> Result<(), String> {
+        self.shim.hangup().map_err(|error| error.to_string())
+    }
+
+    fn set_muted(&mut self, muted: bool) -> Result<(), String> {
+        self.shim
+            .set_muted(muted)
+            .map_err(|error| error.to_string())
+    }
+}
+
+pub fn c_string<const N: usize>(buffer: &[c_char; N]) -> String {
+    unsafe { CStr::from_ptr(buffer.as_ptr()) }
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_path_wins() {
+        let path = resolve_shim_path(Some("/tmp/libshim.so")).expect("path");
+        assert_eq!(path, PathBuf::from("/tmp/libshim.so"));
+    }
+}

--- a/src/crates/voip-host/src/shim.rs
+++ b/src/crates/voip-host/src/shim.rs
@@ -99,6 +99,22 @@ pub struct ShimBackend {
     next_outgoing_call_id: u64,
 }
 
+struct StartAudioSettings {
+    audio_enabled: c_int,
+    mic_gain: c_int,
+    output_volume: c_int,
+}
+
+impl StartAudioSettings {
+    fn from_config(config: &VoipConfig) -> Self {
+        Self {
+            audio_enabled: 1,
+            mic_gain: config.mic_gain,
+            output_volume: config.output_volume,
+        }
+    }
+}
+
 pub fn resolve_shim_path(explicit_path: Option<&str>) -> Result<PathBuf, ShimError> {
     if let Some(path) = explicit_path.filter(|value| !value.trim().is_empty()) {
         return Ok(PathBuf::from(path));
@@ -177,6 +193,7 @@ impl LiblinphoneShim {
         let capture_dev_id = CString::new(config.capture_dev_id.as_str())?;
         let media_dev_id = CString::new(config.media_dev_id.as_str())?;
         let voice_note_store_dir = CString::new(config.voice_note_store_dir.as_str())?;
+        let audio_settings = StartAudioSettings::from_config(config);
 
         self.check(unsafe {
             (self.start)(
@@ -200,9 +217,9 @@ impl LiblinphoneShim {
                 ringer_dev_id.as_ptr(),
                 capture_dev_id.as_ptr(),
                 media_dev_id.as_ptr(),
-                1,
-                0,
-                config.output_volume,
+                audio_settings.audio_enabled,
+                audio_settings.mic_gain,
+                audio_settings.output_volume,
                 voice_note_store_dir.as_ptr(),
             )
         })
@@ -356,10 +373,28 @@ pub fn c_string<const N: usize>(buffer: &[c_char; N]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn explicit_path_wins() {
         let path = resolve_shim_path(Some("/tmp/libshim.so")).expect("path");
         assert_eq!(path, PathBuf::from("/tmp/libshim.so"));
+    }
+
+    #[test]
+    fn start_audio_settings_forward_configured_gain_and_volume() {
+        let config = VoipConfig::from_payload(&json!({
+            "sip_server": "sip.example.com",
+            "sip_identity": "sip:alice@example.com",
+            "mic_gain": 42,
+            "output_volume": 73
+        }))
+        .expect("config");
+
+        let settings = StartAudioSettings::from_config(&config);
+
+        assert_eq!(settings.audio_enabled, 1);
+        assert_eq!(settings.mic_gain, 42);
+        assert_eq!(settings.output_volume, 73);
     }
 }

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from yoyopod.backends.voip.rust_host import RustHostBackend
 from yoyopod.integrations.call.models import (
+    BackendRecovered,
     BackendStopped,
     CallState,
     CallStateChanged,
@@ -268,6 +269,7 @@ def test_ready_after_worker_restart_resends_configure_register() -> None:
     backend.handle_worker_state_change(_state("running", "started"))
     backend.handle_worker_message(_event("voip.ready", {"capabilities": ["calls"]}))
     assert [item[1] for item in supervisor.sent] == ["voip.configure", "voip.register"]
+    assert received == []
 
     backend.handle_worker_state_change(_state("degraded", "process_exited"))
     backend.handle_worker_state_change(_state("running", "started"))
@@ -282,6 +284,8 @@ def test_ready_after_worker_restart_resends_configure_register() -> None:
     assert backend.running is True
     assert isinstance(received[0], BackendStopped)
     assert received[0].reason == "process_exited"
+    assert isinstance(received[1], BackendRecovered)
+    assert received[1].reason == "worker_ready"
 
 
 def test_iterate_is_noop_and_unsupported_messaging_fails() -> None:

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -50,6 +50,48 @@ class _FakeSupervisor:
         return True
 
 
+class _SingleRunningSupervisor(_FakeSupervisor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.running = False
+
+    def start(self, domain: str) -> bool:
+        if self.running:
+            raise RuntimeError("worker already running")
+        self.running = True
+        return super().start(domain)
+
+    def stop(self, domain: str, *, grace_seconds: float = 1.0) -> None:
+        self.running = False
+        super().stop(domain, grace_seconds=grace_seconds)
+
+
+class _RejectingStartupSupervisor(_FakeSupervisor):
+    def __init__(self, rejected_type: str) -> None:
+        super().__init__()
+        self.rejected_type = rejected_type
+
+    def send_command(
+        self,
+        domain: str,
+        *,
+        type: str,
+        payload: dict[str, Any] | None = None,
+        request_id: str | None = None,
+        timestamp_ms: int = 0,
+        deadline_ms: int = 0,
+    ) -> bool:
+        super().send_command(
+            domain,
+            type=type,
+            payload=payload,
+            request_id=request_id,
+            timestamp_ms=timestamp_ms,
+            deadline_ms=deadline_ms,
+        )
+        return type != self.rejected_type
+
+
 class _StrictSupervisor(_FakeSupervisor):
     def stop(self, domain: str, *, grace_seconds: float = 1.0) -> None:
         if not any(registered_domain == domain for registered_domain, _config in self.registered):
@@ -206,8 +248,8 @@ def test_worker_events_translate_to_voip_events() -> None:
     assert len(received) == 4
 
 
-def test_worker_startup_error_marks_backend_stopped() -> None:
-    supervisor = _FakeSupervisor()
+def test_worker_startup_error_stops_worker_and_marks_backend_stopped() -> None:
+    supervisor = _SingleRunningSupervisor()
     backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
     received: list[object] = []
     backend.on_event(received.append)
@@ -223,8 +265,22 @@ def test_worker_startup_error_marks_backend_stopped() -> None:
     )
 
     assert backend.running is False
+    assert supervisor.stopped == [("voip", 1.0)]
     assert isinstance(received[0], BackendStopped)
     assert received[0].reason == "voip.register command_failed: shim missing"
+
+    assert backend.start() is True
+    assert supervisor.started == ["voip", "voip"]
+
+
+def test_startup_send_failure_stops_worker_before_returning_false() -> None:
+    supervisor = _RejectingStartupSupervisor("voip.register")
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+
+    assert backend.start() is False
+
+    assert backend.running is False
+    assert supervisor.stopped == [("voip", 1.0)]
 
 
 def test_worker_call_command_errors_surface_call_error_events() -> None:

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -21,6 +21,7 @@ class _FakeSupervisor:
         self.started: list[str] = []
         self.stopped: list[tuple[str, float]] = []
         self.sent: list[tuple[str, str, dict[str, Any]]] = []
+        self.request_ids: list[str | None] = []
 
     def register(self, domain: str, config: Any) -> None:
         self.registered.append((domain, config))
@@ -42,8 +43,9 @@ class _FakeSupervisor:
         timestamp_ms: int = 0,
         deadline_ms: int = 0,
     ) -> bool:
-        del request_id, timestamp_ms, deadline_ms
+        del timestamp_ms, deadline_ms
         self.sent.append((domain, type, payload or {}))
+        self.request_ids.append(request_id)
         return True
 
 
@@ -59,6 +61,27 @@ def _event(message_type: str, payload: dict[str, Any], *, domain: str = "voip") 
     return SimpleNamespace(domain=domain, kind="event", type=message_type, payload=payload)
 
 
+def _reply(
+    kind: str,
+    message_type: str,
+    payload: dict[str, Any],
+    *,
+    request_id: str | None,
+    domain: str = "voip",
+) -> Any:
+    return SimpleNamespace(
+        domain=domain,
+        kind=kind,
+        type=message_type,
+        request_id=request_id,
+        payload=payload,
+    )
+
+
+def _state(state: str, reason: str, *, domain: str = "voip") -> Any:
+    return SimpleNamespace(domain=domain, state=state, reason=reason)
+
+
 def test_start_registers_worker_and_sends_configure_register() -> None:
     supervisor = _FakeSupervisor()
     backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
@@ -70,6 +93,7 @@ def test_start_registers_worker_and_sends_configure_register() -> None:
     assert supervisor.started == ["voip"]
     assert [item[1] for item in supervisor.sent] == ["voip.configure", "voip.register"]
     assert supervisor.sent[0][2]["sip_identity"] == "sip:alice@example.com"
+    assert supervisor.request_ids == ["voip-voip_configure-1", "voip-voip_register-2"]
     assert backend.running is True
 
 
@@ -128,6 +152,53 @@ def test_worker_events_translate_to_voip_events() -> None:
     assert isinstance(received[3], BackendStopped)
     assert received[3].reason == "iterate failed"
     assert len(received) == 4
+
+
+def test_worker_startup_error_marks_backend_stopped() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+    backend.start()
+
+    backend.handle_worker_message(
+        _reply(
+            "error",
+            "voip.error",
+            {"code": "command_failed", "message": "shim missing"},
+            request_id=supervisor.request_ids[1],
+        )
+    )
+
+    assert backend.running is False
+    assert isinstance(received[0], BackendStopped)
+    assert received[0].reason == "voip.register command_failed: shim missing"
+
+
+def test_ready_after_worker_restart_resends_configure_register() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+    backend.start()
+
+    backend.handle_worker_state_change(_state("running", "started"))
+    backend.handle_worker_message(_event("voip.ready", {"capabilities": ["calls"]}))
+    assert [item[1] for item in supervisor.sent] == ["voip.configure", "voip.register"]
+
+    backend.handle_worker_state_change(_state("degraded", "process_exited"))
+    backend.handle_worker_state_change(_state("running", "started"))
+    backend.handle_worker_message(_event("voip.ready", {"capabilities": ["calls"]}))
+
+    assert [item[1] for item in supervisor.sent] == [
+        "voip.configure",
+        "voip.register",
+        "voip.configure",
+        "voip.register",
+    ]
+    assert backend.running is True
+    assert isinstance(received[0], BackendStopped)
+    assert received[0].reason == "process_exited"
 
 
 def test_iterate_is_noop_and_unsupported_messaging_fails() -> None:

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -49,6 +49,34 @@ class _FakeSupervisor:
         return True
 
 
+class _StrictSupervisor(_FakeSupervisor):
+    def stop(self, domain: str, *, grace_seconds: float = 1.0) -> None:
+        if not any(registered_domain == domain for registered_domain, _config in self.registered):
+            raise KeyError(domain)
+        super().stop(domain, grace_seconds=grace_seconds)
+
+    def send_command(
+        self,
+        domain: str,
+        *,
+        type: str,
+        payload: dict[str, Any] | None = None,
+        request_id: str | None = None,
+        timestamp_ms: int = 0,
+        deadline_ms: int = 0,
+    ) -> bool:
+        if not any(registered_domain == domain for registered_domain, _config in self.registered):
+            raise KeyError(domain)
+        return super().send_command(
+            domain,
+            type=type,
+            payload=payload,
+            request_id=request_id,
+            timestamp_ms=timestamp_ms,
+            deadline_ms=deadline_ms,
+        )
+
+
 def _config() -> VoIPConfig:
     return VoIPConfig(
         sip_server="sip.example.com",
@@ -95,6 +123,31 @@ def test_start_registers_worker_and_sends_configure_register() -> None:
     assert supervisor.sent[0][2]["sip_identity"] == "sip:alice@example.com"
     assert supervisor.request_ids == ["voip-voip_configure-1", "voip-voip_register-2"]
     assert backend.running is True
+
+
+def test_stop_before_worker_registration_is_noop() -> None:
+    supervisor = _StrictSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+
+    backend.stop()
+
+    assert supervisor.sent == []
+    assert supervisor.stopped == []
+    assert backend.running is False
+
+
+def test_delayed_intentional_stop_state_does_not_emit_backend_stopped() -> None:
+    supervisor = _StrictSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+    backend.start()
+
+    backend.stop()
+    backend.handle_worker_state_change(_state("stopped", "stop"))
+
+    assert not received
+    assert backend.running is False
 
 
 def test_call_commands_send_worker_commands() -> None:

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from yoyopod.backends.voip.rust_host import RustHostBackend
+from yoyopod.integrations.call.models import (
+    BackendStopped,
+    CallState,
+    CallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged,
+    VoIPConfig,
+)
+
+
+class _FakeSupervisor:
+    def __init__(self) -> None:
+        self.registered: list[tuple[str, Any]] = []
+        self.started: list[str] = []
+        self.stopped: list[tuple[str, float]] = []
+        self.sent: list[tuple[str, str, dict[str, Any]]] = []
+
+    def register(self, domain: str, config: Any) -> None:
+        self.registered.append((domain, config))
+
+    def start(self, domain: str) -> bool:
+        self.started.append(domain)
+        return True
+
+    def stop(self, domain: str, *, grace_seconds: float = 1.0) -> None:
+        self.stopped.append((domain, grace_seconds))
+
+    def send_command(
+        self,
+        domain: str,
+        *,
+        type: str,
+        payload: dict[str, Any] | None = None,
+        request_id: str | None = None,
+        timestamp_ms: int = 0,
+        deadline_ms: int = 0,
+    ) -> bool:
+        del request_id, timestamp_ms, deadline_ms
+        self.sent.append((domain, type, payload or {}))
+        return True
+
+
+def _config() -> VoIPConfig:
+    return VoIPConfig(
+        sip_server="sip.example.com",
+        sip_username="alice",
+        sip_identity="sip:alice@example.com",
+    )
+
+
+def _event(message_type: str, payload: dict[str, Any], *, domain: str = "voip") -> Any:
+    return SimpleNamespace(domain=domain, kind="event", type=message_type, payload=payload)
+
+
+def test_start_registers_worker_and_sends_configure_register() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+
+    assert backend.start() is True
+
+    assert supervisor.registered[0][0] == "voip"
+    assert supervisor.registered[0][1].argv == ["/bin/voip"]
+    assert supervisor.started == ["voip"]
+    assert [item[1] for item in supervisor.sent] == ["voip.configure", "voip.register"]
+    assert supervisor.sent[0][2]["sip_identity"] == "sip:alice@example.com"
+    assert backend.running is True
+
+
+def test_call_commands_send_worker_commands() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    backend.start()
+    supervisor.sent.clear()
+
+    assert backend.make_call("sip:bob@example.com") is True
+    assert backend.answer_call() is True
+    assert backend.reject_call() is True
+    assert backend.hangup() is True
+    assert backend.mute() is True
+    assert backend.unmute() is True
+
+    assert [item[1] for item in supervisor.sent] == [
+        "voip.dial",
+        "voip.answer",
+        "voip.reject",
+        "voip.hangup",
+        "voip.set_mute",
+        "voip.set_mute",
+    ]
+    assert supervisor.sent[0][2] == {"uri": "sip:bob@example.com"}
+    assert supervisor.sent[4][2] == {"muted": True}
+    assert supervisor.sent[5][2] == {"muted": False}
+
+
+def test_worker_events_translate_to_voip_events() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+
+    backend.handle_worker_message(
+        _event("voip.registration_changed", {"state": "ok", "reason": ""})
+    )
+    backend.handle_worker_message(
+        _event("voip.incoming_call", {"call_id": "call-1", "from_uri": "sip:bob@example.com"})
+    )
+    backend.handle_worker_message(
+        _event("voip.call_state_changed", {"call_id": "call-1", "state": "streams_running"})
+    )
+    backend.handle_worker_message(
+        _event("voip.backend_stopped", {"reason": "iterate failed"})
+    )
+    backend.handle_worker_message(_event("voip.backend_stopped", {"reason": "wrong"}, domain="ui"))
+
+    assert isinstance(received[0], RegistrationStateChanged)
+    assert received[0].state == RegistrationState.OK
+    assert isinstance(received[1], IncomingCallDetected)
+    assert received[1].caller_address == "sip:bob@example.com"
+    assert isinstance(received[2], CallStateChanged)
+    assert received[2].state == CallState.STREAMS_RUNNING
+    assert isinstance(received[3], BackendStopped)
+    assert received[3].reason == "iterate failed"
+    assert len(received) == 4
+
+
+def test_iterate_is_noop_and_unsupported_messaging_fails() -> None:
+    backend = RustHostBackend(_config(), worker_supervisor=_FakeSupervisor(), worker_path="/bin/voip")
+
+    assert backend.iterate() == 0
+    assert backend.get_iterate_metrics() is None
+    assert backend.send_text_message("sip:bob@example.com", "hi") is None
+    assert backend.start_voice_note_recording("/tmp/a.wav") is False
+    assert backend.stop_voice_note_recording() is None
+    assert backend.cancel_voice_note_recording() is False
+    assert (
+        backend.send_voice_note(
+            "sip:bob@example.com",
+            file_path="/tmp/a.wav",
+            duration_ms=1000,
+            mime_type="audio/wav",
+        )
+        is None
+    )

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -138,9 +138,7 @@ def test_worker_events_translate_to_voip_events() -> None:
     backend.handle_worker_message(
         _event("voip.call_state_changed", {"call_id": "call-1", "state": "streams_running"})
     )
-    backend.handle_worker_message(
-        _event("voip.backend_stopped", {"reason": "iterate failed"})
-    )
+    backend.handle_worker_message(_event("voip.backend_stopped", {"reason": "iterate failed"}))
     backend.handle_worker_message(_event("voip.backend_stopped", {"reason": "wrong"}, domain="ui"))
 
     assert isinstance(received[0], RegistrationStateChanged)
@@ -175,6 +173,38 @@ def test_worker_startup_error_marks_backend_stopped() -> None:
     assert received[0].reason == "voip.register command_failed: shim missing"
 
 
+def test_worker_call_command_errors_surface_call_error_events() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+    backend.start()
+
+    commands = [
+        lambda: backend.make_call("sip:bob@example.com"),
+        backend.answer_call,
+        backend.reject_call,
+        backend.hangup,
+        backend.mute,
+        backend.unmute,
+    ]
+    for send_command in commands:
+        assert send_command() is True
+        backend.handle_worker_message(
+            _reply(
+                "error",
+                "voip.error",
+                {"code": "command_failed", "message": "shim rejected command"},
+                request_id=supervisor.request_ids[-1],
+            )
+        )
+
+    assert backend.running is True
+    call_errors = [event for event in received if isinstance(event, CallStateChanged)]
+    assert len(call_errors) == len(commands)
+    assert all(event.state == CallState.ERROR for event in call_errors)
+
+
 def test_ready_after_worker_restart_resends_configure_register() -> None:
     supervisor = _FakeSupervisor()
     backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
@@ -202,7 +232,9 @@ def test_ready_after_worker_restart_resends_configure_register() -> None:
 
 
 def test_iterate_is_noop_and_unsupported_messaging_fails() -> None:
-    backend = RustHostBackend(_config(), worker_supervisor=_FakeSupervisor(), worker_path="/bin/voip")
+    backend = RustHostBackend(
+        _config(), worker_supervisor=_FakeSupervisor(), worker_path="/bin/voip"
+    )
 
     assert backend.iterate() == 0
     assert backend.get_iterate_metrics() is None

--- a/tests/backends/test_voip_backend.py
+++ b/tests/backends/test_voip_backend.py
@@ -16,6 +16,7 @@ from cffi import FFI
 
 from yoyopod.backends.voip import LiblinphoneBackend, LiblinphoneBinding, MockVoIPBackend
 from yoyopod.integrations.call.models import (
+    BackendRecovered,
     BackendStopped,
     CallState,
     CallStateChanged,
@@ -912,3 +913,28 @@ def test_voip_manager_handles_backend_stop_event() -> None:
     assert manager.running is False
     assert manager.registered is False
     assert manager.registration_state == RegistrationState.FAILED
+
+
+def test_voip_manager_marks_available_after_backend_recovery() -> None:
+    """A recovered worker should restore availability after an unexpected stop."""
+
+    backend = MockVoIPBackend()
+    manager = VoIPManager(build_config(), backend=backend)
+    availability_changes: list[tuple[bool, str, RegistrationState]] = []
+    manager.on_availability_change(
+        lambda available, reason, registration_state: availability_changes.append(
+            (available, reason, registration_state)
+        )
+    )
+
+    assert manager.start()
+    backend.emit(RegistrationStateChanged(state=RegistrationState.OK))
+    backend.emit(BackendStopped(reason="process_exited"))
+    backend.emit(BackendRecovered(reason="worker_ready"))
+
+    assert manager.running is True
+    assert manager.registration_state == RegistrationState.PROGRESS
+    assert availability_changes[-2:] == [
+        (False, "process_exited", RegistrationState.FAILED),
+        (True, "worker_ready", RegistrationState.PROGRESS),
+    ]

--- a/tests/core/test_bootstrap.py
+++ b/tests/core/test_bootstrap.py
@@ -1036,7 +1036,11 @@ def test_setup_voip_callbacks_subscribes_worker_message_handler() -> None:
     call_runtime = _FakeCallRuntime()
     subscribed: list[tuple[object, object]] = []
     handler = lambda *_args: None
-    voip_manager.backend = SimpleNamespace(handle_worker_message=handler)
+    state_handler = lambda *_args: None
+    voip_manager.backend = SimpleNamespace(
+        handle_worker_message=handler,
+        handle_worker_state_change=state_handler,
+    )
     voice_note_events = SimpleNamespace(
         handle_voice_note_summary_changed=lambda *_args: None,
         handle_voice_note_activity_changed=lambda *_args: None,
@@ -1058,6 +1062,7 @@ def test_setup_voip_callbacks_subscribes_worker_message_handler() -> None:
     RuntimeBootService(app).setup_voip_callbacks()
 
     assert (WorkerMessageReceivedEvent, handler) in subscribed
+    assert (WorkerDomainStateChangedEvent, state_handler) in subscribed
 
 
 def test_setup_music_callbacks_schedule_playback_handlers_on_main_thread() -> None:

--- a/tests/core/test_bootstrap.py
+++ b/tests/core/test_bootstrap.py
@@ -13,7 +13,7 @@ from yoyopod.core.bootstrap import RuntimeBootService
 from yoyopod.core.bootstrap.screens_boot import ScreensBoot
 from yoyopod.core.bootstrap.managers_boot import ManagersBoot
 from yoyopod.core.bus import Bus
-from yoyopod.core.events import WorkerDomainStateChangedEvent
+from yoyopod.core.events import WorkerDomainStateChangedEvent, WorkerMessageReceivedEvent
 from yoyopod.core.scheduler import MainThreadScheduler
 from yoyopod.core.workers import WorkerProcessConfig
 from yoyopod.integrations.voice import VoiceSettings
@@ -1029,6 +1029,37 @@ def test_setup_voip_callbacks_bind_direct_call_handlers() -> None:
     assert synced == {"talk": 1, "active": 1}
 
 
+def test_setup_voip_callbacks_subscribes_worker_message_handler() -> None:
+    """Worker-backed VoIP backends should receive supervised worker messages."""
+
+    voip_manager = _FakeVoipManager()
+    call_runtime = _FakeCallRuntime()
+    subscribed: list[tuple[object, object]] = []
+    handler = lambda *_args: None
+    voip_manager.backend = SimpleNamespace(handle_worker_message=handler)
+    voice_note_events = SimpleNamespace(
+        handle_voice_note_summary_changed=lambda *_args: None,
+        handle_voice_note_activity_changed=lambda *_args: None,
+        handle_voice_note_failure=lambda *_args: None,
+        sync_talk_summary_context=lambda: None,
+        sync_active_voice_note_context=lambda: None,
+    )
+    app = SimpleNamespace(
+        voip_manager=voip_manager,
+        call_runtime=call_runtime,
+        voice_note_events=voice_note_events,
+        context=None,
+        call_history_store=None,
+        bus=SimpleNamespace(
+            subscribe=lambda event_type, callback: subscribed.append((event_type, callback))
+        ),
+    )
+
+    RuntimeBootService(app).setup_voip_callbacks()
+
+    assert (WorkerMessageReceivedEvent, handler) in subscribed
+
+
 def test_setup_music_callbacks_schedule_playback_handlers_on_main_thread() -> None:
     """Music callbacks should schedule playback handlers back onto the main thread."""
 
@@ -1066,6 +1097,137 @@ def test_setup_music_callbacks_schedule_playback_handlers_on_main_thread() -> No
         ("availability", (True, "connected")),
     ]
     assert music_backend.warm_start_calls == 1
+
+
+def test_voip_rust_host_env_helpers_and_sidecar_conflict(
+    monkeypatch,
+) -> None:
+    """Rust host and the legacy Python sidecar flags should be visible and exclusive."""
+
+    from yoyopod.core.bootstrap.managers_boot import (
+        _rust_voip_host_enabled,
+        _rust_voip_host_worker_path,
+        _voip_sidecar_enabled,
+    )
+
+    monkeypatch.setenv("YOYOPOD_RUST_VOIP_HOST", "true")
+    monkeypatch.setenv("YOYOPOD_RUST_VOIP_HOST_WORKER", "/tmp/yoyopod-voip-host")
+    monkeypatch.setenv("YOYOPOD_VOIP_SIDECAR", "1")
+
+    assert _rust_voip_host_enabled() is True
+    assert _voip_sidecar_enabled() is True
+    assert _rust_voip_host_worker_path() == "/tmp/yoyopod-voip-host"
+
+
+def test_rust_host_backend_receives_worker_supervisor(monkeypatch) -> None:
+    """ManagersBoot should inject WorkerSupervisor into the Rust VoIP Host backend."""
+
+    captured_interval: list[float] = []
+
+    class _FakeVoipConfig:
+        iterate_interval_ms = 20
+        sip_server = "sip.example.com"
+        sip_identity = "sip:alice@example.com"
+
+        @classmethod
+        def from_config_manager(cls, _config_manager):
+            return cls()
+
+    class _FakeVoipManager:
+        def __init__(self, *_args, **kwargs) -> None:
+            self.backend = kwargs.get("backend")
+            self.background_iterate_enabled = kwargs.get("background_iterate_enabled")
+            self.running = False
+            self.registration_state = "none"
+
+        def start(self) -> bool:
+            return False
+
+    class _FakeMusicConfig:
+        music_dir = "data/test_music"
+
+        @classmethod
+        def from_config_manager(cls, _config_manager):
+            return cls()
+
+    class _FakeMusicBackend:
+        def __init__(self, _config) -> None:
+            self.is_connected = False
+
+    class _FakeLocalMusicService:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+    class _FakeOutputVolumeController:
+        def __init__(self, _music_backend) -> None:
+            return None
+
+    class _FakePowerManager:
+        def __init__(self) -> None:
+            self.config = SimpleNamespace(enabled=False, poll_interval_seconds=30.0)
+
+        @classmethod
+        def from_config_manager(cls, _config_manager):
+            return cls()
+
+    class _FakeNetworkManager:
+        def __init__(self) -> None:
+            self.config = SimpleNamespace(enabled=False)
+
+        @classmethod
+        def from_config_manager(cls, *_args, **_kwargs):
+            return cls()
+
+    class _FakeCloudManager:
+        def __init__(self, *, app, config_manager) -> None:
+            self.app = app
+            self.config_manager = config_manager
+
+        def prepare_boot(self) -> None:
+            return None
+
+    monkeypatch.setenv("YOYOPOD_RUST_VOIP_HOST", "1")
+    monkeypatch.setenv("YOYOPOD_RUST_VOIP_HOST_WORKER", "/bin/yoyopod-voip-host")
+
+    app = SimpleNamespace(
+        config_manager=_FakeConfigManager(),
+        people_directory=None,
+        worker_supervisor=object(),
+        recent_track_store=None,
+        context=AppContext(),
+        runtime_loop=SimpleNamespace(
+            set_configured_voip_iterate_interval_seconds=captured_interval.append
+        ),
+        scheduler=SimpleNamespace(run_on_main=lambda fn: fn()),
+        output_volume=None,
+        audio_volume_controller=None,
+        simulate=False,
+        network_events=SimpleNamespace(sync_network_context_from_manager=lambda: None),
+    )
+    service = ManagersBoot(
+        app,
+        logger=SimpleNamespace(
+            info=lambda *_args, **_kwargs: None,
+            warning=lambda *_args, **_kwargs: None,
+            error=lambda *_args, **_kwargs: None,
+            exception=lambda *_args, **_kwargs: None,
+        ),
+        voip_config_cls=_FakeVoipConfig,
+        voip_manager_cls=_FakeVoipManager,
+        music_config_cls=_FakeMusicConfig,
+        mpv_backend_cls=_FakeMusicBackend,
+        local_music_service_cls=_FakeLocalMusicService,
+        output_volume_controller_cls=_FakeOutputVolumeController,
+        power_manager_cls=_FakePowerManager,
+        network_manager_cls=_FakeNetworkManager,
+        cloud_manager_cls=_FakeCloudManager,
+    )
+
+    assert service.init_managers() is True
+    assert app.voip_manager.backend.worker_supervisor is app.worker_supervisor
+    assert app.voip_manager.backend.worker_path == "/bin/yoyopod-voip-host"
+    assert app.voip_manager.background_iterate_enabled is False
+    assert captured_interval == [0.02]
 
 
 def test_setup_event_subscriptions_keeps_legacy_runtime_helper_flow() -> None:

--- a/tests/integrations/test_call.py
+++ b/tests/integrations/test_call.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from tests.fixtures.app import build_test_app, drain_all
+from yoyopod.core.events import BackendStoppedEvent
 from yoyopod.integrations.call import (
     CallHistoryEntry,
     CallHistoryStore,
@@ -162,6 +163,10 @@ class FakeVoipManager:
         for callback in self.call_state_callbacks:
             callback(state)
 
+    def emit_availability(self, available: bool, reason: str) -> None:
+        for callback in self.availability_callbacks:
+            callback(available, reason, SimpleNamespace(value="failed"))
+
     def emit_message_summary(
         self,
         unread_count: int,
@@ -216,6 +221,21 @@ def test_call_setup_seeds_state_helpers_and_history(tmp_path: Path) -> None:
 
     teardown(app)
     assert "call" not in app.integrations
+
+
+def test_unexpected_call_worker_exit_requests_recovery(tmp_path: Path) -> None:
+    app = build_test_app()
+    stopped_events: list[BackendStoppedEvent] = []
+    app.bus.subscribe(BackendStoppedEvent, stopped_events.append)
+    history_store = CallHistoryStore(tmp_path / "call_history.json")
+    manager = FakeVoipManager()
+    setup(app, manager=manager, call_history_store=history_store, ringer=FakeRinger())
+    drain_all(app)
+
+    manager.emit_availability(False, "process_exited")
+    drain_all(app)
+
+    assert stopped_events == [BackendStoppedEvent(domain="call", reason="process_exited")]
 
 
 def test_call_flow_updates_focus_mute_and_history(tmp_path: Path) -> None:

--- a/yoyopod/backends/voip/__init__.py
+++ b/yoyopod/backends/voip/__init__.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from yoyopod.backends.voip.liblinphone import LiblinphoneBackend
     from yoyopod.backends.voip.mock_backend import MockVoIPBackend
     from yoyopod.backends.voip.protocol import VoIPBackend, VoIPIterateMetrics
+    from yoyopod.backends.voip.rust_host import RustHostBackend
 
 
 _EXPORTS = {
@@ -27,6 +28,7 @@ _EXPORTS = {
         "LiblinphoneNativeEvent",
     ),
     "MockVoIPBackend": ("yoyopod.backends.voip.mock_backend", "MockVoIPBackend"),
+    "RustHostBackend": ("yoyopod.backends.voip.rust_host", "RustHostBackend"),
     "VoIPBackend": ("yoyopod.backends.voip.protocol", "VoIPBackend"),
     "VoIPIterateMetrics": ("yoyopod.backends.voip.protocol", "VoIPIterateMetrics"),
 }
@@ -50,6 +52,7 @@ __all__ = [
     "LiblinphoneBindingError",
     "LiblinphoneNativeEvent",
     "MockVoIPBackend",
+    "RustHostBackend",
     "VoIPBackend",
     "VoIPIterateMetrics",
 ]

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -12,6 +12,7 @@ from loguru import logger
 from yoyopod.backends.voip.protocol import VoIPIterateMetrics
 from yoyopod.core.workers import WorkerProcessConfig
 from yoyopod.integrations.call.models import (
+    BackendRecovered,
     BackendStopped,
     CallState,
     CallStateChanged,
@@ -279,11 +280,14 @@ class RustHostBackend:
     def _handle_worker_ready(self) -> None:
         if self._reconfigure_on_ready or not self._startup_commands_sent:
             logger.info("Rust VoIP Host ready; sending configure/register")
+            was_stopped = self._last_stop_reason is not None
             if not self._send_startup_commands():
                 self._mark_stopped("worker_ready_reconfigure_failed")
                 return
             self.running = True
             self._last_stop_reason = None
+            if was_stopped:
+                self._dispatch(BackendRecovered(reason="worker_ready"))
         self._ready_seen = True
         self._reconfigure_on_ready = False
 

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -97,6 +97,9 @@ class RustHostBackend:
             if not bool(start(self.domain)):
                 return False
             if not self._send_startup_commands():
+                self._stop_after_startup_command_failure(
+                    "startup_command_failed", notify_backend_stopped=False
+                )
                 return False
         except Exception as exc:
             logger.error("Rust VoIP Host start failed: {}", exc)
@@ -282,7 +285,7 @@ class RustHostBackend:
             logger.info("Rust VoIP Host ready; sending configure/register")
             was_stopped = self._last_stop_reason is not None
             if not self._send_startup_commands():
-                self._mark_stopped("worker_ready_reconfigure_failed")
+                self._stop_after_startup_command_failure("worker_ready_reconfigure_failed")
                 return
             self.running = True
             self._last_stop_reason = None
@@ -295,13 +298,43 @@ class RustHostBackend:
         command = self._pop_pending_command(request_id)
         reason = _worker_error_reason(payload, command=command)
         if command in _STARTUP_COMMANDS or command is None:
-            self._mark_stopped(reason)
+            self._stop_after_startup_command_failure(reason)
             return
         if command in _CALL_CONTROL_COMMANDS:
             logger.warning("Rust VoIP Host call command failed: {}", reason)
             self._dispatch(CallStateChanged(state=CallState.ERROR))
             return
         logger.warning("Rust VoIP Host command failed: {}", reason)
+
+    def _stop_after_startup_command_failure(
+        self,
+        reason: str,
+        *,
+        notify_backend_stopped: bool = True,
+    ) -> None:
+        stop = getattr(self.worker_supervisor, "stop", None)
+        if self._registered_with_supervisor and callable(stop):
+            was_stopping = self._stopping
+            self._stopping = True
+            try:
+                stop(self.domain, grace_seconds=1.0)
+            except Exception as exc:
+                logger.warning(
+                    "Rust VoIP Host failed to stop worker after startup command failure {}: {}",
+                    reason,
+                    exc,
+                )
+            finally:
+                self._stopping = was_stopping
+        self._pending_commands.clear()
+        self._startup_commands_sent = False
+        self._ready_seen = False
+        self._reconfigure_on_ready = False
+        self.running = False
+        if notify_backend_stopped:
+            self._mark_stopped(reason)
+        else:
+            self._last_stop_reason = reason
 
     def _mark_stopped(self, reason: str) -> None:
         if not self.running and self._last_stop_reason == reason:

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -32,6 +32,7 @@ _CALL_CONTROL_COMMANDS = frozenset(
         "voip.set_mute",
     }
 )
+_INTENTIONAL_STOP_REASONS = frozenset({"stop", "stop_all"})
 
 
 class RustHostBackend:
@@ -108,10 +109,11 @@ class RustHostBackend:
     def stop(self) -> None:
         self._stopping = True
         try:
-            self._send("voip.unregister", {})
-            stop = getattr(self.worker_supervisor, "stop", None)
-            if callable(stop):
-                stop(self.domain, grace_seconds=1.0)
+            if self._registered_with_supervisor:
+                self._send("voip.unregister", {})
+                stop = getattr(self.worker_supervisor, "stop", None)
+                if callable(stop):
+                    stop(self.domain, grace_seconds=1.0)
         finally:
             self._pending_commands.clear()
             self._startup_commands_sent = False
@@ -217,8 +219,9 @@ class RustHostBackend:
                 self._reconfigure_on_ready = True
             return
         if state in {"degraded", "disabled", "stopped"}:
-            self._reconfigure_on_ready = not self._stopping
-            if self._stopping:
+            intentional_stop = state == "stopped" and reason in _INTENTIONAL_STOP_REASONS
+            self._reconfigure_on_ready = not self._stopping and not intentional_stop
+            if self._stopping or intentional_stop:
                 self.running = False
                 return
             self._mark_stopped(reason)

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -45,6 +45,13 @@ class RustHostBackend:
         self.running = False
         self.event_callbacks: list[Callable[[VoIPEvent], None]] = []
         self._registered_with_supervisor = False
+        self._request_counter = 0
+        self._pending_commands: dict[str, str] = {}
+        self._startup_commands_sent = False
+        self._ready_seen = False
+        self._reconfigure_on_ready = False
+        self._stopping = False
+        self._last_stop_reason: str | None = None
 
     def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
         self.event_callbacks.append(callback)
@@ -76,9 +83,7 @@ class RustHostBackend:
                 self._registered_with_supervisor = True
             if not bool(start(self.domain)):
                 return False
-            if not self._send("voip.configure", self._config_payload()):
-                return False
-            if not self._send("voip.register", {}):
+            if not self._send_startup_commands():
                 return False
         except Exception as exc:
             logger.error("Rust VoIP Host start failed: {}", exc)
@@ -86,14 +91,23 @@ class RustHostBackend:
             return False
 
         self.running = True
+        self._last_stop_reason = None
         return True
 
     def stop(self) -> None:
-        self._send("voip.unregister", {})
-        stop = getattr(self.worker_supervisor, "stop", None)
-        if callable(stop):
-            stop(self.domain, grace_seconds=1.0)
-        self.running = False
+        self._stopping = True
+        try:
+            self._send("voip.unregister", {})
+            stop = getattr(self.worker_supervisor, "stop", None)
+            if callable(stop):
+                stop(self.domain, grace_seconds=1.0)
+        finally:
+            self._pending_commands.clear()
+            self._startup_commands_sent = False
+            self._ready_seen = False
+            self._reconfigure_on_ready = False
+            self.running = False
+            self._stopping = False
 
     def iterate(self) -> int:
         return 0
@@ -149,11 +163,22 @@ class RustHostBackend:
     def handle_worker_message(self, event: Any) -> None:
         if getattr(event, "domain", self.domain) != self.domain:
             return
-        if getattr(event, "kind", "event") != "event":
-            return
 
         payload = getattr(event, "payload", {}) or {}
         event_type = getattr(event, "type", "")
+        request_id = getattr(event, "request_id", None)
+        kind = getattr(event, "kind", "event")
+        if kind == "result":
+            self._pop_pending_command(request_id)
+            return
+        if kind == "error":
+            self._handle_worker_error(payload, request_id=request_id)
+            return
+        if kind != "event":
+            return
+        if event_type == "voip.ready":
+            self._handle_worker_ready()
+            return
         if event_type == "voip.registration_changed":
             self._dispatch(
                 RegistrationStateChanged(
@@ -170,18 +195,45 @@ class RustHostBackend:
             self._dispatch(CallStateChanged(state=_call_state(str(payload.get("state", "idle")))))
             return
         if event_type == "voip.backend_stopped":
-            self.running = False
-            self._dispatch(BackendStopped(reason=str(payload.get("reason", ""))))
+            self._mark_stopped(str(payload.get("reason", "")) or "backend_stopped")
+
+    def handle_worker_state_change(self, event: Any) -> None:
+        if getattr(event, "domain", self.domain) != self.domain:
+            return
+
+        state = str(getattr(event, "state", ""))
+        reason = str(getattr(event, "reason", "")) or state
+        if state == "running":
+            if self._ready_seen:
+                self._reconfigure_on_ready = True
+            return
+        if state in {"degraded", "disabled", "stopped"}:
+            self._reconfigure_on_ready = not self._stopping
+            if self._stopping:
+                self.running = False
+                return
+            self._mark_stopped(reason)
 
     def _send(self, message_type: str, payload: dict[str, Any]) -> bool:
         send_command = getattr(self.worker_supervisor, "send_command", None)
         if not callable(send_command):
             return False
+        request_id = self._next_request_id(message_type)
         try:
-            return bool(send_command(self.domain, type=message_type, payload=payload))
+            sent = bool(
+                send_command(
+                    self.domain,
+                    type=message_type,
+                    payload=payload,
+                    request_id=request_id,
+                )
+            )
         except Exception as exc:
             logger.error("Rust VoIP Host command {} failed: {}", message_type, exc)
             return False
+        if sent:
+            self._pending_commands[request_id] = message_type
+        return sent
 
     def _dispatch(self, event: VoIPEvent) -> None:
         for callback in list(self.event_callbacks):
@@ -204,6 +256,50 @@ class RustHostBackend:
         merged.update(self.env)
         return merged
 
+    def _send_startup_commands(self) -> bool:
+        if not self._send("voip.configure", self._config_payload()):
+            return False
+        if not self._send("voip.register", {}):
+            return False
+        self._startup_commands_sent = True
+        return True
+
+    def _handle_worker_ready(self) -> None:
+        if self._reconfigure_on_ready or not self._startup_commands_sent:
+            logger.info("Rust VoIP Host ready; sending configure/register")
+            if not self._send_startup_commands():
+                self._mark_stopped("worker_ready_reconfigure_failed")
+                return
+            self.running = True
+            self._last_stop_reason = None
+        self._ready_seen = True
+        self._reconfigure_on_ready = False
+
+    def _handle_worker_error(self, payload: dict[str, Any], *, request_id: str | None) -> None:
+        command = self._pop_pending_command(request_id)
+        reason = _worker_error_reason(payload, command=command)
+        if command in {"voip.configure", "voip.register"} or command is None:
+            self._mark_stopped(reason)
+            return
+        logger.warning("Rust VoIP Host command failed: {}", reason)
+
+    def _mark_stopped(self, reason: str) -> None:
+        if not self.running and self._last_stop_reason == reason:
+            return
+        self.running = False
+        self._last_stop_reason = reason
+        self._dispatch(BackendStopped(reason=reason))
+
+    def _next_request_id(self, message_type: str) -> str:
+        self._request_counter += 1
+        command_name = message_type.replace(".", "_")
+        return f"{self.domain}-{command_name}-{self._request_counter}"
+
+    def _pop_pending_command(self, request_id: str | None) -> str | None:
+        if request_id is None:
+            return None
+        return self._pending_commands.pop(request_id, None)
+
 
 def _registration_state(value: str) -> RegistrationState:
     try:
@@ -217,3 +313,12 @@ def _call_state(value: str) -> CallState:
         return CallState(value)
     except ValueError:
         return CallState.IDLE
+
+
+def _worker_error_reason(payload: dict[str, Any], *, command: str | None) -> str:
+    code = str(payload.get("code", "worker_error")).strip() or "worker_error"
+    message = str(payload.get("message", "")).strip()
+    prefix = f"{command} {code}" if command else code
+    if message:
+        return f"{prefix}: {message}"
+    return prefix

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -1,0 +1,219 @@
+"""VoIPBackend adapter backed by the Rust VoIP Host worker."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from collections.abc import Callable
+from typing import Any
+
+from loguru import logger
+
+from yoyopod.backends.voip.protocol import VoIPIterateMetrics
+from yoyopod.core.workers import WorkerProcessConfig
+from yoyopod.integrations.call.models import (
+    BackendStopped,
+    CallState,
+    CallStateChanged,
+    IncomingCallDetected,
+    RegistrationState,
+    RegistrationStateChanged,
+    VoIPConfig,
+    VoIPEvent,
+)
+
+
+class RustHostBackend:
+    """Calls-only VoIPBackend adapter for the Rust VoIP Host."""
+
+    def __init__(
+        self,
+        config: VoIPConfig,
+        *,
+        worker_supervisor: Any,
+        worker_path: str,
+        domain: str = "voip",
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+    ) -> None:
+        self.config = config
+        self.worker_supervisor = worker_supervisor
+        self.worker_path = worker_path
+        self.domain = domain
+        self.env = env
+        self.cwd = cwd
+        self.running = False
+        self.event_callbacks: list[Callable[[VoIPEvent], None]] = []
+        self._registered_with_supervisor = False
+
+    def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
+        self.event_callbacks.append(callback)
+
+    def start(self) -> bool:
+        if self.running:
+            return True
+        if not self.config.is_backend_start_configured():
+            logger.error("Rust VoIP Host requires sip_server and sip_identity")
+            return False
+
+        register = getattr(self.worker_supervisor, "register", None)
+        start = getattr(self.worker_supervisor, "start", None)
+        if not callable(register) or not callable(start):
+            logger.error("Rust VoIP Host supervisor is unavailable")
+            return False
+
+        try:
+            if not self._registered_with_supervisor:
+                register(
+                    self.domain,
+                    WorkerProcessConfig(
+                        name=self.domain,
+                        argv=[self.worker_path],
+                        cwd=self.cwd,
+                        env=self._process_env(),
+                    ),
+                )
+                self._registered_with_supervisor = True
+            if not bool(start(self.domain)):
+                return False
+            if not self._send("voip.configure", self._config_payload()):
+                return False
+            if not self._send("voip.register", {}):
+                return False
+        except Exception as exc:
+            logger.error("Rust VoIP Host start failed: {}", exc)
+            self.running = False
+            return False
+
+        self.running = True
+        return True
+
+    def stop(self) -> None:
+        self._send("voip.unregister", {})
+        stop = getattr(self.worker_supervisor, "stop", None)
+        if callable(stop):
+            stop(self.domain, grace_seconds=1.0)
+        self.running = False
+
+    def iterate(self) -> int:
+        return 0
+
+    def get_iterate_metrics(self) -> VoIPIterateMetrics | None:
+        return None
+
+    def make_call(self, sip_address: str) -> bool:
+        return self._send("voip.dial", {"uri": sip_address})
+
+    def answer_call(self) -> bool:
+        return self._send("voip.answer", {})
+
+    def reject_call(self) -> bool:
+        return self._send("voip.reject", {})
+
+    def hangup(self) -> bool:
+        return self._send("voip.hangup", {})
+
+    def mute(self) -> bool:
+        return self._send("voip.set_mute", {"muted": True})
+
+    def unmute(self) -> bool:
+        return self._send("voip.set_mute", {"muted": False})
+
+    def send_text_message(self, sip_address: str, text: str) -> str | None:
+        del sip_address, text
+        logger.warning("Rust VoIP Host does not support text messages in calls-only mode")
+        return None
+
+    def start_voice_note_recording(self, file_path: str) -> bool:
+        del file_path
+        logger.warning("Rust VoIP Host does not support voice notes in calls-only mode")
+        return False
+
+    def stop_voice_note_recording(self) -> int | None:
+        return None
+
+    def cancel_voice_note_recording(self) -> bool:
+        return False
+
+    def send_voice_note(
+        self,
+        sip_address: str,
+        *,
+        file_path: str,
+        duration_ms: int,
+        mime_type: str,
+    ) -> str | None:
+        del sip_address, file_path, duration_ms, mime_type
+        return None
+
+    def handle_worker_message(self, event: Any) -> None:
+        if getattr(event, "domain", self.domain) != self.domain:
+            return
+        if getattr(event, "kind", "event") != "event":
+            return
+
+        payload = getattr(event, "payload", {}) or {}
+        event_type = getattr(event, "type", "")
+        if event_type == "voip.registration_changed":
+            self._dispatch(
+                RegistrationStateChanged(
+                    state=_registration_state(str(payload.get("state", "none")))
+                )
+            )
+            return
+        if event_type == "voip.incoming_call":
+            self._dispatch(
+                IncomingCallDetected(caller_address=str(payload.get("from_uri", "")))
+            )
+            return
+        if event_type == "voip.call_state_changed":
+            self._dispatch(CallStateChanged(state=_call_state(str(payload.get("state", "idle")))))
+            return
+        if event_type == "voip.backend_stopped":
+            self.running = False
+            self._dispatch(BackendStopped(reason=str(payload.get("reason", ""))))
+
+    def _send(self, message_type: str, payload: dict[str, Any]) -> bool:
+        send_command = getattr(self.worker_supervisor, "send_command", None)
+        if not callable(send_command):
+            return False
+        try:
+            return bool(send_command(self.domain, type=message_type, payload=payload))
+        except Exception as exc:
+            logger.error("Rust VoIP Host command {} failed: {}", message_type, exc)
+            return False
+
+    def _dispatch(self, event: VoIPEvent) -> None:
+        for callback in list(self.event_callbacks):
+            try:
+                callback(event)
+            except Exception:
+                logger.exception("Rust VoIP Host callback raised for {}", type(event).__name__)
+
+    def _config_payload(self) -> dict[str, Any]:
+        payload = dataclasses.asdict(self.config)
+        payload["conference_factory_uri"] = self.config.effective_conference_factory_uri()
+        payload["file_transfer_server_url"] = self.config.effective_file_transfer_server_url()
+        payload["lime_server_url"] = self.config.effective_lime_server_url()
+        return payload
+
+    def _process_env(self) -> dict[str, str] | None:
+        if self.env is None:
+            return None
+        merged = dict(os.environ)
+        merged.update(self.env)
+        return merged
+
+
+def _registration_state(value: str) -> RegistrationState:
+    try:
+        return RegistrationState(value)
+    except ValueError:
+        return RegistrationState.NONE
+
+
+def _call_state(value: str) -> CallState:
+    try:
+        return CallState(value)
+    except ValueError:
+        return CallState.IDLE

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -22,6 +22,17 @@ from yoyopod.integrations.call.models import (
     VoIPEvent,
 )
 
+_STARTUP_COMMANDS = frozenset({"voip.configure", "voip.register"})
+_CALL_CONTROL_COMMANDS = frozenset(
+    {
+        "voip.dial",
+        "voip.answer",
+        "voip.reject",
+        "voip.hangup",
+        "voip.set_mute",
+    }
+)
+
 
 class RustHostBackend:
     """Calls-only VoIPBackend adapter for the Rust VoIP Host."""
@@ -187,9 +198,7 @@ class RustHostBackend:
             )
             return
         if event_type == "voip.incoming_call":
-            self._dispatch(
-                IncomingCallDetected(caller_address=str(payload.get("from_uri", "")))
-            )
+            self._dispatch(IncomingCallDetected(caller_address=str(payload.get("from_uri", ""))))
             return
         if event_type == "voip.call_state_changed":
             self._dispatch(CallStateChanged(state=_call_state(str(payload.get("state", "idle")))))
@@ -278,8 +287,12 @@ class RustHostBackend:
     def _handle_worker_error(self, payload: dict[str, Any], *, request_id: str | None) -> None:
         command = self._pop_pending_command(request_id)
         reason = _worker_error_reason(payload, command=command)
-        if command in {"voip.configure", "voip.register"} or command is None:
+        if command in _STARTUP_COMMANDS or command is None:
             self._mark_stopped(reason)
+            return
+        if command in _CALL_CONTROL_COMMANDS:
+            logger.warning("Rust VoIP Host call command failed: {}", reason)
+            self._dispatch(CallStateChanged(state=CallState.ERROR))
             return
         logger.warning("Rust VoIP Host command failed: {}", reason)
 

--- a/yoyopod/core/bootstrap/callbacks_boot.py
+++ b/yoyopod/core/bootstrap/callbacks_boot.py
@@ -57,11 +57,17 @@ class CallbacksBoot:
 
         backend = getattr(self.app.voip_manager, "backend", None)
         handle_worker_message = getattr(backend, "handle_worker_message", None)
+        handle_worker_state_change = getattr(backend, "handle_worker_state_change", None)
         bus = getattr(self.app, "bus", None)
         if callable(handle_worker_message) and bus is not None:
-            from yoyopod.core.events import WorkerMessageReceivedEvent
+            from yoyopod.core.events import (
+                WorkerDomainStateChangedEvent,
+                WorkerMessageReceivedEvent,
+            )
 
             bus.subscribe(WorkerMessageReceivedEvent, handle_worker_message)
+            if callable(handle_worker_state_change):
+                bus.subscribe(WorkerDomainStateChangedEvent, handle_worker_state_change)
 
         self.logger.info("  VoIP callbacks registered")
 

--- a/yoyopod/core/bootstrap/callbacks_boot.py
+++ b/yoyopod/core/bootstrap/callbacks_boot.py
@@ -54,6 +54,15 @@ class CallbacksBoot:
         )
         self.app.voice_note_events.sync_talk_summary_context()
         self.app.voice_note_events.sync_active_voice_note_context()
+
+        backend = getattr(self.app.voip_manager, "backend", None)
+        handle_worker_message = getattr(backend, "handle_worker_message", None)
+        bus = getattr(self.app, "bus", None)
+        if callable(handle_worker_message) and bus is not None:
+            from yoyopod.core.events import WorkerMessageReceivedEvent
+
+            bus.subscribe(WorkerMessageReceivedEvent, handle_worker_message)
+
         self.logger.info("  VoIP callbacks registered")
 
     def setup_music_callbacks(self) -> None:

--- a/yoyopod/core/bootstrap/managers_boot.py
+++ b/yoyopod/core/bootstrap/managers_boot.py
@@ -23,6 +23,22 @@ def _voip_sidecar_enabled() -> bool:
     return raw in {"1", "true", "yes", "on"}
 
 
+def _rust_voip_host_enabled() -> bool:
+    """Return whether the Rust VoIP Host worker should back the manager."""
+
+    raw = os.environ.get("YOYOPOD_RUST_VOIP_HOST", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _rust_voip_host_worker_path() -> str:
+    """Return the Rust VoIP Host worker binary path."""
+
+    return os.environ.get(
+        "YOYOPOD_RUST_VOIP_HOST_WORKER",
+        "src/crates/voip-host/build/yoyopod-voip-host",
+    ).strip()
+
+
 class ManagersBoot:
     """Initialize manager-level runtime integrations."""
 
@@ -67,7 +83,24 @@ class ManagersBoot:
             voip_config = self.voip_config_cls.from_config_manager(config_manager)
             sidecar_backed_backend = None
             background_iterate_enabled = True
-            if _voip_sidecar_enabled():
+            if _voip_sidecar_enabled() and _rust_voip_host_enabled():
+                raise RuntimeError(
+                    "YOYOPOD_VOIP_SIDECAR and YOYOPOD_RUST_VOIP_HOST cannot both be enabled"
+                )
+            if _rust_voip_host_enabled():
+                self.logger.info(
+                    "    YOYOPOD_RUST_VOIP_HOST=1 - using Rust VoIP Host backend"
+                )
+                from yoyopod.backends.voip.rust_host import RustHostBackend
+
+                sidecar_backed_backend = RustHostBackend(
+                    voip_config,
+                    worker_supervisor=self.app.worker_supervisor,
+                    worker_path=_rust_voip_host_worker_path(),
+                )
+                # The Rust host drives liblinphone iterate inside the worker.
+                background_iterate_enabled = False
+            elif _voip_sidecar_enabled():
                 self.logger.info("    YOYOPOD_VOIP_SIDECAR=1 — using sidecar-backed VoIP backend")
                 from yoyopod.backends.voip.supervisor_backed import (
                     SupervisorBackedBackend,

--- a/yoyopod/integrations/call/__init__.py
+++ b/yoyopod/integrations/call/__init__.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     )
     from yoyopod.integrations.call.status import is_voip_configured, sync_context_voip_status
     from yoyopod.integrations.call.models import (
+        BackendRecovered,
         BackendStopped,
         CallState,
         CallStateChanged,
@@ -128,6 +129,7 @@ _PUBLIC_EXPORTS = {
     ),
     "CallStateChanged": ("yoyopod.integrations.call.models", "CallStateChanged"),
     "IncomingCallDetected": ("yoyopod.integrations.call.models", "IncomingCallDetected"),
+    "BackendRecovered": ("yoyopod.integrations.call.models", "BackendRecovered"),
     "BackendStopped": ("yoyopod.integrations.call.models", "BackendStopped"),
     "MessageReceived": ("yoyopod.integrations.call.models", "MessageReceived"),
     "MessageDeliveryChanged": (
@@ -576,6 +578,7 @@ __all__ = [
     "RegistrationStateChanged",
     "CallStateChanged",
     "IncomingCallDetected",
+    "BackendRecovered",
     "BackendStopped",
     "MessageReceived",
     "MessageDeliveryChanged",

--- a/yoyopod/integrations/call/handlers.py
+++ b/yoyopod/integrations/call/handlers.py
@@ -167,7 +167,7 @@ def handle_availability_changed_event(
         event.registration_state.value,
         {"reason": event.reason or "availability_changed"},
     )
-    if not event.available and event.reason in {"backend_stopped", "start_failed"}:
+    if not event.available and _should_request_call_recovery(event.reason):
         app.bus.publish(BackendStoppedEvent(domain="call", reason=event.reason))
     if not event.available:
         _stop_ringer(integration)
@@ -461,3 +461,17 @@ def _as_registration_state(value: object) -> RegistrationState:
         return RegistrationState(str(value or RegistrationState.NONE.value))
     except ValueError:
         return RegistrationState.NONE
+
+
+def _should_request_call_recovery(reason: str) -> bool:
+    normalized = str(reason or "").strip()
+    if normalized in {
+        "backend_stopped",
+        "process_exited",
+        "restart_failed",
+        "start_failed",
+        "max_restarts_exceeded",
+        "worker_ready_reconfigure_failed",
+    }:
+        return True
+    return normalized.startswith("voip.")

--- a/yoyopod/integrations/call/manager.py
+++ b/yoyopod/integrations/call/manager.py
@@ -15,6 +15,7 @@ from yoyopod.backends.voip import LiblinphoneBackend
 from yoyopod.integrations.call.messaging import MessagingService
 from yoyopod.integrations.call.message_store import VoIPMessageStore
 from yoyopod.integrations.call.models import (
+    BackendRecovered,
     BackendStopped,
     CallState,
     CallStateChanged,
@@ -513,6 +514,12 @@ class VoIPManager:
             self._update_registration_state(RegistrationState.FAILED)
             self.running = False
             self._notify_availability_change(False, event.reason or "backend_stopped")
+            return
+        if isinstance(event, BackendRecovered):
+            logger.info("VoIP backend recovered: {}", event.reason or "backend_recovered")
+            self.running = True
+            self._update_registration_state(RegistrationState.PROGRESS)
+            self._notify_availability_change(True, event.reason or "backend_recovered")
             return
         if isinstance(event, MessageReceived):
             self._messaging_service.handle_message_received(event.message)

--- a/yoyopod/integrations/call/models.py
+++ b/yoyopod/integrations/call/models.py
@@ -224,6 +224,13 @@ class BackendStopped:
 
 
 @dataclass(frozen=True, slots=True)
+class BackendRecovered:
+    """Typed event emitted when a stopped backend becomes usable again."""
+
+    reason: str = "backend_recovered"
+
+
+@dataclass(frozen=True, slots=True)
 class MessageReceived:
     """Typed event emitted when a new message is received."""
 
@@ -262,6 +269,7 @@ VoIPEvent: TypeAlias = (
     | CallStateChanged
     | IncomingCallDetected
     | BackendStopped
+    | BackendRecovered
     | MessageReceived
     | MessageDeliveryChanged
     | MessageDownloadCompleted


### PR DESCRIPTION
## Summary
- Add the calls-only Rust VoIP Host worker under `src/crates/voip-host`.
- Bind the existing Liblinphone C shim through Rust `libloading` and handle configure/register/dial/answer/reject/hangup/mute commands.
- Add an opt-in Python `RustHostBackend` behind `YOYOPOD_RUST_VOIP_HOST=1` with worker event translation into the existing VoIP manager flow.
- Keep the Rust worker iterating liblinphone on a timed loop so registration and call-state events advance even when Python is not sending commands.
- Resolve the `main` conflict from the Python VoIP sidecar default-on change by letting the Rust VoIP Host opt-in take precedence over the default sidecar path.
- Handle Rust worker lifecycle failures: `voip.error` startup failures now surface as backend-stopped events, restarted workers reconfigure/register on `voip.ready`, and worker state changes are wired into the VoIP backend.
- Accept `worker.stop` in the Rust VoIP Host shutdown path so supervisor stops can terminate gracefully.
- Forward configured `mic_gain` through the Rust liblinphone shim start call so device microphone calibration is preserved.
- Surface failed Rust call-control commands as `CallStateChanged(ERROR)` events instead of logging only, so optimistic Python call/UI state is released after worker rejection.
- Make Rust host shutdown safe before worker registration and ignore delayed intentional supervisor stop events.
- Restore manager availability after Rust worker recovery by emitting a `BackendRecovered` event when `voip.ready` reconfiguration follows an unexpected stop.
- Upload the ARM64 `yoyopod-voip-host-<sha>` CI artifact and document the CI-artifact deploy path.

## Validation
- `uv run pytest -q tests/backends/test_rust_host_voip.py tests/backends/test_voip_backend.py` (`38 passed`)
- `cargo test --manifest-path src/Cargo.toml -p yoyopod-voip-host --locked` (`20 passed`, from the previous Rust-source change)
- `cargo fmt --manifest-path src/Cargo.toml --all -- --check` and `cargo test --manifest-path src/Cargo.toml --workspace --locked` (from the previous Rust-source change)
- `uv run python scripts/quality.py gate`
- `uv run pytest -q` (`1885 passed, 22 skipped`)
- Pre-push rerun: `uv run python scripts/quality.py gate` and `uv run pytest -q` (`1885 passed, 22 skipped`)
- Latest CI run: https://github.com/attmous/yoyocore/actions/runs/25081273259 (`changes`, `quality`, `test`, `voice-go`, and `ui-rust` passed; `slot-arm64` skipped because this PR run did not request a slot artifact)

## Hardware
- Previously validated on `rpi-zero` using the CI artifact `yoyopod-voip-host-a65c1baaf3cab474c3405b7927497e85e84f772e`.
- Installed artifact at `/opt/yoyopod-dev/checkout/src/crates/voip-host/build/yoyopod-voip-host`; no Rust build was run on the Pi.
- `yoyopod-dev.service` restarted cleanly and remained active.
- Runtime logs confirmed Rust VoIP Host path and registration flow: `none -> progress -> ok`, followed by `VoIP ready to receive calls`.
- The latest P1/P2 review fixes change Python-side lifecycle/error/recovery handling around that path and are covered by local/CI regression tests.