### PR TITLE
Promote Rust VoIP runtime snapshots

### DIFF
--- a/docs/superpowers/plans/2026-04-29-rust-voip-runtime-facade.md
+++ b/docs/superpowers/plans/2026-04-29-rust-voip-runtime-facade.md
@@ -1,0 +1,112 @@
+# Rust VoIP Runtime Facade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Rust VoIP host the canonical owner for live VoIP runtime state while Python remains the app supervisor, persistence mirror, UI bridge, and music coordination bridge.
+
+**Architecture:** The Rust worker already owns liblinphone and emits `voip.snapshot` events. This slice promotes those snapshots into the app-facing state source: Python parses typed Rust snapshots, mirrors them into `VoIPManager`, and keeps existing Python services as compatibility/persistence adapters. Commands still flow through the existing `VoIPBackend` facade so current UI and voice command surfaces do not change.
+
+**Tech Stack:** Rust 2021 workspace under `src/`, Python 3.12, NDJSON worker protocol, pytest, Cargo tests, GitHub Actions ARM64 artifacts, Raspberry Pi Zero 2W.
+
+---
+
+## Scope
+
+This is one PR after the hardware validation of `9eab168b88a9ffe964d4738ad3ba854846161d98`.
+
+In scope:
+
+- Typed Rust VoIP runtime snapshot model on the Python side.
+- `RustHostBackend` stores the latest Rust-owned snapshot.
+- `RustHostBackend` dispatches a snapshot event when Rust emits `voip.snapshot`.
+- `VoIPManager` mirrors registration, call, lifecycle, active peer, active call id, active voice-note state, and last message facts from the Rust snapshot.
+- Python message store and call history remain persistence mirrors.
+- Existing Python UI/runtime consumers keep using `VoIPManager`.
+
+Out of scope:
+
+- Moving app bus, scheduler, UI host, music interruption policy, contacts directory, config loading, or file persistence to Rust.
+- Removing the Python sidecar or in-process Liblinphone fallback.
+- Replacing the C liblinphone shim with direct Rust bindings.
+
+## Task 1: Add Typed Runtime Snapshot Models
+
+**Files:**
+- Modify: `yoyopod/integrations/call/models.py`
+- Test: `tests/backends/test_rust_host_voip.py`
+
+- [x] Add frozen dataclasses for `VoIPLifecycleSnapshot`, `VoIPVoiceNoteSnapshot`, `VoIPMessageSnapshot`, `VoIPRuntimeSnapshot`, and `VoIPRuntimeSnapshotChanged`.
+- [x] Keep enum conversion strict at the adapter edge, not inside the dataclasses.
+- [x] Add tests proving a Rust `voip.snapshot` payload becomes a typed snapshot event.
+
+## Task 2: Promote Rust Snapshots in `RustHostBackend`
+
+**Files:**
+- Modify: `yoyopod/backends/voip/rust_host.py`
+- Test: `tests/backends/test_rust_host_voip.py`
+
+- [x] Store the latest typed snapshot on every `voip.snapshot`.
+- [x] Expose `get_runtime_snapshot() -> VoIPRuntimeSnapshot | None`.
+- [x] Dispatch `VoIPRuntimeSnapshotChanged` after the existing deduplicated registration/call updates.
+- [x] Preserve existing `RegistrationStateChanged` and `CallStateChanged` events for compatibility.
+- [x] Treat malformed snapshot enum fields as safe defaults instead of crashing the worker bridge.
+
+## Task 3: Mirror Rust-Owned State in `VoIPManager`
+
+**Files:**
+- Modify: `yoyopod/integrations/call/manager.py`
+- Test: `tests/backends/test_voip_backend.py`
+
+- [x] Handle `VoIPRuntimeSnapshotChanged`.
+- [x] Mirror `running`, `registered`, `registration_state`, `call_state`, `current_call_id`, and `caller_address`.
+- [x] Continue using `_update_registration_state()` and `_update_call_state()` where callbacks are expected.
+- [x] Avoid duplicate callback emissions when individual events and snapshots report the same state.
+- [x] Keep `CallRuntime` and music interruption behavior driven by current callbacks for this PR.
+
+## Task 4: Mirror Rust Voice-Note Runtime Facts
+
+**Files:**
+- Modify: `yoyopod/integrations/call/voice_notes.py`
+- Test: `tests/integrations/test_voip_services.py`
+
+- [x] Add an `apply_runtime_snapshot()` method that updates an active draft from Rust voice-note state.
+- [x] Preserve existing Python-created draft metadata: recipient, display name, local file, and send timeout.
+- [x] Map Rust `recording`, `recorded`, `sending`, `sent`, `failed`, and `idle` to existing UI-facing `send_state` values.
+- [x] Do not delete local files just because Rust reports `idle`; only explicit discard/cancel deletes.
+
+## Task 5: Mirror Rust Last-Message Facts Without Taking Over Persistence
+
+**Files:**
+- Modify: `yoyopod/integrations/call/messaging.py`
+- Test: `tests/integrations/test_voip_services.py`
+
+- [x] Add an `apply_runtime_snapshot()` method for `last_message`.
+- [x] Use it to update known records when Rust reports a delivery state or local file path.
+- [x] Do not create incomplete records without peer/kind/direction; wait for normal message events for that.
+- [x] Notify summary callbacks only when mirrored persistence changes.
+
+## Task 6: Rust Snapshot Contract Coverage
+
+**Files:**
+- Modify: `src/crates/voip-host/src/host.rs`
+- Modify: `src/crates/voip-host/src/main.rs`
+- Test: Rust unit tests under `src/crates/voip-host/src/`
+
+- [x] Ensure `voip.snapshot` includes lifecycle, call, voice-note, pending outbound message, and last-message facts after relevant commands/events.
+- [x] Keep the schema compatible with existing merged fields.
+- [x] Add tests for voice-note and message snapshot updates after worker command paths.
+
+Note: the Rust host implementation and tests already satisfied this task in the merged baseline; this slice verified them with the workspace Cargo test suite and added the Python adapter/manager coverage.
+
+## Task 7: Verification and PR Prep
+
+**Files:**
+- Modify docs only if the runtime contract changes beyond current docs.
+
+- [x] Run focused Python tests after each task.
+- [x] Run `cargo fmt --manifest-path src/Cargo.toml --all --check`.
+- [x] Run `cargo test --manifest-path src/Cargo.toml --workspace --locked`.
+- [x] Run `uv run python scripts/quality.py gate`.
+- [x] Run `uv run pytest -q`.
+- [ ] Commit and push once the full gate passes.
+- [ ] Open a single PR with commits grouped by snapshot model, Python bridge, Rust contract, and tests.

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -20,6 +20,7 @@ from yoyopod.integrations.call.models import (
     RegistrationState,
     RegistrationStateChanged,
     VoIPConfig,
+    VoIPRuntimeSnapshotChanged,
 )
 
 
