### PR TITLE
fix(cli): load service env for VoIP validation

### DIFF
--- a/tests/cli/test_pi_validate_voip.py
+++ b/tests/cli/test_pi_validate_voip.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+import yoyopod_cli.pi.validate.voip as pi_validate_voip
+from yoyopod_cli.pi.validate import app as pi_validate_app
+
+
+def test_voip_validation_loads_service_env_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    env_file = tmp_path / "yoyopod-dev.env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "# service-style env file",
+                "YOYOPOD_SIP_IDENTITY='sip:tifo@sip.linphone.org'",
+                "YOYOPOD_SIP_USERNAME=tifo",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("YOYOPOD_SIP_IDENTITY", "")
+    monkeypatch.setenv("YOYOPOD_SIP_USERNAME", "")
+
+    observed: list[tuple[str, str]] = []
+
+    def fake_quick_check(config_dir: str, registration_timeout: float) -> None:
+        observed.append(
+            (
+                os.environ["YOYOPOD_SIP_IDENTITY"],
+                os.environ["YOYOPOD_SIP_USERNAME"],
+            )
+        )
+
+    monkeypatch.setattr(pi_validate_voip, "_run_quick_voip_check", fake_quick_check)
+
+    result = CliRunner().invoke(
+        pi_validate_app,
+        ["voip", "--env-file", str(env_file)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert observed == [("sip:tifo@sip.linphone.org", "tifo")]

--- a/yoyopod_cli/pi/validate/cloud_voice.py
+++ b/yoyopod_cli/pi/validate/cloud_voice.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import math
 import os
 import queue
-import shlex
 import shutil
 import subprocess
 import threading
@@ -35,36 +34,13 @@ from yoyopod.integrations.voice.worker_contract import (
 )
 from yoyopod_cli.common import REPO_ROOT, configure_logging, resolve_config_dir
 from yoyopod_cli.pi.validate._common import _CheckResult, _print_summary
+from yoyopod_cli.pi.validate.service_env import load_service_env_file, resolve_service_env_file
 
 
 def _load_cloud_voice_env_file(env_file: Path) -> list[str]:
     """Load service-style KEY=VALUE assignments into this validation process."""
 
-    if not env_file.exists():
-        return []
-
-    loaded: list[str] = []
-    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        try:
-            parts = shlex.split(line, comments=True, posix=True)
-        except ValueError:
-            continue
-        if not parts:
-            continue
-        if parts[0] == "export":
-            parts = parts[1:]
-        if not parts or "=" not in parts[0]:
-            continue
-        key, value = parts[0].split("=", 1)
-        key = key.strip()
-        if not key:
-            continue
-        os.environ[key] = value
-        loaded.append(key)
-    return loaded
+    return load_service_env_file(env_file)
 
 
 def _cloud_voice_env_file_check(env_file: Path, loaded_keys: list[str]) -> _CheckResult:
@@ -854,9 +830,7 @@ def cloud_voice(
 
     configure_logging(verbose)
     config_path = resolve_config_dir(config_dir)
-    env_path = Path(env_file)
-    if not env_path.is_absolute():
-        env_path = REPO_ROOT / env_path
+    env_path = resolve_service_env_file(env_file)
 
     logger.info("Running target cloud voice validation")
 

--- a/yoyopod_cli/pi/validate/service_env.py
+++ b/yoyopod_cli/pi/validate/service_env.py
@@ -1,0 +1,48 @@
+"""Helpers for importing systemd EnvironmentFile settings in Pi validators."""
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+
+from yoyopod_cli.common import REPO_ROOT
+
+
+def resolve_service_env_file(env_file: str) -> Path:
+    """Resolve an EnvironmentFile path from CLI input."""
+
+    env_path = Path(env_file)
+    if not env_path.is_absolute():
+        env_path = REPO_ROOT / env_path
+    return env_path
+
+
+def load_service_env_file(env_file: Path) -> list[str]:
+    """Load service-style KEY=VALUE assignments into this process environment."""
+
+    if not env_file.exists():
+        return []
+
+    loaded: list[str] = []
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            parts = shlex.split(line, comments=True, posix=True)
+        except ValueError:
+            continue
+        if not parts:
+            continue
+        if parts[0] == "export":
+            parts = parts[1:]
+        if not parts or "=" not in parts[0]:
+            continue
+        key, value = parts[0].split("=", 1)
+        key = key.strip()
+        if not key:
+            continue
+        os.environ[key] = value
+        loaded.append(key)
+    return loaded

--- a/yoyopod_cli/pi/validate/voip.py
+++ b/yoyopod_cli/pi/validate/voip.py
@@ -12,8 +12,9 @@ from typing import Annotated, Any, Callable, Protocol, cast
 
 import typer
 
-from yoyopod_cli.pi.validate._common import _CheckResult, _print_summary
 from yoyopod_cli.common import REPO_ROOT, configure_logging, resolve_config_dir
+from yoyopod_cli.pi.validate._common import _CheckResult, _print_summary
+from yoyopod_cli.pi.validate.service_env import load_service_env_file, resolve_service_env_file
 
 # ---------------------------------------------------------------------------
 # VoIP check helper
@@ -975,6 +976,13 @@ def voip(
     config_dir: Annotated[
         str, typer.Option("--config-dir", help="Configuration directory to use.")
     ] = "config",
+    env_file: Annotated[
+        str,
+        typer.Option(
+            "--env-file",
+            help="Service EnvironmentFile to load before resolving VoIP settings.",
+        ),
+    ] = "/etc/default/yoyopod-dev",
     registration_timeout: Annotated[
         float, typer.Option("--registration-timeout", help="Registration timeout in seconds.")
     ] = 90.0,
@@ -1080,6 +1088,8 @@ def voip(
 ) -> None:
     """VoIP validation: quick check (default) or soak drill (--soak registration|reconnect|call)."""
     configure_logging(verbose)
+    if env_file.strip():
+        load_service_env_file(resolve_service_env_file(env_file))
     if not soak:
         return _run_quick_voip_check(config_dir, registration_timeout)
     if soak == "registration":


### PR DESCRIPTION
## Summary
- add a shared service EnvironmentFile parser for Pi validation commands
- load /etc/default/yoyopod-dev before resolving VoIP validation config
- reuse the shared parser from cloud voice validation

## Tests
- uv run python scripts/quality.py gate
- uv run pytest -q