### PR TITLE
[codex] Let Rust VoIP snapshots own app call runtime mirrors

### DIFF
--- a/tests/backends/test_voip_backend.py
+++ b/tests/backends/test_voip_backend.py
@@ -581,6 +581,36 @@ def test_voip_manager_waits_for_rust_snapshot_before_mute_state() -> None:
     assert manager.is_muted is False
 
 
+def test_voip_manager_publishes_runtime_snapshot_callbacks_without_call_state_change() -> None:
+    """Rust snapshots should surface facts that do not emit call-state callbacks."""
+
+    backend = SnapshotOwnedMockVoIPBackend()
+    manager = VoIPManager(build_config(), backend=backend)
+    snapshots: list[VoIPRuntimeSnapshot] = []
+    call_states: list[CallState] = []
+    manager.on_runtime_snapshot_change(snapshots.append)
+    manager.on_call_state_change(call_states.append)
+
+    assert manager.start()
+    muted_snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        muted=True,
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+    )
+
+    backend.emit(VoIPRuntimeSnapshotChanged(snapshot=muted_snapshot))
+
+    assert snapshots == [muted_snapshot]
+    assert call_states == []
+    assert manager.is_muted is True
+
+
 def test_voip_manager_starts_timer_on_streams_running_without_connected() -> None:
     """Streams-running callbacks should start live duration tracking on their own."""
 

