### PR TITLE
Add Rust VoIP host voice notes

### DIFF
--- a/src/crates/voip-host/src/host.rs
+++ b/src/crates/voip-host/src/host.rs
@@ -12,6 +12,16 @@ pub trait CallBackend {
     fn hangup(&mut self) -> Result<(), String>;
     fn set_muted(&mut self, muted: bool) -> Result<(), String>;
     fn send_text_message(&mut self, sip_address: &str, text: &str) -> Result<String, String>;
+    fn start_voice_recording(&mut self, file_path: &str) -> Result<(), String>;
+    fn stop_voice_recording(&mut self) -> Result<i32, String>;
+    fn cancel_voice_recording(&mut self) -> Result<(), String>;
+    fn send_voice_note(
+        &mut self,
+        sip_address: &str,
+        file_path: &str,
+        duration_ms: i32,
+        mime_type: &str,
+    ) -> Result<String, String>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -169,14 +179,44 @@ impl VoipHost {
             return Err("voip text message requires client_id".to_string());
         }
         let backend_id = backend.send_text_message(sip_address, text)?;
-        let backend_id = backend_id.trim();
-        if backend_id.is_empty() {
-            return Err("voip text message backend returned empty message id".to_string());
+        self.remember_outbound_message_id(&backend_id, client_id, "voip text message")?;
+        Ok(client_id.to_string())
+    }
+
+    pub fn start_voice_recording<B: CallBackend>(
+        &mut self,
+        backend: &mut B,
+        file_path: &str,
+    ) -> Result<(), String> {
+        backend.start_voice_recording(file_path)
+    }
+
+    pub fn stop_voice_recording<B: CallBackend>(&mut self, backend: &mut B) -> Result<i32, String> {
+        backend.stop_voice_recording()
+    }
+
+    pub fn cancel_voice_recording<B: CallBackend>(
+        &mut self,
+        backend: &mut B,
+    ) -> Result<(), String> {
+        backend.cancel_voice_recording()
+    }
+
+    pub fn send_voice_note<B: CallBackend>(
+        &mut self,
+        backend: &mut B,
+        sip_address: &str,
+        file_path: &str,
+        duration_ms: i32,
+        mime_type: &str,
+        client_id: &str,
+    ) -> Result<String, String> {
+        let client_id = client_id.trim();
+        if client_id.is_empty() {
+            return Err("voip voice note requires client_id".to_string());
         }
-        if backend_id != client_id {
-            self.outbound_message_ids
-                .insert(backend_id.to_string(), client_id.to_string());
-        }
+        let backend_id = backend.send_voice_note(sip_address, file_path, duration_ms, mime_type)?;
+        self.remember_outbound_message_id(&backend_id, client_id, "voip voice note")?;
         Ok(client_id.to_string())
     }
 
@@ -274,6 +314,23 @@ impl VoipHost {
         }
         client_id.unwrap_or_else(|| backend_id.to_string())
     }
