### PR TITLE
Split Rust VoIP host session state

### DIFF
--- a/docs/superpowers/plans/2026-04-29-rust-voip-session-ownership.md
+++ b/docs/superpowers/plans/2026-04-29-rust-voip-session-ownership.md
@@ -1,0 +1,42 @@
+# Rust VoIP Session Ownership Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the Rust VoIP host domain state into focused modules while keeping Python-facing behavior and worker protocol unchanged.
+
+**Architecture:** `VoipHost` remains the public facade used by `worker.rs`, but it delegates call/mute state, lifecycle state, message correlation, voice-note state, and snapshot rendering to small Rust modules under `yoyopod_rs/voip-host/src/`. Integration tests cover the new module APIs and existing host/worker tests prove protocol compatibility.
+
+**Tech Stack:** Rust 2021, Cargo integration tests, Bazel Rust targets, Python adapter compatibility tests.
+
+---
+
+## Files
+
+- Create `yoyopod_rs/voip-host/src/calls.rs` for call id, peer, call state, and mute ownership.
+- Create `yoyopod_rs/voip-host/src/lifecycle.rs` for lifecycle state, recovery tracking, and lifecycle event draining.
+- Create `yoyopod_rs/voip-host/src/messages.rs` for `MessageRecord`, last-message snapshots, outbound message id translation, and terminal delivery checks.
+- Create `yoyopod_rs/voip-host/src/voice_notes.rs` for voice-note recording/sending state.
+- Create `yoyopod_rs/voip-host/src/runtime_snapshot.rs` for canonical `voip.snapshot` payload assembly.
+- Modify `yoyopod_rs/voip-host/src/lib.rs` to expose the new modules.
+- Modify `yoyopod_rs/voip-host/src/host.rs` so `VoipHost` delegates to those modules without changing its public methods.
+- Add integration tests under `yoyopod_rs/voip-host/tests/` for the new module APIs.
+
+## Tasks
+
+- [ ] Add failing integration tests for call session state transitions and mute reset behavior.
+- [ ] Add failing integration tests for outbound message id translation and terminal cleanup.
+- [ ] Add failing integration tests for voice-note state transitions and snapshot payload fields.
+- [ ] Add failing integration tests for lifecycle recovery events and runtime snapshot composition.
+- [ ] Implement the new Rust domain modules with small, readable APIs.
+- [ ] Refactor `VoipHost` to use the new modules while preserving `VoipHost` method signatures.
+- [ ] Run focused Rust tests for `yoyopod-voip-host`.
+- [ ] Run full Rust, Bazel, quality, and pytest gates.
+- [ ] Commit and push the stacked branch.
+
+## Acceptance Criteria
+
+- `host.rs` no longer directly owns low-level call, lifecycle, message, voice-note, or snapshot JSON internals.
+- Existing worker messages and snapshot schema remain compatible.
+- Rust module tests describe the domain behavior without relying on Python.
+- Python tests remain green, proving the app facade still sees the same behavior.
+- Code remains human-readable: small modules, explicit names, simple control flow, and `rustfmt` clean.

--- a/yoyopod_rs/voip-host/BUILD.bazel
+++ b/yoyopod_rs/voip-host/BUILD.bazel
@@ -21,11 +21,16 @@ yoyopod_rust_host_binary(
 )
 
 VOIP_HOST_TESTS = [
+    "calls",
     "config",
     "events",
     "host",
+    "lifecycle",
+    "messages",
     "protocol",
+    "runtime_snapshot",
     "shim",
+    "voice_notes",
     "worker",
 ]
 

