### PR TITLE
Add Rust VoIP session snapshots

### DIFF
--- a/src/crates/voip-host/src/host.rs
+++ b/src/crates/voip-host/src/host.rs
@@ -77,24 +77,82 @@ pub enum BackendEvent {
     },
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VoiceNoteSessionState {
+    state: String,
+    file_path: String,
+    duration_ms: i32,
+    mime_type: String,
+    message_id: String,
+}
+
+impl Default for VoiceNoteSessionState {
+    fn default() -> Self {
+        Self {
+            state: "idle".to_string(),
+            file_path: String::new(),
+            duration_ms: 0,
+            mime_type: String::new(),
+            message_id: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MessageSessionState {
+    message_id: String,
+    kind: String,
+    direction: String,
+    delivery_state: String,
+    local_file_path: String,
+    error: String,
+}
+
+#[derive(Debug)]
 pub struct VoipHost {
     config: Option<VoipConfig>,
     registered: bool,
+    registration_state: String,
+    call_state: String,
     active_call_id: Option<String>,
+    active_call_peer: String,
+    voice_note: VoiceNoteSessionState,
+    last_message: Option<MessageSessionState>,
     outbound_message_ids: HashMap<String, String>,
+}
+
+impl Default for VoipHost {
+    fn default() -> Self {
+        Self {
+            config: None,
+            registered: false,
+            registration_state: "none".to_string(),
+            call_state: "idle".to_string(),
+            active_call_id: None,
+            active_call_peer: String::new(),
+            voice_note: VoiceNoteSessionState::default(),
+            last_message: None,
+            outbound_message_ids: HashMap::new(),
+        }
+    }
 }
 
 impl VoipHost {
     pub fn configure(&mut self, config: VoipConfig) {
         self.config = Some(config);
         self.registered = false;
+        self.registration_state = "none".to_string();
+        self.call_state = "idle".to_string();
         self.active_call_id = None;
+        self.active_call_peer.clear();
+        self.voice_note = VoiceNoteSessionState::default();
+        self.last_message = None;
         self.outbound_message_ids.clear();
     }
 
     pub fn mark_registered(&mut self, registered: bool) {
         self.registered = registered;
+        self.registration_state = if registered { "ok" } else { "none" }.to_string();
     }
 
     pub fn set_active_call_id(&mut self, call_id: Option<String>) {
@@ -106,6 +164,40 @@ impl VoipHost {
             "configured": self.config.is_some(),
             "registered": self.registered,
             "active_call_id": self.active_call_id,
+        })
+    }
+
+    pub fn session_snapshot_payload(&self) -> serde_json::Value {
+        let last_message = self
+            .last_message
+            .as_ref()
+            .map(|message| {
+                json!({
+                    "message_id": message.message_id,
+                    "kind": message.kind,
+                    "direction": message.direction,
+                    "delivery_state": message.delivery_state,
+                    "local_file_path": message.local_file_path,
+                    "error": message.error,
+                })
+            })
+            .unwrap_or(serde_json::Value::Null);
+        json!({
+            "configured": self.config.is_some(),
+            "registered": self.registered,
+            "registration_state": self.registration_state,
+            "call_state": self.call_state,
+            "active_call_id": self.active_call_id,
+            "active_call_peer": self.active_call_peer,
+            "pending_outbound_messages": self.outbound_message_ids.len(),
+            "voice_note": {
+                "state": self.voice_note.state,
+                "file_path": self.voice_note.file_path,
+                "duration_ms": self.voice_note.duration_ms,
+                "mime_type": self.voice_note.mime_type,
+                "message_id": self.voice_note.message_id,
+            },
+            "last_message": last_message,
         })
     }
 
@@ -129,7 +221,11 @@ impl VoipHost {
     pub fn unregister<B: CallBackend>(&mut self, backend: &mut B) {
         backend.stop();
         self.registered = false;
+        self.registration_state = "none".to_string();
+        self.call_state = "idle".to_string();
         self.active_call_id = None;
+        self.active_call_peer.clear();
+        self.voice_note = VoiceNoteSessionState::default();
         self.outbound_message_ids.clear();
     }
 
@@ -140,6 +236,8 @@ impl VoipHost {
     ) -> Result<(), String> {
         let call_id = backend.make_call(sip_address)?;
         self.active_call_id = Some(call_id);
+        self.active_call_peer = sip_address.to_string();
+        self.call_state = "outgoing_init".to_string();
         Ok(())
     }
 
@@ -150,12 +248,16 @@ impl VoipHost {
     pub fn reject<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
         backend.reject_call()?;
         self.active_call_id = None;
+        self.active_call_peer.clear();
+        self.call_state = "released".to_string();
         Ok(())
     }
 
     pub fn hangup<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
         backend.hangup()?;
         self.active_call_id = None;
+        self.active_call_peer.clear();
+        self.call_state = "released".to_string();
         Ok(())
     }
 
@@ -188,18 +290,31 @@ impl VoipHost {
         backend: &mut B,
         file_path: &str,
     ) -> Result<(), String> {
-        backend.start_voice_recording(file_path)
+        backend.start_voice_recording(file_path)?;
+        self.voice_note = VoiceNoteSessionState {
+            state: "recording".to_string(),
+            file_path: file_path.to_string(),
+            duration_ms: 0,
+            mime_type: "audio/wav".to_string(),
+            message_id: String::new(),
+        };
+        Ok(())
     }
 
     pub fn stop_voice_recording<B: CallBackend>(&mut self, backend: &mut B) -> Result<i32, String> {
-        backend.stop_voice_recording()
+        let duration_ms = backend.stop_voice_recording()?;
+        self.voice_note.state = "recorded".to_string();
+        self.voice_note.duration_ms = duration_ms;
+        Ok(duration_ms)
     }
 
     pub fn cancel_voice_recording<B: CallBackend>(
         &mut self,
         backend: &mut B,
     ) -> Result<(), String> {
-        backend.cancel_voice_recording()
+        backend.cancel_voice_recording()?;
+        self.voice_note = VoiceNoteSessionState::default();
+        Ok(())
     }
 
     pub fn send_voice_note<B: CallBackend>(
@@ -217,6 +332,13 @@ impl VoipHost {
         }
         let backend_id = backend.send_voice_note(sip_address, file_path, duration_ms, mime_type)?;
         self.remember_outbound_message_id(&backend_id, client_id, "voip voice note")?;
+        self.voice_note = VoiceNoteSessionState {
+            state: "sending".to_string(),
+            file_path: file_path.to_string(),
+            duration_ms,
+            mime_type: mime_type.to_string(),
+            message_id: client_id.to_string(),
+        };
         Ok(client_id.to_string())
     }
 
@@ -238,21 +360,26 @@ impl VoipHost {
     fn apply_backend_event(&mut self, event: &BackendEvent) {
         match event {
             BackendEvent::RegistrationChanged { state, .. } => {
+                self.registration_state = state.clone();
                 if state == "ok" {
                     self.registered = true;
                 } else if matches!(state.as_str(), "failed" | "cleared" | "none") {
                     self.registered = false;
                 }
             }
-            BackendEvent::IncomingCall { call_id, .. } => {
+            BackendEvent::IncomingCall { call_id, from_uri } => {
                 self.active_call_id = Some(call_id.clone());
+                self.active_call_peer = from_uri.clone();
+                self.call_state = "incoming".to_string();
             }
             BackendEvent::CallStateChanged { call_id, state } => {
+                self.call_state = state.clone();
                 if matches!(state.as_str(), "idle" | "released" | "error" | "end") {
                     if self.active_call_id.as_deref() == Some(call_id.as_str())
                         || self.active_call_id.is_none()
                     {
                         self.active_call_id = None;
+                        self.active_call_peer.clear();
                     }
                 } else {
                     self.active_call_id = Some(call_id.clone());
@@ -260,13 +387,76 @@ impl VoipHost {
             }
             BackendEvent::BackendStopped { .. } => {
                 self.registered = false;
+                self.registration_state = "failed".to_string();
+                self.call_state = "idle".to_string();
                 self.active_call_id = None;
+                self.active_call_peer.clear();
                 self.outbound_message_ids.clear();
             }
-            BackendEvent::MessageReceived { .. }
-            | BackendEvent::MessageDeliveryChanged { .. }
-            | BackendEvent::MessageDownloadCompleted { .. }
-            | BackendEvent::MessageFailed { .. } => {}
+            BackendEvent::MessageReceived { message } => {
+                self.last_message = Some(MessageSessionState {
+                    message_id: message.message_id.clone(),
+                    kind: message.kind.clone(),
+                    direction: message.direction.clone(),
+                    delivery_state: message.delivery_state.clone(),
+                    local_file_path: message.local_file_path.clone(),
+                    error: String::new(),
+                });
+            }
+            BackendEvent::MessageDeliveryChanged {
+                message_id,
+                delivery_state,
+                local_file_path,
+                error,
+            } => {
+                self.last_message = Some(MessageSessionState {
+                    message_id: message_id.clone(),
+                    kind: String::new(),
+                    direction: String::new(),
+                    delivery_state: delivery_state.clone(),
+                    local_file_path: local_file_path.clone(),
+                    error: error.clone(),
+                });
+                if self.voice_note.message_id == *message_id {
+                    self.voice_note.state = match delivery_state.as_str() {
+                        "failed" => "failed",
+                        "sent" | "delivered" => "sent",
+                        _ => "sending",
+                    }
+                    .to_string();
+                }
+            }
+            BackendEvent::MessageDownloadCompleted {
+                message_id,
+                local_file_path,
+                mime_type,
+            } => {
+                self.last_message = Some(MessageSessionState {
+                    message_id: message_id.clone(),
+                    kind: String::new(),
+                    direction: String::new(),
+                    delivery_state: "delivered".to_string(),
+                    local_file_path: local_file_path.clone(),
+                    error: String::new(),
+                });
+                if self.voice_note.message_id == *message_id {
+                    self.voice_note.file_path = local_file_path.clone();
+                    self.voice_note.mime_type = mime_type.clone();
+                }
+            }
+            BackendEvent::MessageFailed { message_id, reason } => {
+                self.last_message = Some(MessageSessionState {
+                    message_id: message_id.clone(),
+                    kind: String::new(),
+                    direction: String::new(),
+                    delivery_state: "failed".to_string(),
+                    local_file_path: String::new(),
+                    error: reason.clone(),
+                });
+                if self.voice_note.message_id == *message_id {
+                    self.voice_note.state = "failed".to_string();
+                }
+            }
         }
     }
 
@@ -362,6 +552,171 @@ mod tests {
         assert_eq!(payload["configured"], true);
         assert_eq!(payload["registered"], true);
         assert_eq!(payload["active_call_id"], "call-1");
+    }
+
+    #[test]
+    fn session_snapshot_tracks_call_message_and_voice_note_state() {
+        #[derive(Default)]
+        struct SnapshotBackend {
+            calls: Vec<String>,
+        }
+
+        impl CallBackend for SnapshotBackend {
+            fn start(&mut self, _config: &VoipConfig) -> Result<(), String> {
+                self.calls.push("start".to_string());
+                Ok(())
+            }
+
+            fn stop(&mut self) {
+                self.calls.push("stop".to_string());
+            }
+
+            fn iterate(&mut self) -> Result<Vec<BackendEvent>, String> {
+                Ok(vec![])
+            }
+
+            fn make_call(&mut self, _sip_address: &str) -> Result<String, String> {
+                Ok("call-1".to_string())
+            }
+
+            fn answer_call(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn reject_call(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn hangup(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn set_muted(&mut self, _muted: bool) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn send_text_message(
+                &mut self,
+                _sip_address: &str,
+                _text: &str,
+            ) -> Result<String, String> {
+                Ok("backend-msg-1".to_string())
+            }
+
+            fn start_voice_recording(&mut self, file_path: &str) -> Result<(), String> {
+                self.calls.push(format!("record:{file_path}"));
+                Ok(())
+            }
+
+            fn stop_voice_recording(&mut self) -> Result<i32, String> {
+                self.calls.push("stop_recording".to_string());
+                Ok(1250)
+            }
+
+            fn cancel_voice_recording(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn send_voice_note(
+                &mut self,
+                _sip_address: &str,
+                _file_path: &str,
+                _duration_ms: i32,
+                _mime_type: &str,
+            ) -> Result<String, String> {
+                Ok("backend-vn-1".to_string())
+            }
+        }
+
+        let mut host = VoipHost::default();
+        let mut backend = SnapshotBackend::default();
+        host.configure(config());
+        host.register(&mut backend).expect("register");
+
+        assert_eq!(
+            host.session_snapshot_payload()["registration_state"],
+            "none"
+        );
+        assert_eq!(host.session_snapshot_payload()["call_state"], "idle");
+        assert_eq!(
+            host.session_snapshot_payload()["voice_note"]["state"],
+            "idle"
+        );
+
+        host.apply_backend_event(&BackendEvent::RegistrationChanged {
+            state: "ok".to_string(),
+            reason: "".to_string(),
+        });
+        host.apply_backend_event(&BackendEvent::IncomingCall {
+            call_id: "call-1".to_string(),
+            from_uri: "sip:bob@example.com".to_string(),
+        });
+        host.apply_backend_event(&BackendEvent::CallStateChanged {
+            call_id: "call-1".to_string(),
+            state: "streams_running".to_string(),
+        });
+
+        let snapshot = host.session_snapshot_payload();
+        assert_eq!(snapshot["configured"], true);
+        assert_eq!(snapshot["registered"], true);
+        assert_eq!(snapshot["registration_state"], "ok");
+        assert_eq!(snapshot["active_call_id"], "call-1");
+        assert_eq!(snapshot["call_state"], "streams_running");
+
+        host.start_voice_recording(&mut backend, "/tmp/note.wav")
+            .expect("start voice note");
+        assert_eq!(
+            host.session_snapshot_payload()["voice_note"]["state"],
+            "recording"
+        );
+        assert_eq!(
+            host.session_snapshot_payload()["voice_note"]["file_path"],
+            "/tmp/note.wav"
+        );
+
+        host.stop_voice_recording(&mut backend)
+            .expect("stop voice note");
+        assert_eq!(
+            host.session_snapshot_payload()["voice_note"]["state"],
+            "recorded"
+        );
+        assert_eq!(
+            host.session_snapshot_payload()["voice_note"]["duration_ms"],
+            1250
+        );
+
+        host.send_voice_note(
+            &mut backend,
+            "sip:bob@example.com",
+            "/tmp/note.wav",
+            1250,
+            "audio/wav",
+            "client-vn-1",
+        )
+        .expect("send voice note");
+        assert_eq!(
+            host.session_snapshot_payload()["voice_note"]["state"],
+            "sending"
+        );
+        assert_eq!(
+            host.session_snapshot_payload()["voice_note"]["message_id"],
+            "client-vn-1"
+        );
+        assert_eq!(
+            host.session_snapshot_payload()["pending_outbound_messages"],
+            1
+        );
+
+        host.apply_backend_event(&BackendEvent::MessageDeliveryChanged {
+            message_id: "client-vn-1".to_string(),
+            delivery_state: "delivered".to_string(),
+            local_file_path: "/tmp/note.wav".to_string(),
+            error: "".to_string(),
+        });
+        let snapshot = host.session_snapshot_payload();
+        assert_eq!(snapshot["voice_note"]["state"], "sent");
+        assert_eq!(snapshot["last_message"]["message_id"], "client-vn-1");
+        assert_eq!(snapshot["last_message"]["delivery_state"], "delivered");
     }
 }
 

--- a/src/crates/voip-host/src/main.rs
+++ b/src/crates/voip-host/src/main.rs
@@ -127,6 +127,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"configured": true}),
             ))?;
+            write_session_snapshot(host)?;
         }
         "voip.health" => {
             let mut payload = host.health_payload();
@@ -149,6 +150,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"registered": true}),
             ))?;
+            write_session_snapshot(host)?;
         }
         "voip.unregister" => {
             if let Some(mut backend_ref) = backend.take() {
@@ -159,6 +161,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"registered": false}),
             ))?;