+
+    fn remember_outbound_message_id(
+        &mut self,
+        backend_id: &str,
+        client_id: &str,
+        label: &str,
+    ) -> Result<(), String> {
+        let backend_id = backend_id.trim();
+        if backend_id.is_empty() {
+            return Err(format!("{label} backend returned empty message id"));
+        }
+        if backend_id != client_id {
+            self.outbound_message_ids
+                .insert(backend_id.to_string(), client_id.to_string());
+        }
+        Ok(())
+    }
 }
 
 fn is_terminal_delivery_state(value: &str) -> bool {
@@ -360,6 +417,34 @@ mod command_tests {
         fn send_text_message(&mut self, sip_address: &str, text: &str) -> Result<String, String> {
             self.calls.push(format!("text:{sip_address}:{text}"));
             Ok("backend-msg-1".to_string())
+        }
+
+        fn start_voice_recording(&mut self, file_path: &str) -> Result<(), String> {
+            self.calls.push(format!("record:{file_path}"));
+            Ok(())
+        }
+
+        fn stop_voice_recording(&mut self) -> Result<i32, String> {
+            self.calls.push("stop_recording".to_string());
+            Ok(1250)
+        }
+
+        fn cancel_voice_recording(&mut self) -> Result<(), String> {
+            self.calls.push("cancel_recording".to_string());
+            Ok(())
+        }
+
+        fn send_voice_note(
+            &mut self,
+            sip_address: &str,
+            file_path: &str,
+            duration_ms: i32,
+            mime_type: &str,
+        ) -> Result<String, String> {
+            self.calls.push(format!(
+                "voice:{sip_address}:{file_path}:{duration_ms}:{mime_type}"
+            ));
+            Ok("backend-vn-1".to_string())
         }
     }
 
@@ -473,6 +558,28 @@ mod command_tests {
                 self.calls.push(format!("text:{sip_address}:{text}"));
                 Ok("backend-msg-1".to_string())
             }
+
+            fn start_voice_recording(&mut self, _file_path: &str) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn stop_voice_recording(&mut self) -> Result<i32, String> {
+                Ok(1250)
+            }
+
+            fn cancel_voice_recording(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn send_voice_note(
+                &mut self,
+                _sip_address: &str,
+                _file_path: &str,
+                _duration_ms: i32,
+                _mime_type: &str,
+            ) -> Result<String, String> {
+                Ok("backend-vn-1".to_string())
+            }
         }
 
         let mut host = VoipHost::default();
@@ -507,6 +614,150 @@ mod command_tests {
                 message_id: "client-msg-1".to_string(),
                 delivery_state: "delivered".to_string(),
                 local_file_path: "".to_string(),
+                error: "".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn voice_note_recording_commands_forward_to_backend() {
+        let mut host = VoipHost::default();
+        let mut backend = FakeBackend::default();
+        host.configure(config());
+        host.register(&mut backend).unwrap();
+
+        host.start_voice_recording(&mut backend, "/tmp/a.wav")
+            .expect("start voice recording");
+        let duration_ms = host
+            .stop_voice_recording(&mut backend)
+            .expect("stop voice recording");
+        host.cancel_voice_recording(&mut backend)
+            .expect("cancel voice recording");
+
+        assert_eq!(duration_ms, 1250);
+        assert_eq!(
+            backend.calls,
+            vec![
+                "start",
+                "record:/tmp/a.wav",
+                "stop_recording",
+                "cancel_recording"
+            ]
+        );
+    }
+
+    #[test]
+    fn send_voice_note_returns_client_id_and_maps_delivery_back_to_client_id() {
+        let mut host = VoipHost::default();
+        let mut backend = FakeBackend::default();
+        host.configure(config());
+        host.register(&mut backend).unwrap();
+
+        let message_id = host
+            .send_voice_note(
+                &mut backend,
+                "sip:bob@example.com",
+                "/tmp/a.wav",
+                1250,
+                "audio/wav",
+                "client-vn-1",
+            )
+            .expect("send voice note");
+
+        assert_eq!(message_id, "client-vn-1");
+        assert_eq!(
+            backend.calls,
+            vec![
+                "start",
+                "voice:sip:bob@example.com:/tmp/a.wav:1250:audio/wav"
+            ]
+        );
+
+        struct EventBackend {
+            events: Vec<BackendEvent>,
+        }
+
+        impl CallBackend for EventBackend {
+            fn start(&mut self, _config: &VoipConfig) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn stop(&mut self) {}
+
+            fn iterate(&mut self) -> Result<Vec<BackendEvent>, String> {
+                Ok(std::mem::take(&mut self.events))
+            }
+
+            fn make_call(&mut self, _sip_address: &str) -> Result<String, String> {
+                Ok("call-outgoing".to_string())
+            }
+
+            fn answer_call(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn reject_call(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn hangup(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn set_muted(&mut self, _muted: bool) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn send_text_message(
+                &mut self,
+                _sip_address: &str,
+                _text: &str,
+            ) -> Result<String, String> {
+                Ok("backend-msg-1".to_string())
+            }
+
+            fn start_voice_recording(&mut self, _file_path: &str) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn stop_voice_recording(&mut self) -> Result<i32, String> {
+                Ok(1250)
+            }
+
+            fn cancel_voice_recording(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn send_voice_note(
+                &mut self,
+                _sip_address: &str,
+                _file_path: &str,
+                _duration_ms: i32,
+                _mime_type: &str,
+            ) -> Result<String, String> {
+                Ok("backend-vn-1".to_string())
+            }
+        }
+
+        let mut event_backend = EventBackend {
+            events: vec![BackendEvent::MessageDeliveryChanged {
+                message_id: "backend-vn-1".to_string(),
+                delivery_state: "delivered".to_string(),
+                local_file_path: "/tmp/a.wav".to_string(),
+                error: "".to_string(),
+            }],
+        };
+
+        let events = host
+            .poll_backend_events(&mut event_backend)
+            .expect("poll voice note delivery");
+
+        assert_eq!(
+            events,
+            vec![BackendEvent::MessageDeliveryChanged {
+                message_id: "client-vn-1".to_string(),
+                delivery_state: "delivered".to_string(),
+                local_file_path: "/tmp/a.wav".to_string(),
                 error: "".to_string(),
             }]
         );
@@ -577,6 +828,28 @@ mod command_tests {
                 _text: &str,
             ) -> Result<String, String> {
                 Ok("backend-msg-1".to_string())
+            }
+
+            fn start_voice_recording(&mut self, _file_path: &str) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn stop_voice_recording(&mut self) -> Result<i32, String> {
+                Ok(1250)
+            }
+
+            fn cancel_voice_recording(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn send_voice_note(
+                &mut self,
+                _sip_address: &str,
+                _file_path: &str,
+                _duration_ms: i32,
+                _mime_type: &str,
+            ) -> Result<String, String> {
+                Ok("backend-vn-1".to_string())
             }
         }
 

--- a/src/crates/voip-host/src/main.rs
+++ b/src/crates/voip-host/src/main.rs
@@ -3,7 +3,15 @@ use clap::Parser;
 use serde_json::json;
 use std::io::{self, BufRead, Write};
 use std::sync::mpsc::{self, RecvTimeoutError};
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
+
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
+#[cfg(unix)]
+use std::os::raw::c_int;
 
 mod config;
 mod events;
@@ -24,6 +32,8 @@ struct Args {
 }
 
 fn main() -> Result<()> {
+    init_protocol_stdout()?;
+
     let args = Args::parse();
     let explicit_shim_path = if args.shim_path.trim().is_empty() {
         None
@@ -35,7 +45,7 @@ fn main() -> Result<()> {
 
     write_envelope(&WorkerEnvelope::event(
         "voip.ready",
-        json!({"capabilities":["calls", "text_messages"]}),
+        json!({"capabilities":["calls", "text_messages", "voice_notes"]}),
     ))?;
 
     let (stdin_tx, stdin_rx) = mpsc::channel();
@@ -243,6 +253,93 @@ fn handle_command(
                 ))?;
             }
         }
+        "voip.start_voice_note_recording" => {
+            let file_path = envelope.payload["file_path"].as_str().unwrap_or("").trim();
+            if file_path.is_empty() {
+                write_envelope(&WorkerEnvelope::error(
+                    "voip.error",
+                    envelope.request_id,
+                    "invalid_command",
+                    "voip.start_voice_note_recording requires file_path",
+                ))?;
+            } else {
+                let backend_ref = backend
+                    .as_mut()
+                    .ok_or_else(|| anyhow!("voip host is not registered"))?;
+                host.start_voice_recording(backend_ref, file_path)
+                    .map_err(|error| anyhow!(error))?;
+                write_envelope(&WorkerEnvelope::result(
+                    "voip.start_voice_note_recording",
+                    envelope.request_id,
+                    json!({"recording": true}),
+                ))?;
+            }
+        }
+        "voip.stop_voice_note_recording" => {
+            let backend_ref = backend
+                .as_mut()
+                .ok_or_else(|| anyhow!("voip host is not registered"))?;
+            let duration_ms = host
+                .stop_voice_recording(backend_ref)
+                .map_err(|error| anyhow!(error))?;
+            write_envelope(&WorkerEnvelope::result(
+                "voip.stop_voice_note_recording",
+                envelope.request_id,
+                json!({"duration_ms": duration_ms}),
+            ))?;
+        }
+        "voip.cancel_voice_note_recording" => {
+            let backend_ref = backend
+                .as_mut()
+                .ok_or_else(|| anyhow!("voip host is not registered"))?;
+            host.cancel_voice_recording(backend_ref)
+                .map_err(|error| anyhow!(error))?;
+            write_envelope(&WorkerEnvelope::result(
+                "voip.cancel_voice_note_recording",
+                envelope.request_id,
+                json!({"cancelled": true}),
+            ))?;
+        }
+        "voip.send_voice_note" => {
+            let uri = envelope.payload["uri"].as_str().unwrap_or("").trim();
+            let file_path = envelope.payload["file_path"].as_str().unwrap_or("").trim();
+            let mime_type = envelope.payload["mime_type"].as_str().unwrap_or("").trim();
+            let client_id = envelope.payload["client_id"].as_str().unwrap_or("").trim();
+            let duration_ms = envelope.payload["duration_ms"].as_i64().unwrap_or(-1);
+            if uri.is_empty()
+                || file_path.is_empty()
+                || mime_type.is_empty()
+                || client_id.is_empty()
+                || duration_ms < 0
+                || duration_ms > i32::MAX as i64
+            {
+                write_envelope(&WorkerEnvelope::error(
+                    "voip.error",
+                    envelope.request_id,
+                    "invalid_command",
+                    "voip.send_voice_note requires uri, file_path, duration_ms, mime_type, and client_id",
+                ))?;
+            } else {
+                let backend_ref = backend
+                    .as_mut()
+                    .ok_or_else(|| anyhow!("voip host is not registered"))?;
+                let message_id = host
+                    .send_voice_note(
+                        backend_ref,
+                        uri,
+                        file_path,
+                        duration_ms as i32,
+                        mime_type,
+                        client_id,
+                    )
+                    .map_err(|error| anyhow!(error))?;
+                write_envelope(&WorkerEnvelope::result(
+                    "voip.send_voice_note",
+                    envelope.request_id,
+                    json!({"message_id": message_id}),
+                ))?;
+            }
+        }
         "voip.shutdown" | "worker.stop" => {
             if let Some(mut backend_ref) = backend.take() {
                 host.unregister(&mut backend_ref);
@@ -362,10 +459,63 @@ fn backend_event_envelope(event: host::BackendEvent) -> WorkerEnvelope {
 
 fn write_envelope(envelope: &WorkerEnvelope) -> Result<()> {
     let encoded = envelope.encode()?;
-    let mut stdout = io::stdout().lock();
-    stdout.write_all(&encoded)?;
-    stdout.flush()?;
+    let output = protocol_stdout();
+    let mut output = output
+        .lock()
+        .map_err(|_| anyhow!("protocol stdout lock poisoned"))?;
+    output.write_all(&encoded)?;
+    output.flush()?;
     Ok(())
+}
+
+static PROTOCOL_STDOUT: OnceLock<Mutex<Box<dyn Write + Send>>> = OnceLock::new();
+
+fn init_protocol_stdout() -> Result<()> {
+    PROTOCOL_STDOUT
+        .set(Mutex::new(capture_protocol_stdout()?))
+        .map_err(|_| anyhow!("protocol stdout already initialized"))?;
+    Ok(())
+}
+
+fn protocol_stdout() -> &'static Mutex<Box<dyn Write + Send>> {
+    PROTOCOL_STDOUT.get_or_init(|| Mutex::new(default_protocol_stdout()))
+}
+
+fn default_protocol_stdout() -> Box<dyn Write + Send> {
+    Box::new(io::stdout())
+}
+
+#[cfg(unix)]
+fn capture_protocol_stdout() -> io::Result<Box<dyn Write + Send>> {
+    const STDOUT_FILENO: c_int = 1;
+    const STDERR_FILENO: c_int = 2;
+
+    extern "C" {
+        fn close(fd: c_int) -> c_int;
+        fn dup(fd: c_int) -> c_int;
+        fn dup2(oldfd: c_int, newfd: c_int) -> c_int;
+    }
+
+    let protocol_fd = unsafe { dup(STDOUT_FILENO) };
+    if protocol_fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    if unsafe { dup2(STDERR_FILENO, STDOUT_FILENO) } < 0 {
+        let error = io::Error::last_os_error();
+        unsafe {
+            close(protocol_fd);
+        }
+        return Err(error);
+    }
+
+    let protocol_file = unsafe { File::from_raw_fd(protocol_fd) };
+    Ok(Box::new(protocol_file))
+}
+
+#[cfg(not(unix))]
+fn capture_protocol_stdout() -> io::Result<Box<dyn Write + Send>> {
+    Ok(default_protocol_stdout())
 }
 
 #[cfg(test)]

--- a/src/crates/voip-host/src/shim.rs
+++ b/src/crates/voip-host/src/shim.rs
@@ -78,6 +78,16 @@ type MakeCallFn = unsafe extern "C" fn(*const c_char) -> c_int;
 type SetMutedFn = unsafe extern "C" fn(i32) -> c_int;
 type SendTextMessageFn =
     unsafe extern "C" fn(*const c_char, *const c_char, *mut c_char, u32) -> c_int;
+type StartVoiceRecordingFn = unsafe extern "C" fn(*const c_char) -> c_int;
+type StopVoiceRecordingFn = unsafe extern "C" fn(*mut i32) -> c_int;
+type SendVoiceNoteFn = unsafe extern "C" fn(
+    *const c_char,
+    *const c_char,
+    i32,
+    *const c_char,
+    *mut c_char,
+    u32,
+) -> c_int;
 type LastErrorFn = unsafe extern "C" fn() -> *const c_char;
 
 pub struct LiblinphoneShim {
@@ -94,6 +104,10 @@ pub struct LiblinphoneShim {
     hangup: SimpleCallFn,
     set_muted: SetMutedFn,
     send_text_message: SendTextMessageFn,
+    start_voice_recording: StartVoiceRecordingFn,
+    stop_voice_recording: StopVoiceRecordingFn,
+    cancel_voice_recording: SimpleCallFn,
+    send_voice_note: SendVoiceNoteFn,
     last_error: LastErrorFn,
 }
 
@@ -173,6 +187,16 @@ impl LiblinphoneShim {
             send_text_message: unsafe {
                 symbol(&library, b"yoyopod_liblinphone_send_text_message\0")
             }?,
+            start_voice_recording: unsafe {
+                symbol(&library, b"yoyopod_liblinphone_start_voice_recording\0")
+            }?,
+            stop_voice_recording: unsafe {
+                symbol(&library, b"yoyopod_liblinphone_stop_voice_recording\0")
+            }?,
+            cancel_voice_recording: unsafe {
+                symbol(&library, b"yoyopod_liblinphone_cancel_voice_recording\0")
+            }?,
+            send_voice_note: unsafe { symbol(&library, b"yoyopod_liblinphone_send_voice_note\0") }?,
             last_error: unsafe { symbol(&library, b"yoyopod_liblinphone_last_error\0") }?,
             _library: library,
         })
@@ -279,6 +303,45 @@ impl LiblinphoneShim {
         Ok(c_string(&message_id))
     }
 
+    pub fn start_voice_recording(&self, file_path: &str) -> Result<(), ShimError> {
+        let file_path = CString::new(file_path)?;
+        self.check(unsafe { (self.start_voice_recording)(file_path.as_ptr()) })
+    }
+
+    pub fn stop_voice_recording(&self) -> Result<i32, ShimError> {
+        let mut duration_ms = 0;
+        self.check(unsafe { (self.stop_voice_recording)(&mut duration_ms) })?;
+        Ok(duration_ms)
+    }
+
+    pub fn cancel_voice_recording(&self) -> Result<(), ShimError> {
+        self.check(unsafe { (self.cancel_voice_recording)() })
+    }
+
+    pub fn send_voice_note(
+        &self,
+        sip_address: &str,
+        file_path: &str,
+        duration_ms: i32,
+        mime_type: &str,
+    ) -> Result<String, ShimError> {
+        let sip_address = CString::new(sip_address)?;
+        let file_path = CString::new(file_path)?;
+        let mime_type = CString::new(mime_type)?;
+        let mut message_id = [0 as c_char; 128];
+        self.check(unsafe {
+            (self.send_voice_note)(
+                sip_address.as_ptr(),
+                file_path.as_ptr(),
+                duration_ms,
+                mime_type.as_ptr(),
+                message_id.as_mut_ptr(),
+                message_id.len() as u32,
+            )
+        })?;
+        Ok(c_string(&message_id))
+    }
+
     fn last_error(&self) -> String {
         unsafe {
             let raw = (self.last_error)();
@@ -368,6 +431,36 @@ impl CallBackend for ShimBackend {
     fn send_text_message(&mut self, sip_address: &str, text: &str) -> Result<String, String> {
         self.shim
             .send_text_message(sip_address, text)
+            .map_err(|error| error.to_string())
+    }
+
+    fn start_voice_recording(&mut self, file_path: &str) -> Result<(), String> {
+        self.shim
+            .start_voice_recording(file_path)
+            .map_err(|error| error.to_string())
+    }
+
+    fn stop_voice_recording(&mut self) -> Result<i32, String> {
+        self.shim
+            .stop_voice_recording()
+            .map_err(|error| error.to_string())
+    }
+
+    fn cancel_voice_recording(&mut self) -> Result<(), String> {
+        self.shim
+            .cancel_voice_recording()
+            .map_err(|error| error.to_string())
+    }
+
+    fn send_voice_note(
+        &mut self,
+        sip_address: &str,
+        file_path: &str,
+        duration_ms: i32,
+        mime_type: &str,
+    ) -> Result<String, String> {
+        self.shim
+            .send_voice_note(sip_address, file_path, duration_ms, mime_type)
             .map_err(|error| error.to_string())
     }
 }

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+from yoyopod.backends.voip import rust_host
 from yoyopod.backends.voip.rust_host import RustHostBackend
 from yoyopod.integrations.call.models import (
     BackendRecovered,
@@ -289,6 +290,102 @@ def test_text_message_command_error_emits_message_failed() -> None:
     assert failures[-1].reason == "voip.send_text_message command_failed: peer offline"
 
 
+def test_voice_note_recording_commands_send_worker_commands(monkeypatch) -> None:
+    monotonic_values = iter([100.0, 102.5])
+    monkeypatch.setattr(rust_host.time, "monotonic", lambda: next(monotonic_values))
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    backend.start()
+    supervisor.sent.clear()
+
+    assert backend.start_voice_note_recording("/tmp/a.wav") is True
+    assert backend.stop_voice_note_recording() == 2500
+    assert backend.cancel_voice_note_recording() is True
+
+    assert supervisor.sent == [
+        ("voip", "voip.start_voice_note_recording", {"file_path": "/tmp/a.wav"}),
+        ("voip", "voip.stop_voice_note_recording", {}),
+        ("voip", "voip.cancel_voice_note_recording", {}),
+    ]
+
+
+def test_stop_voice_note_without_active_recording_returns_none() -> None:
+    backend = RustHostBackend(
+        _config(), worker_supervisor=_FakeSupervisor(), worker_path="/bin/voip"
+    )
+
+    assert backend.stop_voice_note_recording() is None
+
+
+def test_send_voice_note_returns_client_id_and_sends_worker_command() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    backend.start()
+    supervisor.sent.clear()
+
+    message_id = backend.send_voice_note(
+        "sip:bob@example.com",
+        file_path="/tmp/a.wav",
+        duration_ms=1200,
+        mime_type="audio/wav",
+    )
+
+    assert message_id is not None
+    assert message_id.startswith("rust-msg-")
+    assert supervisor.sent == [
+        (
+            "voip",
+            "voip.send_voice_note",
+            {
+                "uri": "sip:bob@example.com",
+                "file_path": "/tmp/a.wav",
+                "duration_ms": 1200,
+                "mime_type": "audio/wav",
+                "client_id": message_id,
+            },
+        )
+    ]
+
+
+def test_voice_note_command_errors_emit_message_failed() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+    backend.start()
+
+    assert backend.start_voice_note_recording("/tmp/a.wav") is True
+    backend.handle_worker_message(
+        _reply(
+            "error",
+            "voip.error",
+            {"code": "command_failed", "message": "mic unavailable"},
+            request_id=supervisor.request_ids[-1],
+        )
+    )
+
+    message_id = backend.send_voice_note(
+        "sip:bob@example.com",
+        file_path="/tmp/a.wav",
+        duration_ms=1200,
+        mime_type="audio/wav",
+    )
+    backend.handle_worker_message(
+        _reply(
+            "error",
+            "voip.error",
+            {"code": "command_failed", "message": "upload failed"},
+            request_id=supervisor.request_ids[-1],
+        )
+    )
+
+    failures = [event for event in received if isinstance(event, MessageFailed)]
+    assert failures[0].message_id == ""
+    assert failures[0].reason == "voip.start_voice_note_recording command_failed: mic unavailable"
+    assert failures[1].message_id == message_id
+    assert failures[1].reason == "voip.send_voice_note command_failed: upload failed"
+
+
 def test_worker_events_translate_to_voip_events() -> None:
     supervisor = _FakeSupervisor()
     backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
@@ -476,22 +573,10 @@ def test_ready_after_worker_restart_resends_configure_register() -> None:
     assert received[1].reason == "worker_ready"
 
 
-def test_iterate_is_noop_and_unsupported_voice_notes_fail() -> None:
+def test_iterate_is_noop() -> None:
     backend = RustHostBackend(
         _config(), worker_supervisor=_FakeSupervisor(), worker_path="/bin/voip"
     )
 
     assert backend.iterate() == 0
     assert backend.get_iterate_metrics() is None
-    assert backend.start_voice_note_recording("/tmp/a.wav") is False
-    assert backend.stop_voice_note_recording() is None
-    assert backend.cancel_voice_note_recording() is False
-    assert (
-        backend.send_voice_note(
-            "sip:bob@example.com",
-            file_path="/tmp/a.wav",
-            duration_ms=1000,
-            mime_type="audio/wav",
-        )
-        is None
-    )

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import os
+import time
 import uuid
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -43,7 +44,14 @@ _CALL_CONTROL_COMMANDS = frozenset(
         "voip.set_mute",
     }
 )
-_TEXT_MESSAGE_COMMANDS = frozenset({"voip.send_text_message"})
+_MESSAGE_SEND_COMMANDS = frozenset({"voip.send_text_message", "voip.send_voice_note"})
+_VOICE_NOTE_RECORDING_COMMANDS = frozenset(
+    {
+        "voip.start_voice_note_recording",
+        "voip.stop_voice_note_recording",
+        "voip.cancel_voice_note_recording",
+    }
+)
 _INTENTIONAL_STOP_REASONS = frozenset({"stop", "stop_all"})
 
 
@@ -77,6 +85,7 @@ class RustHostBackend:
         self._reconfigure_on_ready = False
         self._stopping = False
         self._last_stop_reason: str | None = None
+        self._recording_start_monotonic: float | None = None
 
     def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
         self.event_callbacks.append(callback)
@@ -136,6 +145,7 @@ class RustHostBackend:
             self._startup_commands_sent = False
             self._ready_seen = False
             self._reconfigure_on_ready = False
+            self._recording_start_monotonic = None
             self.running = False
             self._stopping = False
 
@@ -175,15 +185,26 @@ class RustHostBackend:
         return message_id
 
     def start_voice_note_recording(self, file_path: str) -> bool:
-        del file_path
-        logger.warning("Rust VoIP Host does not support voice notes in calls-only mode")
-        return False
+        request_id = self._send_with_request_id(
+            "voip.start_voice_note_recording", {"file_path": file_path}
+        )
+        if request_id is None:
+            return False
+        self._recording_start_monotonic = time.monotonic()
+        return True
 
     def stop_voice_note_recording(self) -> int | None:
-        return None
+        start = self._recording_start_monotonic
+        if start is None:
+            return None
+        if self._send_with_request_id("voip.stop_voice_note_recording", {}) is None:
+            return None
+        self._recording_start_monotonic = None
+        return max(0, int((time.monotonic() - start) * 1000))
 
     def cancel_voice_note_recording(self) -> bool:
-        return False
+        self._recording_start_monotonic = None
+        return self._send("voip.cancel_voice_note_recording", {})
 
     def send_voice_note(
         self,
@@ -193,8 +214,21 @@ class RustHostBackend:
         duration_ms: int,
         mime_type: str,
     ) -> str | None:
-        del sip_address, file_path, duration_ms, mime_type
-        return None
+        message_id = self._next_message_id()
+        request_id = self._send_with_request_id(
+            "voip.send_voice_note",
+            {
+                "uri": sip_address,
+                "file_path": file_path,
+                "duration_ms": int(duration_ms),
+                "mime_type": mime_type,
+                "client_id": message_id,
+            },
+        )
+        if request_id is None:
+            return None
+        self._pending_message_ids[request_id] = message_id
+        return message_id
 
     def handle_worker_message(self, event: Any) -> None:
         if getattr(event, "domain", self.domain) != self.domain:
@@ -368,11 +402,15 @@ class RustHostBackend:
             logger.warning("Rust VoIP Host call command failed: {}", reason)
             self._dispatch(CallStateChanged(state=CallState.ERROR))
             return
-        if command in _TEXT_MESSAGE_COMMANDS:
+        if command in _VOICE_NOTE_RECORDING_COMMANDS:
+            self._recording_start_monotonic = None
+            self._dispatch(MessageFailed(message_id="", reason=reason))
+            return
+        if command in _MESSAGE_SEND_COMMANDS:
             if message_id:
                 self._dispatch(MessageFailed(message_id=message_id, reason=reason))
             else:
-                logger.warning("Rust VoIP Host text message command failed: {}", reason)
+                logger.warning("Rust VoIP Host message command failed: {}", reason)
             return
         logger.warning("Rust VoIP Host command failed: {}", reason)
 
@@ -401,6 +439,7 @@ class RustHostBackend:
         self._startup_commands_sent = False
         self._ready_seen = False
         self._reconfigure_on_ready = False
+        self._recording_start_monotonic = None
         self.running = False
         if notify_backend_stopped:
             self._mark_stopped(reason)


### PR DESCRIPTION
## Summary
- add Rust VoIP host commands for voice-note recording start/stop/cancel and send
- wire Rust liblinphone shim loading to the existing native voice-note functions
- update Python RustHostBackend to own voice-note command submission, optimistic stop duration, and failure events
- keep Rust worker stdout reserved for NDJSON protocol output while native/library stdout is redirected to stderr

## Verification
- cargo fmt --manifest-path src/Cargo.toml --all --check
- cargo test --manifest-path src/Cargo.toml --workspace --locked
- uv run python scripts/quality.py gate
- uv run pytest -q

## Hardware Validation
- Board: rpi-zero dev lane, checkout 1d99c83e20398373c00cef046bf3ba4eb00a31d6
- CI artifact: yoyopod-voip-host-1d99c83e20398373c00cef046bf3ba4eb00a31d6 from run 25101998938, artifact 6704160091
- Installed at: /opt/yoyopod-dev/checkout/src/crates/voip-host/build/yoyopod-voip-host
- Binary SHA256: 91868fa97e95294946870ea9e4ee2332702696622810d078a9bddec368aa2f67
- Smoke result: strict stdout protocol pass; worker advertised voice_notes; SIP registration progress -> ok; recorded WAV data/communication/voice_notes/rust-hw-smoke-strict-20260429T095007Z.wav (45568 bytes, 2.848s); send_voice_note returned message_id=rust-hw-smoke-strict-client-1; cancel removed its temp recording file
- Left running: yoyopod-dev.service with Rust VoIP host process active