--- a/yoyopod_rs/voip-host/src/calls.rs
+++ b/yoyopod_rs/voip-host/src/calls.rs
@@ -1,0 +1,87 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallSession {
+    state: String,
+    active_call_id: Option<String>,
+    active_peer: String,
+    muted: bool,
+}
+
+impl Default for CallSession {
+    fn default() -> Self {
+        Self {
+            state: "idle".to_string(),
+            active_call_id: None,
+            active_peer: String::new(),
+            muted: false,
+        }
+    }
+}
+
+impl CallSession {
+    pub fn state(&self) -> &str {
+        &self.state
+    }
+
+    pub fn active_call_id(&self) -> Option<&str> {
+        self.active_call_id.as_deref()
+    }
+
+    pub fn active_peer(&self) -> &str {
+        &self.active_peer
+    }
+
+    pub fn muted(&self) -> bool {
+        self.muted
+    }
+
+    pub fn set_active_call_id(&mut self, call_id: Option<String>) {
+        self.active_call_id = call_id;
+    }
+
+    pub fn start_outgoing(&mut self, call_id: &str, peer: &str) {
+        self.active_call_id = Some(call_id.to_string());
+        self.active_peer = peer.to_string();
+        self.state = "outgoing_init".to_string();
+    }
+
+    pub fn incoming(&mut self, call_id: &str, peer: &str) {
+        self.active_call_id = Some(call_id.to_string());
+        self.active_peer = peer.to_string();
+        self.state = "incoming".to_string();
+    }
+
+    pub fn set_muted(&mut self, muted: bool) {
+        self.muted = muted;
+    }
+
+    pub fn apply_call_state(&mut self, call_id: &str, state: &str) {
+        self.state = state.to_string();
+        if is_terminal_call_state(state) {
+            if self.active_call_id.as_deref() == Some(call_id) || self.active_call_id.is_none() {
+                self.clear_identity();
+            }
+        } else {
+            self.active_call_id = Some(call_id.to_string());
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.state = "idle".to_string();
+        self.clear_identity();
+    }
+
+    pub fn clear_with_state(&mut self, state: &str) {
+        self.state = state.to_string();
+        self.clear_identity();
+    }
+
+    fn clear_identity(&mut self) {
+        self.active_call_id = None;
+        self.active_peer.clear();
+        self.muted = false;
+    }
+}
+
+fn is_terminal_call_state(state: &str) -> bool {
+    matches!(state, "idle" | "released" | "error" | "end")
+}

--- a/yoyopod_rs/voip-host/src/host.rs
+++ b/yoyopod_rs/voip-host/src/host.rs
@@ -1,6 +1,13 @@
+use crate::calls::CallSession;
 use crate::config::VoipConfig;
+use crate::lifecycle::LifecycleState;
+use crate::messages::{is_terminal_delivery_state, MessageSessionState, OutboundMessageIds};
+use crate::runtime_snapshot::RuntimeSnapshot;
+use crate::voice_notes::VoiceNoteSession;
 use serde_json::json;
-use std::collections::HashMap;
+
+pub use crate::lifecycle::LifecycleEvent;
+pub use crate::messages::MessageRecord;
 
 pub trait CallBackend {
     fn start(&mut self, config: &VoipConfig) -> Result<(), String>;
@@ -22,22 +29,6 @@ pub trait CallBackend {
         duration_ms: i32,
         mime_type: &str,
     ) -> Result<String, String>;
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MessageRecord {
-    pub message_id: String,
-    pub peer_sip_address: String,
-    pub sender_sip_address: String,
-    pub recipient_sip_address: String,
-    pub kind: String,
-    pub direction: String,
-    pub delivery_state: String,
-    pub text: String,
-    pub local_file_path: String,
-    pub mime_type: String,
-    pub duration_ms: i32,
-    pub unread: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,61 +68,16 @@ pub enum BackendEvent {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LifecycleEvent {
-    pub state: String,
-    pub previous_state: String,
-    pub reason: String,
-    pub recovered: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct VoiceNoteSessionState {
-    state: String,
-    file_path: String,
-    duration_ms: i32,
-    mime_type: String,
-    message_id: String,
-}
-
-impl Default for VoiceNoteSessionState {
-    fn default() -> Self {
-        Self {
-            state: "idle".to_string(),
-            file_path: String::new(),
-            duration_ms: 0,
-            mime_type: String::new(),
-            message_id: String::new(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct MessageSessionState {
-    message_id: String,
-    kind: String,
-    direction: String,
-    delivery_state: String,
-    local_file_path: String,
-    error: String,
-}
-
 #[derive(Debug)]
 pub struct VoipHost {
     config: Option<VoipConfig>,
     registered: bool,
     registration_state: String,
-    lifecycle_state: String,
-    lifecycle_reason: String,
-    recovery_pending: bool,
-    lifecycle_events: Vec<LifecycleEvent>,
-    call_state: String,
-    active_call_id: Option<String>,
-    active_call_peer: String,
-    muted: bool,
-    voice_note: VoiceNoteSessionState,
+    lifecycle: LifecycleState,
+    call: CallSession,
+    voice_note: VoiceNoteSession,
     last_message: Option<MessageSessionState>,
-    outbound_message_ids: HashMap<String, String>,
+    outbound_message_ids: OutboundMessageIds,
 }
 
 impl Default for VoipHost {
@@ -140,17 +86,11 @@ impl Default for VoipHost {
             config: None,
             registered: false,
             registration_state: "none".to_string(),
-            lifecycle_state: "unconfigured".to_string(),
-            lifecycle_reason: String::new(),
-            recovery_pending: false,
-            lifecycle_events: Vec::new(),
-            call_state: "idle".to_string(),
-            active_call_id: None,
-            active_call_peer: String::new(),
-            muted: false,
-            voice_note: VoiceNoteSessionState::default(),
+            lifecycle: LifecycleState::default(),
+            call: CallSession::default(),
+            voice_note: VoiceNoteSession::default(),
             last_message: None,
-            outbound_message_ids: HashMap::new(),
+            outbound_message_ids: OutboundMessageIds::default(),
         }
     }
 }
@@ -160,13 +100,10 @@ impl VoipHost {
         self.config = Some(config);
         self.registered = false;
         self.registration_state = "none".to_string();
-        self.recovery_pending = false;
-        self.record_lifecycle("configured", "configured", false);
-        self.call_state = "idle".to_string();
-        self.active_call_id = None;
-        self.active_call_peer.clear();
-        self.muted = false;
-        self.voice_note = VoiceNoteSessionState::default();
+        self.lifecycle.clear_recovery_pending();
+        self.lifecycle.record("configured", "configured", false);
+        self.call.clear();
+        self.voice_note.reset();
         self.last_message = None;
         self.outbound_message_ids.clear();
     }
@@ -175,67 +112,41 @@ impl VoipHost {
         self.registered = registered;
         self.registration_state = if registered { "ok" } else { "none" }.to_string();
         if registered {
-            self.record_lifecycle("registered", "registered", false);
+            self.lifecycle.record("registered", "registered", false);
         }
     }
 
     pub fn set_active_call_id(&mut self, call_id: Option<String>) {
-        self.active_call_id = call_id;
+        self.call.set_active_call_id(call_id);
     }
 
     pub fn health_payload(&self) -> serde_json::Value {
         json!({
             "configured": self.config.is_some(),
             "registered": self.registered,
-            "active_call_id": self.active_call_id,
-            "lifecycle_state": self.lifecycle_state,
-            "lifecycle_reason": self.lifecycle_reason,
-            "backend_available": self.registered && self.lifecycle_state == "registered",
+            "active_call_id": self.call.active_call_id(),
+            "lifecycle_state": self.lifecycle.state(),
+            "lifecycle_reason": self.lifecycle.reason(),
+            "backend_available": self.lifecycle.backend_available(self.registered),
         })
     }
 
     pub fn lifecycle_payload(&self) -> serde_json::Value {
-        json!({
-            "state": self.lifecycle_state,
-            "reason": self.lifecycle_reason,
-            "backend_available": self.registered && self.lifecycle_state == "registered",
-        })
+        self.lifecycle.payload(self.registered)
     }
 
     pub fn session_snapshot_payload(&self) -> serde_json::Value {
-        let last_message = self
-            .last_message
-            .as_ref()
-            .map(|message| {
-                json!({
-                    "message_id": message.message_id,
-                    "kind": message.kind,
-                    "direction": message.direction,
-                    "delivery_state": message.delivery_state,
-                    "local_file_path": message.local_file_path,
-                    "error": message.error,
-                })
-            })
-            .unwrap_or(serde_json::Value::Null);
-        json!({
-            "configured": self.config.is_some(),
-            "registered": self.registered,
-            "registration_state": self.registration_state,
-            "lifecycle": self.lifecycle_payload(),
-            "call_state": self.call_state,
-            "active_call_id": self.active_call_id,
-            "active_call_peer": self.active_call_peer,
-            "muted": self.muted,
-            "pending_outbound_messages": self.outbound_message_ids.len(),
-            "voice_note": {
-                "state": self.voice_note.state,
-                "file_path": self.voice_note.file_path,
-                "duration_ms": self.voice_note.duration_ms,
-                "mime_type": self.voice_note.mime_type,
-                "message_id": self.voice_note.message_id,
-            },
-            "last_message": last_message,
-        })
+        RuntimeSnapshot {
+            configured: self.config.is_some(),
+            registered: self.registered,
+            registration_state: &self.registration_state,
+            lifecycle: &self.lifecycle,
+            call: &self.call,
+            voice_note: &self.voice_note,
+            last_message: self.last_message.as_ref(),
+            pending_outbound_messages: self.outbound_message_ids.len(),
+        }
+        .payload()
     }
 
     pub fn iterate_interval_ms(&self) -> u64 {
@@ -251,19 +162,19 @@ impl VoipHost {
             .as_ref()
             .ok_or_else(|| "voip host is not configured".to_string())?
             .clone();
-        self.record_lifecycle("registering", "registering", false);
+        self.lifecycle.record("registering", "registering", false);
         if let Err(error) = backend.start(&config) {
             self.registered = false;
             self.registration_state = "failed".to_string();
-            self.recovery_pending = true;
-            self.record_lifecycle("failed", &error, false);
+            self.lifecycle.mark_recovery_pending();
+            self.lifecycle.record("failed", &error, false);
             return Err(error);
         }
         self.registered = true;
         self.registration_state = "none".to_string();
-        let recovered = self.recovery_pending;
-        self.recovery_pending = false;
-        self.record_lifecycle("registered", "registered", recovered);
+        let recovered = self.lifecycle.recovery_pending();
+        self.lifecycle.clear_recovery_pending();
+        self.lifecycle.record("registered", "registered", recovered);
         Ok(())
     }
 
@@ -271,13 +182,10 @@ impl VoipHost {
         backend.stop();
         self.registered = false;
         self.registration_state = "none".to_string();
-        self.recovery_pending = false;
-        self.record_lifecycle("stopped", "unregistered", false);
-        self.call_state = "idle".to_string();
-        self.active_call_id = None;
-        self.active_call_peer.clear();
-        self.muted = false;
-        self.voice_note = VoiceNoteSessionState::default();
+        self.lifecycle.clear_recovery_pending();
+        self.lifecycle.record("stopped", "unregistered", false);
+        self.call.clear();
+        self.voice_note.reset();
         self.outbound_message_ids.clear();
     }
 
@@ -287,9 +195,7 @@ impl VoipHost {
         sip_address: &str,
     ) -> Result<(), String> {
         let call_id = backend.make_call(sip_address)?;
-        self.active_call_id = Some(call_id);
-        self.active_call_peer = sip_address.to_string();
-        self.call_state = "outgoing_init".to_string();
+        self.call.start_outgoing(&call_id, sip_address);
         Ok(())
     }
 
@@ -299,19 +205,13 @@ impl VoipHost {
 
     pub fn reject<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
         backend.reject_call()?;
-        self.active_call_id = None;
-        self.active_call_peer.clear();
-        self.call_state = "released".to_string();
-        self.muted = false;
+        self.call.clear_with_state("released");
         Ok(())
     }
 
     pub fn hangup<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
         backend.hangup()?;
-        self.active_call_id = None;
-        self.active_call_peer.clear();
-        self.call_state = "released".to_string();
-        self.muted = false;
+        self.call.clear_with_state("released");
         Ok(())
     }
 
@@ -321,7 +221,7 @@ impl VoipHost {
         muted: bool,
     ) -> Result<(), String> {
         backend.set_muted(muted)?;
-        self.muted = muted;
+        self.call.set_muted(muted);
         Ok(())
     }
 
@@ -337,7 +237,8 @@ impl VoipHost {
             return Err("voip text message requires client_id".to_string());
         }
         let backend_id = backend.send_text_message(sip_address, text)?;
-        self.remember_outbound_message_id(&backend_id, client_id, "voip text message")?;
+        self.outbound_message_ids
+            .remember(&backend_id, client_id, "voip text message")?;
         Ok(client_id.to_string())
     }
 
@@ -347,20 +248,13 @@ impl VoipHost {
         file_path: &str,
     ) -> Result<(), String> {
         backend.start_voice_recording(file_path)?;
-        self.voice_note = VoiceNoteSessionState {
-            state: "recording".to_string(),
-            file_path: file_path.to_string(),
-            duration_ms: 0,
-            mime_type: "audio/wav".to_string(),
-            message_id: String::new(),
-        };
+        self.voice_note.start_recording(file_path);
         Ok(())
     }
 
     pub fn stop_voice_recording<B: CallBackend>(&mut self, backend: &mut B) -> Result<i32, String> {
         let duration_ms = backend.stop_voice_recording()?;
-        self.voice_note.state = "recorded".to_string();
-        self.voice_note.duration_ms = duration_ms;
+        self.voice_note.finish_recording(duration_ms);
         Ok(duration_ms)
     }
 
@@ -369,7 +263,7 @@ impl VoipHost {
         backend: &mut B,
     ) -> Result<(), String> {
         backend.cancel_voice_recording()?;
-        self.voice_note = VoiceNoteSessionState::default();
+        self.voice_note.reset();
         Ok(())
     }
 
@@ -387,14 +281,10 @@ impl VoipHost {
             return Err("voip voice note requires client_id".to_string());
         }
         let backend_id = backend.send_voice_note(sip_address, file_path, duration_ms, mime_type)?;
-        self.remember_outbound_message_id(&backend_id, client_id, "voip voice note")?;
-        self.voice_note = VoiceNoteSessionState {
-            state: "sending".to_string(),
-            file_path: file_path.to_string(),
-            duration_ms,
-            mime_type: mime_type.to_string(),
-            message_id: client_id.to_string(),
-        };
+        self.outbound_message_ids
+            .remember(&backend_id, client_id, "voip voice note")?;
+        self.voice_note
+            .start_sending(file_path, duration_ms, mime_type, client_id);
         Ok(client_id.to_string())
     }
 
@@ -414,7 +304,7 @@ impl VoipHost {
     }
 
     pub fn take_lifecycle_events(&mut self) -> Vec<LifecycleEvent> {
-        std::mem::take(&mut self.lifecycle_events)
+        self.lifecycle.take_events()
     }
 
     fn apply_backend_event(&mut self, event: &BackendEvent) {
@@ -428,44 +318,21 @@ impl VoipHost {
                 }
             }
             BackendEvent::IncomingCall { call_id, from_uri } => {
-                self.active_call_id = Some(call_id.clone());
-                self.active_call_peer = from_uri.clone();
-                self.call_state = "incoming".to_string();
+                self.call.incoming(call_id, from_uri);
             }
             BackendEvent::CallStateChanged { call_id, state } => {
-                self.call_state = state.clone();
-                if matches!(state.as_str(), "idle" | "released" | "error" | "end") {
-                    if self.active_call_id.as_deref() == Some(call_id.as_str())
-                        || self.active_call_id.is_none()
-                    {
-                        self.active_call_id = None;
-                        self.active_call_peer.clear();
-                        self.muted = false;
-                    }
-                } else {
-                    self.active_call_id = Some(call_id.clone());
-                }
+                self.call.apply_call_state(call_id, state);
             }
             BackendEvent::BackendStopped { reason } => {
                 self.registered = false;
                 self.registration_state = "failed".to_string();
-                self.recovery_pending = true;
-                self.record_lifecycle("failed", reason, false);
-                self.call_state = "idle".to_string();
-                self.active_call_id = None;
-                self.active_call_peer.clear();
-                self.muted = false;
+                self.lifecycle.mark_recovery_pending();
+                self.lifecycle.record("failed", reason, false);
+                self.call.clear();
                 self.outbound_message_ids.clear();
             }
             BackendEvent::MessageReceived { message } => {
-                self.last_message = Some(MessageSessionState {
-                    message_id: message.message_id.clone(),
-                    kind: message.kind.clone(),
-                    direction: message.direction.clone(),
-                    delivery_state: message.delivery_state.clone(),
-                    local_file_path: message.local_file_path.clone(),
-                    error: String::new(),
-                });
+                self.last_message = Some(MessageSessionState::received(message));
             }
             BackendEvent::MessageDeliveryChanged {
                 message_id,
@@ -473,53 +340,30 @@ impl VoipHost {
                 local_file_path,
                 error,
             } => {
-                self.last_message = Some(MessageSessionState {
-                    message_id: message_id.clone(),
-                    kind: String::new(),
-                    direction: String::new(),
-                    delivery_state: delivery_state.clone(),
-                    local_file_path: local_file_path.clone(),
-                    error: error.clone(),
-                });
-                if self.voice_note.message_id == *message_id {
-                    self.voice_note.state = match delivery_state.as_str() {
-                        "failed" => "failed",
-                        "sent" | "delivered" => "sent",
-                        _ => "sending",
-                    }
-                    .to_string();
-                }
+                self.last_message = Some(MessageSessionState::delivery_changed(
+                    message_id,
+                    delivery_state,
+                    local_file_path,
+                    error,
+                ));
+                self.voice_note
+                    .apply_delivery(message_id, delivery_state, local_file_path);
             }
             BackendEvent::MessageDownloadCompleted {
                 message_id,
                 local_file_path,
                 mime_type,
             } => {
-                self.last_message = Some(MessageSessionState {
-                    message_id: message_id.clone(),
-                    kind: String::new(),
-                    direction: String::new(),
-                    delivery_state: "delivered".to_string(),
-                    local_file_path: local_file_path.clone(),
-                    error: String::new(),
-                });
-                if self.voice_note.message_id == *message_id {
-                    self.voice_note.file_path = local_file_path.clone();
-                    self.voice_note.mime_type = mime_type.clone();
-                }
+                self.last_message = Some(MessageSessionState::download_completed(
+                    message_id,
+                    local_file_path,
+                ));
+                self.voice_note
+                    .apply_download(message_id, local_file_path, mime_type);
             }
             BackendEvent::MessageFailed { message_id, reason } => {
-                self.last_message = Some(MessageSessionState {
-                    message_id: message_id.clone(),
-                    kind: String::new(),
-                    direction: String::new(),
-                    delivery_state: "failed".to_string(),
-                    local_file_path: String::new(),
-                    error: reason.clone(),
-                });
-                if self.voice_note.message_id == *message_id {
-                    self.voice_note.state = "failed".to_string();
-                }
+                self.last_message = Some(MessageSessionState::failed(message_id, reason));
+                self.voice_note.fail(message_id);
             }
         }
     }
@@ -562,45 +406,6 @@ impl VoipHost {
     }
 
     fn translate_message_id(&mut self, backend_id: &str, terminal: bool) -> String {
-        let client_id = self.outbound_message_ids.get(backend_id).cloned();
-        if terminal && client_id.is_some() {
-            self.outbound_message_ids.remove(backend_id);
-        }
-        client_id.unwrap_or_else(|| backend_id.to_string())
+        self.outbound_message_ids.translate(backend_id, terminal)
     }
-
-    fn remember_outbound_message_id(
-        &mut self,
-        backend_id: &str,
-        client_id: &str,
-        label: &str,
-    ) -> Result<(), String> {
-        let backend_id = backend_id.trim();
-        if backend_id.is_empty() {
-            return Err(format!("{label} backend returned empty message id"));
-        }
-        if backend_id != client_id {
-            self.outbound_message_ids
-                .insert(backend_id.to_string(), client_id.to_string());
-        }
-        Ok(())
-    }
-
-    fn record_lifecycle(&mut self, state: &str, reason: &str, recovered: bool) {
-        let previous_state = self.lifecycle_state.clone();
-        let state = state.to_string();
-        let reason = reason.to_string();
-        self.lifecycle_state = state.clone();
-        self.lifecycle_reason = reason.clone();
-        self.lifecycle_events.push(LifecycleEvent {
-            state,
-            previous_state,
-            reason,
-            recovered,
-        });
-    }
-}
-
-fn is_terminal_delivery_state(value: &str) -> bool {
-    matches!(value, "delivered" | "failed")
 }

--- a/yoyopod_rs/voip-host/src/lib.rs
+++ b/yoyopod_rs/voip-host/src/lib.rs
@@ -1,6 +1,11 @@
+pub mod calls;
 pub mod config;
 pub mod events;
 pub mod host;
+pub mod lifecycle;
+pub mod messages;
 pub mod protocol;
+pub mod runtime_snapshot;
 pub mod shim;
+pub mod voice_notes;
 pub mod worker;

--- a/yoyopod_rs/voip-host/src/lifecycle.rs
+++ b/yoyopod_rs/voip-host/src/lifecycle.rs
@@ -1,0 +1,80 @@
+use serde_json::json;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LifecycleEvent {
+    pub state: String,
+    pub previous_state: String,
+    pub reason: String,
+    pub recovered: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LifecycleState {
+    state: String,
+    reason: String,
+    recovery_pending: bool,
+    events: Vec<LifecycleEvent>,
+}
+
+impl Default for LifecycleState {
+    fn default() -> Self {
+        Self {
+            state: "unconfigured".to_string(),
+            reason: String::new(),
+            recovery_pending: false,
+            events: Vec::new(),
+        }
+    }
+}
+
+impl LifecycleState {
+    pub fn state(&self) -> &str {
+        &self.state
+    }
+
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+
+    pub fn recovery_pending(&self) -> bool {
+        self.recovery_pending
+    }
+
+    pub fn mark_recovery_pending(&mut self) {
+        self.recovery_pending = true;
+    }
+
+    pub fn clear_recovery_pending(&mut self) {
+        self.recovery_pending = false;
+    }
+
+    pub fn backend_available(&self, registered: bool) -> bool {
+        registered && self.state == "registered"
+    }
+
+    pub fn payload(&self, registered: bool) -> serde_json::Value {
+        json!({
+            "state": self.state,
+            "reason": self.reason,
+            "backend_available": self.backend_available(registered),
+        })
+    }
+
+    pub fn record(&mut self, state: &str, reason: &str, recovered: bool) {
+        let previous_state = self.state.clone();
+        let state = state.to_string();
+        let reason = reason.to_string();
+        self.state = state.clone();
+        self.reason = reason.clone();
+        self.events.push(LifecycleEvent {
+            state,
+            previous_state,
+            reason,
+            recovered,
+        });
+    }
+
+    pub fn take_events(&mut self) -> Vec<LifecycleEvent> {
+        std::mem::take(&mut self.events)
+    }
+}

--- a/yoyopod_rs/voip-host/src/messages.rs
+++ b/yoyopod_rs/voip-host/src/messages.rs
@@ -1,0 +1,134 @@
+use serde_json::json;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageRecord {
+    pub message_id: String,
+    pub peer_sip_address: String,
+    pub sender_sip_address: String,
+    pub recipient_sip_address: String,
+    pub kind: String,
+    pub direction: String,
+    pub delivery_state: String,
+    pub text: String,
+    pub local_file_path: String,
+    pub mime_type: String,
+    pub duration_ms: i32,
+    pub unread: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageSessionState {
+    message_id: String,
+    kind: String,
+    direction: String,
+    delivery_state: String,
+    local_file_path: String,
+    error: String,
+}
+
+impl MessageSessionState {
+    pub fn received(message: &MessageRecord) -> Self {
+        Self {
+            message_id: message.message_id.clone(),
+            kind: message.kind.clone(),
+            direction: message.direction.clone(),
+            delivery_state: message.delivery_state.clone(),
+            local_file_path: message.local_file_path.clone(),
+            error: String::new(),
+        }
+    }
+
+    pub fn delivery_changed(
+        message_id: &str,
+        delivery_state: &str,
+        local_file_path: &str,
+        error: &str,
+    ) -> Self {
+        Self {
+            message_id: message_id.to_string(),
+            kind: String::new(),
+            direction: String::new(),
+            delivery_state: delivery_state.to_string(),
+            local_file_path: local_file_path.to_string(),
+            error: error.to_string(),
+        }
+    }
+
+    pub fn download_completed(message_id: &str, local_file_path: &str) -> Self {
+        Self {
+            message_id: message_id.to_string(),
+            kind: String::new(),
+            direction: String::new(),
+            delivery_state: "delivered".to_string(),
+            local_file_path: local_file_path.to_string(),
+            error: String::new(),
+        }
+    }
+
+    pub fn failed(message_id: &str, reason: &str) -> Self {
+        Self {
+            message_id: message_id.to_string(),
+            kind: String::new(),
+            direction: String::new(),
+            delivery_state: "failed".to_string(),
+            local_file_path: String::new(),
+            error: reason.to_string(),
+        }
+    }
+
+    pub fn payload(&self) -> serde_json::Value {
+        json!({
+            "message_id": self.message_id,
+            "kind": self.kind,
+            "direction": self.direction,
+            "delivery_state": self.delivery_state,
+            "local_file_path": self.local_file_path,
+            "error": self.error,
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct OutboundMessageIds {
+    ids: HashMap<String, String>,
+}
+
+impl OutboundMessageIds {
+    pub fn len(&self) -> usize {
+        self.ids.len()
+    }
+
+    pub fn clear(&mut self) {
+        self.ids.clear();
+    }
+
+    pub fn translate(&mut self, backend_id: &str, terminal: bool) -> String {
+        let client_id = self.ids.get(backend_id).cloned();
+        if terminal && client_id.is_some() {
+            self.ids.remove(backend_id);
+        }
+        client_id.unwrap_or_else(|| backend_id.to_string())
+    }
+
+    pub fn remember(
+        &mut self,
+        backend_id: &str,
+        client_id: &str,
+        label: &str,
+    ) -> Result<(), String> {
+        let backend_id = backend_id.trim();
+        if backend_id.is_empty() {
+            return Err(format!("{label} backend returned empty message id"));
+        }
+        if backend_id != client_id {
+            self.ids
+                .insert(backend_id.to_string(), client_id.to_string());
+        }
+        Ok(())
+    }
+}
+
+pub fn is_terminal_delivery_state(value: &str) -> bool {
+    matches!(value, "delivered" | "failed")
+}

--- a/yoyopod_rs/voip-host/src/runtime_snapshot.rs
+++ b/yoyopod_rs/voip-host/src/runtime_snapshot.rs
@@ -1,0 +1,39 @@
+use crate::calls::CallSession;
+use crate::lifecycle::LifecycleState;
+use crate::messages::MessageSessionState;
+use crate::voice_notes::VoiceNoteSession;
+use serde_json::json;
+
+pub struct RuntimeSnapshot<'a> {
+    pub configured: bool,
+    pub registered: bool,
+    pub registration_state: &'a str,
+    pub lifecycle: &'a LifecycleState,
+    pub call: &'a CallSession,
+    pub voice_note: &'a VoiceNoteSession,
+    pub last_message: Option<&'a MessageSessionState>,
+    pub pending_outbound_messages: usize,
+}
+
+impl RuntimeSnapshot<'_> {
+    pub fn payload(&self) -> serde_json::Value {
+        let last_message = self
+            .last_message
+            .map(MessageSessionState::payload)
+            .unwrap_or(serde_json::Value::Null);
+
+        json!({
+            "configured": self.configured,
+            "registered": self.registered,
+            "registration_state": self.registration_state,
+            "lifecycle": self.lifecycle.payload(self.registered),
+            "call_state": self.call.state(),
+            "active_call_id": self.call.active_call_id(),
+            "active_call_peer": self.call.active_peer(),
+            "muted": self.call.muted(),
+            "pending_outbound_messages": self.pending_outbound_messages,
+            "voice_note": self.voice_note.payload(),
+            "last_message": last_message,
+        })
+    }
+}

--- a/yoyopod_rs/voip-host/src/voice_notes.rs
+++ b/yoyopod_rs/voip-host/src/voice_notes.rs
@@ -1,0 +1,96 @@
+use serde_json::json;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceNoteSession {
+    state: String,
+    file_path: String,
+    duration_ms: i32,
+    mime_type: String,
+    message_id: String,
+}
+
+impl Default for VoiceNoteSession {
+    fn default() -> Self {
+        Self {
+            state: "idle".to_string(),
+            file_path: String::new(),
+            duration_ms: 0,
+            mime_type: String::new(),
+            message_id: String::new(),
+        }
+    }
+}
+
+impl VoiceNoteSession {
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    pub fn start_recording(&mut self, file_path: &str) {
+        self.state = "recording".to_string();
+        self.file_path = file_path.to_string();
+        self.duration_ms = 0;
+        self.mime_type = "audio/wav".to_string();
+        self.message_id.clear();
+    }
+
+    pub fn finish_recording(&mut self, duration_ms: i32) {
+        self.state = "recorded".to_string();
+        self.duration_ms = duration_ms;
+    }
+
+    pub fn start_sending(
+        &mut self,
+        file_path: &str,
+        duration_ms: i32,
+        mime_type: &str,
+        message_id: &str,
+    ) {
+        self.state = "sending".to_string();
+        self.file_path = file_path.to_string();
+        self.duration_ms = duration_ms;
+        self.mime_type = mime_type.to_string();
+        self.message_id = message_id.to_string();
+    }
+
+    pub fn apply_delivery(
+        &mut self,
+        message_id: &str,
+        delivery_state: &str,
+        _local_file_path: &str,
+    ) {
+        if self.message_id != message_id {
+            return;
+        }
+        self.state = match delivery_state {
+            "failed" => "failed",
+            "sent" | "delivered" => "sent",
+            _ => "sending",
+        }
+        .to_string();
+    }
+
+    pub fn apply_download(&mut self, message_id: &str, local_file_path: &str, mime_type: &str) {
+        if self.message_id != message_id {
+            return;
+        }
+        self.file_path = local_file_path.to_string();
+        self.mime_type = mime_type.to_string();
+    }
+
+    pub fn fail(&mut self, message_id: &str) {
+        if self.message_id == message_id {
+            self.state = "failed".to_string();
+        }
+    }
+
+    pub fn payload(&self) -> serde_json::Value {
+        json!({
+            "state": self.state,
+            "file_path": self.file_path,
+            "duration_ms": self.duration_ms,
+            "mime_type": self.mime_type,
+            "message_id": self.message_id,
+        })
+    }
+}

--- a/yoyopod_rs/voip-host/tests/calls.rs
+++ b/yoyopod_rs/voip-host/tests/calls.rs
@@ -1,0 +1,46 @@
+use yoyopod_voip_host::calls::CallSession;
+
+#[test]
+fn call_session_owns_active_call_peer_and_mute_reset() {
+    let mut session = CallSession::default();
+
+    assert_eq!(session.state(), "idle");
+    assert_eq!(session.active_call_id(), None);
+    assert_eq!(session.active_peer(), "");
+    assert!(!session.muted());
+
+    session.start_outgoing("call-1", "sip:bob@example.com");
+    session.set_muted(true);
+    session.apply_call_state("call-1", "streams_running");
+
+    assert_eq!(session.state(), "streams_running");
+    assert_eq!(session.active_call_id(), Some("call-1"));
+    assert_eq!(session.active_peer(), "sip:bob@example.com");
+    assert!(session.muted());
+
+    session.apply_call_state("call-1", "released");
+
+    assert_eq!(session.state(), "released");
+    assert_eq!(session.active_call_id(), None);
+    assert_eq!(session.active_peer(), "");
+    assert!(!session.muted());
+}
+
+#[test]
+fn incoming_call_and_explicit_terminal_actions_clear_session() {
+    let mut session = CallSession::default();
+
+    session.incoming("call-2", "sip:alice@example.com");
+    session.set_muted(true);
+
+    assert_eq!(session.state(), "incoming");
+    assert_eq!(session.active_call_id(), Some("call-2"));
+    assert_eq!(session.active_peer(), "sip:alice@example.com");
+
+    session.clear_with_state("released");
+
+    assert_eq!(session.state(), "released");
+    assert_eq!(session.active_call_id(), None);
+    assert_eq!(session.active_peer(), "");
+    assert!(!session.muted());
+}

--- a/yoyopod_rs/voip-host/tests/lifecycle.rs
+++ b/yoyopod_rs/voip-host/tests/lifecycle.rs
@@ -1,0 +1,27 @@
+use yoyopod_voip_host::lifecycle::LifecycleState;
+
+#[test]
+fn lifecycle_state_records_recovery_and_drains_events() {
+    let mut lifecycle = LifecycleState::default();
+
+    assert_eq!(lifecycle.state(), "unconfigured");
+    assert_eq!(lifecycle.reason(), "");
+    assert!(!lifecycle.backend_available(false));
+
+    lifecycle.record("configured", "configured", false);
+    lifecycle.mark_recovery_pending();
+    lifecycle.record("failed", "shim missing", false);
+    lifecycle.record("registered", "registered", true);
+
+    assert_eq!(lifecycle.state(), "registered");
+    assert_eq!(lifecycle.reason(), "registered");
+    assert!(lifecycle.backend_available(true));
+
+    let events = lifecycle.take_events();
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].state, "configured");
+    assert_eq!(events[1].previous_state, "configured");
+    assert_eq!(events[1].reason, "shim missing");
+    assert!(events[2].recovered);
+    assert!(lifecycle.take_events().is_empty());
+}

--- a/yoyopod_rs/voip-host/tests/messages.rs
+++ b/yoyopod_rs/voip-host/tests/messages.rs
@@ -1,0 +1,54 @@
+use yoyopod_voip_host::messages::{
+    is_terminal_delivery_state, MessageRecord, MessageSessionState, OutboundMessageIds,
+};
+
+#[test]
+fn outbound_message_ids_translate_backend_ids_until_terminal_delivery() {
+    let mut ids = OutboundMessageIds::default();
+
+    ids.remember("backend-msg-1", "client-msg-1", "voip text message")
+        .expect("remember id");
+
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids.translate("backend-msg-1", false), "client-msg-1");
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids.translate("backend-msg-1", true), "client-msg-1");
+    assert_eq!(ids.len(), 0);
+    assert_eq!(ids.translate("backend-msg-1", true), "backend-msg-1");
+}
+
+#[test]
+fn last_message_snapshots_keep_runtime_facts_for_payloads() {
+    let record = MessageRecord {
+        message_id: "msg-1".to_string(),
+        peer_sip_address: "sip:bob@example.com".to_string(),
+        sender_sip_address: "sip:bob@example.com".to_string(),
+        recipient_sip_address: "sip:alice@example.com".to_string(),
+        kind: "text".to_string(),
+        direction: "incoming".to_string(),
+        delivery_state: "delivered".to_string(),
+        text: "hello".to_string(),
+        local_file_path: "".to_string(),
+        mime_type: "".to_string(),
+        duration_ms: 0,
+        unread: true,
+    };
+
+    let received = MessageSessionState::received(&record);
+    assert_eq!(received.payload()["message_id"], "msg-1");
+    assert_eq!(received.payload()["kind"], "text");
+    assert_eq!(received.payload()["direction"], "incoming");
+    assert_eq!(received.payload()["delivery_state"], "delivered");
+
+    let failed = MessageSessionState::failed("msg-1", "peer offline");
+    assert_eq!(failed.payload()["delivery_state"], "failed");
+    assert_eq!(failed.payload()["error"], "peer offline");
+}
+
+#[test]
+fn terminal_delivery_states_match_worker_cleanup_contract() {
+    assert!(is_terminal_delivery_state("delivered"));
+    assert!(is_terminal_delivery_state("failed"));
+    assert!(!is_terminal_delivery_state("sent"));
+    assert!(!is_terminal_delivery_state("pending"));
+}

--- a/yoyopod_rs/voip-host/tests/runtime_snapshot.rs
+++ b/yoyopod_rs/voip-host/tests/runtime_snapshot.rs
@@ -1,0 +1,45 @@
+use yoyopod_voip_host::calls::CallSession;
+use yoyopod_voip_host::lifecycle::LifecycleState;
+use yoyopod_voip_host::messages::MessageSessionState;
+use yoyopod_voip_host::runtime_snapshot::RuntimeSnapshot;
+use yoyopod_voip_host::voice_notes::VoiceNoteSession;
+
+#[test]
+fn runtime_snapshot_composes_canonical_voip_payload() {
+    let mut lifecycle = LifecycleState::default();
+    lifecycle.record("registered", "registered", false);
+
+    let mut call = CallSession::default();
+    call.start_outgoing("call-1", "sip:bob@example.com");
+    call.set_muted(true);
+
+    let mut voice_note = VoiceNoteSession::default();
+    voice_note.start_sending("/tmp/note.wav", 1250, "audio/wav", "client-vn-1");
+
+    let last_message =
+        MessageSessionState::delivery_changed("client-vn-1", "delivered", "/tmp/note.wav", "");
+
+    let payload = RuntimeSnapshot {
+        configured: true,
+        registered: true,
+        registration_state: "ok",
+        lifecycle: &lifecycle,
+        call: &call,
+        voice_note: &voice_note,
+        last_message: Some(&last_message),
+        pending_outbound_messages: 1,
+    }
+    .payload();
+
+    assert_eq!(payload["configured"], true);
+    assert_eq!(payload["registered"], true);
+    assert_eq!(payload["registration_state"], "ok");
+    assert_eq!(payload["lifecycle"]["state"], "registered");
+    assert_eq!(payload["call_state"], "outgoing_init");
+    assert_eq!(payload["active_call_id"], "call-1");
+    assert_eq!(payload["active_call_peer"], "sip:bob@example.com");
+    assert_eq!(payload["muted"], true);
+    assert_eq!(payload["voice_note"]["message_id"], "client-vn-1");
+    assert_eq!(payload["last_message"]["message_id"], "client-vn-1");
+    assert_eq!(payload["pending_outbound_messages"], 1);
+}

--- a/yoyopod_rs/voip-host/tests/voice_notes.rs
+++ b/yoyopod_rs/voip-host/tests/voice_notes.rs
@@ -1,0 +1,41 @@
+use yoyopod_voip_host::voice_notes::VoiceNoteSession;
+
+#[test]
+fn voice_note_session_tracks_record_send_and_delivery_state() {
+    let mut session = VoiceNoteSession::default();
+
+    assert_eq!(session.payload()["state"], "idle");
+
+    session.start_recording("/tmp/note.wav");
+    assert_eq!(session.payload()["state"], "recording");
+    assert_eq!(session.payload()["file_path"], "/tmp/note.wav");
+    assert_eq!(session.payload()["mime_type"], "audio/wav");
+
+    session.finish_recording(1250);
+    assert_eq!(session.payload()["state"], "recorded");
+    assert_eq!(session.payload()["duration_ms"], 1250);
+
+    session.start_sending("/tmp/note.wav", 1250, "audio/wav", "client-vn-1");
+    assert_eq!(session.payload()["state"], "sending");
+    assert_eq!(session.payload()["message_id"], "client-vn-1");
+
+    session.apply_delivery("other", "failed", "/tmp/other.wav");
+    assert_eq!(session.payload()["state"], "sending");
+
+    session.apply_delivery("client-vn-1", "delivered", "/tmp/note.wav");
+    assert_eq!(session.payload()["state"], "sent");
+    assert_eq!(session.payload()["file_path"], "/tmp/note.wav");
+}
+
+#[test]
+fn voice_note_session_resets_after_cancel_or_unregister() {
+    let mut session = VoiceNoteSession::default();
+
+    session.start_recording("/tmp/note.wav");
+    session.reset();
+
+    assert_eq!(session.payload()["state"], "idle");
+    assert_eq!(session.payload()["file_path"], "");
+    assert_eq!(session.payload()["duration_ms"], 0);
+    assert_eq!(session.payload()["message_id"], "");
+}


### PR DESCRIPTION
## Summary
- split Rust VoIP host session ownership into focused calls, lifecycle, messages, voice-notes, and runtime snapshot modules
- keep the existing VoipHost public facade and worker protocol stable
- add module-level Rust integration tests and Bazel targets for the new VoIP domain modules

## Test Plan
- cargo fmt --manifest-path yoyopod_rs\\Cargo.toml --all --check
- cargo test --manifest-path yoyopod_rs\\Cargo.toml --workspace --locked
- cargo test --manifest-path yoyopod_rs\\Cargo.toml --workspace --locked --features whisplay-hardware
- npx --yes @bazel/bazelisk test //yoyopod_rs/ui-host/... //yoyopod_rs/voip-host/...
- uv run python scripts\\quality.py gate
- uv run pytest -q