### PR TITLE
[codex] Promote Rust-owned VoIP runtime facts

### DIFF
--- a/docs/superpowers/plans/2026-04-29-rust-voip-domain-facade.md
+++ b/docs/superpowers/plans/2026-04-29-rust-voip-domain-facade.md
@@ -1,0 +1,23 @@
+# Rust VoIP Domain Facade Slice
+
+## Goal
+
+Move the next set of VoIP runtime facts under the Rust host while Python remains the command bridge, persistence mirror, and app callback surface.
+
+## Acceptance Criteria
+
+- Rust `voip.snapshot` includes mute state and keeps it consistent across `voip.set_mute`, configure, unregister, and backend failure reset paths.
+- Python parses and mirrors the Rust-owned mute state from `VoIPRuntimeSnapshot`.
+- In Rust-host mode, outgoing Python commands do not invent call identity or mute state before Rust snapshots report them.
+- Legacy Python/mock backends keep their current optimistic behavior where no Rust snapshot owner exists.
+- Code follows clean-code and Rust coding guidelines: small focused helpers, readable names, no broad refactors, and tests that describe behavior.
+
+## Work Plan
+
+- [x] Add failing Rust host tests for snapshot-owned mute state.
+- [x] Add failing Python tests for snapshot-owned mute and outgoing-call identity.
+- [x] Add `muted` to the Rust `VoipHost` state and snapshot payload.
+- [x] Add `muted` to Python `VoIPRuntimeSnapshot` parsing and manager mirroring.
+- [x] Gate optimistic Python command updates behind a legacy-backend check.
+- [x] Run focused tests, then full quality gates.
+- [ ] Commit, push, and open a PR.

--- a/src/crates/voip-host/src/host.rs
+++ b/src/crates/voip-host/src/host.rs
@@ -302,6 +302,7 @@ impl VoipHost {
         self.active_call_id = None;
         self.active_call_peer.clear();
         self.call_state = "released".to_string();
+        self.muted = false;
         Ok(())
     }
 
@@ -310,6 +311,7 @@ impl VoipHost {
         self.active_call_id = None;
         self.active_call_peer.clear();
         self.call_state = "released".to_string();
+        self.muted = false;
         Ok(())
     }
 
@@ -1053,6 +1055,7 @@ mod command_tests {
             host.health_payload()["active_call_id"],
             serde_json::Value::Null
         );
+        assert_eq!(host.session_snapshot_payload()["muted"], false);
     }
 
     #[test]