+            write_session_snapshot(host)?;
         }
         "voip.dial" => {
             let uri = envelope.payload["uri"].as_str().unwrap_or("").trim();
@@ -180,6 +183,7 @@ fn handle_command(
                     envelope.request_id,
                     host.health_payload(),
                 ))?;
+                write_session_snapshot(host)?;
             }
         }
         "voip.answer" => {
@@ -192,6 +196,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"accepted": true}),
             ))?;
+            write_session_snapshot(host)?;
         }
         "voip.reject" => {
             let backend_ref = backend
@@ -203,6 +208,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"rejected": true}),
             ))?;
+            write_session_snapshot(host)?;
         }
         "voip.hangup" => {
             let backend_ref = backend
@@ -214,6 +220,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"hung_up": true}),
             ))?;
+            write_session_snapshot(host)?;
         }
         "voip.set_mute" => {
             let muted = envelope.payload["muted"].as_bool().unwrap_or(false);
@@ -251,6 +258,7 @@ fn handle_command(
                     envelope.request_id,
                     json!({"message_id": message_id}),
                 ))?;
+                write_session_snapshot(host)?;
             }
         }
         "voip.start_voice_note_recording" => {
@@ -273,6 +281,7 @@ fn handle_command(
                     envelope.request_id,
                     json!({"recording": true}),
                 ))?;