@@ -474,9 +475,83 @@ def test_worker_snapshot_updates_registration_and_call_state_without_duplicates(
         )
     )
 
-    assert [type(event) for event in received] == [RegistrationStateChanged, CallStateChanged]
-    assert received[0].state == RegistrationState.OK
-    assert received[1].state == CallState.STREAMS_RUNNING
+    compatibility_events = [
+        event
+        for event in received
+        if isinstance(event, RegistrationStateChanged | CallStateChanged)
+    ]
+    snapshot_events = [event for event in received if isinstance(event, VoIPRuntimeSnapshotChanged)]
+
+    assert [type(event) for event in compatibility_events] == [
+        RegistrationStateChanged,
+        CallStateChanged,
+    ]
+    assert compatibility_events[0].state == RegistrationState.OK
+    assert compatibility_events[1].state == CallState.STREAMS_RUNNING
+    assert len(snapshot_events) == 2
+
+
+def test_worker_snapshot_dispatches_typed_runtime_snapshot() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    received: list[object] = []
+    backend.on_event(received.append)
+
+    backend.handle_worker_message(
+        _event(
+            "voip.snapshot",
+            {
+                "configured": True,
+                "registered": True,
+                "registration_state": "ok",
+                "call_state": "streams_running",
+                "active_call_id": "call-1",
+                "active_call_peer": "sip:bob@example.com",
+                "pending_outbound_messages": 2,
+                "lifecycle": {
+                    "state": "registered",
+                    "reason": "registered",
+                    "backend_available": True,
+                },
+                "voice_note": {
+                    "state": "sending",
+                    "file_path": "/tmp/note.wav",
+                    "duration_ms": 1200,
+                    "mime_type": "audio/wav",
+                    "message_id": "msg-1",
+                },
+                "last_message": {
+                    "message_id": "msg-1",
+                    "kind": "voice_note",
+                    "direction": "outgoing",
+                    "delivery_state": "sent",
+                    "local_file_path": "/tmp/note.wav",
+                    "error": "",
+                },
+            },
+        )
+    )
+
+    snapshot_events = [event for event in received if isinstance(event, VoIPRuntimeSnapshotChanged)]
+    assert len(snapshot_events) == 1
+    snapshot = snapshot_events[0].snapshot
+    assert backend.get_runtime_snapshot() == snapshot
+    assert snapshot.configured is True
+    assert snapshot.registered is True
+    assert snapshot.registration_state == RegistrationState.OK
+    assert snapshot.call_state == CallState.STREAMS_RUNNING
+    assert snapshot.active_call_id == "call-1"
+    assert snapshot.active_call_peer == "sip:bob@example.com"
+    assert snapshot.pending_outbound_messages == 2
+    assert snapshot.lifecycle.state == "registered"
+    assert snapshot.lifecycle.backend_available is True
+    assert snapshot.voice_note.state == "sending"
+    assert snapshot.voice_note.file_path == "/tmp/note.wav"
+    assert snapshot.voice_note.message_id == "msg-1"
+    assert snapshot.last_message is not None
+    assert snapshot.last_message.message_id == "msg-1"
+    assert snapshot.last_message.kind == MessageKind.VOICE_NOTE
+    assert snapshot.last_message.delivery_state == MessageDeliveryState.SENT
 
 
 def test_worker_message_events_translate_to_voip_events() -> None:

--- a/tests/backends/test_voip_backend.py
+++ b/tests/backends/test_voip_backend.py
@@ -31,7 +31,12 @@ from yoyopod.integrations.call.models import (
     RegistrationStateChanged,
     VoIPConfig,
     VoIPEvent,
+    VoIPLifecycleSnapshot,
+    VoIPMessageSnapshot,
     VoIPMessageRecord,
+    VoIPRuntimeSnapshot,
+    VoIPRuntimeSnapshotChanged,
+    VoIPVoiceNoteSnapshot,
 )
 from yoyopod.integrations.call import VoIPManager
 
@@ -420,6 +425,47 @@ def test_voip_manager_applies_backend_events_and_resolves_contact_names() -> Non
     assert manager.get_caller_info()["display_name"] == "Parent"
 
 
