### PR TITLE
[codex] Move VoIP session lifecycle ownership into Rust snapshots

### DIFF
--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -529,6 +529,17 @@ def test_worker_snapshot_dispatches_typed_runtime_snapshot() -> None:
                     "local_file_path": "/tmp/note.wav",
                     "error": "",
                 },
+                "call_session": {
+                    "active": False,
+                    "session_id": "call-1",
+                    "direction": "outgoing",
+                    "peer_sip_address": "sip:bob@example.com",
+                    "answered": True,
+                    "terminal_state": "released",
+                    "local_end_action": "hangup",
+                    "duration_seconds": 17,
+                    "history_outcome": "completed",
+                },
             },
         )
     )
@@ -554,6 +565,11 @@ def test_worker_snapshot_dispatches_typed_runtime_snapshot() -> None:
     assert snapshot.last_message.message_id == "msg-1"
     assert snapshot.last_message.kind == MessageKind.VOICE_NOTE
     assert snapshot.last_message.delivery_state == MessageDeliveryState.SENT
+    assert snapshot.call_session.session_id == "call-1"
+    assert snapshot.call_session.direction == "outgoing"
+    assert snapshot.call_session.peer_sip_address == "sip:bob@example.com"
+    assert snapshot.call_session.history_outcome == "completed"
+    assert snapshot.call_session.duration_seconds == 17
 
 
 def test_worker_message_events_translate_to_voip_events() -> None:

--- a/tests/backends/test_voip_backend.py
+++ b/tests/backends/test_voip_backend.py
@@ -611,6 +611,56 @@ def test_voip_manager_publishes_runtime_snapshot_callbacks_without_call_state_ch
     assert manager.is_muted is True
 
 
+def test_voip_manager_derives_availability_from_rust_lifecycle_snapshots() -> None:
+    """Rust lifecycle snapshots should drive recovery availability without side events."""
+
+    backend = SnapshotOwnedMockVoIPBackend()
+    manager = VoIPManager(build_config(), backend=backend)
+    availability_changes: list[tuple[bool, str, RegistrationState]] = []
+    manager.on_availability_change(
+        lambda available, reason, registration_state: availability_changes.append(
+            (available, reason, registration_state)
+        )
+    )
+
+    assert manager.start()
+    availability_changes.clear()
+
+    failed_snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=False,
+        registration_state=RegistrationState.FAILED,
+        lifecycle=VoIPLifecycleSnapshot(
+            state="failed",
+            reason="process_exited",
+            backend_available=False,
+        ),
+    )
+    backend.emit(VoIPRuntimeSnapshotChanged(snapshot=failed_snapshot))
+
+    assert manager.running is False
+    assert manager.registered is False
+    assert availability_changes == [
+        (False, "process_exited", RegistrationState.FAILED),
+    ]
+
+    recovered_snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+    )
+    backend.emit(VoIPRuntimeSnapshotChanged(snapshot=recovered_snapshot))
+
+    assert manager.running is True
+    assert manager.registered is True
+    assert availability_changes[-1] == (True, "registered", RegistrationState.OK)
+
+
 def test_voip_manager_starts_timer_on_streams_running_without_connected() -> None:
     """Streams-running callbacks should start live duration tracking on their own."""
 

--- a/tests/integrations/test_call.py
+++ b/tests/integrations/test_call.py
@@ -456,6 +456,73 @@ def test_rust_owned_terminal_session_snapshot_persists_history_once(
     assert app.states.get_value("call.history_unread_count") == 0
 
 
+def test_rust_owned_terminal_session_snapshot_allows_reused_session_ids_across_calls(
+    tmp_path: Path,
+) -> None:
+    app = build_test_app()
+    setup_focus(app)
+    history_store = CallHistoryStore(tmp_path / "call_history.json")
+    manager = FakeVoipManager(runtime_snapshot_owned=True)
+    setup(app, manager=manager, call_history_store=history_store, ringer=FakeRinger())
+    drain_all(app)
+
+    active_snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        call_state=CallState.INCOMING,
+        active_call_peer="sip:bob@example.com",
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+        call_session=VoIPCallSessionSnapshot(
+            active=True,
+            session_id="sip:bob@example.com",
+            direction="incoming",
+            peer_sip_address="sip:bob@example.com",
+        ),
+    )
+    terminal_snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        call_state=CallState.RELEASED,
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+        call_session=VoIPCallSessionSnapshot(
+            active=False,
+            session_id="sip:bob@example.com",
+            direction="incoming",
+            peer_sip_address="sip:bob@example.com",
+            terminal_state=CallState.RELEASED.value,
+            history_outcome="missed",
+        ),
+    )
+
+    manager.emit_runtime_snapshot(active_snapshot)
+    drain_all(app)
+    manager.emit_runtime_snapshot(terminal_snapshot)
+    drain_all(app)
+
+    manager.emit_runtime_snapshot(active_snapshot)
+    drain_all(app)
+    manager.emit_runtime_snapshot(terminal_snapshot)
+    drain_all(app)
+
+    recent = history_store.list_recent(3)
+    assert len(recent) == 2
+    assert [entry.sip_address for entry in recent] == [
+        "sip:bob@example.com",
+        "sip:bob@example.com",
+    ]
+    assert [entry.outcome for entry in recent] == ["missed", "missed"]
+
+
 def test_incoming_calls_ring_and_history_can_be_marked_seen(tmp_path: Path) -> None:
     app = build_test_app()
     setup_focus(app)