--- a/tests/integrations/test_call.py
+++ b/tests/integrations/test_call.py
@@ -16,11 +16,14 @@ from yoyopod.integrations.call import (
     MarkHistorySeenCommand,
     MuteCommand,
     PlayLatestVoiceNoteCommand,
+    RegistrationState,
     SendActiveVoiceNoteCommand,
     SendTextMessageCommand,
     StartVoiceNoteRecordingCommand,
     StopVoiceNoteRecordingCommand,
     UnmuteCommand,
+    VoIPLifecycleSnapshot,
+    VoIPRuntimeSnapshot,
     VoiceNoteSummaryChangedEvent,
     setup,
     teardown,
@@ -31,7 +34,7 @@ from yoyopod.core.focus import setup as setup_focus
 class FakeVoipManager:
     """Minimal manager double for scaffold call integration tests."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, runtime_snapshot_owned: bool = False) -> None:
         self.running = False
         self.registration_state = "none"
         self.call_state = CallState.IDLE
@@ -53,6 +56,8 @@ class FakeVoipManager:
         self.incoming_call_callbacks = []
         self.availability_callbacks = []
         self.message_summary_callbacks = []
+        self.runtime_snapshot_callbacks = []
+        self.runtime_snapshot_owned = runtime_snapshot_owned
 
     def start(self) -> bool:
         self.start_calls += 1
@@ -152,6 +157,12 @@ class FakeVoipManager:
     def on_message_summary_change(self, callback) -> None:
         self.message_summary_callbacks.append(callback)
 
+    def on_runtime_snapshot_change(self, callback) -> None:
+        self.runtime_snapshot_callbacks.append(callback)
+
+    def owns_runtime_snapshot(self) -> bool:
+        return self.runtime_snapshot_owned
+
     def emit_incoming_call(self, caller_address: str, caller_name: str) -> None:
         self.caller_address = caller_address
         self.caller_name = caller_name
@@ -174,6 +185,15 @@ class FakeVoipManager:
     ) -> None:
         for callback in self.message_summary_callbacks:
             callback(unread_count, latest_by_contact)
+
+    def emit_runtime_snapshot(self, snapshot: VoIPRuntimeSnapshot) -> None:
+        self.call_state = snapshot.call_state
+        self.current_call_id = snapshot.active_call_id or None
+        self.caller_address = snapshot.active_call_peer
+        self.caller_name = snapshot.active_call_peer
+        self.is_muted = snapshot.muted
+        for callback in self.runtime_snapshot_callbacks:
+            callback(snapshot)
 
 
 class FakeRinger:
@@ -276,6 +296,86 @@ def test_call_flow_updates_focus_mute_and_history(tmp_path: Path) -> None:
     assert recent_entry.display_name == "Ada"
     assert recent_entry.outcome == "completed"
     assert recent_entry.duration_seconds == 17
+
+
+def test_rust_owned_call_runtime_waits_for_snapshot_before_mirroring_state(
+    tmp_path: Path,
+) -> None:
+    app = build_test_app()
+    setup_focus(app)
+    history_store = CallHistoryStore(tmp_path / "call_history.json")
+    manager = FakeVoipManager(runtime_snapshot_owned=True)
+    setup(app, manager=manager, call_history_store=history_store, ringer=FakeRinger())
+    drain_all(app)
+
+    assert app.services.call(
+        "call",
+        "dial",
+        DialCommand(sip_address="sip:ada@example.com", contact_name="Ada"),
+    )
+    drain_all(app)
+
+    assert manager.dial_calls == [("sip:ada@example.com", "Ada")]
+    assert app.states.get_value("focus.owner") is None
+    assert app.states.get_value("call.state") == "idle"
+
+    manager.emit_runtime_snapshot(
+        VoIPRuntimeSnapshot(
+            configured=True,
+            registered=True,
+            registration_state=RegistrationState.OK,
+            call_state=CallState.OUTGOING,
+            active_call_id="call-1",
+            active_call_peer="sip:ada@example.com",
+            lifecycle=VoIPLifecycleSnapshot(
+                state="registered",
+                reason="registered",
+                backend_available=True,
+            ),
+        )
+    )
+    manager.emit_call_state(CallState.OUTGOING)
+    drain_all(app)
+
+    assert app.states.get_value("focus.owner") == "call"
+    assert app.states.get_value("call.state") == "outgoing"
+    assert app.states.get("call.state").attrs["caller_address"] == "sip:ada@example.com"
+
+
+def test_rust_owned_mute_waits_for_snapshot_before_mirroring_state(
+    tmp_path: Path,
+) -> None:
+    app = build_test_app()
+    setup_focus(app)
+    history_store = CallHistoryStore(tmp_path / "call_history.json")
+    manager = FakeVoipManager(runtime_snapshot_owned=True)
+    setup(app, manager=manager, call_history_store=history_store, ringer=FakeRinger())
+    drain_all(app)
+
+    assert app.services.call("call", "mute", MuteCommand()) is True
+    drain_all(app)
+    assert app.states.get_value("call.muted") is False
+
+    manager.emit_runtime_snapshot(
+        VoIPRuntimeSnapshot(
+            configured=True,
+            registered=True,
+            registration_state=RegistrationState.OK,
+            call_state=CallState.STREAMS_RUNNING,
+            active_call_id="call-1",
+            active_call_peer="sip:ada@example.com",
+            muted=True,
+            lifecycle=VoIPLifecycleSnapshot(
+                state="registered",
+                reason="registered",
+                backend_available=True,
+            ),
+        )
+    )
+    drain_all(app)
+
+    assert app.states.get_value("call.muted") is True
+    assert app.states.get_value("call.state") == "active"
 
 
 def test_incoming_calls_ring_and_history_can_be_marked_seen(tmp_path: Path) -> None:

--- a/yoyopod/integrations/call/__init__.py
+++ b/yoyopod/integrations/call/__init__.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
         RegistrationChangedEvent,
         VoiceNoteSummaryChangedEvent,
         VoIPAvailabilityChangedEvent,
+        VoIPRuntimeSnapshotChangedEvent,
     )
     from yoyopod.integrations.call.runtime import CallRuntime
     from yoyopod.integrations.call.history import CallHistoryEntry, CallHistoryStore
@@ -169,6 +170,10 @@ _PUBLIC_EXPORTS = {
         "yoyopod.integrations.call.events",
         "VoIPAvailabilityChangedEvent",
     ),
+    "VoIPRuntimeSnapshotChangedEvent": (
+        "yoyopod.integrations.call.events",
+        "VoIPRuntimeSnapshotChangedEvent",
+    ),
     "VoiceNoteDraft": ("yoyopod.integrations.call.voice_notes", "VoiceNoteDraft"),
     "VoiceNoteEventHandler": ("yoyopod.integrations.call.voice_notes", "VoiceNoteEventHandler"),
     "VoiceNoteService": ("yoyopod.integrations.call.voice_notes", "VoiceNoteService"),
@@ -215,6 +220,7 @@ def setup(
         RegistrationChangedEvent,
         VoiceNoteSummaryChangedEvent,
         VoIPAvailabilityChangedEvent,
+        VoIPRuntimeSnapshotChangedEvent,
     )
     from yoyopod.integrations.call.handlers import (
         answer,
@@ -225,6 +231,7 @@ def setup(
         handle_call_state_changed_event,
         handle_incoming_call_event,
         handle_registration_changed_event,
+        handle_runtime_snapshot_changed_event,
         handle_voice_note_summary_changed_event,
         hangup,
         mark_history_seen,
@@ -288,6 +295,10 @@ def setup(
         lambda event: handle_availability_changed_event(app, integration, event),
     )
     app.bus.subscribe(
+        VoIPRuntimeSnapshotChangedEvent,
+        lambda event: handle_runtime_snapshot_changed_event(app, integration, event),
+    )
+    app.bus.subscribe(
         CallHistoryUpdatedEvent,
         lambda event: handle_call_history_updated_event(app, integration, event),
     )
@@ -316,6 +327,11 @@ def setup(
             )
         )
     )
+    on_runtime_snapshot_change = getattr(actual_manager, "on_runtime_snapshot_change", None)
+    if callable(on_runtime_snapshot_change):
+        on_runtime_snapshot_change(
+            lambda snapshot: app.bus.publish(VoIPRuntimeSnapshotChangedEvent(snapshot=snapshot))
+        )
     actual_manager.on_message_summary_change(
         lambda unread_count, latest_by_contact: app.bus.publish(
             VoiceNoteSummaryChangedEvent(
@@ -603,6 +619,7 @@ __all__ = [
     "VoIPIterateMetrics",
     "VoIPManager",
     "VoIPAvailabilityChangedEvent",
+    "VoIPRuntimeSnapshotChangedEvent",
     "VoiceNoteDraft",
     "VoiceNoteEventHandler",
     "VoiceNoteService",

--- a/yoyopod/integrations/call/events.py
+++ b/yoyopod/integrations/call/events.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from yoyopod.integrations.call.models import CallState, RegistrationState
+from yoyopod.integrations.call.models import CallState, RegistrationState, VoIPRuntimeSnapshot
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,6 +46,13 @@ class VoIPAvailabilityChangedEvent:
 
 
 @dataclass(frozen=True, slots=True)
+class VoIPRuntimeSnapshotChangedEvent:
+    """Published when the Rust VoIP host reports a runtime snapshot."""
+
+    snapshot: VoIPRuntimeSnapshot
+
+
+@dataclass(frozen=True, slots=True)
 class CallHistoryUpdatedEvent:
     """Published when missed-call history counters change."""
 
@@ -70,4 +77,5 @@ __all__ = [
     "RegistrationChangedEvent",
     "VoiceNoteSummaryChangedEvent",
     "VoIPAvailabilityChangedEvent",
+    "VoIPRuntimeSnapshotChangedEvent",
 ]

--- a/yoyopod/integrations/call/handlers.py
+++ b/yoyopod/integrations/call/handlers.py
@@ -10,6 +10,7 @@ from yoyopod.integrations.call.events import (
     IncomingCallEvent,
     RegistrationChangedEvent,
     VoIPAvailabilityChangedEvent,
+    VoIPRuntimeSnapshotChangedEvent,
 )
 from yoyopod.integrations.call.commands import (
     AnswerCommand,
@@ -173,6 +174,17 @@ def handle_availability_changed_event(
         _stop_ringer(integration)
 
 
+def handle_runtime_snapshot_changed_event(
+    app: Any,
+    integration: Any,
+    event: VoIPRuntimeSnapshotChangedEvent,
+) -> None:
+    """Mirror Rust-owned runtime facts that may change without a call-state transition."""
+
+    _apply_call_state(app, integration.manager, event.snapshot.call_state)
+    app.states.set("call.muted", bool(event.snapshot.muted), {})
+
+
 def handle_call_history_updated_event(
     app: Any,
     _integration: Any,
@@ -206,13 +218,15 @@ def handle_voice_note_summary_changed_event(
 
 
 def dial(app: Any, integration: Any, command: DialCommand) -> bool:
-    """Place an outgoing call and seed optimistic outgoing state."""
+    """Place an outgoing call and mirror state only when Python owns call runtime."""
 
     if not isinstance(command, DialCommand):
         raise TypeError("call.dial expects DialCommand")
     success = bool(integration.manager.make_call(command.sip_address, command.contact_name))
     if not success:
         return False
+    if _manager_owns_runtime_snapshot(integration.manager):
+        return True
     _request_focus(app)
     integration.session_tracker.ensure_outgoing_call(
         {
@@ -263,23 +277,23 @@ def reject(integration: Any, command: RejectCommand) -> bool:
 
 
 def mute(app: Any, integration: Any, command: MuteCommand) -> bool:
-    """Mute the active call and mirror the new mute flag."""
+    """Mute the active call and mirror state only when Python owns call runtime."""
 
     if not isinstance(command, MuteCommand):
         raise TypeError("call.mute expects MuteCommand")
     success = bool(integration.manager.mute())
-    if success:
+    if success and not _manager_owns_runtime_snapshot(integration.manager):
         app.states.set("call.muted", True, {})
     return success
 
 
 def unmute(app: Any, integration: Any, command: UnmuteCommand) -> bool:
-    """Unmute the active call and mirror the new mute flag."""
+    """Unmute the active call and mirror state only when Python owns call runtime."""
 
     if not isinstance(command, UnmuteCommand):
         raise TypeError("call.unmute expects UnmuteCommand")
     success = bool(integration.manager.unmute())
-    if success:
+    if success and not _manager_owns_runtime_snapshot(integration.manager):
         app.states.set("call.muted", False, {})
     return success
 
@@ -452,6 +466,13 @@ def _call_duration_seconds(manager: Any) -> int:
     if not callable(get_call_duration):
         return 0
     return max(0, int(get_call_duration() or 0))
+
+
+def _manager_owns_runtime_snapshot(manager: Any) -> bool:
+    owns_runtime_snapshot = getattr(manager, "owns_runtime_snapshot", None)
+    if not callable(owns_runtime_snapshot):
+        return False
+    return bool(owns_runtime_snapshot())
 
 
 def _as_registration_state(value: object) -> RegistrationState:

--- a/yoyopod/integrations/call/manager.py
+++ b/yoyopod/integrations/call/manager.py
@@ -99,6 +99,7 @@ class VoIPManager:
         self.call_state_callbacks: list[Callable[[CallState], None]] = []
         self.incoming_call_callbacks: list[Callable[[str, str], None]] = []
         self.availability_callbacks: list[Callable[[bool, str, RegistrationState], None]] = []
+        self.runtime_snapshot_callbacks: list[Callable[[VoIPRuntimeSnapshot], None]] = []
         self._event_scheduler = event_scheduler
         self._background_iterate_enabled = bool(background_iterate_enabled and event_scheduler)
         if background_iterate_enabled and event_scheduler is None:
@@ -216,6 +217,11 @@ class VoIPManager:
         """Return the latest Rust-owned VoIP runtime snapshot when available."""
 
         return self._runtime_snapshot
+
+    def owns_runtime_snapshot(self) -> bool:
+        """Return whether the backend is the source of truth for live runtime facts."""
+
+        return self._backend_owns_runtime_snapshot()
 
     def poll_housekeeping(self) -> None:
         """Run lightweight coordinator-thread-only maintenance alongside background iterate."""
@@ -353,6 +359,12 @@ class VoIPManager:
         callback: Callable[[bool, str, RegistrationState], None],
     ) -> None:
         self.availability_callbacks.append(callback)
+
+    def on_runtime_snapshot_change(
+        self,
+        callback: Callable[[VoIPRuntimeSnapshot], None],
+    ) -> None:
+        self.runtime_snapshot_callbacks.append(callback)
 
     def on_message_received(self, callback: Callable[[VoIPMessageRecord], None]) -> None:
         self._messaging_service.on_message_received(callback)
@@ -560,10 +572,11 @@ class VoIPManager:
         }
         self._update_registration_state(snapshot.registration_state)
         self._sync_call_identity(snapshot)
-        self._update_call_state(snapshot.call_state)
         self.is_muted = snapshot.muted
+        self._update_call_state(snapshot.call_state)
         self._voice_note_service.apply_runtime_snapshot(snapshot)
         self._messaging_service.apply_runtime_snapshot(snapshot)
+        self._notify_runtime_snapshot_change(snapshot)
 
     def _sync_call_identity(self, snapshot: VoIPRuntimeSnapshot) -> None:
         has_active_call = bool(snapshot.active_call_id or snapshot.active_call_peer)
@@ -697,6 +710,13 @@ class VoIPManager:
                 callback(available, reason, self.registration_state)
             except Exception as exc:
                 logger.error("Error in availability callback: {}", exc)
+
+    def _notify_runtime_snapshot_change(self, snapshot: VoIPRuntimeSnapshot) -> None:
+        for callback in self.runtime_snapshot_callbacks:
+            try:
+                callback(snapshot)
+            except Exception as exc:
+                logger.error("Error in runtime snapshot callback: {}", exc)
 
     def _stop_voice_note_playback(self) -> None:
         self._voice_note_service.stop_voice_note_playback()


### PR DESCRIPTION
## Summary
- add an app-level VoIP runtime snapshot event and bridge it from VoIPManager
- expose `owns_runtime_snapshot()` so call service handlers can tell when Rust is the live runtime owner
- stop optimistic Python mirroring for dial/mute/unmute when Rust owns snapshots, and mirror call/mute state from snapshots instead

## Validation
- `uv run python scripts/quality.py gate`
- `uv run pytest -q` (1911 passed, 22 skipped)