+def test_voip_manager_mirrors_rust_runtime_snapshot_without_duplicate_callbacks() -> None:
+    """Rust-owned runtime snapshots should become the app-facing live VoIP state."""
+
+    backend = MockVoIPBackend()
+    people_directory = FakePeopleDirectory({"sip:bob@example.com": "Bob"})
+    manager = VoIPManager(build_config(), people_directory=people_directory, backend=backend)
+    registration_states: list[RegistrationState] = []
+    call_states: list[CallState] = []
+    manager.on_registration_change(registration_states.append)
+    manager.on_call_state_change(call_states.append)
+
+    assert manager.start()
+    snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        call_state=CallState.STREAMS_RUNNING,
+        active_call_id="call-1",
+        active_call_peer="sip:bob@example.com",
+        pending_outbound_messages=1,
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+    )
+
+    backend.emit(VoIPRuntimeSnapshotChanged(snapshot=snapshot))
+    backend.emit(VoIPRuntimeSnapshotChanged(snapshot=snapshot))
+
+    assert manager.running is True
+    assert manager.registered is True
+    assert manager.registration_state == RegistrationState.OK
+    assert manager.call_state == CallState.STREAMS_RUNNING
+    assert manager.current_call_id == "call-1"
+    assert manager.caller_address == "sip:bob@example.com"
+    assert manager.get_caller_info()["display_name"] == "Bob"
+    assert registration_states == [RegistrationState.OK]
+    assert call_states == [CallState.STREAMS_RUNNING]
+
+
 def test_voip_manager_delegates_outgoing_commands_to_backend() -> None:
     """Outgoing commands should not invent local call phases before backend events arrive."""
 
@@ -494,6 +540,48 @@ def test_voip_manager_tracks_voice_note_send_and_delivery() -> None:
     )
 
     assert manager.get_active_voice_note().send_state == "sent"
+
+
+def test_voip_manager_routes_rust_runtime_snapshot_to_voice_note_and_message_mirrors() -> None:
+    """VoIPManager should fan Rust snapshots into its compatibility services."""
+
+    backend = MockVoIPBackend()
+    manager = VoIPManager(build_config(), backend=backend)
+
+    assert manager.start()
+    assert manager.start_voice_note_recording("sip:mom@example.com", recipient_name="Mom")
+    assert manager.stop_voice_note_recording() is not None
+    assert manager.send_active_voice_note()
+    draft = manager.get_active_voice_note()
+    assert draft is not None
+
+    backend.emit(
+        VoIPRuntimeSnapshotChanged(
+            snapshot=VoIPRuntimeSnapshot(
+                voice_note=VoIPVoiceNoteSnapshot(
+                    state="sent",
+                    file_path=draft.file_path,
+                    duration_ms=draft.duration_ms,
+                    mime_type=draft.mime_type,
+                    message_id=draft.message_id,
+                ),
+                last_message=VoIPMessageSnapshot(
+                    message_id=draft.message_id,
+                    kind=MessageKind.VOICE_NOTE,
+                    direction=MessageDirection.OUTGOING,
+                    delivery_state=MessageDeliveryState.DELIVERED,
+                    local_file_path=draft.file_path,
+                ),
+            )
+        )
+    )
+
+    active = manager.get_active_voice_note()
+    assert active is not None
+    assert active.send_state == "sent"
+    stored = manager.latest_voice_note_for_contact("sip:mom@example.com")
+    assert stored is not None
+    assert stored.delivery_state == MessageDeliveryState.DELIVERED
 
 
 def test_voip_manager_fails_voice_note_send_without_transfer_server() -> None:
@@ -841,9 +929,9 @@ def test_voip_manager_builds_message_store_under_directory(tmp_path: Path) -> No
 def test_liblinphone_shim_records_voice_notes_as_wav() -> None:
     """The native recorder shim should explicitly match the .wav files used by the app."""
 