--- a/tests/integrations/test_call.py
+++ b/tests/integrations/test_call.py
@@ -22,6 +22,7 @@ from yoyopod.integrations.call import (
     StartVoiceNoteRecordingCommand,
     StopVoiceNoteRecordingCommand,
     UnmuteCommand,
+    VoIPCallSessionSnapshot,
     VoIPLifecycleSnapshot,
     VoIPRuntimeSnapshot,
     VoiceNoteSummaryChangedEvent,
@@ -332,6 +333,12 @@ def test_rust_owned_call_runtime_waits_for_snapshot_before_mirroring_state(
                 reason="registered",
                 backend_available=True,
             ),
+            call_session=VoIPCallSessionSnapshot(
+                active=True,
+                session_id="call-1",
+                direction="outgoing",
+                peer_sip_address="sip:ada@example.com",
+            ),
         )
     )
     manager.emit_call_state(CallState.OUTGOING)
@@ -376,6 +383,77 @@ def test_rust_owned_mute_waits_for_snapshot_before_mirroring_state(
 
     assert app.states.get_value("call.muted") is True
     assert app.states.get_value("call.state") == "active"
+
+
+def test_rust_owned_terminal_session_snapshot_persists_history_once(
+    tmp_path: Path,
+) -> None:
+    app = build_test_app()
+    setup_focus(app)
+    history_store = CallHistoryStore(tmp_path / "call_history.json")
+    manager = FakeVoipManager(runtime_snapshot_owned=True)
+    setup(app, manager=manager, call_history_store=history_store, ringer=FakeRinger())
+    drain_all(app)
+
+    manager.emit_runtime_snapshot(
+        VoIPRuntimeSnapshot(
+            configured=True,
+            registered=True,
+            registration_state=RegistrationState.OK,
+            call_state=CallState.STREAMS_RUNNING,
+            active_call_id="call-1",
+            active_call_peer="sip:ada@example.com",
+            lifecycle=VoIPLifecycleSnapshot(
+                state="registered",
+                reason="registered",
+                backend_available=True,
+            ),
+            call_session=VoIPCallSessionSnapshot(
+                active=True,
+                session_id="call-1",
+                direction="outgoing",
+                peer_sip_address="sip:ada@example.com",
+                answered=True,
+            ),
+        )
+    )
+    drain_all(app)
+    assert app.states.get_value("focus.owner") == "call"
+    assert history_store.list_recent(1) == []
+
+    terminal_snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        call_state=CallState.RELEASED,
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+        call_session=VoIPCallSessionSnapshot(
+            active=False,
+            session_id="call-1",
+            direction="outgoing",
+            peer_sip_address="sip:ada@example.com",
+            answered=True,
+            terminal_state=CallState.RELEASED.value,
+            local_end_action="hangup",
+            duration_seconds=12,
+            history_outcome="completed",
+        ),
+    )
+    manager.emit_runtime_snapshot(terminal_snapshot)
+    manager.emit_runtime_snapshot(terminal_snapshot)
+    drain_all(app)
+
+    recent = history_store.list_recent(2)
+    assert len(recent) == 1
+    assert recent[0].sip_address == "sip:ada@example.com"
+    assert recent[0].outcome == "completed"
+    assert recent[0].duration_seconds == 12
+    assert app.states.get_value("focus.owner") is None
+    assert app.states.get_value("call.history_unread_count") == 0
 
 
 def test_incoming_calls_ring_and_history_can_be_marked_seen(tmp_path: Path) -> None:

--- a/tests/integrations/test_call.py
+++ b/tests/integrations/test_call.py
@@ -523,6 +523,57 @@ def test_rust_owned_terminal_session_snapshot_allows_reused_session_ids_across_c
     assert [entry.outcome for entry in recent] == ["missed", "missed"]
 
 