+                write_session_snapshot(host)?;
             }
         }
         "voip.stop_voice_note_recording" => {
@@ -287,6 +296,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"duration_ms": duration_ms}),
             ))?;
+            write_session_snapshot(host)?;
         }
         "voip.cancel_voice_note_recording" => {
             let backend_ref = backend
@@ -299,6 +309,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"cancelled": true}),
             ))?;
+            write_session_snapshot(host)?;
         }
         "voip.send_voice_note" => {
             let uri = envelope.payload["uri"].as_str().unwrap_or("").trim();
@@ -338,6 +349,7 @@ fn handle_command(
                     envelope.request_id,
                     json!({"message_id": message_id}),
                 ))?;
+                write_session_snapshot(host)?;
             }
         }
         "voip.shutdown" | "worker.stop" => {
@@ -349,6 +361,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"shutdown": true}),
             ))?;
+            write_session_snapshot(host)?;
             return Ok(LoopAction::Shutdown);
         }
         _ => {
@@ -377,16 +390,38 @@ fn poll_backend(host: &mut VoipHost, backend: &mut Option<shim::ShimBackend>) ->
         emit_backend_events(
             host.poll_backend_events(backend_ref)
                 .map_err(|error| anyhow!(error))?,
+            host,
         )?;
     }
     Ok(())
 }
 