@@ -1337,13 +1340,21 @@ mod command_tests {
         host.configure(config());
         host.register(&mut backend).unwrap();
         host.dial(&mut backend, "sip:bob@example.com").unwrap();
+        host.set_muted(&mut backend, true).expect("mute");
 
         host.reject(&mut backend).expect("reject");
+        assert_eq!(host.session_snapshot_payload()["muted"], false);
         host.unregister(&mut backend);
 
         assert_eq!(
             backend.calls,
-            vec!["start", "dial:sip:bob@example.com", "reject", "stop"]
+            vec![
+                "start",
+                "dial:sip:bob@example.com",
+                "mute:true",
+                "reject",
+                "stop"
+            ]
         );
         assert_eq!(host.health_payload()["registered"], false);
         assert_eq!(

--- a/src/crates/voip-host/src/host.rs
+++ b/src/crates/voip-host/src/host.rs
@@ -128,6 +128,7 @@ pub struct VoipHost {
     call_state: String,
     active_call_id: Option<String>,
     active_call_peer: String,
+    muted: bool,
     voice_note: VoiceNoteSessionState,
     last_message: Option<MessageSessionState>,
     outbound_message_ids: HashMap<String, String>,
@@ -146,6 +147,7 @@ impl Default for VoipHost {
             call_state: "idle".to_string(),
             active_call_id: None,
             active_call_peer: String::new(),
+            muted: false,
             voice_note: VoiceNoteSessionState::default(),
             last_message: None,
             outbound_message_ids: HashMap::new(),
@@ -163,6 +165,7 @@ impl VoipHost {
         self.call_state = "idle".to_string();
         self.active_call_id = None;
         self.active_call_peer.clear();
+        self.muted = false;
         self.voice_note = VoiceNoteSessionState::default();
         self.last_message = None;
         self.outbound_message_ids.clear();
@@ -222,6 +225,7 @@ impl VoipHost {
             "call_state": self.call_state,
             "active_call_id": self.active_call_id,
             "active_call_peer": self.active_call_peer,
+            "muted": self.muted,
             "pending_outbound_messages": self.outbound_message_ids.len(),
             "voice_note": {
                 "state": self.voice_note.state,
@@ -272,6 +276,7 @@ impl VoipHost {
         self.call_state = "idle".to_string();
         self.active_call_id = None;
         self.active_call_peer.clear();
+        self.muted = false;
         self.voice_note = VoiceNoteSessionState::default();
         self.outbound_message_ids.clear();
     }
@@ -313,7 +318,9 @@ impl VoipHost {
         backend: &mut B,
         muted: bool,
     ) -> Result<(), String> {
-        backend.set_muted(muted)
+        backend.set_muted(muted)?;
+        self.muted = muted;
+        Ok(())
     }
 
     pub fn send_text_message<B: CallBackend>(
@@ -431,6 +438,7 @@ impl VoipHost {
                     {
                         self.active_call_id = None;
                         self.active_call_peer.clear();
+                        self.muted = false;
                     }
                 } else {
                     self.active_call_id = Some(call_id.clone());
@@ -444,6 +452,7 @@ impl VoipHost {
                 self.call_state = "idle".to_string();
                 self.active_call_id = None;
                 self.active_call_peer.clear();
+                self.muted = false;
                 self.outbound_message_ids.clear();
             }
             BackendEvent::MessageReceived { message } => {
@@ -1044,6 +1053,27 @@ mod command_tests {
             host.health_payload()["active_call_id"],
             serde_json::Value::Null
         );
+    }
+
+    #[test]
+    fn mute_state_is_owned_by_host_snapshots_and_resets_on_stop() {
+        let mut host = VoipHost::default();
+        let mut backend = FakeBackend::default();
+        host.configure(config());
+        host.register(&mut backend).unwrap();
+
+        assert_eq!(host.session_snapshot_payload()["muted"], false);
+
+        host.set_muted(&mut backend, true).expect("mute");
+        assert_eq!(host.session_snapshot_payload()["muted"], true);
+
+        host.set_muted(&mut backend, false).expect("unmute");
+        assert_eq!(host.session_snapshot_payload()["muted"], false);
+
+        host.set_muted(&mut backend, true)
+            .expect("mute before stop");
+        host.unregister(&mut backend);
+        assert_eq!(host.session_snapshot_payload()["muted"], false);
     }
 
     #[test]

--- a/src/crates/voip-host/src/main.rs
+++ b/src/crates/voip-host/src/main.rs
@@ -241,6 +241,7 @@ fn handle_command(
                 envelope.request_id,
                 json!({"muted": muted}),
             ))?;
+            write_session_snapshot(host)?;
         }
         "voip.send_text_message" => {
             let uri = envelope.payload["uri"].as_str().unwrap_or("").trim();

--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -507,6 +507,7 @@ def test_worker_snapshot_dispatches_typed_runtime_snapshot() -> None:
                 "call_state": "streams_running",
                 "active_call_id": "call-1",
                 "active_call_peer": "sip:bob@example.com",
+                "muted": True,
                 "pending_outbound_messages": 2,
                 "lifecycle": {
                     "state": "registered",
@@ -542,6 +543,7 @@ def test_worker_snapshot_dispatches_typed_runtime_snapshot() -> None:
     assert snapshot.call_state == CallState.STREAMS_RUNNING
     assert snapshot.active_call_id == "call-1"
     assert snapshot.active_call_peer == "sip:bob@example.com"
+    assert snapshot.muted is True
     assert snapshot.pending_outbound_messages == 2
     assert snapshot.lifecycle.state == "registered"
     assert snapshot.lifecycle.backend_available is True

--- a/tests/backends/test_voip_backend.py
+++ b/tests/backends/test_voip_backend.py
@@ -155,6 +155,17 @@ class BackgroundIterateMockVoIPBackend(MockVoIPBackend):
         )
 
 
+class SnapshotOwnedMockVoIPBackend(MockVoIPBackend):
+    """Mock backend that marks runtime facts as Rust-snapshot owned."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.runtime_snapshot: VoIPRuntimeSnapshot | None = None
+
+    def get_runtime_snapshot(self) -> VoIPRuntimeSnapshot | None:
+        return self.runtime_snapshot
+
+
 def build_config(storage_root: Path | None = None) -> VoIPConfig:
     """Create a small test configuration with isolated on-disk storage."""
 
@@ -481,6 +492,93 @@ def test_voip_manager_delegates_outgoing_commands_to_backend() -> None:
     assert call_states == []
     assert manager.call_state == CallState.IDLE
     assert manager.get_caller_info()["display_name"] == "Bob"
+
+
+def test_voip_manager_waits_for_rust_snapshot_before_call_identity() -> None:
+    """Rust-host mode should not invent active-call identity before Rust reports it."""
+
+    backend = SnapshotOwnedMockVoIPBackend()
+    people_directory = FakePeopleDirectory({"sip:bob@example.com": "Bob"})
+    manager = VoIPManager(build_config(), people_directory=people_directory, backend=backend)
+
+    assert manager.start()
+    backend.emit(RegistrationStateChanged(state=RegistrationState.OK))
+
+    assert manager.make_call("sip:bob@example.com", contact_name="Bob")
+    assert backend.commands == ["call sip:bob@example.com"]
+    assert manager.caller_address is None
+    assert manager.caller_name is None
+    assert manager.get_caller_info()["display_name"] == "Unknown"
+
+    snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        call_state=CallState.OUTGOING,
+        active_call_id="call-1",
+        active_call_peer="sip:bob@example.com",
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+    )
+    backend.runtime_snapshot = snapshot
+    backend.emit(VoIPRuntimeSnapshotChanged(snapshot=snapshot))
+
+    assert manager.current_call_id == "call-1"
+    assert manager.caller_address == "sip:bob@example.com"
+    assert manager.get_caller_info()["display_name"] == "Bob"
+
+
+def test_voip_manager_waits_for_rust_snapshot_before_mute_state() -> None:
+    """Rust-host mode should mirror mute state only after Rust snapshots report it."""
+
+    backend = SnapshotOwnedMockVoIPBackend()
+    manager = VoIPManager(build_config(), backend=backend)
+
+    assert manager.start()
+    assert manager.is_muted is False
+
+    assert manager.mute()
+    assert backend.commands == ["mute"]
+    assert manager.is_muted is False
+
+    muted_snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        muted=True,
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+    )
+    backend.runtime_snapshot = muted_snapshot
+    backend.emit(VoIPRuntimeSnapshotChanged(snapshot=muted_snapshot))
+
+    assert manager.is_muted is True
+
+    assert manager.unmute()
+    assert backend.commands == ["mute", "unmute"]
+    assert manager.is_muted is True
+
+    unmuted_snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        muted=False,
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+    )
+    backend.runtime_snapshot = unmuted_snapshot
+    backend.emit(VoIPRuntimeSnapshotChanged(snapshot=unmuted_snapshot))
+
+    assert manager.is_muted is False
 
 
 def test_voip_manager_starts_timer_on_streams_running_without_connected() -> None:

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -596,6 +596,7 @@ def _runtime_snapshot(payload: dict[str, Any]) -> VoIPRuntimeSnapshot:
         call_state=_call_state(str(payload.get("call_state", "idle"))),
         active_call_id=str(payload.get("active_call_id", "") or ""),
         active_call_peer=str(payload.get("active_call_peer", "") or ""),
+        muted=_bool_payload(payload.get("muted", False)),
         pending_outbound_messages=_duration_ms(payload.get("pending_outbound_messages")),
         lifecycle=VoIPLifecycleSnapshot(
             state=str(lifecycle_payload.get("state", "unconfigured") or "unconfigured"),

--- a/yoyopod/integrations/call/manager.py
+++ b/yoyopod/integrations/call/manager.py
@@ -78,6 +78,7 @@ class VoIPManager:
         self.caller_name: str | None = None
         self.call_start_time: float | None = None
         self.is_muted = False
+        self._runtime_snapshot: VoIPRuntimeSnapshot | None = None
         self._pending_terminal_action: str | None = None
         self._message_store = message_store or self._build_message_store()
         self._messaging_service = MessagingService(
@@ -211,6 +212,11 @@ class VoIPManager:
         with self._iterate_state_lock:
             return self._iterate_snapshot
 
+    def get_runtime_snapshot(self) -> VoIPRuntimeSnapshot | None:
+        """Return the latest Rust-owned VoIP runtime snapshot when available."""
+
+        return self._runtime_snapshot
+
     def poll_housekeeping(self) -> None:
         """Run lightweight coordinator-thread-only maintenance alongside background iterate."""
 
@@ -221,12 +227,14 @@ class VoIPManager:
             logger.error("Cannot make call: not registered")
             return False
 
-        self.caller_address = sip_address
-        self.caller_name = contact_name or self._lookup_contact_name(sip_address)
-        logger.info("Making call to: {} ({})", self.caller_name, sip_address)
+        resolved_name = contact_name or self._lookup_contact_name(sip_address)
+        logger.info("Making call to: {} ({})", resolved_name, sip_address)
         if not self.backend.make_call(sip_address):
             return False
 
+        if not self._backend_owns_runtime_snapshot():
+            self.caller_address = sip_address
+            self.caller_name = resolved_name
         self._pending_terminal_action = None
         return True
 
@@ -255,7 +263,8 @@ class VoIPManager:
         if self.is_muted:
             return False
         if self.backend.mute():
-            self.is_muted = True
+            if not self._backend_owns_runtime_snapshot():
+                self.is_muted = True
             return True
         return False
 
@@ -263,7 +272,8 @@ class VoIPManager:
         if not self.is_muted:
             return False
         if self.backend.unmute():
-            self.is_muted = False
+            if not self._backend_owns_runtime_snapshot():
+                self.is_muted = False
             return True
         return False
 
@@ -541,6 +551,7 @@ class VoIPManager:
             self._messaging_service.handle_message_failed(event)
 
     def _apply_runtime_snapshot(self, snapshot: VoIPRuntimeSnapshot) -> None:
+        self._runtime_snapshot = snapshot
         lifecycle_state = snapshot.lifecycle.state.strip().lower()
         self.running = snapshot.lifecycle.backend_available or lifecycle_state not in {
             "failed",
@@ -550,6 +561,7 @@ class VoIPManager:
         self._update_registration_state(snapshot.registration_state)
         self._sync_call_identity(snapshot)
         self._update_call_state(snapshot.call_state)
+        self.is_muted = snapshot.muted
         self._voice_note_service.apply_runtime_snapshot(snapshot)
         self._messaging_service.apply_runtime_snapshot(snapshot)
 
@@ -570,6 +582,9 @@ class VoIPManager:
             self.current_call_id = None
             self.caller_address = None
             self.caller_name = None
+
+    def _backend_owns_runtime_snapshot(self) -> bool:
+        return callable(getattr(self.backend, "get_runtime_snapshot", None))
 
     def _notify_message_summary_change(self) -> None:
         self._messaging_service.notify_message_summary_change()

--- a/yoyopod/integrations/call/models.py
+++ b/yoyopod/integrations/call/models.py
@@ -237,6 +237,7 @@ class VoIPRuntimeSnapshot:
     call_state: CallState = CallState.IDLE
     active_call_id: str = ""
     active_call_peer: str = ""
+    muted: bool = False
     pending_outbound_messages: int = 0
     lifecycle: VoIPLifecycleSnapshot = field(default_factory=VoIPLifecycleSnapshot)
     voice_note: VoIPVoiceNoteSnapshot = field(default_factory=VoIPVoiceNoteSnapshot)


### PR DESCRIPTION
## Summary

- Add Rust-owned mute state to `voip.snapshot` and emit a snapshot after `voip.set_mute`.
- Mirror `muted` through the Python Rust host parser and `VoIPManager` runtime snapshot facade.
- Stop Python from inventing active-call identity or mute state for snapshot-owned Rust backends before Rust reports the canonical snapshot.

## Why

This advances the VoIP migration path by making more live runtime facts owned by the Rust VoIP host while keeping Python as the command bridge, persistence mirror, and app callback surface.

## Validation

- `cargo fmt --manifest-path src/Cargo.toml --all --check`
- `cargo test --manifest-path src/Cargo.toml --workspace --locked`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`