### PR TITLE
Add Rust VoIP host text messaging

### DIFF
--- a/src/crates/voip-host/src/events.rs
+++ b/src/crates/voip-host/src/events.rs
@@ -27,6 +27,27 @@ pub enum CallState {
     End,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageKind {
+    Text,
+    VoiceNote,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageDirection {
+    Incoming,
+    Outgoing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageDeliveryState {
+    Queued,
+    Sending,
+    Sent,
+    Delivered,
+    Failed,
+}
+
 impl RegistrationState {
     pub fn from_native(value: i32) -> Self {
         match value {
@@ -93,6 +114,63 @@ impl CallState {
     }
 }
 
+impl MessageKind {
+    pub fn from_native(value: i32) -> Self {
+        if value == 2 {
+            Self::VoiceNote
+        } else {
+            Self::Text
+        }
+    }
+
+    pub fn as_protocol(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::VoiceNote => "voice_note",
+        }
+    }
+}
+
+impl MessageDirection {
+    pub fn from_native(value: i32) -> Self {
+        if value == 2 {
+            Self::Outgoing
+        } else {
+            Self::Incoming
+        }
+    }
+
+    pub fn as_protocol(self) -> &'static str {
+        match self {
+            Self::Incoming => "incoming",
+            Self::Outgoing => "outgoing",
+        }
+    }
+}
+
+impl MessageDeliveryState {
+    pub fn from_native(value: i32) -> Self {
+        match value {
+            1 => Self::Queued,
+            2 => Self::Sending,
+            3 => Self::Sent,
+            4 => Self::Delivered,
+            5 => Self::Failed,
+            _ => Self::Failed,
+        }
+    }
+
+    pub fn as_protocol(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Sending => "sending",
+            Self::Sent => "sent",
+            Self::Delivered => "delivered",
+            Self::Failed => "failed",
+        }
+    }
+}
+
 pub fn registration_payload(state: RegistrationState, reason: &str) -> Value {
     json!({"state": state.as_protocol(), "reason": reason})
 }
@@ -127,6 +205,23 @@ mod tests {
         assert!(CallState::Error.is_terminal());
         assert!(CallState::End.is_terminal());
         assert!(!CallState::Connected.is_terminal());
+    }
+
+    #[test]
+    fn maps_native_message_values_to_python_values() {
+        assert_eq!(MessageKind::from_native(1).as_protocol(), "text");
+        assert_eq!(MessageKind::from_native(2).as_protocol(), "voice_note");
+        assert_eq!(MessageDirection::from_native(1).as_protocol(), "incoming");
+        assert_eq!(MessageDirection::from_native(2).as_protocol(), "outgoing");
+        assert_eq!(MessageDeliveryState::from_native(1).as_protocol(), "queued");
+        assert_eq!(
+            MessageDeliveryState::from_native(4).as_protocol(),
+            "delivered"
+        );
+        assert_eq!(
+            MessageDeliveryState::from_native(99).as_protocol(),
+            "failed"
+        );
     }
 
     #[test]

--- a/src/crates/voip-host/src/host.rs
+++ b/src/crates/voip-host/src/host.rs
@@ -1,5 +1,6 @@
 use crate::config::VoipConfig;
 use serde_json::json;
+use std::collections::HashMap;
 
 pub trait CallBackend {
     fn start(&mut self, config: &VoipConfig) -> Result<(), String>;
@@ -10,14 +11,60 @@ pub trait CallBackend {
     fn reject_call(&mut self) -> Result<(), String>;
     fn hangup(&mut self) -> Result<(), String>;
     fn set_muted(&mut self, muted: bool) -> Result<(), String>;
+    fn send_text_message(&mut self, sip_address: &str, text: &str) -> Result<String, String>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageRecord {
+    pub message_id: String,
+    pub peer_sip_address: String,
+    pub sender_sip_address: String,
+    pub recipient_sip_address: String,
+    pub kind: String,
+    pub direction: String,
+    pub delivery_state: String,
+    pub text: String,
+    pub local_file_path: String,
+    pub mime_type: String,
+    pub duration_ms: i32,
+    pub unread: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BackendEvent {
-    RegistrationChanged { state: String, reason: String },
-    IncomingCall { call_id: String, from_uri: String },
-    CallStateChanged { call_id: String, state: String },
-    BackendStopped { reason: String },
+    RegistrationChanged {
+        state: String,
+        reason: String,
+    },
+    IncomingCall {
+        call_id: String,
+        from_uri: String,
+    },
+    CallStateChanged {
+        call_id: String,
+        state: String,
+    },
+    BackendStopped {
+        reason: String,
+    },
+    MessageReceived {
+        message: MessageRecord,
+    },
+    MessageDeliveryChanged {
+        message_id: String,
+        delivery_state: String,
+        local_file_path: String,
+        error: String,
+    },
+    MessageDownloadCompleted {
+        message_id: String,
+        local_file_path: String,
+        mime_type: String,
+    },
+    MessageFailed {
+        message_id: String,
+        reason: String,
+    },
 }
 
 #[derive(Debug, Default)]
@@ -25,6 +72,7 @@ pub struct VoipHost {
     config: Option<VoipConfig>,
     registered: bool,
     active_call_id: Option<String>,
+    outbound_message_ids: HashMap<String, String>,
 }
 
 impl VoipHost {
@@ -32,6 +80,7 @@ impl VoipHost {
         self.config = Some(config);
         self.registered = false;
         self.active_call_id = None;
+        self.outbound_message_ids.clear();
     }
 
     pub fn mark_registered(&mut self, registered: bool) {
@@ -71,6 +120,7 @@ impl VoipHost {
         backend.stop();
         self.registered = false;
         self.active_call_id = None;
+        self.outbound_message_ids.clear();
     }
 
     pub fn dial<B: CallBackend>(
@@ -107,11 +157,38 @@ impl VoipHost {
         backend.set_muted(muted)
     }
 
+    pub fn send_text_message<B: CallBackend>(
+        &mut self,
+        backend: &mut B,
+        sip_address: &str,
+        text: &str,
+        client_id: &str,
+    ) -> Result<String, String> {
+        let client_id = client_id.trim();
+        if client_id.is_empty() {
+            return Err("voip text message requires client_id".to_string());
+        }
+        let backend_id = backend.send_text_message(sip_address, text)?;
+        let backend_id = backend_id.trim();
+        if backend_id.is_empty() {
+            return Err("voip text message backend returned empty message id".to_string());
+        }
+        if backend_id != client_id {
+            self.outbound_message_ids
+                .insert(backend_id.to_string(), client_id.to_string());
+        }
+        Ok(client_id.to_string())
+    }
+
     pub fn poll_backend_events<B: CallBackend>(
         &mut self,
         backend: &mut B,
     ) -> Result<Vec<BackendEvent>, String> {
-        let events = backend.iterate()?;
+        let events: Vec<BackendEvent> = backend
+            .iterate()?
+            .into_iter()
+            .map(|event| self.translate_backend_event(event))
+            .collect();
         for event in &events {
             self.apply_backend_event(event);
         }
@@ -144,9 +221,63 @@ impl VoipHost {
             BackendEvent::BackendStopped { .. } => {
                 self.registered = false;
                 self.active_call_id = None;
+                self.outbound_message_ids.clear();
             }
+            BackendEvent::MessageReceived { .. }
+            | BackendEvent::MessageDeliveryChanged { .. }
+            | BackendEvent::MessageDownloadCompleted { .. }
+            | BackendEvent::MessageFailed { .. } => {}
         }
     }
+
+    fn translate_backend_event(&mut self, event: BackendEvent) -> BackendEvent {
+        match event {
+            BackendEvent::MessageReceived { mut message } => {
+                message.message_id = self.translate_message_id(&message.message_id, false);
+                BackendEvent::MessageReceived { message }
+            }
+            BackendEvent::MessageDeliveryChanged {
+                message_id,
+                delivery_state,
+                local_file_path,
+                error,
+            } => {
+                let terminal = is_terminal_delivery_state(&delivery_state);
+                BackendEvent::MessageDeliveryChanged {
+                    message_id: self.translate_message_id(&message_id, terminal),
+                    delivery_state,
+                    local_file_path,
+                    error,
+                }
+            }
+            BackendEvent::MessageDownloadCompleted {
+                message_id,
+                local_file_path,
+                mime_type,
+            } => BackendEvent::MessageDownloadCompleted {
+                message_id: self.translate_message_id(&message_id, false),
+                local_file_path,
+                mime_type,
+            },
+            BackendEvent::MessageFailed { message_id, reason } => BackendEvent::MessageFailed {
+                message_id: self.translate_message_id(&message_id, true),
+                reason,
+            },
+            other => other,
+        }
+    }
+
+    fn translate_message_id(&mut self, backend_id: &str, terminal: bool) -> String {
+        let client_id = self.outbound_message_ids.get(backend_id).cloned();
+        if terminal && client_id.is_some() {
+            self.outbound_message_ids.remove(backend_id);
+        }
+        client_id.unwrap_or_else(|| backend_id.to_string())
+    }
+}
+
+fn is_terminal_delivery_state(value: &str) -> bool {
+    matches!(value, "delivered" | "failed")
 }
 
 #[cfg(test)]
@@ -225,6 +356,11 @@ mod command_tests {
             self.calls.push(format!("mute:{muted}"));
             Ok(())
         }
+
+        fn send_text_message(&mut self, sip_address: &str, text: &str) -> Result<String, String> {
+            self.calls.push(format!("text:{sip_address}:{text}"));
+            Ok("backend-msg-1".to_string())
+        }
     }
 
     fn config() -> VoipConfig {
@@ -289,6 +425,94 @@ mod command_tests {
     }
 
     #[test]
+    fn send_text_message_returns_client_id_and_maps_delivery_back_to_client_id() {
+        struct EventBackend {
+            calls: Vec<String>,
+            events: Vec<BackendEvent>,
+        }
+
+        impl CallBackend for EventBackend {
+            fn start(&mut self, _config: &VoipConfig) -> Result<(), String> {
+                self.calls.push("start".to_string());
+                Ok(())
+            }
+
+            fn stop(&mut self) {
+                self.calls.push("stop".to_string());
+            }
+
+            fn iterate(&mut self) -> Result<Vec<BackendEvent>, String> {
+                Ok(std::mem::take(&mut self.events))
+            }
+
+            fn make_call(&mut self, _sip_address: &str) -> Result<String, String> {
+                Ok("call-outgoing".to_string())
+            }
+
+            fn answer_call(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn reject_call(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn hangup(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn set_muted(&mut self, _muted: bool) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn send_text_message(
+                &mut self,
+                sip_address: &str,
+                text: &str,
+            ) -> Result<String, String> {
+                self.calls.push(format!("text:{sip_address}:{text}"));
+                Ok("backend-msg-1".to_string())
+            }
+        }
+
+        let mut host = VoipHost::default();
+        host.configure(config());
+        let mut backend = EventBackend {
+            calls: Vec::new(),
+            events: Vec::new(),
+        };
+        host.register(&mut backend).unwrap();
+
+        let message_id = host
+            .send_text_message(&mut backend, "sip:bob@example.com", "hello", "client-msg-1")
+            .expect("send text");
+
+        assert_eq!(message_id, "client-msg-1");
+        assert_eq!(
+            backend.calls,
+            vec!["start", "text:sip:bob@example.com:hello"]
+        );
+
+        backend.events = vec![BackendEvent::MessageDeliveryChanged {
+            message_id: "backend-msg-1".to_string(),
+            delivery_state: "delivered".to_string(),
+            local_file_path: "".to_string(),
+            error: "".to_string(),
+        }];
+        let events = host.poll_backend_events(&mut backend).expect("poll");
+
+        assert_eq!(
+            events,
+            vec![BackendEvent::MessageDeliveryChanged {
+                message_id: "client-msg-1".to_string(),
+                delivery_state: "delivered".to_string(),
+                local_file_path: "".to_string(),
+                error: "".to_string(),
+            }]
+        );
+    }
+
+    #[test]
     fn reject_and_unregister_clear_state() {
         let mut host = VoipHost::default();
         let mut backend = FakeBackend::default();
@@ -345,6 +569,14 @@ mod command_tests {
 
             fn set_muted(&mut self, _muted: bool) -> Result<(), String> {
                 Ok(())
+            }
+
+            fn send_text_message(
+                &mut self,
+                _sip_address: &str,
+                _text: &str,
+            ) -> Result<String, String> {
+                Ok("backend-msg-1".to_string())
             }
         }
 

--- a/src/crates/voip-host/src/main.rs
+++ b/src/crates/voip-host/src/main.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
 
     write_envelope(&WorkerEnvelope::event(
         "voip.ready",
-        json!({"capabilities":["calls"]}),
+        json!({"capabilities":["calls", "text_messages"]}),
     ))?;
 
     let (stdin_tx, stdin_rx) = mpsc::channel();
@@ -218,6 +218,31 @@ fn handle_command(
                 json!({"muted": muted}),
             ))?;
         }
+        "voip.send_text_message" => {
+            let uri = envelope.payload["uri"].as_str().unwrap_or("").trim();
+            let text = envelope.payload["text"].as_str().unwrap_or("");
+            let client_id = envelope.payload["client_id"].as_str().unwrap_or("").trim();
+            if uri.is_empty() || text.is_empty() || client_id.is_empty() {
+                write_envelope(&WorkerEnvelope::error(
+                    "voip.error",
+                    envelope.request_id,
+                    "invalid_command",
+                    "voip.send_text_message requires uri, text, and client_id",
+                ))?;
+            } else {
+                let backend_ref = backend
+                    .as_mut()
+                    .ok_or_else(|| anyhow!("voip host is not registered"))?;
+                let message_id = host
+                    .send_text_message(backend_ref, uri, text, client_id)
+                    .map_err(|error| anyhow!(error))?;
+                write_envelope(&WorkerEnvelope::result(
+                    "voip.send_text_message",
+                    envelope.request_id,
+                    json!({"message_id": message_id}),
+                ))?;
+            }
+        }
         "voip.shutdown" | "worker.stop" => {
             if let Some(mut backend_ref) = backend.take() {
                 host.unregister(&mut backend_ref);
@@ -284,6 +309,54 @@ fn backend_event_envelope(event: host::BackendEvent) -> WorkerEnvelope {
         host::BackendEvent::BackendStopped { reason } => {
             WorkerEnvelope::event("voip.backend_stopped", json!({"reason": reason}))
         }
+        host::BackendEvent::MessageReceived { message } => WorkerEnvelope::event(
+            "voip.message_received",
+            json!({
+                "message_id": message.message_id,
+                "peer_sip_address": message.peer_sip_address,
+                "sender_sip_address": message.sender_sip_address,
+                "recipient_sip_address": message.recipient_sip_address,
+                "kind": message.kind,
+                "direction": message.direction,
+                "delivery_state": message.delivery_state,
+                "text": message.text,
+                "local_file_path": message.local_file_path,
+                "mime_type": message.mime_type,
+                "duration_ms": message.duration_ms,
+                "unread": message.unread,
+                "display_name": "",
+            }),
+        ),
+        host::BackendEvent::MessageDeliveryChanged {
+            message_id,
+            delivery_state,
+            local_file_path,
+            error,
+        } => WorkerEnvelope::event(
+            "voip.message_delivery_changed",
+            json!({
+                "message_id": message_id,
+                "delivery_state": delivery_state,
+                "local_file_path": local_file_path,
+                "error": error,
+            }),
+        ),
+        host::BackendEvent::MessageDownloadCompleted {
+            message_id,
+            local_file_path,
+            mime_type,
+        } => WorkerEnvelope::event(
+            "voip.message_download_completed",
+            json!({
+                "message_id": message_id,
+                "local_file_path": local_file_path,
+                "mime_type": mime_type,
+            }),
+        ),
+        host::BackendEvent::MessageFailed { message_id, reason } => WorkerEnvelope::event(
+            "voip.message_failed",
+            json!({"message_id": message_id, "reason": reason}),
+        ),
     }
 }
 
@@ -309,6 +382,31 @@ mod tests {
         assert_eq!(envelope.message_type, "voip.incoming_call");
         assert_eq!(envelope.payload["call_id"], "call-1");
         assert_eq!(envelope.payload["from_uri"], "sip:bob@example.com");
+    }
+
+    #[test]
+    fn message_events_map_to_worker_envelopes() {
+        let envelope = backend_event_envelope(host::BackendEvent::MessageReceived {
+            message: host::MessageRecord {
+                message_id: "msg-1".to_string(),
+                peer_sip_address: "sip:bob@example.com".to_string(),
+                sender_sip_address: "sip:bob@example.com".to_string(),
+                recipient_sip_address: "sip:alice@example.com".to_string(),
+                kind: "text".to_string(),
+                direction: "incoming".to_string(),
+                delivery_state: "delivered".to_string(),
+                text: "hello".to_string(),
+                local_file_path: "".to_string(),
+                mime_type: "".to_string(),
+                duration_ms: 0,
+                unread: true,
+            },
+        });
+
+        assert_eq!(envelope.message_type, "voip.message_received");
+        assert_eq!(envelope.payload["message_id"], "msg-1");
+        assert_eq!(envelope.payload["kind"], "text");
+        assert_eq!(envelope.payload["text"], "hello");
     }
 
     #[test]

--- a/src/crates/voip-host/src/shim.rs
+++ b/src/crates/voip-host/src/shim.rs
@@ -1,5 +1,5 @@
 use crate::config::VoipConfig;
-use crate::host::{BackendEvent, CallBackend};
+use crate::host::{BackendEvent, CallBackend, MessageRecord};
 use libloading::Library;
 use std::env;
 use std::ffi::{CStr, CString};
@@ -76,6 +76,8 @@ type StartFn = unsafe extern "C" fn(
 type SimpleCallFn = unsafe extern "C" fn() -> c_int;
 type MakeCallFn = unsafe extern "C" fn(*const c_char) -> c_int;
 type SetMutedFn = unsafe extern "C" fn(i32) -> c_int;
+type SendTextMessageFn =
+    unsafe extern "C" fn(*const c_char, *const c_char, *mut c_char, u32) -> c_int;
 type LastErrorFn = unsafe extern "C" fn() -> *const c_char;
 
 pub struct LiblinphoneShim {
@@ -91,6 +93,7 @@ pub struct LiblinphoneShim {
     reject_call: SimpleCallFn,
     hangup: SimpleCallFn,
     set_muted: SetMutedFn,
+    send_text_message: SendTextMessageFn,
     last_error: LastErrorFn,
 }
 
@@ -167,6 +170,9 @@ impl LiblinphoneShim {
             reject_call: unsafe { symbol(&library, b"yoyopod_liblinphone_reject_call\0") }?,
             hangup: unsafe { symbol(&library, b"yoyopod_liblinphone_hangup\0") }?,
             set_muted: unsafe { symbol(&library, b"yoyopod_liblinphone_set_muted\0") }?,
+            send_text_message: unsafe {
+                symbol(&library, b"yoyopod_liblinphone_send_text_message\0")
+            }?,
             last_error: unsafe { symbol(&library, b"yoyopod_liblinphone_last_error\0") }?,
             _library: library,
         })
@@ -258,6 +264,21 @@ impl LiblinphoneShim {
         self.check(unsafe { (self.set_muted)(if muted { 1 } else { 0 }) })
     }
 
+    pub fn send_text_message(&self, sip_address: &str, text: &str) -> Result<String, ShimError> {
+        let sip_address = CString::new(sip_address)?;
+        let text = CString::new(text)?;
+        let mut message_id = [0 as c_char; 128];
+        self.check(unsafe {
+            (self.send_text_message)(
+                sip_address.as_ptr(),
+                text.as_ptr(),
+                message_id.as_mut_ptr(),
+                message_id.len() as u32,
+            )
+        })?;
+        Ok(c_string(&message_id))
+    }
+
     fn last_error(&self) -> String {
         unsafe {
             let raw = (self.last_error)();
@@ -284,27 +305,8 @@ impl LiblinphoneShim {
             if has_event == 0 {
                 break;
             }
-            match event.event_type {
-                1 => events.push(BackendEvent::RegistrationChanged {
-                    state: crate::events::RegistrationState::from_native(event.registration_state)
-                        .as_protocol()
-                        .to_string(),
-                    reason: c_string(&event.reason),
-                }),
-                2 => events.push(BackendEvent::CallStateChanged {
-                    call_id: c_string(&event.peer_sip_address),
-                    state: crate::events::CallState::from_native(event.call_state)
-                        .as_protocol()
-                        .to_string(),
-                }),
-                3 => events.push(BackendEvent::IncomingCall {
-                    call_id: c_string(&event.peer_sip_address),
-                    from_uri: c_string(&event.peer_sip_address),
-                }),
-                4 => events.push(BackendEvent::BackendStopped {
-                    reason: c_string(&event.reason),
-                }),
-                _ => {}
+            if let Some(backend_event) = native_event_to_backend_event(&event) {
+                events.push(backend_event);
             }
         }
         Ok(events)
@@ -362,6 +364,80 @@ impl CallBackend for ShimBackend {
             .set_muted(muted)
             .map_err(|error| error.to_string())
     }
+
+    fn send_text_message(&mut self, sip_address: &str, text: &str) -> Result<String, String> {
+        self.shim
+            .send_text_message(sip_address, text)
+            .map_err(|error| error.to_string())
+    }
+}
+
+fn native_event_to_backend_event(event: &NativeEvent) -> Option<BackendEvent> {
+    match event.event_type {
+        1 => Some(BackendEvent::RegistrationChanged {
+            state: crate::events::RegistrationState::from_native(event.registration_state)
+                .as_protocol()
+                .to_string(),
+            reason: c_string(&event.reason),
+        }),
+        2 => Some(BackendEvent::CallStateChanged {
+            call_id: c_string(&event.peer_sip_address),
+            state: crate::events::CallState::from_native(event.call_state)
+                .as_protocol()
+                .to_string(),
+        }),
+        3 => Some(BackendEvent::IncomingCall {
+            call_id: c_string(&event.peer_sip_address),
+            from_uri: c_string(&event.peer_sip_address),
+        }),
+        4 => Some(BackendEvent::BackendStopped {
+            reason: c_string(&event.reason),
+        }),
+        5 => Some(BackendEvent::MessageReceived {
+            message: MessageRecord {
+                message_id: c_string(&event.message_id),
+                peer_sip_address: c_string(&event.peer_sip_address),
+                sender_sip_address: c_string(&event.sender_sip_address),
+                recipient_sip_address: c_string(&event.recipient_sip_address),
+                kind: crate::events::MessageKind::from_native(event.message_kind)
+                    .as_protocol()
+                    .to_string(),
+                direction: crate::events::MessageDirection::from_native(event.message_direction)
+                    .as_protocol()
+                    .to_string(),
+                delivery_state: crate::events::MessageDeliveryState::from_native(
+                    event.message_delivery_state,
+                )
+                .as_protocol()
+                .to_string(),
+                text: c_string(&event.text),
+                local_file_path: c_string(&event.local_file_path),
+                mime_type: c_string(&event.mime_type),
+                duration_ms: event.duration_ms,
+                unread: event.unread != 0,
+            },
+        }),
+        6 => Some(BackendEvent::MessageDeliveryChanged {
+            message_id: c_string(&event.message_id),
+            delivery_state: crate::events::MessageDeliveryState::from_native(
+                event.message_delivery_state,
+            )
+            .as_protocol()
+            .to_string(),
+            local_file_path: c_string(&event.local_file_path),
+            error: c_string(&event.reason),
+        }),
+        7 => Some(BackendEvent::MessageDownloadCompleted {
+            message_id: c_string(&event.message_id),
+            local_file_path: c_string(&event.local_file_path),
+            mime_type: c_string(&event.mime_type),
+        }),
+        8 => Some(BackendEvent::MessageFailed {
+            message_id: c_string(&event.message_id),
+            reason: c_string(&event.reason),
+        }),
+        _ => None,
+    }
 }
 
 pub fn c_string<const N: usize>(buffer: &[c_char; N]) -> String {
@@ -396,5 +472,89 @@ mod tests {
         assert_eq!(settings.audio_enabled, 1);
         assert_eq!(settings.mic_gain, 42);
         assert_eq!(settings.output_volume, 73);
+    }
+
+    #[test]
+    fn native_message_event_maps_to_backend_message_record() {
+        let mut event = NativeEvent {
+            event_type: 5,
+            message_kind: 1,
+            message_direction: 1,
+            message_delivery_state: 4,
+            duration_ms: 1200,
+            unread: 1,
+            ..Default::default()
+        };
+        write_c_string(&mut event.message_id, "msg-1");
+        write_c_string(&mut event.peer_sip_address, "sip:bob@example.com");
+        write_c_string(&mut event.sender_sip_address, "sip:bob@example.com");
+        write_c_string(&mut event.recipient_sip_address, "sip:alice@example.com");
+        write_c_string(&mut event.text, "hello");
+        write_c_string(&mut event.mime_type, "text/plain");
+
+        let backend_event = native_event_to_backend_event(&event).expect("backend event");
+
+        assert_eq!(
+            backend_event,
+            BackendEvent::MessageReceived {
+                message: MessageRecord {
+                    message_id: "msg-1".to_string(),
+                    peer_sip_address: "sip:bob@example.com".to_string(),
+                    sender_sip_address: "sip:bob@example.com".to_string(),
+                    recipient_sip_address: "sip:alice@example.com".to_string(),
+                    kind: "text".to_string(),
+                    direction: "incoming".to_string(),
+                    delivery_state: "delivered".to_string(),
+                    text: "hello".to_string(),
+                    local_file_path: "".to_string(),
+                    mime_type: "text/plain".to_string(),
+                    duration_ms: 1200,
+                    unread: true,
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn native_message_delivery_events_map_to_backend_events() {
+        let mut delivery = NativeEvent {
+            event_type: 6,
+            message_delivery_state: 5,
+            ..Default::default()
+        };
+        write_c_string(&mut delivery.message_id, "msg-1");
+        write_c_string(&mut delivery.local_file_path, "/tmp/msg.wav");
+        write_c_string(&mut delivery.reason, "peer offline");
+
+        assert_eq!(
+            native_event_to_backend_event(&delivery),
+            Some(BackendEvent::MessageDeliveryChanged {
+                message_id: "msg-1".to_string(),
+                delivery_state: "failed".to_string(),
+                local_file_path: "/tmp/msg.wav".to_string(),
+                error: "peer offline".to_string(),
+            })
+        );
+
+        let mut failed = NativeEvent {
+            event_type: 8,
+            ..Default::default()
+        };
+        write_c_string(&mut failed.message_id, "msg-2");
+        write_c_string(&mut failed.reason, "send failed");
+
+        assert_eq!(
+            native_event_to_backend_event(&failed),
+            Some(BackendEvent::MessageFailed {
+                message_id: "msg-2".to_string(),
+                reason: "send failed".to_string(),
+            })
+        );
+    }
+
+    fn write_c_string<const N: usize>(buffer: &mut [c_char; N], value: &str) {
+        for (slot, byte) in buffer.iter_mut().zip(value.bytes()) {
+            *slot = byte as c_char;
+        }
     }
 }

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -248,6 +248,24 @@ def test_send_text_message_returns_client_id_and_sends_worker_command() -> None:
     ]
 
 
+def test_text_message_ids_do_not_repeat_across_backend_instances() -> None:
+    first = RustHostBackend(_config(), worker_supervisor=_FakeSupervisor(), worker_path="/bin/voip")
+    second = RustHostBackend(
+        _config(), worker_supervisor=_FakeSupervisor(), worker_path="/bin/voip"
+    )
+    first.start()
+    second.start()
+
+    first_message_id = first.send_text_message("sip:bob@example.com", "hi")
+    second_message_id = second.send_text_message("sip:bob@example.com", "hi")
+
+    assert first_message_id is not None
+    assert second_message_id is not None
+    assert first_message_id.startswith("rust-msg-")
+    assert second_message_id.startswith("rust-msg-")
+    assert first_message_id != second_message_id
+
+
 def test_text_message_command_error_emits_message_failed() -> None:
     supervisor = _FakeSupervisor()
     backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -10,6 +10,12 @@ from yoyopod.integrations.call.models import (
     CallState,
     CallStateChanged,
     IncomingCallDetected,
+    MessageDeliveryChanged,
+    MessageDeliveryState,
+    MessageDownloadCompleted,
+    MessageFailed,
+    MessageKind,
+    MessageReceived,
     RegistrationState,
     RegistrationStateChanged,
     VoIPConfig,
@@ -219,6 +225,52 @@ def test_call_commands_send_worker_commands() -> None:
     assert supervisor.sent[5][2] == {"muted": False}
 
 
+def test_send_text_message_returns_client_id_and_sends_worker_command() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    backend.start()
+    supervisor.sent.clear()
+
+    message_id = backend.send_text_message("sip:bob@example.com", "hi")
+
+    assert message_id is not None
+    assert message_id.startswith("rust-msg-")
+    assert supervisor.sent == [
+        (
+            "voip",
+            "voip.send_text_message",
+            {
+                "uri": "sip:bob@example.com",
+                "text": "hi",
+                "client_id": message_id,
+            },
+        )
+    ]
+
+
+def test_text_message_command_error_emits_message_failed() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+    backend.start()
+
+    message_id = backend.send_text_message("sip:bob@example.com", "hi")
+    backend.handle_worker_message(
+        _reply(
+            "error",
+            "voip.error",
+            {"code": "command_failed", "message": "peer offline"},
+            request_id=supervisor.request_ids[-1],
+        )
+    )
+
+    failures = [event for event in received if isinstance(event, MessageFailed)]
+    assert failures
+    assert failures[-1].message_id == message_id
+    assert failures[-1].reason == "voip.send_text_message command_failed: peer offline"
+
+
 def test_worker_events_translate_to_voip_events() -> None:
     supervisor = _FakeSupervisor()
     backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
@@ -246,6 +298,68 @@ def test_worker_events_translate_to_voip_events() -> None:
     assert isinstance(received[3], BackendStopped)
     assert received[3].reason == "iterate failed"
     assert len(received) == 4
+
+
+def test_worker_message_events_translate_to_voip_events() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+
+    backend.handle_worker_message(
+        _event(
+            "voip.message_received",
+            {
+                "message_id": "msg-1",
+                "peer_sip_address": "sip:bob@example.com",
+                "sender_sip_address": "sip:bob@example.com",
+                "recipient_sip_address": "sip:alice@example.com",
+                "kind": "text",
+                "direction": "incoming",
+                "delivery_state": "delivered",
+                "created_at": "2026-04-29T00:00:00+00:00",
+                "updated_at": "2026-04-29T00:00:00+00:00",
+                "text": "hello",
+                "local_file_path": "",
+                "mime_type": "",
+                "duration_ms": 0,
+                "unread": True,
+            },
+        )
+    )
+    backend.handle_worker_message(
+        _event(
+            "voip.message_delivery_changed",
+            {
+                "message_id": "msg-1",
+                "delivery_state": "delivered",
+                "local_file_path": "",
+                "error": "",
+            },
+        )
+    )
+    backend.handle_worker_message(
+        _event(
+            "voip.message_download_completed",
+            {"message_id": "msg-1", "local_file_path": "/tmp/a.wav", "mime_type": "audio/wav"},
+        )
+    )
+    backend.handle_worker_message(
+        _event("voip.message_failed", {"message_id": "msg-1", "reason": "peer offline"})
+    )
+
+    assert isinstance(received[0], MessageReceived)
+    assert received[0].message.id == "msg-1"
+    assert received[0].message.kind == MessageKind.TEXT
+    assert received[0].message.delivery_state == MessageDeliveryState.DELIVERED
+    assert received[0].message.text == "hello"
+    assert isinstance(received[1], MessageDeliveryChanged)
+    assert received[1].message_id == "msg-1"
+    assert received[1].delivery_state == MessageDeliveryState.DELIVERED
+    assert isinstance(received[2], MessageDownloadCompleted)
+    assert received[2].local_file_path == "/tmp/a.wav"
+    assert isinstance(received[3], MessageFailed)
+    assert received[3].reason == "peer offline"
 
 
 def test_worker_startup_error_stops_worker_and_marks_backend_stopped() -> None:
@@ -344,14 +458,13 @@ def test_ready_after_worker_restart_resends_configure_register() -> None:
     assert received[1].reason == "worker_ready"
 
 
-def test_iterate_is_noop_and_unsupported_messaging_fails() -> None:
+def test_iterate_is_noop_and_unsupported_voice_notes_fail() -> None:
     backend = RustHostBackend(
         _config(), worker_supervisor=_FakeSupervisor(), worker_path="/bin/voip"
     )
 
     assert backend.iterate() == 0
     assert backend.get_iterate_metrics() is None
-    assert backend.send_text_message("sip:bob@example.com", "hi") is None
     assert backend.start_voice_note_recording("/tmp/a.wav") is False
     assert backend.stop_voice_note_recording() is None
     assert backend.cancel_voice_note_recording() is False

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import os
+import uuid
 from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
@@ -69,7 +70,6 @@ class RustHostBackend:
         self.event_callbacks: list[Callable[[VoIPEvent], None]] = []
         self._registered_with_supervisor = False
         self._request_counter = 0
-        self._message_counter = 0
         self._pending_commands: dict[str, str] = {}
         self._pending_message_ids: dict[str, str] = {}
         self._startup_commands_sent = False
@@ -420,8 +420,7 @@ class RustHostBackend:
         return f"{self.domain}-{command_name}-{self._request_counter}"
 
     def _next_message_id(self) -> str:
-        self._message_counter += 1
-        return f"rust-msg-{self._message_counter}"
+        return f"rust-msg-{uuid.uuid4()}"
 
     def _pop_pending_command(self, request_id: str | None) -> str | None:
         if request_id is None:

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 import os
 from collections.abc import Callable
+from datetime import datetime, timezone
 from typing import Any
 
 from loguru import logger
@@ -17,10 +18,18 @@ from yoyopod.integrations.call.models import (
     CallState,
     CallStateChanged,
     IncomingCallDetected,
+    MessageDeliveryChanged,
+    MessageDeliveryState,
+    MessageDirection,
+    MessageDownloadCompleted,
+    MessageFailed,
+    MessageKind,
+    MessageReceived,
     RegistrationState,
     RegistrationStateChanged,
     VoIPConfig,
     VoIPEvent,
+    VoIPMessageRecord,
 )
 
 _STARTUP_COMMANDS = frozenset({"voip.configure", "voip.register"})
@@ -33,11 +42,12 @@ _CALL_CONTROL_COMMANDS = frozenset(
         "voip.set_mute",
     }
 )
+_TEXT_MESSAGE_COMMANDS = frozenset({"voip.send_text_message"})
 _INTENTIONAL_STOP_REASONS = frozenset({"stop", "stop_all"})
 
 
 class RustHostBackend:
-    """Calls-only VoIPBackend adapter for the Rust VoIP Host."""
+    """VoIPBackend adapter backed by the Rust VoIP Host worker."""
 
     def __init__(
         self,
@@ -59,7 +69,9 @@ class RustHostBackend:
         self.event_callbacks: list[Callable[[VoIPEvent], None]] = []
         self._registered_with_supervisor = False
         self._request_counter = 0
+        self._message_counter = 0
         self._pending_commands: dict[str, str] = {}
+        self._pending_message_ids: dict[str, str] = {}
         self._startup_commands_sent = False
         self._ready_seen = False
         self._reconfigure_on_ready = False
@@ -120,6 +132,7 @@ class RustHostBackend:
                     stop(self.domain, grace_seconds=1.0)
         finally:
             self._pending_commands.clear()
+            self._pending_message_ids.clear()
             self._startup_commands_sent = False
             self._ready_seen = False
             self._reconfigure_on_ready = False
@@ -151,9 +164,15 @@ class RustHostBackend:
         return self._send("voip.set_mute", {"muted": False})
 
     def send_text_message(self, sip_address: str, text: str) -> str | None:
-        del sip_address, text
-        logger.warning("Rust VoIP Host does not support text messages in calls-only mode")
-        return None
+        message_id = self._next_message_id()
+        request_id = self._send_with_request_id(
+            "voip.send_text_message",
+            {"uri": sip_address, "text": text, "client_id": message_id},
+        )
+        if request_id is None:
+            return None
+        self._pending_message_ids[request_id] = message_id
+        return message_id
 
     def start_voice_note_recording(self, file_path: str) -> bool:
         del file_path
@@ -186,6 +205,7 @@ class RustHostBackend:
         request_id = getattr(event, "request_id", None)
         kind = getattr(event, "kind", "event")
         if kind == "result":
+            self._pending_message_ids.pop(request_id, None)
             self._pop_pending_command(request_id)
             return
         if kind == "error":
@@ -211,6 +231,45 @@ class RustHostBackend:
             return
         if event_type == "voip.backend_stopped":
             self._mark_stopped(str(payload.get("reason", "")) or "backend_stopped")
+            return
+        if event_type == "voip.message_received":
+            message = _message_record(payload)
+            if message is not None:
+                self._dispatch(MessageReceived(message=message))
+            return
+        if event_type == "voip.message_delivery_changed":
+            delivery_state = _message_delivery_state(str(payload.get("delivery_state", "")))
+            if delivery_state is None:
+                logger.warning(
+                    "Rust VoIP Host emitted unknown message delivery state {!r}",
+                    payload.get("delivery_state", ""),
+                )
+                return
+            self._dispatch(
+                MessageDeliveryChanged(
+                    message_id=str(payload.get("message_id", "")),
+                    delivery_state=delivery_state,
+                    local_file_path=str(payload.get("local_file_path", "")),
+                    error=str(payload.get("error", "")),
+                )
+            )
+            return
+        if event_type == "voip.message_download_completed":
+            self._dispatch(
+                MessageDownloadCompleted(
+                    message_id=str(payload.get("message_id", "")),
+                    local_file_path=str(payload.get("local_file_path", "")),
+                    mime_type=str(payload.get("mime_type", "")),
+                )
+            )
+            return
+        if event_type == "voip.message_failed":
+            self._dispatch(
+                MessageFailed(
+                    message_id=str(payload.get("message_id", "")),
+                    reason=str(payload.get("reason", "")),
+                )
+            )
 
     def handle_worker_state_change(self, event: Any) -> None:
         if getattr(event, "domain", self.domain) != self.domain:
@@ -231,9 +290,12 @@ class RustHostBackend:
             self._mark_stopped(reason)
 
     def _send(self, message_type: str, payload: dict[str, Any]) -> bool:
+        return self._send_with_request_id(message_type, payload) is not None
+
+    def _send_with_request_id(self, message_type: str, payload: dict[str, Any]) -> str | None:
         send_command = getattr(self.worker_supervisor, "send_command", None)
         if not callable(send_command):
-            return False
+            return None
         request_id = self._next_request_id(message_type)
         try:
             sent = bool(
@@ -246,10 +308,11 @@ class RustHostBackend:
             )
         except Exception as exc:
             logger.error("Rust VoIP Host command {} failed: {}", message_type, exc)
-            return False
+            return None
         if sent:
             self._pending_commands[request_id] = message_type
-        return sent
+            return request_id
+        return None
 
     def _dispatch(self, event: VoIPEvent) -> None:
         for callback in list(self.event_callbacks):
@@ -297,12 +360,19 @@ class RustHostBackend:
     def _handle_worker_error(self, payload: dict[str, Any], *, request_id: str | None) -> None:
         command = self._pop_pending_command(request_id)
         reason = _worker_error_reason(payload, command=command)
+        message_id = self._pending_message_ids.pop(request_id, "") if request_id else ""
         if command in _STARTUP_COMMANDS or command is None:
             self._stop_after_startup_command_failure(reason)
             return
         if command in _CALL_CONTROL_COMMANDS:
             logger.warning("Rust VoIP Host call command failed: {}", reason)
             self._dispatch(CallStateChanged(state=CallState.ERROR))
+            return
+        if command in _TEXT_MESSAGE_COMMANDS:
+            if message_id:
+                self._dispatch(MessageFailed(message_id=message_id, reason=reason))
+            else:
+                logger.warning("Rust VoIP Host text message command failed: {}", reason)
             return
         logger.warning("Rust VoIP Host command failed: {}", reason)
 
@@ -327,6 +397,7 @@ class RustHostBackend:
             finally:
                 self._stopping = was_stopping
         self._pending_commands.clear()
+        self._pending_message_ids.clear()
         self._startup_commands_sent = False
         self._ready_seen = False
         self._reconfigure_on_ready = False
@@ -348,6 +419,10 @@ class RustHostBackend:
         command_name = message_type.replace(".", "_")
         return f"{self.domain}-{command_name}-{self._request_counter}"
 
+    def _next_message_id(self) -> str:
+        self._message_counter += 1
+        return f"rust-msg-{self._message_counter}"
+
     def _pop_pending_command(self, request_id: str | None) -> str | None:
         if request_id is None:
             return None
@@ -366,6 +441,86 @@ def _call_state(value: str) -> CallState:
         return CallState(value)
     except ValueError:
         return CallState.IDLE
+
+
+def _message_record(payload: dict[str, Any]) -> VoIPMessageRecord | None:
+    kind = _message_kind(str(payload.get("kind", "")))
+    direction = _message_direction(str(payload.get("direction", "")))
+    delivery_state = _message_delivery_state(str(payload.get("delivery_state", "")))
+    if kind is None or direction is None or delivery_state is None:
+        logger.warning(
+            "Rust VoIP Host emitted message with unknown enum values: "
+            "kind={!r} direction={!r} delivery_state={!r}",
+            payload.get("kind", ""),
+            payload.get("direction", ""),
+            payload.get("delivery_state", ""),
+        )
+        return None
+
+    timestamp = _iso_timestamp(payload.get("created_at"))
+    updated_at = (
+        _iso_timestamp(payload.get("updated_at")) if payload.get("updated_at") else timestamp
+    )
+    return VoIPMessageRecord(
+        id=str(payload.get("message_id", "")),
+        peer_sip_address=str(payload.get("peer_sip_address", "")),
+        sender_sip_address=str(payload.get("sender_sip_address", "")),
+        recipient_sip_address=str(payload.get("recipient_sip_address", "")),
+        kind=kind,
+        direction=direction,
+        delivery_state=delivery_state,
+        created_at=timestamp,
+        updated_at=updated_at,
+        text=str(payload.get("text", "")),
+        local_file_path=str(payload.get("local_file_path", "")),
+        mime_type=str(payload.get("mime_type", "")),
+        duration_ms=_duration_ms(payload.get("duration_ms")),
+        unread=_bool_payload(payload.get("unread", False)),
+        display_name=str(payload.get("display_name", "")),
+    )
+
+
+def _message_kind(value: str) -> MessageKind | None:
+    try:
+        return MessageKind(value)
+    except ValueError:
+        return None
+
+
+def _message_direction(value: str) -> MessageDirection | None:
+    try:
+        return MessageDirection(value)
+    except ValueError:
+        return None
+
+
+def _message_delivery_state(value: str) -> MessageDeliveryState | None:
+    try:
+        return MessageDeliveryState(value)
+    except ValueError:
+        return None
+
+
+def _iso_timestamp(value: Any) -> str:
+    timestamp = str(value or "").strip()
+    if timestamp:
+        return timestamp
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _duration_ms(value: Any) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bool_payload(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
 
 
 def _worker_error_reason(payload: dict[str, Any], *, command: str | None) -> str:


### PR DESCRIPTION
## Summary
- extend the Rust VoIP host with text-message command handling and backend-id to client-id translation
- wire the Rust liblinphone shim to the existing native text-message API and native message events
- map Rust worker message events into the Python VoIP message dataclasses while keeping voice notes unsupported in this slice

## Verification
- cargo fmt --manifest-path src/Cargo.toml --all --check
- cargo test --manifest-path src/Cargo.toml --workspace --locked
- uv run python scripts/quality.py gate
- uv run pytest -q