-fn emit_backend_events(events: Vec<host::BackendEvent>) -> Result<()> {
-    for event in events {
-        write_envelope(&backend_event_envelope(event))?;
+fn emit_backend_events(events: Vec<host::BackendEvent>, host: &VoipHost) -> Result<()> {
+    for envelope in backend_event_envelopes(events, host) {
+        write_envelope(&envelope)?;
     }
     Ok(())
+}
+
+fn backend_event_envelopes(
+    events: Vec<host::BackendEvent>,
+    host: &VoipHost,
+) -> Vec<WorkerEnvelope> {
+    if events.is_empty() {
+        return Vec::new();
+    }
+    let mut envelopes: Vec<WorkerEnvelope> =
+        events.into_iter().map(backend_event_envelope).collect();
+    envelopes.push(session_snapshot_envelope(host));
+    envelopes
+}
+
+fn write_session_snapshot(host: &VoipHost) -> Result<()> {
+    write_envelope(&session_snapshot_envelope(host))
+}
+
+fn session_snapshot_envelope(host: &VoipHost) -> WorkerEnvelope {
+    WorkerEnvelope::event("voip.snapshot", host.session_snapshot_payload())
 }
 
 fn backend_event_envelope(event: host::BackendEvent) -> WorkerEnvelope {
@@ -557,6 +592,33 @@ mod tests {
         assert_eq!(envelope.payload["message_id"], "msg-1");
         assert_eq!(envelope.payload["kind"], "text");
         assert_eq!(envelope.payload["text"], "hello");
+    }
+
+    #[test]
+    fn backend_event_batch_appends_canonical_snapshot() {
+        let mut host = VoipHost::default();
+        host.configure(
+            VoipConfig::from_payload(&json!({
+                "sip_server": "sip.example.com",
+                "sip_identity": "sip:alice@example.com"
+            }))
+            .expect("config"),
+        );
+        host.mark_registered(true);
+
+        let envelopes = backend_event_envelopes(
+            vec![host::BackendEvent::RegistrationChanged {
+                state: "ok".to_string(),
+                reason: "".to_string(),
+            }],
+            &host,
+        );
+
+        assert_eq!(envelopes.len(), 2);
+        assert_eq!(envelopes[0].message_type, "voip.registration_changed");
+        assert_eq!(envelopes[1].message_type, "voip.snapshot");
+        assert_eq!(envelopes[1].payload["registered"], true);
+        assert_eq!(envelopes[1].payload["registration_state"], "ok");
     }
 
     #[test]

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -415,6 +415,46 @@ def test_worker_events_translate_to_voip_events() -> None:
     assert len(received) == 4
 
 
+def test_worker_snapshot_updates_registration_and_call_state_without_duplicates() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+
+    backend.handle_worker_message(
+        _event(
+            "voip.snapshot",
+            {
+                "configured": True,
+                "registered": True,
+                "registration_state": "ok",
+                "call_state": "streams_running",
+                "active_call_id": "call-1",
+                "pending_outbound_messages": 0,
+                "voice_note": {"state": "idle", "file_path": "", "duration_ms": 0},
+            },
+        )
+    )
+    backend.handle_worker_message(
+        _event(
+            "voip.snapshot",
+            {
+                "configured": True,
+                "registered": True,
+                "registration_state": "ok",
+                "call_state": "streams_running",
+                "active_call_id": "call-1",
+                "pending_outbound_messages": 0,
+                "voice_note": {"state": "idle", "file_path": "", "duration_ms": 0},
+            },
+        )
+    )
+
+    assert [type(event) for event in received] == [RegistrationStateChanged, CallStateChanged]
+    assert received[0].state == RegistrationState.OK
+    assert received[1].state == CallState.STREAMS_RUNNING
+
+
 def test_worker_message_events_translate_to_voip_events() -> None:
     supervisor = _FakeSupervisor()
     backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -86,6 +86,8 @@ class RustHostBackend:
         self._stopping = False
         self._last_stop_reason: str | None = None
         self._recording_start_monotonic: float | None = None
+        self._snapshot_registration_state = RegistrationState.NONE
+        self._snapshot_call_state = CallState.IDLE
 
     def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
         self.event_callbacks.append(callback)
@@ -146,6 +148,8 @@ class RustHostBackend:
             self._ready_seen = False
             self._reconfigure_on_ready = False
             self._recording_start_monotonic = None
+            self._snapshot_registration_state = RegistrationState.NONE
+            self._snapshot_call_state = CallState.IDLE
             self.running = False
             self._stopping = False
 
@@ -250,18 +254,19 @@ class RustHostBackend:
         if event_type == "voip.ready":
             self._handle_worker_ready()
             return
+        if event_type == "voip.snapshot":
+            self._handle_session_snapshot(payload)
+            return
         if event_type == "voip.registration_changed":
-            self._dispatch(
-                RegistrationStateChanged(
-                    state=_registration_state(str(payload.get("state", "none")))
-                )
+            self._dispatch_registration_state(
+                _registration_state(str(payload.get("state", "none")))
             )
             return
         if event_type == "voip.incoming_call":
             self._dispatch(IncomingCallDetected(caller_address=str(payload.get("from_uri", ""))))
             return
         if event_type == "voip.call_state_changed":
-            self._dispatch(CallStateChanged(state=_call_state(str(payload.get("state", "idle")))))
+            self._dispatch_call_state(_call_state(str(payload.get("state", "idle"))))
             return
         if event_type == "voip.backend_stopped":
             self._mark_stopped(str(payload.get("reason", "")) or "backend_stopped")
@@ -440,11 +445,34 @@ class RustHostBackend:
         self._ready_seen = False
         self._reconfigure_on_ready = False
         self._recording_start_monotonic = None
+        self._snapshot_registration_state = RegistrationState.NONE
+        self._snapshot_call_state = CallState.IDLE
         self.running = False
         if notify_backend_stopped:
             self._mark_stopped(reason)
         else:
             self._last_stop_reason = reason
+
+    def _handle_session_snapshot(self, payload: dict[str, Any]) -> None:
+        registration_state = str(payload.get("registration_state", "") or "").strip()
+        if not registration_state:
+            registration_state = (
+                "ok" if _bool_payload(payload.get("registered", False)) else "none"
+            )
+        self._dispatch_registration_state(_registration_state(registration_state))
+        self._dispatch_call_state(_call_state(str(payload.get("call_state", "idle"))))
+
+    def _dispatch_registration_state(self, state: RegistrationState) -> None:
+        if state == self._snapshot_registration_state:
+            return
+        self._snapshot_registration_state = state
+        self._dispatch(RegistrationStateChanged(state=state))
+
+    def _dispatch_call_state(self, state: CallState) -> None:
+        if state == self._snapshot_call_state:
+            return
+        self._snapshot_call_state = state
+        self._dispatch(CallStateChanged(state=state))
 
     def _mark_stopped(self, reason: str) -> None:
         if not self.running and self._last_stop_reason == reason:


### PR DESCRIPTION
## Summary
- add canonical Rust VoIP session snapshots for registration, call, message, and voice-note state
- add Rust-owned VoIP lifecycle state/events for configured, registering, registered, failed, stopped, and recovered paths
- emit lifecycle events and `voip.snapshot` after Rust VoIP host state changes/backend event batches
- consume `voip.snapshot` and `voip.lifecycle_changed` in Python RustHostBackend with deduped state and recovered/stopped handling

## Verification
- cargo fmt --manifest-path src/Cargo.toml --all --check
- cargo test --manifest-path src/Cargo.toml --workspace --locked
- uv run python scripts/quality.py gate
- uv run pytest -q