### PR TITLE
Add Rust VoIP lifecycle events

### DIFF
--- a/src/crates/voip-host/src/host.rs
+++ b/src/crates/voip-host/src/host.rs
@@ -78,6 +78,14 @@ pub enum BackendEvent {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LifecycleEvent {
+    pub state: String,
+    pub previous_state: String,
+    pub reason: String,
+    pub recovered: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct VoiceNoteSessionState {
     state: String,
     file_path: String,
@@ -113,6 +121,10 @@ pub struct VoipHost {
     config: Option<VoipConfig>,
     registered: bool,
     registration_state: String,
+    lifecycle_state: String,
+    lifecycle_reason: String,
+    recovery_pending: bool,
+    lifecycle_events: Vec<LifecycleEvent>,
     call_state: String,
     active_call_id: Option<String>,
     active_call_peer: String,
@@ -127,6 +139,10 @@ impl Default for VoipHost {
             config: None,
             registered: false,
             registration_state: "none".to_string(),
+            lifecycle_state: "unconfigured".to_string(),
+            lifecycle_reason: String::new(),
+            recovery_pending: false,
+            lifecycle_events: Vec::new(),
             call_state: "idle".to_string(),
             active_call_id: None,
             active_call_peer: String::new(),
@@ -142,6 +158,8 @@ impl VoipHost {
         self.config = Some(config);
         self.registered = false;
         self.registration_state = "none".to_string();
+        self.recovery_pending = false;
+        self.record_lifecycle("configured", "configured", false);
         self.call_state = "idle".to_string();
         self.active_call_id = None;
         self.active_call_peer.clear();
@@ -153,6 +171,9 @@ impl VoipHost {
     pub fn mark_registered(&mut self, registered: bool) {
         self.registered = registered;
         self.registration_state = if registered { "ok" } else { "none" }.to_string();
+        if registered {
+            self.record_lifecycle("registered", "registered", false);
+        }
     }
 
     pub fn set_active_call_id(&mut self, call_id: Option<String>) {
@@ -164,6 +185,17 @@ impl VoipHost {
             "configured": self.config.is_some(),
             "registered": self.registered,
             "active_call_id": self.active_call_id,
+            "lifecycle_state": self.lifecycle_state,
+            "lifecycle_reason": self.lifecycle_reason,
+            "backend_available": self.registered && self.lifecycle_state == "registered",
+        })
+    }
+
+    pub fn lifecycle_payload(&self) -> serde_json::Value {
+        json!({
+            "state": self.lifecycle_state,
+            "reason": self.lifecycle_reason,
+            "backend_available": self.registered && self.lifecycle_state == "registered",
         })
     }
 
@@ -186,6 +218,7 @@ impl VoipHost {
             "configured": self.config.is_some(),
             "registered": self.registered,
             "registration_state": self.registration_state,
+            "lifecycle": self.lifecycle_payload(),
             "call_state": self.call_state,
             "active_call_id": self.active_call_id,
             "active_call_peer": self.active_call_peer,
@@ -212,9 +245,21 @@ impl VoipHost {
         let config = self
             .config
             .as_ref()
-            .ok_or_else(|| "voip host is not configured".to_string())?;
-        backend.start(config)?;
+            .ok_or_else(|| "voip host is not configured".to_string())?
+            .clone();
+        self.record_lifecycle("registering", "registering", false);
+        if let Err(error) = backend.start(&config) {
+            self.registered = false;
+            self.registration_state = "failed".to_string();
+            self.recovery_pending = true;
+            self.record_lifecycle("failed", &error, false);
+            return Err(error);
+        }
         self.registered = true;
+        self.registration_state = "none".to_string();
+        let recovered = self.recovery_pending;
+        self.recovery_pending = false;
+        self.record_lifecycle("registered", "registered", recovered);
         Ok(())
     }
 
@@ -222,6 +267,8 @@ impl VoipHost {
         backend.stop();
         self.registered = false;
         self.registration_state = "none".to_string();
+        self.recovery_pending = false;
+        self.record_lifecycle("stopped", "unregistered", false);
         self.call_state = "idle".to_string();
         self.active_call_id = None;
         self.active_call_peer.clear();
@@ -357,6 +404,10 @@ impl VoipHost {
         Ok(events)
     }
 
+    pub fn take_lifecycle_events(&mut self) -> Vec<LifecycleEvent> {
+        std::mem::take(&mut self.lifecycle_events)
+    }
+
     fn apply_backend_event(&mut self, event: &BackendEvent) {
         match event {
             BackendEvent::RegistrationChanged { state, .. } => {
@@ -385,9 +436,11 @@ impl VoipHost {
                     self.active_call_id = Some(call_id.clone());
                 }
             }
-            BackendEvent::BackendStopped { .. } => {
+            BackendEvent::BackendStopped { reason } => {
                 self.registered = false;
                 self.registration_state = "failed".to_string();
+                self.recovery_pending = true;
+                self.record_lifecycle("failed", reason, false);
                 self.call_state = "idle".to_string();
                 self.active_call_id = None;
                 self.active_call_peer.clear();
@@ -520,6 +573,20 @@ impl VoipHost {
                 .insert(backend_id.to_string(), client_id.to_string());
         }
         Ok(())
+    }
+
+    fn record_lifecycle(&mut self, state: &str, reason: &str, recovered: bool) {
+        let previous_state = self.lifecycle_state.clone();
+        let state = state.to_string();
+        let reason = reason.to_string();
+        self.lifecycle_state = state.clone();
+        self.lifecycle_reason = reason.clone();
+        self.lifecycle_events.push(LifecycleEvent {
+            state,
+            previous_state,
+            reason,
+            recovered,
+        });
     }
 }
 
@@ -821,6 +888,121 @@ mod command_tests {
 
         assert_eq!(backend.calls, vec!["start"]);
         assert_eq!(host.health_payload()["registered"], true);
+    }
+
+    #[test]
+    fn lifecycle_snapshot_tracks_register_failure_recovery_and_stop() {
+        struct LifecycleBackend {
+            start_results: Vec<Result<(), String>>,
+            stop_calls: usize,
+        }
+
+        impl CallBackend for LifecycleBackend {
+            fn start(&mut self, _config: &VoipConfig) -> Result<(), String> {
+                self.start_results.remove(0)
+            }
+
+            fn stop(&mut self) {
+                self.stop_calls += 1;
+            }
+
+            fn iterate(&mut self) -> Result<Vec<BackendEvent>, String> {
+                Ok(vec![])
+            }
+
+            fn make_call(&mut self, _sip_address: &str) -> Result<String, String> {
+                Ok("call-outgoing".to_string())
+            }
+
+            fn answer_call(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn reject_call(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn hangup(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn set_muted(&mut self, _muted: bool) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn send_text_message(
+                &mut self,
+                _sip_address: &str,
+                _text: &str,
+            ) -> Result<String, String> {
+                Ok("backend-msg-1".to_string())
+            }
+
+            fn start_voice_recording(&mut self, _file_path: &str) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn stop_voice_recording(&mut self) -> Result<i32, String> {
+                Ok(1250)
+            }
+
+            fn cancel_voice_recording(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+
+            fn send_voice_note(
+                &mut self,
+                _sip_address: &str,
+                _file_path: &str,
+                _duration_ms: i32,
+                _mime_type: &str,
+            ) -> Result<String, String> {
+                Ok("backend-vn-1".to_string())
+            }
+        }
+
+        let mut host = VoipHost::default();
+        assert_eq!(
+            host.session_snapshot_payload()["lifecycle"]["state"],
+            "unconfigured"
+        );
+
+        host.configure(config());
+        assert_eq!(
+            host.session_snapshot_payload()["lifecycle"]["state"],
+            "configured"
+        );
+
+        let mut backend = LifecycleBackend {
+            start_results: vec![Err("shim missing".to_string()), Ok(())],
+            stop_calls: 0,
+        };
+        assert_eq!(
+            host.register(&mut backend)
+                .expect_err("register should fail"),
+            "shim missing"
+        );
+        let snapshot = host.session_snapshot_payload();
+        assert_eq!(snapshot["registered"], false);
+        assert_eq!(snapshot["registration_state"], "failed");
+        assert_eq!(snapshot["lifecycle"]["state"], "failed");
+        assert_eq!(snapshot["lifecycle"]["reason"], "shim missing");
+
+        host.register(&mut backend)
+            .expect("register should recover");
+        let lifecycle_events = host.take_lifecycle_events();
+        assert!(lifecycle_events
+            .iter()
+            .any(|event| event.state == "registered" && event.recovered));
+        let snapshot = host.session_snapshot_payload();
+        assert_eq!(snapshot["registered"], true);
+        assert_eq!(snapshot["lifecycle"]["state"], "registered");
+
+        host.unregister(&mut backend);
+        assert_eq!(backend.stop_calls, 1);
+        let snapshot = host.session_snapshot_payload();
+        assert_eq!(snapshot["registered"], false);
+        assert_eq!(snapshot["lifecycle"]["state"], "stopped");
     }
 
     #[test]

--- a/src/crates/voip-host/src/main.rs
+++ b/src/crates/voip-host/src/main.rs
@@ -127,6 +127,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"configured": true}),
             ))?;
+            write_lifecycle_events(host)?;
             write_session_snapshot(host)?;
         }
         "voip.health" => {
@@ -144,12 +145,17 @@ fn handle_command(
                 *backend = Some(unsafe { shim::ShimBackend::load(&path) }?);
             }
             let backend_ref = backend.as_mut().expect("backend was just created");
-            host.register(backend_ref).map_err(|error| anyhow!(error))?;
+            if let Err(error) = host.register(backend_ref) {
+                write_lifecycle_events(host)?;
+                write_session_snapshot(host)?;
+                return Err(anyhow!(error));
+            }
             write_envelope(&WorkerEnvelope::result(
                 "voip.register",
                 envelope.request_id,
                 json!({"registered": true}),
             ))?;
+            write_lifecycle_events(host)?;
             write_session_snapshot(host)?;
         }
         "voip.unregister" => {
@@ -161,6 +167,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"registered": false}),
             ))?;
+            write_lifecycle_events(host)?;
             write_session_snapshot(host)?;
         }
         "voip.dial" => {
@@ -361,6 +368,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"shutdown": true}),
             ))?;
+            write_lifecycle_events(host)?;
             write_session_snapshot(host)?;
             return Ok(LoopAction::Shutdown);
         }
@@ -387,17 +395,21 @@ fn next_loop_timeout(host: &VoipHost, backend_running: bool) -> Duration {
 
 fn poll_backend(host: &mut VoipHost, backend: &mut Option<shim::ShimBackend>) -> Result<()> {
     if let Some(backend_ref) = backend.as_mut() {
-        emit_backend_events(
-            host.poll_backend_events(backend_ref)
-                .map_err(|error| anyhow!(error))?,
-            host,
-        )?;
+        let events = host
+            .poll_backend_events(backend_ref)
+            .map_err(|error| anyhow!(error))?;
+        let lifecycle_events = host.take_lifecycle_events();
+        emit_backend_events(events, lifecycle_events, host)?;
     }
     Ok(())
 }
 
-fn emit_backend_events(events: Vec<host::BackendEvent>, host: &VoipHost) -> Result<()> {
-    for envelope in backend_event_envelopes(events, host) {
+fn emit_backend_events(
+    events: Vec<host::BackendEvent>,
+    lifecycle_events: Vec<host::LifecycleEvent>,
+    host: &VoipHost,
+) -> Result<()> {
+    for envelope in backend_event_envelopes(events, lifecycle_events, host) {
         write_envelope(&envelope)?;
     }
     Ok(())
@@ -405,15 +417,36 @@ fn emit_backend_events(events: Vec<host::BackendEvent>, host: &VoipHost) -> Resu
 
 fn backend_event_envelopes(
     events: Vec<host::BackendEvent>,
+    lifecycle_events: Vec<host::LifecycleEvent>,
     host: &VoipHost,
 ) -> Vec<WorkerEnvelope> {
-    if events.is_empty() {
+    if events.is_empty() && lifecycle_events.is_empty() {
         return Vec::new();
     }
     let mut envelopes: Vec<WorkerEnvelope> =
         events.into_iter().map(backend_event_envelope).collect();
+    envelopes.extend(lifecycle_events.into_iter().map(lifecycle_event_envelope));
     envelopes.push(session_snapshot_envelope(host));
     envelopes
+}
+
+fn write_lifecycle_events(host: &mut VoipHost) -> Result<()> {
+    for event in host.take_lifecycle_events() {
+        write_envelope(&lifecycle_event_envelope(event))?;
+    }
+    Ok(())
+}
+
+fn lifecycle_event_envelope(event: host::LifecycleEvent) -> WorkerEnvelope {
+    WorkerEnvelope::event(
+        "voip.lifecycle_changed",
+        json!({
+            "state": event.state,
+            "previous_state": event.previous_state,
+            "reason": event.reason,
+            "recovered": event.recovered,
+        }),
+    )
 }
 
 fn write_session_snapshot(host: &VoipHost) -> Result<()> {
@@ -611,6 +644,7 @@ mod tests {
                 state: "ok".to_string(),
                 reason: "".to_string(),
             }],
+            vec![],
             &host,
         );
 
@@ -619,6 +653,104 @@ mod tests {
         assert_eq!(envelopes[1].message_type, "voip.snapshot");
         assert_eq!(envelopes[1].payload["registered"], true);
         assert_eq!(envelopes[1].payload["registration_state"], "ok");
+    }
+
+    #[test]
+    fn backend_event_batch_appends_lifecycle_before_snapshot() {
+        struct EventBackend {
+            events: Vec<host::BackendEvent>,
+        }
+
+        impl host::CallBackend for EventBackend {
+            fn start(&mut self, _config: &VoipConfig) -> std::result::Result<(), String> {
+                Ok(())
+            }
+
+            fn stop(&mut self) {}
+
+            fn iterate(&mut self) -> std::result::Result<Vec<host::BackendEvent>, String> {
+                Ok(std::mem::take(&mut self.events))
+            }
+
+            fn make_call(&mut self, _sip_address: &str) -> std::result::Result<String, String> {
+                Ok("call-outgoing".to_string())
+            }
+
+            fn answer_call(&mut self) -> std::result::Result<(), String> {
+                Ok(())
+            }
+
+            fn reject_call(&mut self) -> std::result::Result<(), String> {
+                Ok(())
+            }
+
+            fn hangup(&mut self) -> std::result::Result<(), String> {
+                Ok(())
+            }
+
+            fn set_muted(&mut self, _muted: bool) -> std::result::Result<(), String> {
+                Ok(())
+            }
+
+            fn send_text_message(
+                &mut self,
+                _sip_address: &str,
+                _text: &str,
+            ) -> std::result::Result<String, String> {
+                Ok("backend-msg-1".to_string())
+            }
+
+            fn start_voice_recording(
+                &mut self,
+                _file_path: &str,
+            ) -> std::result::Result<(), String> {
+                Ok(())
+            }
+
+            fn stop_voice_recording(&mut self) -> std::result::Result<i32, String> {
+                Ok(1250)
+            }
+
+            fn cancel_voice_recording(&mut self) -> std::result::Result<(), String> {
+                Ok(())
+            }
+
+            fn send_voice_note(
+                &mut self,
+                _sip_address: &str,
+                _file_path: &str,
+                _duration_ms: i32,
+                _mime_type: &str,
+            ) -> std::result::Result<String, String> {
+                Ok("backend-vn-1".to_string())
+            }
+        }
+
+        let mut host = VoipHost::default();
+        host.configure(
+            VoipConfig::from_payload(&json!({
+                "sip_server": "sip.example.com",
+                "sip_identity": "sip:alice@example.com"
+            }))
+            .expect("config"),
+        );
+        host.take_lifecycle_events();
+        let mut backend = EventBackend {
+            events: vec![host::BackendEvent::BackendStopped {
+                reason: "iterate failed".to_string(),
+            }],
+        };
+        let events = host.poll_backend_events(&mut backend).expect("poll");
+
+        let envelopes = backend_event_envelopes(events, host.take_lifecycle_events(), &host);
+
+        assert_eq!(envelopes.len(), 3);
+        assert_eq!(envelopes[0].message_type, "voip.backend_stopped");
+        assert_eq!(envelopes[1].message_type, "voip.lifecycle_changed");
+        assert_eq!(envelopes[1].payload["state"], "failed");
+        assert_eq!(envelopes[1].payload["reason"], "iterate failed");
+        assert_eq!(envelopes[2].message_type, "voip.snapshot");
+        assert_eq!(envelopes[2].payload["lifecycle"]["state"], "failed");
     }
 
     #[test]

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -542,6 +542,40 @@ def test_worker_startup_error_stops_worker_and_marks_backend_stopped() -> None:
     assert supervisor.started == ["voip", "voip"]
 
 
+def test_worker_lifecycle_failure_owns_startup_stopped_event() -> None:
+    supervisor = _SingleRunningSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+    backend.start()
+
+    backend.handle_worker_message(
+        _event(
+            "voip.lifecycle_changed",
+            {
+                "state": "failed",
+                "previous_state": "registering",
+                "reason": "shim missing",
+                "recovered": False,
+            },
+        )
+    )
+    backend.handle_worker_message(
+        _reply(
+            "error",
+            "voip.error",
+            {"code": "command_failed", "message": "shim missing"},
+            request_id=supervisor.request_ids[1],
+        )
+    )
+
+    assert backend.running is False
+    assert supervisor.stopped == [("voip", 1.0)]
+    stopped = [event for event in received if isinstance(event, BackendStopped)]
+    assert len(stopped) == 1
+    assert stopped[0].reason == "shim missing"
+
+
 def test_startup_send_failure_stops_worker_before_returning_false() -> None:
     supervisor = _RejectingStartupSupervisor("voip.register")
     backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
@@ -609,8 +643,22 @@ def test_ready_after_worker_restart_resends_configure_register() -> None:
     assert backend.running is True
     assert isinstance(received[0], BackendStopped)
     assert received[0].reason == "process_exited"
+    assert len(received) == 1
+
+    backend.handle_worker_message(
+        _event(
+            "voip.lifecycle_changed",
+            {
+                "state": "registered",
+                "previous_state": "registering",
+                "reason": "registered",
+                "recovered": True,
+            },
+        )
+    )
+
     assert isinstance(received[1], BackendRecovered)
-    assert received[1].reason == "worker_ready"
+    assert received[1].reason == "registered"
 
 
 def test_iterate_is_noop() -> None:

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -576,6 +576,32 @@ def test_worker_lifecycle_failure_owns_startup_stopped_event() -> None:
     assert stopped[0].reason == "shim missing"
 
 
+def test_restart_register_error_without_lifecycle_event_reports_backend_stopped() -> None:
+    supervisor = _SingleRunningSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+    backend.start()
+
+    backend.stop()
+    received.clear()
+
+    assert backend.start() is True
+    backend.handle_worker_message(
+        _reply(
+            "error",
+            "voip.error",
+            {"code": "command_failed", "message": "shim missing"},
+            request_id=supervisor.request_ids[-1],
+        )
+    )
+
+    assert backend.running is False
+    stopped = [event for event in received if isinstance(event, BackendStopped)]
+    assert len(stopped) == 1
+    assert stopped[0].reason == "voip.register command_failed: shim missing"
+
+
 def test_startup_send_failure_stops_worker_before_returning_false() -> None:
     supervisor = _RejectingStartupSupervisor("voip.register")
     backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -200,6 +200,30 @@ def test_delayed_intentional_stop_state_does_not_emit_backend_stopped() -> None:
     assert backend.running is False
 
 
+def test_delayed_intentional_lifecycle_stop_does_not_emit_backend_stopped() -> None:
+    supervisor = _StrictSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+    backend.start()
+
+    backend.stop()
+    backend.handle_worker_message(
+        _event(
+            "voip.lifecycle_changed",
+            {
+                "state": "stopped",
+                "previous_state": "registered",
+                "reason": "unregistered",
+                "recovered": False,
+            },
+        )
+    )
+
+    assert not received
+    assert backend.running is False
+
+
 def test_call_commands_send_worker_commands() -> None:
     supervisor = _FakeSupervisor()
     backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -53,6 +53,7 @@ _VOICE_NOTE_RECORDING_COMMANDS = frozenset(
     }
 )
 _INTENTIONAL_STOP_REASONS = frozenset({"stop", "stop_all"})
+_INTENTIONAL_LIFECYCLE_STOP_REASONS = frozenset({"unregistered", "shutdown"})
 
 
 class RustHostBackend:
@@ -466,6 +467,11 @@ class RustHostBackend:
         reason = str(payload.get("reason", "") or "").strip() or state
         recovered = _bool_payload(payload.get("recovered", False))
         self._last_lifecycle_state = state
+        if state == "stopped" and (
+            self._stopping or reason in _INTENTIONAL_LIFECYCLE_STOP_REASONS
+        ):
+            self.running = False
+            return
         if state in {"failed", "stopped"}:
             self._mark_stopped(reason)
             return

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -380,6 +380,7 @@ class RustHostBackend:
         return merged
 
     def _send_startup_commands(self) -> bool:
+        self._last_lifecycle_state = "starting"
         if not self._send("voip.configure", self._config_payload()):
             return False
         if not self._send("voip.register", {}):

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -88,6 +88,7 @@ class RustHostBackend:
         self._recording_start_monotonic: float | None = None
         self._snapshot_registration_state = RegistrationState.NONE
         self._snapshot_call_state = CallState.IDLE
+        self._last_lifecycle_state = "unconfigured"
 
     def on_event(self, callback: Callable[[VoIPEvent], None]) -> None:
         self.event_callbacks.append(callback)
@@ -150,6 +151,7 @@ class RustHostBackend:
             self._recording_start_monotonic = None
             self._snapshot_registration_state = RegistrationState.NONE
             self._snapshot_call_state = CallState.IDLE
+            self._last_lifecycle_state = "stopped"
             self.running = False
             self._stopping = False
 
@@ -256,6 +258,9 @@ class RustHostBackend:
             return
         if event_type == "voip.snapshot":
             self._handle_session_snapshot(payload)
+            return
+        if event_type == "voip.lifecycle_changed":
+            self._handle_lifecycle_changed(payload)
             return
         if event_type == "voip.registration_changed":
             self._dispatch_registration_state(
@@ -385,14 +390,10 @@ class RustHostBackend:
     def _handle_worker_ready(self) -> None:
         if self._reconfigure_on_ready or not self._startup_commands_sent:
             logger.info("Rust VoIP Host ready; sending configure/register")
-            was_stopped = self._last_stop_reason is not None
             if not self._send_startup_commands():
                 self._stop_after_startup_command_failure("worker_ready_reconfigure_failed")
                 return
             self.running = True
-            self._last_stop_reason = None
-            if was_stopped:
-                self._dispatch(BackendRecovered(reason="worker_ready"))
         self._ready_seen = True
         self._reconfigure_on_ready = False
 
@@ -401,7 +402,10 @@ class RustHostBackend:
         reason = _worker_error_reason(payload, command=command)
         message_id = self._pending_message_ids.pop(request_id, "") if request_id else ""
         if command in _STARTUP_COMMANDS or command is None:
-            self._stop_after_startup_command_failure(reason)
+            self._stop_after_startup_command_failure(
+                reason,
+                notify_backend_stopped=self._last_lifecycle_state not in {"failed", "stopped"},
+            )
             return
         if command in _CALL_CONTROL_COMMANDS:
             logger.warning("Rust VoIP Host call command failed: {}", reason)
@@ -447,11 +451,29 @@ class RustHostBackend:
         self._recording_start_monotonic = None
         self._snapshot_registration_state = RegistrationState.NONE
         self._snapshot_call_state = CallState.IDLE
+        self._last_lifecycle_state = "failed"
         self.running = False
         if notify_backend_stopped:
             self._mark_stopped(reason)
         else:
             self._last_stop_reason = reason
+
+    def _handle_lifecycle_changed(self, payload: dict[str, Any]) -> None:
+        state = str(payload.get("state", "") or "").strip()
+        if not state:
+            return
+        reason = str(payload.get("reason", "") or "").strip() or state
+        recovered = _bool_payload(payload.get("recovered", False))
+        self._last_lifecycle_state = state
+        if state in {"failed", "stopped"}:
+            self._mark_stopped(reason)
+            return
+        if state == "registered":
+            was_stopped = self._last_stop_reason is not None
+            self.running = True
+            if recovered or was_stopped:
+                self._dispatch(BackendRecovered(reason=reason))
+            self._last_stop_reason = None
 
     def _handle_session_snapshot(self, payload: dict[str, Any]) -> None:
         registration_state = str(payload.get("registration_state", "") or "").strip()
@@ -479,6 +501,8 @@ class RustHostBackend:
             return
         self.running = False
         self._last_stop_reason = reason
+        if self._last_lifecycle_state != "stopped":
+            self._last_lifecycle_state = "failed"
         self._dispatch(BackendStopped(reason=reason))
 
     def _next_request_id(self, message_type: str) -> str:


### PR DESCRIPTION
## Summary
- add Rust-owned VoIP lifecycle state for configured, registering, registered, failed, stopped, and recovered paths
- emit `voip.lifecycle_changed` and include lifecycle state in `voip.snapshot`/health payloads
- make Python RustHostBackend use Rust lifecycle events for backend stopped/recovered decisions instead of recovering from `voip.ready`

## Verification
- cargo fmt --manifest-path src/Cargo.toml --all --check
- cargo test --manifest-path src/Cargo.toml --workspace --locked
- uv run python scripts/quality.py gate
- uv run pytest -q