+def test_rust_owned_terminal_only_snapshots_allow_reused_session_ids_after_new_incoming_call(
+    tmp_path: Path,
+) -> None:
+    app = build_test_app()
+    setup_focus(app)
+    history_store = CallHistoryStore(tmp_path / "call_history.json")
+    manager = FakeVoipManager(runtime_snapshot_owned=True)
+    setup(app, manager=manager, call_history_store=history_store, ringer=FakeRinger())
+    drain_all(app)
+
+    terminal_snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        call_state=CallState.RELEASED,
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+        call_session=VoIPCallSessionSnapshot(
+            active=False,
+            session_id="sip:bob@example.com",
+            direction="incoming",
+            peer_sip_address="sip:bob@example.com",
+            terminal_state=CallState.RELEASED.value,
+            history_outcome="missed",
+        ),
+    )
+
+    manager.emit_incoming_call("sip:bob@example.com", "Bob")
+    drain_all(app)
+    manager.emit_runtime_snapshot(terminal_snapshot)
+    drain_all(app)
+    manager.emit_runtime_snapshot(terminal_snapshot)
+    drain_all(app)
+
+    manager.emit_incoming_call("sip:bob@example.com", "Bob")
+    drain_all(app)
+    manager.emit_runtime_snapshot(terminal_snapshot)
+    drain_all(app)
+
+    recent = history_store.list_recent(3)
+    assert len(recent) == 2
+    assert [entry.sip_address for entry in recent] == [
+        "sip:bob@example.com",
+        "sip:bob@example.com",
+    ]
+    assert [entry.outcome for entry in recent] == ["missed", "missed"]
+
+
 def test_incoming_calls_ring_and_history_can_be_marked_seen(tmp_path: Path) -> None:
     app = build_test_app()
     setup_focus(app)

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -29,6 +29,7 @@ from yoyopod.integrations.call.models import (
     MessageReceived,
     RegistrationState,
     RegistrationStateChanged,
+    VoIPCallSessionSnapshot,
     VoIPConfig,
     VoIPEvent,
     VoIPLifecycleSnapshot,
@@ -588,6 +589,7 @@ def _message_record(payload: dict[str, Any]) -> VoIPMessageRecord | None:
 
 def _runtime_snapshot(payload: dict[str, Any]) -> VoIPRuntimeSnapshot:
     lifecycle_payload = _dict_payload(payload.get("lifecycle"))
+    call_session_payload = _dict_payload(payload.get("call_session"))
     voice_note_payload = _dict_payload(payload.get("voice_note"))
     return VoIPRuntimeSnapshot(
         configured=_bool_payload(payload.get("configured", False)),
@@ -602,6 +604,17 @@ def _runtime_snapshot(payload: dict[str, Any]) -> VoIPRuntimeSnapshot:
             state=str(lifecycle_payload.get("state", "unconfigured") or "unconfigured"),
             reason=str(lifecycle_payload.get("reason", "") or ""),
             backend_available=_bool_payload(lifecycle_payload.get("backend_available", False)),
+        ),
+        call_session=VoIPCallSessionSnapshot(
+            active=_bool_payload(call_session_payload.get("active", False)),
+            session_id=str(call_session_payload.get("session_id", "") or ""),
+            direction=str(call_session_payload.get("direction", "") or ""),
+            peer_sip_address=str(call_session_payload.get("peer_sip_address", "") or ""),
+            answered=_bool_payload(call_session_payload.get("answered", False)),
+            terminal_state=str(call_session_payload.get("terminal_state", "") or ""),
+            local_end_action=str(call_session_payload.get("local_end_action", "") or ""),
+            duration_seconds=_duration_ms(call_session_payload.get("duration_seconds")),
+            history_outcome=str(call_session_payload.get("history_outcome", "") or ""),
         ),
         voice_note=VoIPVoiceNoteSnapshot(
             state=str(voice_note_payload.get("state", "idle") or "idle"),

--- a/yoyopod/integrations/call/__init__.py
+++ b/yoyopod/integrations/call/__init__.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
         RegistrationState,
         RegistrationStateChanged,
         VoIPConfig,
+        VoIPCallSessionSnapshot,
         VoIPEvent,
         VoIPLifecycleSnapshot,
         VoIPMessageSnapshot,
@@ -124,6 +125,10 @@ _PUBLIC_EXPORTS = {
     "MessageDirection": ("yoyopod.integrations.call.models", "MessageDirection"),
     "MessageDeliveryState": ("yoyopod.integrations.call.models", "MessageDeliveryState"),
     "VoIPConfig": ("yoyopod.integrations.call.models", "VoIPConfig"),
+    "VoIPCallSessionSnapshot": (
+        "yoyopod.integrations.call.models",
+        "VoIPCallSessionSnapshot",
+    ),
     "VoIPLifecycleSnapshot": (
         "yoyopod.integrations.call.models",
         "VoIPLifecycleSnapshot",
@@ -196,6 +201,7 @@ class CallIntegration:
     last_voice_note_unread_count: int = 0
     last_voice_note_unread_by_address: dict[str, int] = field(default_factory=dict)
     last_voice_note_summary: dict[str, dict[str, object]] = field(default_factory=dict)
+    finalized_rust_call_sessions: set[str] = field(default_factory=set)
 
 
 def setup(
@@ -597,6 +603,7 @@ __all__ = [
     "MessageDirection",
     "MessageDeliveryState",
     "VoIPConfig",
+    "VoIPCallSessionSnapshot",
     "VoIPLifecycleSnapshot",
     "VoIPMessageSnapshot",
     "VoIPMessageRecord",

--- a/yoyopod/integrations/call/handlers.py
+++ b/yoyopod/integrations/call/handlers.py
@@ -205,6 +205,7 @@ def _apply_rust_call_session_side_effects(
 ) -> None:
     session = snapshot.call_session
     state = snapshot.call_state
+    _prune_finalized_rust_call_sessions(integration, session)
 
     if session.active:
         if state in _OUTGOING_STATES:
@@ -226,6 +227,17 @@ def _apply_rust_call_session_side_effects(
 
 def _rust_call_session_is_terminal(session: VoIPCallSessionSnapshot) -> bool:
     return bool(session.session_id and session.history_outcome and session.terminal_state)
+
+
+def _prune_finalized_rust_call_sessions(
+    integration: Any,
+    session: VoIPCallSessionSnapshot,
+) -> None:
+    finalized_sessions = getattr(integration, "finalized_rust_call_sessions", None)
+    if not isinstance(finalized_sessions, set):
+        return
+    if session.active or not _rust_call_session_is_terminal(session):
+        finalized_sessions.clear()
 
 
 def _persist_rust_call_session_history(

--- a/yoyopod/integrations/call/handlers.py
+++ b/yoyopod/integrations/call/handlers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from yoyopod.core.events import BackendStoppedEvent
 from yoyopod.integrations.call.events import (
@@ -28,7 +28,13 @@ from yoyopod.integrations.call.commands import (
     UnmuteCommand,
 )
 from yoyopod.integrations.call.events import CallHistoryUpdatedEvent, VoiceNoteSummaryChangedEvent
-from yoyopod.integrations.call.models import CallState, RegistrationState
+from yoyopod.integrations.call.history import CallDirection, CallHistoryEntry, CallOutcome
+from yoyopod.integrations.call.models import (
+    CallState,
+    RegistrationState,
+    VoIPCallSessionSnapshot,
+    VoIPRuntimeSnapshot,
+)
 from yoyopod.core.focus import ReleaseFocusCommand, RequestFocusCommand
 
 _OUTGOING_STATES = {
@@ -78,7 +84,8 @@ def seed_call_state(app: Any, integration: Any, *, available: bool) -> None:
 def handle_incoming_call_event(app: Any, integration: Any, event: IncomingCallEvent) -> None:
     """Mirror incoming-call metadata into the state store and focus/ringer helpers."""
 
-    integration.session_tracker.begin_incoming_call(event.caller_address, event.caller_name)
+    if not _manager_owns_runtime_snapshot(integration.manager):
+        integration.session_tracker.begin_incoming_call(event.caller_address, event.caller_name)
     _request_focus(app)
     _start_ringer(app, integration)
     app.states.set(
@@ -102,6 +109,11 @@ def handle_call_state_changed_event(
 
     manager = integration.manager
     state = event.state
+
+    if _manager_owns_runtime_snapshot(manager):
+        _apply_call_state(app, manager, state)
+        app.states.set("call.muted", bool(getattr(manager, "is_muted", False)), {})
+        return
 
     if state in _OUTGOING_STATES:
         _request_focus(app)
@@ -181,8 +193,78 @@ def handle_runtime_snapshot_changed_event(
 ) -> None:
     """Mirror Rust-owned runtime facts that may change without a call-state transition."""
 
+    _apply_rust_call_session_side_effects(app, integration, event.snapshot)
     _apply_call_state(app, integration.manager, event.snapshot.call_state)
     app.states.set("call.muted", bool(event.snapshot.muted), {})
+
+
+def _apply_rust_call_session_side_effects(
+    app: Any,
+    integration: Any,
+    snapshot: VoIPRuntimeSnapshot,
+) -> None:
+    session = snapshot.call_session
+    state = snapshot.call_state
+
+    if session.active:
+        if state in _OUTGOING_STATES:
+            _request_focus(app)
+            _stop_ringer(integration)
+        elif state == CallState.INCOMING:
+            _request_focus(app)
+            _start_ringer(app, integration)
+        elif state in _ACTIVE_STATES:
+            _request_focus(app)
+            _stop_ringer(integration)
+        return
+
+    if _rust_call_session_is_terminal(session):
+        _stop_ringer(integration)
+        _persist_rust_call_session_history(app, integration, session)
+        _release_focus_if_owned(app)
+
+
+def _rust_call_session_is_terminal(session: VoIPCallSessionSnapshot) -> bool:
+    return bool(session.session_id and session.history_outcome and session.terminal_state)
+
+
+def _persist_rust_call_session_history(
+    app: Any,
+    integration: Any,
+    session: VoIPCallSessionSnapshot,
+) -> None:
+    finalized_sessions = getattr(integration, "finalized_rust_call_sessions", None)
+    if not isinstance(finalized_sessions, set):
+        return
+    if session.session_id in finalized_sessions:
+        return
+    direction = cast(
+        CallDirection,
+        session.direction if session.direction in {"incoming", "outgoing"} else "outgoing",
+    )
+    outcome = _history_outcome(session.history_outcome)
+    if outcome is None:
+        publish_call_history_updated(app, integration)
+        return
+    finalized_sessions.add(session.session_id)
+
+    history_store = integration.history_store
+    if history_store is None:
+        publish_call_history_updated(app, integration)
+        return
+
+    sip_address = session.peer_sip_address.strip()
+    display_name = _session_display_name(integration.manager, sip_address)
+    history_store.add_entry(
+        CallHistoryEntry.create(
+            direction=direction,
+            display_name=display_name,
+            sip_address=sip_address,
+            outcome=outcome,
+            duration_seconds=max(0, int(session.duration_seconds)),
+        )
+    )
+    publish_call_history_updated(app, integration)
 
 
 def handle_call_history_updated_event(
@@ -466,6 +548,38 @@ def _call_duration_seconds(manager: Any) -> int:
     if not callable(get_call_duration):
         return 0
     return max(0, int(get_call_duration() or 0))
+
+
+def _history_outcome(value: str) -> CallOutcome | None:
+    outcome = str(value or "").strip()
+    if outcome in {"completed", "missed", "rejected", "cancelled", "failed"}:
+        return cast(CallOutcome, outcome)
+    return None
+
+
+def _session_display_name(manager: Any, sip_address: str) -> str:
+    lookup_contact_name = getattr(manager, "_lookup_contact_name", None)
+    if callable(lookup_contact_name):
+        name = str(lookup_contact_name(sip_address) or "").strip()
+        if name:
+            return name
+    caller = _caller_info(manager)
+    if str(caller.get("address") or "").strip() == sip_address:
+        display_name = str(caller.get("display_name") or caller.get("name") or "").strip()
+        if display_name:
+            return display_name
+    return _extract_username(sip_address)
+
+
+def _extract_username(sip_address: str) -> str:
+    if not sip_address:
+        return "Unknown"
+    if "@" not in sip_address:
+        return sip_address
+    username_part = sip_address.split("@", 1)[0]
+    if ":" in username_part:
+        return username_part.split(":")[-1]
+    return username_part
 
 
 def _manager_owns_runtime_snapshot(manager: Any) -> bool:

--- a/yoyopod/integrations/call/handlers.py
+++ b/yoyopod/integrations/call/handlers.py
@@ -84,6 +84,7 @@ def seed_call_state(app: Any, integration: Any, *, available: bool) -> None:
 def handle_incoming_call_event(app: Any, integration: Any, event: IncomingCallEvent) -> None:
     """Mirror incoming-call metadata into the state store and focus/ringer helpers."""
 
+    _clear_finalized_rust_call_sessions(integration)
     if not _manager_owns_runtime_snapshot(integration.manager):
         integration.session_tracker.begin_incoming_call(event.caller_address, event.caller_name)
     _request_focus(app)
@@ -111,6 +112,8 @@ def handle_call_state_changed_event(
     state = event.state
 
     if _manager_owns_runtime_snapshot(manager):
+        if state not in _TERMINAL_STATES:
+            _clear_finalized_rust_call_sessions(integration)
         _apply_call_state(app, manager, state)
         app.states.set("call.muted", bool(getattr(manager, "is_muted", False)), {})
         return
@@ -240,6 +243,12 @@ def _prune_finalized_rust_call_sessions(
         finalized_sessions.clear()
 
 
+def _clear_finalized_rust_call_sessions(integration: Any) -> None:
+    finalized_sessions = getattr(integration, "finalized_rust_call_sessions", None)
+    if isinstance(finalized_sessions, set):
+        finalized_sessions.clear()
+
+
 def _persist_rust_call_session_history(
     app: Any,
     integration: Any,
@@ -320,6 +329,7 @@ def dial(app: Any, integration: Any, command: DialCommand) -> bool:
     if not success:
         return False
     if _manager_owns_runtime_snapshot(integration.manager):
+        _clear_finalized_rust_call_sessions(integration)
         return True
     _request_focus(app)
     integration.session_tracker.ensure_outgoing_call(

--- a/yoyopod/integrations/call/manager.py
+++ b/yoyopod/integrations/call/manager.py
@@ -100,6 +100,7 @@ class VoIPManager:
         self.incoming_call_callbacks: list[Callable[[str, str], None]] = []
         self.availability_callbacks: list[Callable[[bool, str, RegistrationState], None]] = []
         self.runtime_snapshot_callbacks: list[Callable[[VoIPRuntimeSnapshot], None]] = []
+        self._last_lifecycle_availability: tuple[bool, str, RegistrationState] | None = None
         self._event_scheduler = event_scheduler
         self._background_iterate_enabled = bool(background_iterate_enabled and event_scheduler)
         if background_iterate_enabled and event_scheduler is None:
@@ -574,6 +575,7 @@ class VoIPManager:
         self._sync_call_identity(snapshot)
         self.is_muted = snapshot.muted
         self._update_call_state(snapshot.call_state)
+        self._notify_lifecycle_availability_from_snapshot(snapshot)
         self._voice_note_service.apply_runtime_snapshot(snapshot)
         self._messaging_service.apply_runtime_snapshot(snapshot)
         self._notify_runtime_snapshot_change(snapshot)
@@ -705,11 +707,26 @@ class VoIPManager:
         self.registration_state = RegistrationState.NONE
 
     def _notify_availability_change(self, available: bool, reason: str) -> None:
+        self._last_lifecycle_availability = (available, reason, self.registration_state)
         for callback in self.availability_callbacks:
             try:
                 callback(available, reason, self.registration_state)
             except Exception as exc:
                 logger.error("Error in availability callback: {}", exc)
+
+    def _notify_lifecycle_availability_from_snapshot(
+        self,
+        snapshot: VoIPRuntimeSnapshot,
+    ) -> None:
+        lifecycle_state = snapshot.lifecycle.state.strip().lower()
+        if not lifecycle_state:
+            return
+        reason = snapshot.lifecycle.reason or lifecycle_state
+        available = bool(snapshot.lifecycle.backend_available)
+        key = (available, reason, self.registration_state)
+        if self._last_lifecycle_availability == key:
+            return
+        self._notify_availability_change(available, reason)
 
     def _notify_runtime_snapshot_change(self, snapshot: VoIPRuntimeSnapshot) -> None:
         for callback in self.runtime_snapshot_callbacks:

--- a/yoyopod/integrations/call/models.py
+++ b/yoyopod/integrations/call/models.py
@@ -228,6 +228,21 @@ class VoIPMessageSnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class VoIPCallSessionSnapshot:
+    """Rust-owned call-session facts used for app side effects and history."""
+
+    active: bool = False
+    session_id: str = ""
+    direction: str = ""
+    peer_sip_address: str = ""
+    answered: bool = False
+    terminal_state: str = ""
+    local_end_action: str = ""
+    duration_seconds: int = 0
+    history_outcome: str = ""
+
+
+@dataclass(frozen=True, slots=True)
 class VoIPRuntimeSnapshot:
     """Canonical live VoIP state reported by the Rust worker."""
 
@@ -240,6 +255,7 @@ class VoIPRuntimeSnapshot:
     muted: bool = False
     pending_outbound_messages: int = 0
     lifecycle: VoIPLifecycleSnapshot = field(default_factory=VoIPLifecycleSnapshot)
+    call_session: VoIPCallSessionSnapshot = field(default_factory=VoIPCallSessionSnapshot)
     voice_note: VoIPVoiceNoteSnapshot = field(default_factory=VoIPVoiceNoteSnapshot)
     last_message: VoIPMessageSnapshot | None = None
 

--- a/yoyopod_rs/voip-host/src/calls.rs
+++ b/yoyopod_rs/voip-host/src/calls.rs
@@ -157,7 +157,7 @@ impl CallSession {
     pub fn apply_call_state(&mut self, call_id: &str, state: &str) {
         self.state = state.to_string();
         if is_terminal_call_state(state) {
-            if self.active_call_id.as_deref() == Some(call_id) || self.active_call_id.is_none() {
+            if self.matches_active_session(call_id) {
                 self.finish_session(state, None);
                 self.clear_identity();
             }
@@ -218,6 +218,15 @@ impl CallSession {
             session.duration_seconds = Some(session.started_at.elapsed().as_secs());
             self.last_finished_session = Some(session);
         }
+    }
+
+    fn matches_active_session(&self, call_id: &str) -> bool {
+        self.active_call_id.as_deref() == Some(call_id)
+            || self.active_call_id.is_none()
+            || self
+                .active_session
+                .as_ref()
+                .is_some_and(|session| session.peer_sip_address == call_id)
     }
 }
 

--- a/yoyopod_rs/voip-host/src/calls.rs
+++ b/yoyopod_rs/voip-host/src/calls.rs
@@ -1,9 +1,14 @@
-#[derive(Debug, Clone, PartialEq, Eq)]
+use serde_json::json;
+use std::time::Instant;
+
+#[derive(Debug, Clone)]
 pub struct CallSession {
     state: String,
     active_call_id: Option<String>,
     active_peer: String,
     muted: bool,
+    active_session: Option<CallSessionRecord>,
+    last_finished_session: Option<CallSessionRecord>,
 }
 
 impl Default for CallSession {
@@ -13,7 +18,60 @@ impl Default for CallSession {
             active_call_id: None,
             active_peer: String::new(),
             muted: false,
+            active_session: None,
+            last_finished_session: None,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CallSessionRecord {
+    session_id: String,
+    direction: String,
+    peer_sip_address: String,
+    started_at: Instant,
+    answered: bool,
+    terminal_state: String,
+    local_end_action: String,
+    duration_seconds: Option<u64>,
+}
+
+impl CallSessionRecord {
+    fn new(session_id: &str, direction: &str, peer_sip_address: &str) -> Self {
+        Self {
+            session_id: session_id.to_string(),
+            direction: direction.to_string(),
+            peer_sip_address: peer_sip_address.to_string(),
+            started_at: Instant::now(),
+            answered: false,
+            terminal_state: String::new(),
+            local_end_action: String::new(),
+            duration_seconds: None,
+        }
+    }
+
+    fn duration_seconds(&self) -> u64 {
+        self.duration_seconds
+            .unwrap_or_else(|| self.started_at.elapsed().as_secs())
+    }
+
+    fn history_outcome(&self) -> String {
+        if self.terminal_state.is_empty() {
+            return String::new();
+        }
+        if self.answered {
+            return "completed".to_string();
+        }
+        if self.direction == "incoming" && self.local_end_action == "reject" {
+            return "rejected".to_string();
+        }
+        if self.terminal_state == "error" {
+            return "failed".to_string();
+        }
+        if self.direction == "incoming" {
+            return "missed".to_string();
+        }
+        "cancelled".to_string()
     }
 }
 
@@ -34,6 +92,46 @@ impl CallSession {
         self.muted
     }
 
+    pub fn session_payload(&self) -> serde_json::Value {
+        if let Some(session) = self.active_session.as_ref() {
+            return json!({
+                "active": true,
+                "session_id": session.session_id,
+                "direction": session.direction,
+                "peer_sip_address": session.peer_sip_address,
+                "answered": session.answered,
+                "terminal_state": "",
+                "local_end_action": session.local_end_action,
+                "duration_seconds": session.duration_seconds(),
+                "history_outcome": "",
+            });
+        }
+        if let Some(session) = self.last_finished_session.as_ref() {
+            return json!({
+                "active": false,
+                "session_id": session.session_id,
+                "direction": session.direction,
+                "peer_sip_address": session.peer_sip_address,
+                "answered": session.answered,
+                "terminal_state": session.terminal_state,
+                "local_end_action": session.local_end_action,
+                "duration_seconds": session.duration_seconds(),
+                "history_outcome": session.history_outcome(),
+            });
+        }
+        json!({
+            "active": false,
+            "session_id": "",
+            "direction": "",
+            "peer_sip_address": "",
+            "answered": false,
+            "terminal_state": "",
+            "local_end_action": "",
+            "duration_seconds": 0,
+            "history_outcome": "",
+        })
+    }
+
     pub fn set_active_call_id(&mut self, call_id: Option<String>) {
         self.active_call_id = call_id;
     }
@@ -42,12 +140,14 @@ impl CallSession {
         self.active_call_id = Some(call_id.to_string());
         self.active_peer = peer.to_string();
         self.state = "outgoing_init".to_string();
+        self.begin_session(call_id, "outgoing", peer);
     }
 
     pub fn incoming(&mut self, call_id: &str, peer: &str) {
         self.active_call_id = Some(call_id.to_string());
         self.active_peer = peer.to_string();
         self.state = "incoming".to_string();
+        self.begin_session(call_id, "incoming", peer);
     }
 
     pub fn set_muted(&mut self, muted: bool) {
@@ -58,20 +158,33 @@ impl CallSession {
         self.state = state.to_string();
         if is_terminal_call_state(state) {
             if self.active_call_id.as_deref() == Some(call_id) || self.active_call_id.is_none() {
+                self.finish_session(state, None);
                 self.clear_identity();
             }
         } else {
             self.active_call_id = Some(call_id.to_string());
+            if is_answered_call_state(state) {
+                self.mark_answered();
+            }
         }
     }
 
     pub fn clear(&mut self) {
         self.state = "idle".to_string();
         self.clear_identity();
+        self.active_session = None;
+        self.last_finished_session = None;
     }
 
     pub fn clear_with_state(&mut self, state: &str) {
         self.state = state.to_string();
+        self.finish_session(state, None);
+        self.clear_identity();
+    }
+
+    pub fn clear_with_state_and_action(&mut self, state: &str, local_end_action: &str) {
+        self.state = state.to_string();
+        self.finish_session(state, Some(local_end_action));
         self.clear_identity();
     }
 
@@ -80,8 +193,41 @@ impl CallSession {
         self.active_peer.clear();
         self.muted = false;
     }
+
+    fn begin_session(&mut self, session_id: &str, direction: &str, peer_sip_address: &str) {
+        self.active_session = Some(CallSessionRecord::new(
+            session_id,
+            direction,
+            peer_sip_address,
+        ));
+        self.last_finished_session = None;
+    }
+
+    fn mark_answered(&mut self) {
+        if let Some(session) = self.active_session.as_mut() {
+            session.answered = true;
+        }
+    }
+
+    fn finish_session(&mut self, state: &str, local_end_action: Option<&str>) {
+        if let Some(mut session) = self.active_session.take() {
+            session.terminal_state = state.to_string();
+            if let Some(action) = local_end_action {
+                session.local_end_action = action.to_string();
+            }
+            session.duration_seconds = Some(session.started_at.elapsed().as_secs());
+            self.last_finished_session = Some(session);
+        }
+    }
 }
 
 fn is_terminal_call_state(state: &str) -> bool {
     matches!(state, "idle" | "released" | "error" | "end")
+}
+
+fn is_answered_call_state(state: &str) -> bool {
+    matches!(
+        state,
+        "connected" | "streams_running" | "paused" | "paused_by_remote" | "updated_by_remote"
+    )
 }

--- a/yoyopod_rs/voip-host/src/host.rs
+++ b/yoyopod_rs/voip-host/src/host.rs
@@ -205,13 +205,13 @@ impl VoipHost {
 
     pub fn reject<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
         backend.reject_call()?;
-        self.call.clear_with_state("released");
+        self.call.clear_with_state_and_action("released", "reject");
         Ok(())
     }
 
     pub fn hangup<B: CallBackend>(&mut self, backend: &mut B) -> Result<(), String> {
         backend.hangup()?;
-        self.call.clear_with_state("released");
+        self.call.clear_with_state_and_action("released", "hangup");
         Ok(())
     }
 
@@ -328,7 +328,7 @@ impl VoipHost {
                 self.registration_state = "failed".to_string();
                 self.lifecycle.mark_recovery_pending();
                 self.lifecycle.record("failed", reason, false);
-                self.call.clear();
+                self.call.clear_with_state("error");
                 self.outbound_message_ids.clear();
             }
             BackendEvent::MessageReceived { message } => {

--- a/yoyopod_rs/voip-host/src/runtime_snapshot.rs
+++ b/yoyopod_rs/voip-host/src/runtime_snapshot.rs
@@ -31,6 +31,7 @@ impl RuntimeSnapshot<'_> {
             "active_call_id": self.call.active_call_id(),
             "active_call_peer": self.call.active_peer(),
             "muted": self.call.muted(),
+            "call_session": self.call.session_payload(),
             "pending_outbound_messages": self.pending_outbound_messages,
             "voice_note": self.voice_note.payload(),
             "last_message": last_message,

--- a/yoyopod_rs/voip-host/tests/host.rs
+++ b/yoyopod_rs/voip-host/tests/host.rs
@@ -177,6 +177,34 @@ fn call_session_snapshot_tracks_direction_terminal_outcome_and_duration() {
 }
 
 #[test]
+fn outgoing_terminal_call_state_finalizes_session_when_event_uses_peer_address() {
+    let mut host = VoipHost::default();
+    let mut backend = FakeBackend::default();
+    host.configure(config());
+    host.register(&mut backend).expect("register");
+
+    host.dial(&mut backend, "sip:bob@example.com")
+        .expect("dial");
+
+    poll_one(
+        &mut host,
+        BackendEvent::CallStateChanged {
+            call_id: "sip:bob@example.com".to_string(),
+            state: "released".to_string(),
+        },
+    );
+
+    let snapshot = host.session_snapshot_payload();
+    assert_eq!(snapshot["active_call_id"], Value::Null);
+    assert_eq!(snapshot["active_call_peer"], "");
+    assert_eq!(snapshot["call_session"]["active"], false);
+    assert_eq!(snapshot["call_session"]["session_id"], "call-outgoing");
+    assert_eq!(snapshot["call_session"]["peer_sip_address"], "sip:bob@example.com");
+    assert_eq!(snapshot["call_session"]["terminal_state"], "released");
+    assert_eq!(snapshot["call_session"]["history_outcome"], "cancelled");
+}
+
+#[test]
 fn incoming_call_session_snapshot_reports_missed_terminal_outcome() {
     let mut host = VoipHost::default();
     host.configure(config());

--- a/yoyopod_rs/voip-host/tests/host.rs
+++ b/yoyopod_rs/voip-host/tests/host.rs
@@ -134,6 +134,82 @@ fn session_snapshot_tracks_call_message_and_voice_note_state() {
 }
 
 #[test]
+fn call_session_snapshot_tracks_direction_terminal_outcome_and_duration() {
+    let mut host = VoipHost::default();
+    let mut backend = FakeBackend::default();
+    host.configure(config());
+    host.register(&mut backend).expect("register");
+
+    host.dial(&mut backend, "sip:bob@example.com")
+        .expect("dial");
+    let snapshot = host.session_snapshot_payload();
+    assert_eq!(snapshot["call_session"]["active"], true);
+    assert_eq!(snapshot["call_session"]["session_id"], "call-outgoing");
+    assert_eq!(snapshot["call_session"]["direction"], "outgoing");
+    assert_eq!(
+        snapshot["call_session"]["peer_sip_address"],
+        "sip:bob@example.com"
+    );
+    assert_eq!(snapshot["call_session"]["answered"], false);
+
+    poll_one(
+        &mut host,
+        BackendEvent::CallStateChanged {
+            call_id: "call-outgoing".to_string(),
+            state: "streams_running".to_string(),
+        },
+    );
+    assert_eq!(
+        host.session_snapshot_payload()["call_session"]["answered"],
+        true
+    );
+
+    host.hangup(&mut backend).expect("hangup");
+    let snapshot = host.session_snapshot_payload();
+    assert_eq!(snapshot["call_session"]["active"], false);
+    assert_eq!(snapshot["call_session"]["session_id"], "call-outgoing");
+    assert_eq!(snapshot["call_session"]["terminal_state"], "released");
+    assert_eq!(snapshot["call_session"]["local_end_action"], "hangup");
+    assert_eq!(snapshot["call_session"]["history_outcome"], "completed");
+    assert!(snapshot["call_session"]["duration_seconds"]
+        .as_u64()
+        .is_some());
+}
+
+#[test]
+fn incoming_call_session_snapshot_reports_missed_terminal_outcome() {
+    let mut host = VoipHost::default();
+    host.configure(config());
+
+    poll_one(
+        &mut host,
+        BackendEvent::IncomingCall {
+            call_id: "call-incoming".to_string(),
+            from_uri: "sip:mama@example.com".to_string(),
+        },
+    );
+    let snapshot = host.session_snapshot_payload();
+    assert_eq!(snapshot["call_session"]["active"], true);
+    assert_eq!(snapshot["call_session"]["direction"], "incoming");
+    assert_eq!(
+        snapshot["call_session"]["peer_sip_address"],
+        "sip:mama@example.com"
+    );
+
+    poll_one(
+        &mut host,
+        BackendEvent::CallStateChanged {
+            call_id: "call-incoming".to_string(),
+            state: "released".to_string(),
+        },
+    );
+    let snapshot = host.session_snapshot_payload();
+    assert_eq!(snapshot["call_session"]["active"], false);
+    assert_eq!(snapshot["call_session"]["terminal_state"], "released");
+    assert_eq!(snapshot["call_session"]["history_outcome"], "missed");
+}
+
+#[test]
 fn register_starts_backend_and_health_reports_registered() {
     let mut host = VoipHost::default();
     let mut backend = FakeBackend::default();


### PR DESCRIPTION
## Summary
- add Rust-owned `call_session` facts to VoIP host runtime snapshots, including direction, peer, answered state, terminal action, duration, and history outcome
- parse and expose the typed call-session snapshot through the Python Rust-host adapter and `VoIPRuntimeSnapshot`
- make Python call integration consume Rust session/lifecycle snapshots for focus/ringer/history/availability side effects while avoiding Python session finalization for Rust-owned runtime

## Stack
- Stacked on #411 / `codex/rust-voip-command-intents` because this depends on the runtime snapshot bridge from that PR.

## Validation
- `cargo test --workspace`
- `cargo test --workspace --locked --features whisplay-hardware`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q` (1913 passed, 22 skipped)

## Not run
- `bazel test //yoyopod_rs/ui-host/... //yoyopod_rs/voip-host/...` because `bazel`/`bazelisk` is not installed in this Windows environment.