-    shim_source = Path(
-        "yoyopod/backends/voip/shim_native/liblinphone_shim.c"
-    ).read_text(encoding="utf-8")
+    shim_source = Path("yoyopod/backends/voip/shim_native/liblinphone_shim.c").read_text(
+        encoding="utf-8"
+    )
 
     assert (
         "linphone_recorder_params_set_file_format(params, LinphoneRecorderFileFormatWav);"
@@ -854,9 +942,9 @@ def test_liblinphone_shim_records_voice_notes_as_wav() -> None:
 def test_liblinphone_shim_wires_incoming_message_debug_paths() -> None:
     """The native shim should cover aggregated and undecryptable incoming message paths."""
 
-    shim_source = Path(
-        "yoyopod/backends/voip/shim_native/liblinphone_shim.c"
-    ).read_text(encoding="utf-8")
+    shim_source = Path("yoyopod/backends/voip/shim_native/liblinphone_shim.c").read_text(
+        encoding="utf-8"
+    )
 
     assert (
         "linphone_core_cbs_set_messages_received(g_state.core_cbs, yoyopod_on_messages_received);"

--- a/tests/integrations/test_voip_services.py
+++ b/tests/integrations/test_voip_services.py
@@ -15,7 +15,10 @@ from yoyopod.integrations.call.models import (
     MessageFailed,
     MessageKind,
     VoIPConfig,
+    VoIPMessageSnapshot,
     VoIPMessageRecord,
+    VoIPRuntimeSnapshot,
+    VoIPVoiceNoteSnapshot,
 )
 from yoyopod.integrations.call import VoiceNoteService
 
@@ -138,6 +141,66 @@ def test_messaging_service_decorates_and_persists_incoming_messages(tmp_path: Pa
     assert stored is not None
     assert stored.display_name == "Mom"
     assert received[-1].display_name == "Mom"
+
+
+def test_messaging_service_applies_runtime_snapshot_to_known_message_once(
+    tmp_path: Path,
+) -> None:
+    """Rust last-message snapshots should mirror known records without duplicate summaries."""
+
+    config = build_config(tmp_path)
+    service = MessagingService(
+        config=config,
+        backend=MockVoIPBackend(),
+        message_store=build_message_store(config),
+        lookup_contact_name=lookup_contact_name,
+    )
+    summary_events: list[str] = []
+    service.on_message_summary_change(lambda _unread, _summary: summary_events.append("changed"))
+    service.message_store.upsert(
+        VoIPMessageRecord(
+            id="msg-1",
+            peer_sip_address="sip:mom@example.com",
+            sender_sip_address="sip:alice@example.com",
+            recipient_sip_address="sip:mom@example.com",
+            kind=MessageKind.VOICE_NOTE,
+            direction=MessageDirection.OUTGOING,
+            delivery_state=MessageDeliveryState.SENDING,
+            created_at="2026-04-29T00:00:00+00:00",
+            updated_at="2026-04-29T00:00:00+00:00",
+            local_file_path="",
+        )
+    )
+    snapshot = VoIPRuntimeSnapshot(
+        last_message=VoIPMessageSnapshot(
+            message_id="msg-1",
+            kind=MessageKind.VOICE_NOTE,
+            direction=MessageDirection.OUTGOING,
+            delivery_state=MessageDeliveryState.DELIVERED,
+            local_file_path="/tmp/note.wav",
+        )
+    )
+
+    service.apply_runtime_snapshot(snapshot)
+    service.apply_runtime_snapshot(snapshot)
+    service.apply_runtime_snapshot(
+        VoIPRuntimeSnapshot(
+            last_message=VoIPMessageSnapshot(
+                message_id="unknown",
+                kind=MessageKind.VOICE_NOTE,
+                direction=MessageDirection.OUTGOING,
+                delivery_state=MessageDeliveryState.DELIVERED,
+                local_file_path="/tmp/unknown.wav",
+            )
+        )
+    )
+
+    stored = service.message_store.get("msg-1")
+    assert stored is not None
+    assert stored.delivery_state == MessageDeliveryState.DELIVERED
+    assert stored.local_file_path == "/tmp/note.wav"
+    assert service.message_store.get("unknown") is None
+    assert summary_events == ["changed"]
 
 
 def test_message_store_tracks_unread_voice_note_counts_by_contact(tmp_path: Path) -> None:
@@ -288,6 +351,72 @@ def test_voice_note_service_updates_active_draft_on_delivery_and_failure(
     assert failed is not None
     assert failed.send_state == "failed"
     assert failed.status_text == "Upload failed"
+
+
+def test_voice_note_service_applies_runtime_snapshot_to_active_draft(
+    tmp_path: Path,
+) -> None:
+    """Rust voice-note snapshots should update state without wiping local draft metadata."""
+
+    config = build_config(tmp_path)
+    service = VoiceNoteService(
+        config=config,
+        backend=MockVoIPBackend(),
+        message_store=build_message_store(config),
+        lookup_contact_name=lookup_contact_name,
+        notify_message_summary_change=lambda: None,
+    )
+    assert service.start_voice_note_recording("sip:mom@example.com", "Mom")
+    assert service.stop_voice_note_recording() is not None
+    assert service.send_active_voice_note() is True
+    draft = service.get_active_voice_note()
+    assert draft is not None
+    original_path = draft.file_path
+    draft.send_started_at = 42.0
+
+    service.apply_runtime_snapshot(
+        VoIPRuntimeSnapshot(
+            voice_note=VoIPVoiceNoteSnapshot(
+                state="sending",
+                file_path="",
+                duration_ms=2400,
+                mime_type="audio/ogg",
+                message_id="rust-msg-1",
+            )
+        )
+    )
+
+    sending = service.get_active_voice_note()
+    assert sending is not None
+    assert sending.recipient_address == "sip:mom@example.com"
+    assert sending.recipient_name == "Mom"
+    assert sending.file_path == original_path
+    assert sending.duration_ms == 2400
+    assert sending.mime_type == "audio/ogg"
+    assert sending.message_id == "rust-msg-1"
+    assert sending.send_state == "sending"
+    assert sending.status_text == "Sending..."
+    assert sending.send_started_at == 42.0
+
+    service.apply_runtime_snapshot(
+        VoIPRuntimeSnapshot(
+            voice_note=VoIPVoiceNoteSnapshot(
+                state="failed",
+                message_id="rust-msg-1",
+            ),
+            last_message=VoIPMessageSnapshot(
+                message_id="rust-msg-1",
+                delivery_state=MessageDeliveryState.FAILED,
+                error="Upload failed",
+            ),
+        )
+    )
+
+    failed = service.get_active_voice_note()
+    assert failed is not None
+    assert failed.send_state == "failed"
+    assert failed.status_text == "Upload failed"
+    assert failed.send_started_at == 0.0
 
 
 def test_voice_note_service_enforces_send_timeout_and_marks_store_failed(tmp_path: Path) -> None:

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -31,7 +31,12 @@ from yoyopod.integrations.call.models import (
     RegistrationStateChanged,
     VoIPConfig,
     VoIPEvent,
+    VoIPLifecycleSnapshot,
+    VoIPMessageSnapshot,
     VoIPMessageRecord,
+    VoIPRuntimeSnapshot,
+    VoIPRuntimeSnapshotChanged,
+    VoIPVoiceNoteSnapshot,
 )
 
 _STARTUP_COMMANDS = frozenset({"voip.configure", "voip.register"})
@@ -87,6 +92,7 @@ class RustHostBackend:
         self._stopping = False
         self._last_stop_reason: str | None = None
         self._recording_start_monotonic: float | None = None
+        self._runtime_snapshot: VoIPRuntimeSnapshot | None = None
         self._snapshot_registration_state = RegistrationState.NONE
         self._snapshot_call_state = CallState.IDLE
         self._last_lifecycle_state = "unconfigured"
@@ -150,6 +156,7 @@ class RustHostBackend:
             self._ready_seen = False
             self._reconfigure_on_ready = False
             self._recording_start_monotonic = None
+            self._runtime_snapshot = None
             self._snapshot_registration_state = RegistrationState.NONE
             self._snapshot_call_state = CallState.IDLE
             self._last_lifecycle_state = "stopped"
@@ -161,6 +168,11 @@ class RustHostBackend:
 
     def get_iterate_metrics(self) -> VoIPIterateMetrics | None:
         return None
+
+    def get_runtime_snapshot(self) -> VoIPRuntimeSnapshot | None:
+        """Return the latest canonical runtime snapshot emitted by the Rust worker."""
+
+        return self._runtime_snapshot
 
     def make_call(self, sip_address: str) -> bool:
         return self._send("voip.dial", {"uri": sip_address})
@@ -451,6 +463,7 @@ class RustHostBackend:
         self._ready_seen = False
         self._reconfigure_on_ready = False
         self._recording_start_monotonic = None
+        self._runtime_snapshot = None
         self._snapshot_registration_state = RegistrationState.NONE
         self._snapshot_call_state = CallState.IDLE
         self._last_lifecycle_state = "failed"
@@ -467,9 +480,7 @@ class RustHostBackend:
         reason = str(payload.get("reason", "") or "").strip() or state
         recovered = _bool_payload(payload.get("recovered", False))
         self._last_lifecycle_state = state
-        if state == "stopped" and (
-            self._stopping or reason in _INTENTIONAL_LIFECYCLE_STOP_REASONS
-        ):
+        if state == "stopped" and (self._stopping or reason in _INTENTIONAL_LIFECYCLE_STOP_REASONS):
             self.running = False
             return
         if state in {"failed", "stopped"}:
@@ -483,13 +494,11 @@ class RustHostBackend:
             self._last_stop_reason = None
 
     def _handle_session_snapshot(self, payload: dict[str, Any]) -> None:
-        registration_state = str(payload.get("registration_state", "") or "").strip()
-        if not registration_state:
-            registration_state = (
-                "ok" if _bool_payload(payload.get("registered", False)) else "none"
-            )
-        self._dispatch_registration_state(_registration_state(registration_state))
-        self._dispatch_call_state(_call_state(str(payload.get("call_state", "idle"))))
+        snapshot = _runtime_snapshot(payload)
+        self._runtime_snapshot = snapshot
+        self._dispatch_registration_state(snapshot.registration_state)
+        self._dispatch_call_state(snapshot.call_state)
+        self._dispatch(VoIPRuntimeSnapshotChanged(snapshot=snapshot))
 
     def _dispatch_registration_state(self, state: RegistrationState) -> None:
         if state == self._snapshot_registration_state:
@@ -575,6 +584,61 @@ def _message_record(payload: dict[str, Any]) -> VoIPMessageRecord | None:
         unread=_bool_payload(payload.get("unread", False)),
         display_name=str(payload.get("display_name", "")),
     )
+
+
+def _runtime_snapshot(payload: dict[str, Any]) -> VoIPRuntimeSnapshot:
+    lifecycle_payload = _dict_payload(payload.get("lifecycle"))
+    voice_note_payload = _dict_payload(payload.get("voice_note"))
+    return VoIPRuntimeSnapshot(
+        configured=_bool_payload(payload.get("configured", False)),
+        registered=_bool_payload(payload.get("registered", False)),
+        registration_state=_registration_state(_snapshot_registration_value(payload)),
+        call_state=_call_state(str(payload.get("call_state", "idle"))),
+        active_call_id=str(payload.get("active_call_id", "") or ""),
+        active_call_peer=str(payload.get("active_call_peer", "") or ""),
+        pending_outbound_messages=_duration_ms(payload.get("pending_outbound_messages")),
+        lifecycle=VoIPLifecycleSnapshot(
+            state=str(lifecycle_payload.get("state", "unconfigured") or "unconfigured"),
+            reason=str(lifecycle_payload.get("reason", "") or ""),
+            backend_available=_bool_payload(lifecycle_payload.get("backend_available", False)),
+        ),
+        voice_note=VoIPVoiceNoteSnapshot(
+            state=str(voice_note_payload.get("state", "idle") or "idle"),
+            file_path=str(voice_note_payload.get("file_path", "") or ""),
+            duration_ms=_duration_ms(voice_note_payload.get("duration_ms")),
+            mime_type=str(voice_note_payload.get("mime_type", "") or ""),
+            message_id=str(voice_note_payload.get("message_id", "") or ""),
+        ),
+        last_message=_message_snapshot(payload.get("last_message")),
+    )
+
+
+def _snapshot_registration_value(payload: dict[str, Any]) -> str:
+    registration_state = str(payload.get("registration_state", "") or "").strip()
+    if registration_state:
+        return registration_state
+    return "ok" if _bool_payload(payload.get("registered", False)) else "none"
+
+
+def _message_snapshot(payload: object) -> VoIPMessageSnapshot | None:
+    message_payload = _dict_payload(payload)
+    message_id = str(message_payload.get("message_id", "") or "")
+    if not message_id:
+        return None
+    return VoIPMessageSnapshot(
+        message_id=message_id,
+        kind=_message_kind(str(message_payload.get("kind", ""))),
+        direction=_message_direction(str(message_payload.get("direction", ""))),
+        delivery_state=_message_delivery_state(str(message_payload.get("delivery_state", ""))),
+        local_file_path=str(message_payload.get("local_file_path", "") or ""),
+        error=str(message_payload.get("error", "") or ""),
+    )
+
+
+def _dict_payload(value: object) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
 
 
 def _message_kind(value: str) -> MessageKind | None:

--- a/yoyopod/integrations/call/__init__.py
+++ b/yoyopod/integrations/call/__init__.py
@@ -61,7 +61,12 @@ if TYPE_CHECKING:
         RegistrationStateChanged,
         VoIPConfig,
         VoIPEvent,
+        VoIPLifecycleSnapshot,
+        VoIPMessageSnapshot,
         VoIPMessageRecord,
+        VoIPRuntimeSnapshot,
+        VoIPRuntimeSnapshotChanged,
+        VoIPVoiceNoteSnapshot,
     )
     from yoyopod.integrations.call.voice_notes import VoiceNoteDraft, VoiceNoteService
 
@@ -118,7 +123,21 @@ _PUBLIC_EXPORTS = {
     "MessageDirection": ("yoyopod.integrations.call.models", "MessageDirection"),
     "MessageDeliveryState": ("yoyopod.integrations.call.models", "MessageDeliveryState"),
     "VoIPConfig": ("yoyopod.integrations.call.models", "VoIPConfig"),
+    "VoIPLifecycleSnapshot": (
+        "yoyopod.integrations.call.models",
+        "VoIPLifecycleSnapshot",
+    ),
+    "VoIPMessageSnapshot": ("yoyopod.integrations.call.models", "VoIPMessageSnapshot"),
     "VoIPMessageRecord": ("yoyopod.integrations.call.models", "VoIPMessageRecord"),
+    "VoIPRuntimeSnapshot": ("yoyopod.integrations.call.models", "VoIPRuntimeSnapshot"),
+    "VoIPRuntimeSnapshotChanged": (
+        "yoyopod.integrations.call.models",
+        "VoIPRuntimeSnapshotChanged",
+    ),
+    "VoIPVoiceNoteSnapshot": (
+        "yoyopod.integrations.call.models",
+        "VoIPVoiceNoteSnapshot",
+    ),
     "RegistrationChangedEvent": (
         "yoyopod.integrations.call.events",
         "RegistrationChangedEvent",
@@ -303,8 +322,7 @@ def setup(
                 unread_count=max(0, int(unread_count)),
                 unread_by_address=_voice_note_unread_by_address(actual_manager),
                 latest_by_contact={
-                    str(address): dict(summary)
-                    for address, summary in latest_by_contact.items()
+                    str(address): dict(summary) for address, summary in latest_by_contact.items()
                 },
             )
         )
@@ -434,25 +452,17 @@ def _resolve_voip_config(app: Any, *, explicit: object | None) -> Any:
         ),
         transport=str(getattr(account, "transport", defaults.transport)),
         stun_server=str(getattr(network, "stun_server", "")),
-        conference_factory_uri=str(
-            getattr(messaging, "conference_factory_uri", "")
-        ),
-        file_transfer_server_url=str(
-            getattr(messaging, "file_transfer_server_url", "")
-        ),
+        conference_factory_uri=str(getattr(messaging, "conference_factory_uri", "")),
+        file_transfer_server_url=str(getattr(messaging, "file_transfer_server_url", "")),
         lime_server_url=str(getattr(messaging, "lime_server_url", "")),
         iterate_interval_ms=int(
             getattr(messaging, "iterate_interval_ms", defaults.iterate_interval_ms)
         ),
-        message_store_dir=str(
-            getattr(messaging, "message_store_dir", defaults.message_store_dir)
-        ),
+        message_store_dir=str(getattr(messaging, "message_store_dir", defaults.message_store_dir)),
         voice_note_store_dir=str(
             getattr(messaging, "voice_note_store_dir", defaults.voice_note_store_dir)
         ),
-        call_history_file=str(
-            getattr(calling, "call_history_file", defaults.call_history_file)
-        ),
+        call_history_file=str(getattr(calling, "call_history_file", defaults.call_history_file)),
         voice_note_max_duration_seconds=int(
             getattr(
                 messaging,
@@ -467,13 +477,9 @@ def _resolve_voip_config(app: Any, *, explicit: object | None) -> Any:
                 defaults.auto_download_incoming_voice_recordings,
             )
         ),
-        playback_dev_id=str(
-            getattr(audio, "playback_device_id", defaults.playback_dev_id)
-        ),
+        playback_dev_id=str(getattr(audio, "playback_device_id", defaults.playback_dev_id)),
         ringer_dev_id=str(getattr(audio, "ringer_device_id", defaults.ringer_dev_id)),
-        capture_dev_id=str(
-            getattr(audio, "capture_device_id", defaults.capture_dev_id)
-        ),
+        capture_dev_id=str(getattr(audio, "capture_device_id", defaults.capture_dev_id)),
         media_dev_id=str(getattr(audio, "media_device_id", defaults.media_dev_id)),
         mic_gain=int(getattr(audio, "mic_gain", defaults.mic_gain)),
         output_volume=int(getattr(config, "default_volume", defaults.output_volume)),
@@ -496,7 +502,9 @@ def _restart_manager(manager: object) -> bool:
         return False
     started = bool(start())
     if started:
-        ensure_background_iterate_running = getattr(manager, "ensure_background_iterate_running", None)
+        ensure_background_iterate_running = getattr(
+            manager, "ensure_background_iterate_running", None
+        )
         if callable(ensure_background_iterate_running):
             ensure_background_iterate_running()
     return started
@@ -573,7 +581,12 @@ __all__ = [
     "MessageDirection",
     "MessageDeliveryState",
     "VoIPConfig",
+    "VoIPLifecycleSnapshot",
+    "VoIPMessageSnapshot",
     "VoIPMessageRecord",
+    "VoIPRuntimeSnapshot",
+    "VoIPRuntimeSnapshotChanged",
+    "VoIPVoiceNoteSnapshot",
     "RegistrationChangedEvent",
     "RegistrationStateChanged",
     "CallStateChanged",

--- a/yoyopod/integrations/call/manager.py
+++ b/yoyopod/integrations/call/manager.py
@@ -29,6 +29,8 @@ from yoyopod.integrations.call.models import (
     VoIPConfig,
     VoIPEvent,
     VoIPMessageRecord,
+    VoIPRuntimeSnapshot,
+    VoIPRuntimeSnapshotChanged,
 )
 from yoyopod.integrations.call.voice_notes import VoiceNoteDraft, VoiceNoteService
 
@@ -521,6 +523,9 @@ class VoIPManager:
             self._update_registration_state(RegistrationState.PROGRESS)
             self._notify_availability_change(True, event.reason or "backend_recovered")
             return
+        if isinstance(event, VoIPRuntimeSnapshotChanged):
+            self._apply_runtime_snapshot(event.snapshot)
+            return
         if isinstance(event, MessageReceived):
             self._messaging_service.handle_message_received(event.message)
             return
@@ -534,6 +539,37 @@ class VoIPManager:
         if isinstance(event, MessageFailed):
             self._voice_note_service.handle_message_failed(event)
             self._messaging_service.handle_message_failed(event)
+
+    def _apply_runtime_snapshot(self, snapshot: VoIPRuntimeSnapshot) -> None:
+        lifecycle_state = snapshot.lifecycle.state.strip().lower()
+        self.running = snapshot.lifecycle.backend_available or lifecycle_state not in {
+            "failed",
+            "stopped",
+            "unconfigured",
+        }
+        self._update_registration_state(snapshot.registration_state)
+        self._sync_call_identity(snapshot)
+        self._update_call_state(snapshot.call_state)
+        self._voice_note_service.apply_runtime_snapshot(snapshot)
+        self._messaging_service.apply_runtime_snapshot(snapshot)
+
+    def _sync_call_identity(self, snapshot: VoIPRuntimeSnapshot) -> None:
+        has_active_call = bool(snapshot.active_call_id or snapshot.active_call_peer)
+        if has_active_call:
+            self.current_call_id = snapshot.active_call_id or None
+            if snapshot.active_call_peer:
+                self.caller_address = snapshot.active_call_peer
+                self.caller_name = self._lookup_contact_name(snapshot.active_call_peer)
+            return
+        if snapshot.call_state in (
+            CallState.IDLE,
+            CallState.RELEASED,
+            CallState.END,
+            CallState.ERROR,
+        ):
+            self.current_call_id = None
+            self.caller_address = None
+            self.caller_name = None
 
     def _notify_message_summary_change(self) -> None:
         self._messaging_service.notify_message_summary_change()
@@ -584,7 +620,10 @@ class VoIPManager:
         ):
             self._stop_voice_note_playback()
 
-        if state in (CallState.CONNECTED, CallState.STREAMS_RUNNING) and self.call_start_time is None:
+        if (
+            state in (CallState.CONNECTED, CallState.STREAMS_RUNNING)
+            and self.call_start_time is None
+        ):
             self._start_call_timer()
         elif state in (CallState.RELEASED, CallState.END, CallState.ERROR):
             self._clear_call_session()

--- a/yoyopod/integrations/call/messaging.py
+++ b/yoyopod/integrations/call/messaging.py
@@ -20,6 +20,7 @@ from yoyopod.integrations.call.models import (
     MessageKind,
     VoIPConfig,
     VoIPMessageRecord,
+    VoIPRuntimeSnapshot,
 )
 
 
@@ -155,6 +156,36 @@ class MessagingService:
                 callback(event.message_id, event.reason)
             except Exception as exc:
                 logger.error("Error in message failure callback: {}", exc)
+        self.notify_message_summary_change()
+
+    def apply_runtime_snapshot(self, snapshot: VoIPRuntimeSnapshot) -> None:
+        """Mirror Rust-owned last-message facts into known persisted records."""
+
+        message = snapshot.last_message
+        if message is None or not message.message_id:
+            return
+
+        record = self.message_store.get(message.message_id)
+        if record is None:
+            return
+
+        delivery_state = message.delivery_state or record.delivery_state
+        local_file_path = message.local_file_path or record.local_file_path
+        if delivery_state == record.delivery_state and local_file_path == record.local_file_path:
+            return
+
+        updated = replace(
+            record,
+            delivery_state=delivery_state,
+            local_file_path=local_file_path,
+            updated_at=self._iso_now(),
+        )
+        self.message_store.upsert(updated)
+        for callback in self.message_delivery_callbacks:
+            try:
+                callback(updated)
+            except Exception as exc:
+                logger.error("Error in message snapshot callback: {}", exc)
         self.notify_message_summary_change()
 
     def unread_voice_note_count(self) -> int:

--- a/yoyopod/integrations/call/models.py
+++ b/yoyopod/integrations/call/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import TypeAlias
 
@@ -196,6 +196,54 @@ class VoIPMessageRecord:
 
 
 @dataclass(frozen=True, slots=True)
+class VoIPLifecycleSnapshot:
+    """Rust-owned VoIP host lifecycle facts."""
+
+    state: str = "unconfigured"
+    reason: str = ""
+    backend_available: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class VoIPVoiceNoteSnapshot:
+    """Rust-owned active voice-note facts."""
+
+    state: str = "idle"
+    file_path: str = ""
+    duration_ms: int = 0
+    mime_type: str = ""
+    message_id: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class VoIPMessageSnapshot:
+    """Rust-owned last-message facts from the VoIP worker."""
+
+    message_id: str
+    kind: MessageKind | None = None
+    direction: MessageDirection | None = None
+    delivery_state: MessageDeliveryState | None = None
+    local_file_path: str = ""
+    error: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class VoIPRuntimeSnapshot:
+    """Canonical live VoIP state reported by the Rust worker."""
+
+    configured: bool = False
+    registered: bool = False
+    registration_state: RegistrationState = RegistrationState.NONE
+    call_state: CallState = CallState.IDLE
+    active_call_id: str = ""
+    active_call_peer: str = ""
+    pending_outbound_messages: int = 0
+    lifecycle: VoIPLifecycleSnapshot = field(default_factory=VoIPLifecycleSnapshot)
+    voice_note: VoIPVoiceNoteSnapshot = field(default_factory=VoIPVoiceNoteSnapshot)
+    last_message: VoIPMessageSnapshot | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class RegistrationStateChanged:
     """Typed event emitted when SIP registration changes."""
 
@@ -264,6 +312,13 @@ class MessageFailed:
     reason: str
 
 
+@dataclass(frozen=True, slots=True)
+class VoIPRuntimeSnapshotChanged:
+    """Typed event emitted when Rust reports its canonical runtime snapshot."""
+
+    snapshot: VoIPRuntimeSnapshot
+
+
 VoIPEvent: TypeAlias = (
     RegistrationStateChanged
     | CallStateChanged
@@ -274,4 +329,5 @@ VoIPEvent: TypeAlias = (
     | MessageDeliveryChanged
     | MessageDownloadCompleted
     | MessageFailed
+    | VoIPRuntimeSnapshotChanged
 )

--- a/yoyopod/integrations/call/voice_notes.py
+++ b/yoyopod/integrations/call/voice_notes.py
@@ -21,6 +21,7 @@ from yoyopod.integrations.call.models import (
     MessageKind,
     VoIPConfig,
     VoIPMessageRecord,
+    VoIPRuntimeSnapshot,
 )
 
 if TYPE_CHECKING:
@@ -227,7 +228,10 @@ class VoiceNoteService:
             self._playback_process = None
 
     def handle_message_delivery_changed(self, event: MessageDeliveryChanged) -> None:
-        if self._active_voice_note is None or self._active_voice_note.message_id != event.message_id:
+        if (
+            self._active_voice_note is None
+            or self._active_voice_note.message_id != event.message_id
+        ):
             return
 
         if event.delivery_state in (MessageDeliveryState.SENT, MessageDeliveryState.DELIVERED):
@@ -242,11 +246,59 @@ class VoiceNoteService:
             self._active_voice_note.send_started_at = 0.0
 
     def handle_message_failed(self, event: MessageFailed) -> None:
-        if self._active_voice_note is None or self._active_voice_note.message_id != event.message_id:
+        if (
+            self._active_voice_note is None
+            or self._active_voice_note.message_id != event.message_id
+        ):
             return
         self._active_voice_note.send_state = "failed"
         self._active_voice_note.status_text = event.reason or "Couldn't send"
         self._active_voice_note.send_started_at = 0.0
+
+    def apply_runtime_snapshot(self, snapshot: VoIPRuntimeSnapshot) -> None:
+        """Mirror Rust-owned active voice-note state into the current draft."""
+
+        draft = self._active_voice_note
+        if draft is None:
+            return
+
+        voice_note = snapshot.voice_note
+        state = voice_note.state.strip().lower() or "idle"
+        if state == "idle":
+            return
+
+        if voice_note.file_path and not draft.file_path:
+            draft.file_path = voice_note.file_path
+        if voice_note.duration_ms > 0:
+            draft.duration_ms = voice_note.duration_ms
+        if voice_note.mime_type:
+            draft.mime_type = voice_note.mime_type
+        if voice_note.message_id:
+            draft.message_id = voice_note.message_id
+
+        if state == "recording":
+            draft.send_state = "recording"
+            draft.status_text = "Recording..."
+            return
+        if state == "recorded":
+            draft.send_state = "review"
+            draft.status_text = "Ready to send"
+            return
+        if state == "sending":
+            draft.send_state = "sending"
+            draft.status_text = "Sending..."
+            if draft.send_started_at <= 0.0:
+                draft.send_started_at = time.monotonic()
+            return
+        if state == "sent":
+            draft.send_state = "sent"
+            draft.status_text = "Sent"
+            draft.send_started_at = 0.0
+            return
+        if state == "failed":
+            draft.send_state = "failed"
+            draft.status_text = _snapshot_failure_text(snapshot)
+            draft.send_started_at = 0.0
 
     def check_active_voice_note_timeout(self) -> None:
         draft = self._active_voice_note
@@ -281,6 +333,13 @@ class VoiceNoteService:
     @staticmethod
     def _iso_now() -> str:
         return datetime.now(timezone.utc).isoformat()
+
+
+def _snapshot_failure_text(snapshot: VoIPRuntimeSnapshot) -> str:
+    message = snapshot.last_message
+    if message is not None and message.error:
+        return message.error
+    return "Couldn't send"
 
 
 class VoiceNoteEventHandler:


### PR DESCRIPTION
﻿## Summary
- Adds typed Python models/events for Rust-owned VoIP runtime snapshots and stores the latest snapshot in `RustHostBackend`.
- Mirrors Rust snapshot state through `VoIPManager`, including registration, call identity, voice-note state, and known message delivery facts.
- Keeps Python as supervisor/persistence/UI bridge while preserving existing compatibility events and adding focused runtime ownership tests.

## Notes
- Rust `voip.snapshot` schema was already present in the merged host; this PR verifies that contract with the workspace Cargo tests and adds the Python facade/bridge layer.
- Python message persistence remains the mirror; snapshots only update known records and do not create incomplete message rows.

## Validation
- `cargo fmt --manifest-path src/Cargo.toml --all --check`
- `cargo test --manifest-path src/Cargo.toml --workspace --locked`
- `uv run python -m black --check yoyopod\backends\voip\rust_host.py yoyopod\integrations\call\__init__.py yoyopod\integrations\call\manager.py yoyopod\integrations\call\messaging.py yoyopod\integrations\call\models.py yoyopod\integrations\call\voice_notes.py tests\backends\test_rust_host_voip.py tests\backends\test_voip_backend.py tests\integrations\test_voip_services.py`
- `uv run python -m ruff check yoyopod\backends\voip\rust_host.py yoyopod\integrations\call\__init__.py yoyopod\integrations\call\manager.py yoyopod\integrations\call\messaging.py yoyopod\integrations\call\models.py yoyopod\integrations\call\voice_notes.py tests\backends\test_rust_host_voip.py tests\backends\test_voip_backend.py tests\integrations\test_voip_services.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q` (`1903 passed, 22 skipped`)
