### PR TITLE
Move VoIP message summaries into Rust store

### DIFF
--- a/tests/backends/test_voip_backend.py
+++ b/tests/backends/test_voip_backend.py
@@ -15,6 +15,7 @@ import pytest
 from cffi import FFI
 
 from yoyopod.backends.voip import LiblinphoneBackend, LiblinphoneBinding, MockVoIPBackend
+from yoyopod.backends.voip.rust_host import _runtime_snapshot
 from yoyopod.integrations.call.models import (
     BackendRecovered,
     BackendStopped,
@@ -161,9 +162,14 @@ class SnapshotOwnedMockVoIPBackend(MockVoIPBackend):
     def __init__(self) -> None:
         super().__init__()
         self.runtime_snapshot: VoIPRuntimeSnapshot | None = None
+        self.mark_seen_addresses: list[str] = []
 
     def get_runtime_snapshot(self) -> VoIPRuntimeSnapshot | None:
         return self.runtime_snapshot
+
+    def mark_voice_notes_seen(self, sip_address: str) -> bool:
+        self.mark_seen_addresses.append(sip_address)
+        return True
 
 
 def build_config(storage_root: Path | None = None) -> VoIPConfig:
@@ -609,6 +615,123 @@ def test_voip_manager_publishes_runtime_snapshot_callbacks_without_call_state_ch
     assert snapshots == [muted_snapshot]
     assert call_states == []
     assert manager.is_muted is True
+
+
+def test_rust_runtime_snapshot_parses_message_summary_fields() -> None:
+    """Rust snapshot summaries should survive Python parsing without Python store reads."""
+
+    snapshot = _runtime_snapshot(
+        {
+            "configured": True,
+            "registered": True,
+            "registration_state": "ok",
+            "unread_voice_notes": 2,
+            "unread_voice_notes_by_contact": {"sip:mom@example.com": 2},
+            "latest_voice_note_by_contact": {
+                "sip:mom@example.com": {
+                    "message_id": "note-2",
+                    "direction": "incoming",
+                    "delivery_state": "delivered",
+                    "local_file_path": "/tmp/note-2.wav",
+                    "duration_ms": 2400,
+                    "unread": True,
+                    "display_name": "Mom",
+                }
+            },
+        }
+    )
+
+    assert snapshot.unread_voice_notes == 2
+    assert snapshot.unread_voice_notes_by_contact == {"sip:mom@example.com": 2}
+    assert snapshot.latest_voice_note_by_contact == {
+        "sip:mom@example.com": {
+            "message_id": "note-2",
+            "direction": "incoming",
+            "delivery_state": "delivered",
+            "local_file_path": "/tmp/note-2.wav",
+            "duration_ms": 2400,
+            "unread": True,
+            "display_name": "Mom",
+        }
+    }
+
+
+def test_voip_manager_uses_rust_owned_voice_note_summary_snapshot() -> None:
+    """Rust-host mode should expose voice-note summaries from snapshots, not Python storage."""
+
+    backend = SnapshotOwnedMockVoIPBackend()
+    manager = VoIPManager(build_config(), backend=backend)
+    summary_events: list[tuple[int, dict[str, dict[str, object]]]] = []
+    manager.on_message_summary_change(
+        lambda unread, summary: summary_events.append((unread, dict(summary)))
+    )
+
+    assert manager.start()
+    snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+        unread_voice_notes=1,
+        unread_voice_notes_by_contact={"sip:mom@example.com": 1},
+        latest_voice_note_by_contact={
+            "sip:mom@example.com": {
+                "message_id": "note-1",
+                "direction": "incoming",
+                "delivery_state": "delivered",
+                "local_file_path": "/tmp/note-1.wav",
+                "duration_ms": 1800,
+                "unread": True,
+                "display_name": "Mom",
+            }
+        },
+    )
+
+    backend.runtime_snapshot = snapshot
+    backend.emit(VoIPRuntimeSnapshotChanged(snapshot=snapshot))
+    manager.mark_voice_notes_seen("sip:mom@example.com")
+
+    assert manager.unread_voice_note_count() == 1
+    assert manager.unread_voice_note_counts_by_contact() == {"sip:mom@example.com": 1}
+    assert manager.latest_voice_note_summary()["sip:mom@example.com"]["message_id"] == "note-1"
+    assert summary_events == [(1, snapshot.latest_voice_note_by_contact)]
+    assert backend.mark_seen_addresses == ["sip:mom@example.com"]
+
+
+def test_voip_manager_does_not_persist_rust_owned_message_events_to_python_store(
+    tmp_path: Path,
+) -> None:
+    """Rust-host message events should not repopulate the legacy Python message store."""
+
+    backend = SnapshotOwnedMockVoIPBackend()
+    manager = VoIPManager(build_config(tmp_path), backend=backend)
+
+    assert manager.start()
+    backend.emit(
+        MessageReceived(
+            message=VoIPMessageRecord(
+                id="incoming-note-1",
+                peer_sip_address="sip:mom@example.com",
+                sender_sip_address="sip:mom@example.com",
+                recipient_sip_address="sip:alice@example.com",
+                kind=MessageKind.VOICE_NOTE,
+                direction=MessageDirection.INCOMING,
+                delivery_state=MessageDeliveryState.DELIVERED,
+                created_at="2026-04-29T00:00:00+00:00",
+                updated_at="2026-04-29T00:00:00+00:00",
+                local_file_path="/tmp/note.wav",
+                mime_type="audio/wav",
+                duration_ms=1000,
+                unread=True,
+            )
+        )
+    )
+
+    assert manager._message_store.get("incoming-note-1") is None
 
 
 def test_voip_manager_derives_availability_from_rust_lifecycle_snapshots() -> None:

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -250,6 +250,9 @@ class RustHostBackend:
         self._pending_message_ids[request_id] = message_id
         return message_id
 
+    def mark_voice_notes_seen(self, sip_address: str) -> bool:
+        return self._send("voip.mark_voice_notes_seen", {"uri": sip_address})
+
     def handle_worker_message(self, event: Any) -> None:
         if getattr(event, "domain", self.domain) != self.domain:
             return
@@ -600,6 +603,13 @@ def _runtime_snapshot(payload: dict[str, Any]) -> VoIPRuntimeSnapshot:
         active_call_peer=str(payload.get("active_call_peer", "") or ""),
         muted=_bool_payload(payload.get("muted", False)),
         pending_outbound_messages=_duration_ms(payload.get("pending_outbound_messages")),
+        unread_voice_notes=_duration_ms(payload.get("unread_voice_notes")),
+        unread_voice_notes_by_contact=_int_map_payload(
+            payload.get("unread_voice_notes_by_contact")
+        ),
+        latest_voice_note_by_contact=_summary_map_payload(
+            payload.get("latest_voice_note_by_contact")
+        ),
         lifecycle=VoIPLifecycleSnapshot(
             state=str(lifecycle_payload.get("state", "unconfigured") or "unconfigured"),
             reason=str(lifecycle_payload.get("reason", "") or ""),
@@ -653,6 +663,37 @@ def _dict_payload(value: object) -> dict[str, Any]:
     if isinstance(value, dict):
         return value
     return {}
+
+
+def _int_map_payload(value: object) -> dict[str, int]:
+    payload = _dict_payload(value)
+    result: dict[str, int] = {}
+    for key, raw_value in payload.items():
+        normalized_key = str(key).strip()
+        if not normalized_key:
+            continue
+        result[normalized_key] = _duration_ms(raw_value)
+    return result
+
+
+def _summary_map_payload(value: object) -> dict[str, dict[str, object]]:
+    payload = _dict_payload(value)
+    result: dict[str, dict[str, object]] = {}
+    for key, raw_summary in payload.items():
+        normalized_key = str(key).strip()
+        if not normalized_key:
+            continue
+        summary = _dict_payload(raw_summary)
+        result[normalized_key] = {
+            "message_id": str(summary.get("message_id", "") or ""),
+            "direction": str(summary.get("direction", "") or ""),
+            "delivery_state": str(summary.get("delivery_state", "") or ""),
+            "local_file_path": str(summary.get("local_file_path", "") or ""),
+            "duration_ms": _duration_ms(summary.get("duration_ms")),
+            "unread": _bool_payload(summary.get("unread", False)),
+            "display_name": str(summary.get("display_name", "") or ""),
+        }
+    return result
 
 
 def _message_kind(value: str) -> MessageKind | None:

--- a/yoyopod/integrations/call/manager.py
+++ b/yoyopod/integrations/call/manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 import time
 from dataclasses import dataclass, replace
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, cast
 
@@ -21,8 +22,11 @@ from yoyopod.integrations.call.models import (
     CallStateChanged,
     IncomingCallDetected,
     MessageDeliveryChanged,
+    MessageDeliveryState,
+    MessageDirection,
     MessageDownloadCompleted,
     MessageFailed,
+    MessageKind,
     MessageReceived,
     RegistrationState,
     RegistrationStateChanged,
@@ -79,6 +83,14 @@ class VoIPManager:
         self.call_start_time: float | None = None
         self.is_muted = False
         self._runtime_snapshot: VoIPRuntimeSnapshot | None = None
+        self._last_rust_message_summary_key: (
+            tuple[
+                int,
+                tuple[tuple[str, int], ...],
+                tuple[tuple[str, tuple[tuple[str, str], ...]], ...],
+            ]
+            | None
+        ) = None
         self._pending_terminal_action: str | None = None
         self._message_store = message_store or self._build_message_store()
         self._messaging_service = MessagingService(
@@ -144,7 +156,8 @@ class VoIPManager:
         self._notify_availability_change(
             self.running, "started" if self.running else "start_failed"
         )
-        self._notify_message_summary_change()
+        if not self._backend_owns_runtime_snapshot():
+            self._notify_message_summary_change()
         return self.running
 
     def stop(self, notify_events: bool = True) -> None:
@@ -292,6 +305,9 @@ class VoIPManager:
         return True
 
     def send_text_message(self, sip_address: str, text: str, display_name: str = "") -> bool:
+        if self._backend_owns_runtime_snapshot():
+            message_id = self.backend.send_text_message(sip_address, text)
+            return bool(message_id)
         return self._messaging_service.send_text_message(sip_address, text, display_name)
 
     def start_voice_note_recording(self, recipient_address: str, recipient_name: str = "") -> bool:
@@ -326,21 +342,42 @@ class VoIPManager:
         self._voice_note_service.discard_active_voice_note()
 
     def latest_voice_note_for_contact(self, sip_address: str) -> VoIPMessageRecord | None:
+        if self._backend_owns_runtime_snapshot():
+            return self._runtime_voice_note_record_for_contact(sip_address)
         return self._voice_note_service.latest_voice_note_for_contact(sip_address)
 
     def unread_voice_note_count(self) -> int:
+        if self._backend_owns_runtime_snapshot() and self._runtime_snapshot is not None:
+            return max(0, int(self._runtime_snapshot.unread_voice_notes))
         return self._voice_note_service.unread_voice_note_count()
 
     def unread_voice_note_counts_by_contact(self) -> dict[str, int]:
+        if self._backend_owns_runtime_snapshot() and self._runtime_snapshot is not None:
+            return dict(self._runtime_snapshot.unread_voice_notes_by_contact)
         return self._voice_note_service.unread_voice_note_counts_by_contact()
 
     def latest_voice_note_summary(self) -> dict[str, dict[str, object]]:
+        if self._backend_owns_runtime_snapshot() and self._runtime_snapshot is not None:
+            return {
+                str(address): dict(summary)
+                for address, summary in self._runtime_snapshot.latest_voice_note_by_contact.items()
+            }
         return self._voice_note_service.latest_voice_note_summary()
 
     def mark_voice_notes_seen(self, sip_address: str) -> None:
+        if self._backend_owns_runtime_snapshot():
+            mark_seen = getattr(self.backend, "mark_voice_notes_seen", None)
+            if callable(mark_seen):
+                mark_seen(sip_address)
+            return
         self._voice_note_service.mark_voice_notes_seen(sip_address)
 
     def play_latest_voice_note(self, sip_address: str) -> bool:
+        if self._backend_owns_runtime_snapshot():
+            record = self._runtime_voice_note_record_for_contact(sip_address)
+            if record is None or not record.local_file_path:
+                return False
+            return self._voice_note_service.play_voice_note(record.local_file_path)
         return self._voice_note_service.play_latest_voice_note(sip_address)
 
     def play_voice_note(self, file_path: str) -> bool:
@@ -550,17 +587,25 @@ class VoIPManager:
             self._apply_runtime_snapshot(event.snapshot)
             return
         if isinstance(event, MessageReceived):
+            if self._backend_owns_runtime_snapshot():
+                return
             self._messaging_service.handle_message_received(event.message)
             return
         if isinstance(event, MessageDeliveryChanged):
             self._voice_note_service.handle_message_delivery_changed(event)
+            if self._backend_owns_runtime_snapshot():
+                return
             self._messaging_service.handle_message_delivery_changed(event)
             return
         if isinstance(event, MessageDownloadCompleted):
+            if self._backend_owns_runtime_snapshot():
+                return
             self._messaging_service.handle_message_download_completed(event)
             return
         if isinstance(event, MessageFailed):
             self._voice_note_service.handle_message_failed(event)
+            if self._backend_owns_runtime_snapshot():
+                return
             self._messaging_service.handle_message_failed(event)
 
     def _apply_runtime_snapshot(self, snapshot: VoIPRuntimeSnapshot) -> None:
@@ -577,8 +622,72 @@ class VoIPManager:
         self._update_call_state(snapshot.call_state)
         self._notify_lifecycle_availability_from_snapshot(snapshot)
         self._voice_note_service.apply_runtime_snapshot(snapshot)
-        self._messaging_service.apply_runtime_snapshot(snapshot)
+        if self._backend_owns_runtime_snapshot():
+            self._notify_rust_message_summary_change(snapshot)
+        else:
+            self._messaging_service.apply_runtime_snapshot(snapshot)
         self._notify_runtime_snapshot_change(snapshot)
+
+    def _notify_rust_message_summary_change(self, snapshot: VoIPRuntimeSnapshot) -> None:
+        summary = {
+            str(address): dict(value)
+            for address, value in snapshot.latest_voice_note_by_contact.items()
+        }
+        key = _message_summary_key(
+            snapshot.unread_voice_notes,
+            snapshot.unread_voice_notes_by_contact,
+            summary,
+        )
+        if self._last_rust_message_summary_key == key:
+            return
+        self._last_rust_message_summary_key = key
+        self._messaging_service.notify_external_message_summary_change(
+            max(0, int(snapshot.unread_voice_notes)),
+            summary,
+        )
+
+    def _runtime_voice_note_record_for_contact(
+        self,
+        sip_address: str,
+    ) -> VoIPMessageRecord | None:
+        if self._runtime_snapshot is None or not sip_address:
+            return None
+        summary = self._runtime_snapshot.latest_voice_note_by_contact.get(sip_address)
+        if not isinstance(summary, dict):
+            return None
+        message_id = str(summary.get("message_id", "") or "")
+        if not message_id:
+            return None
+        direction_value = str(summary.get("direction", MessageDirection.INCOMING.value) or "")
+        delivery_value = str(summary.get("delivery_state", MessageDeliveryState.QUEUED.value) or "")
+        try:
+            direction = MessageDirection(direction_value)
+        except ValueError:
+            direction = MessageDirection.INCOMING
+        try:
+            delivery_state = MessageDeliveryState(delivery_value)
+        except ValueError:
+            delivery_state = MessageDeliveryState.QUEUED
+        sender = sip_address if direction == MessageDirection.INCOMING else self.config.sip_identity
+        recipient = (
+            self.config.sip_identity if direction == MessageDirection.INCOMING else sip_address
+        )
+        timestamp = datetime.now(timezone.utc).isoformat()
+        return VoIPMessageRecord(
+            id=message_id,
+            peer_sip_address=sip_address,
+            sender_sip_address=sender,
+            recipient_sip_address=recipient,
+            kind=MessageKind.VOICE_NOTE,
+            direction=direction,
+            delivery_state=delivery_state,
+            created_at=timestamp,
+            updated_at=timestamp,
+            local_file_path=str(summary.get("local_file_path", "") or ""),
+            duration_ms=max(0, int(summary.get("duration_ms", 0) or 0)),
+            unread=bool(summary.get("unread", False)),
+            display_name=str(summary.get("display_name", "") or ""),
+        )
 
     def _sync_call_identity(self, snapshot: VoIPRuntimeSnapshot) -> None:
         has_active_call = bool(snapshot.active_call_id or snapshot.active_call_peer)
@@ -744,6 +853,35 @@ class VoIPManager:
 
     def _check_active_voice_note_timeout(self) -> None:
         self._voice_note_service.check_active_voice_note_timeout()
+
+
+def _message_summary_key(
+    unread_voice_notes: int,
+    unread_by_contact: dict[str, int],
+    latest_by_contact: dict[str, dict[str, object]],
+) -> tuple[
+    int,
+    tuple[tuple[str, int], ...],
+    tuple[tuple[str, tuple[tuple[str, str], ...]], ...],
+]:
+    latest_key = tuple(
+        sorted(
+            (
+                str(address),
+                tuple(sorted((str(field), str(value)) for field, value in dict(summary).items())),
+            )
+            for address, summary in latest_by_contact.items()
+        )
+    )
+    return (
+        max(0, int(unread_voice_notes)),
+        tuple(
+            sorted(
+                (str(address), max(0, int(count))) for address, count in unread_by_contact.items()
+            )
+        ),
+        latest_key,
+    )
 
 
 __all__ = ["VoIPIterateSnapshot", "VoIPManager"]

--- a/yoyopod/integrations/call/messaging.py
+++ b/yoyopod/integrations/call/messaging.py
@@ -200,6 +200,13 @@ class MessagingService:
     def notify_message_summary_change(self) -> None:
         unread = self.unread_voice_note_count()
         summary = self.latest_voice_note_summary()
+        self.notify_external_message_summary_change(unread, summary)
+
+    def notify_external_message_summary_change(
+        self,
+        unread: int,
+        summary: dict[str, dict[str, object]],
+    ) -> None:
         for callback in self.message_summary_callbacks:
             try:
                 callback(unread, summary)

--- a/yoyopod/integrations/call/models.py
+++ b/yoyopod/integrations/call/models.py
@@ -254,6 +254,9 @@ class VoIPRuntimeSnapshot:
     active_call_peer: str = ""
     muted: bool = False
     pending_outbound_messages: int = 0
+    unread_voice_notes: int = 0
+    unread_voice_notes_by_contact: dict[str, int] = field(default_factory=dict)
+    latest_voice_note_by_contact: dict[str, dict[str, object]] = field(default_factory=dict)
     lifecycle: VoIPLifecycleSnapshot = field(default_factory=VoIPLifecycleSnapshot)
     call_session: VoIPCallSessionSnapshot = field(default_factory=VoIPCallSessionSnapshot)
     voice_note: VoIPVoiceNoteSnapshot = field(default_factory=VoIPVoiceNoteSnapshot)

--- a/yoyopod_rs/Cargo.lock
+++ b/yoyopod_rs/Cargo.lock
@@ -129,6 +129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "embedded-graphics"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +216,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +235,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -329,6 +350,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +431,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "time",
 ]
 
 [[package]]

--- a/yoyopod_rs/voip-host/BUILD.bazel
+++ b/yoyopod_rs/voip-host/BUILD.bazel
@@ -26,6 +26,7 @@ VOIP_HOST_TESTS = [
     "events",
     "host",
     "lifecycle",
+    "message_store",
     "messages",
     "protocol",
     "runtime_snapshot",

--- a/yoyopod_rs/voip-host/Cargo.toml
+++ b/yoyopod_rs/voip-host/Cargo.toml
@@ -15,3 +15,4 @@ libloading = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
+time = { version = "0.3", features = ["formatting"] }

--- a/yoyopod_rs/voip-host/src/config.rs
+++ b/yoyopod_rs/voip-host/src/config.rs
@@ -29,6 +29,8 @@ pub struct VoipConfig {
     #[serde(default = "default_iterate_interval_ms")]
     pub iterate_interval_ms: u64,
     #[serde(default)]
+    pub message_store_dir: String,
+    #[serde(default)]
     pub voice_note_store_dir: String,
     #[serde(default)]
     pub auto_download_incoming_voice_recordings: bool,

--- a/yoyopod_rs/voip-host/src/host.rs
+++ b/yoyopod_rs/voip-host/src/host.rs
@@ -1,7 +1,10 @@
 use crate::calls::CallSession;
 use crate::config::VoipConfig;
 use crate::lifecycle::LifecycleState;
-use crate::messages::{is_terminal_delivery_state, MessageSessionState, OutboundMessageIds};
+use crate::message_store::MessageStore;
+use crate::messages::{
+    is_terminal_delivery_state, normalize_message_record, MessageSessionState, OutboundMessageIds,
+};
 use crate::runtime_snapshot::RuntimeSnapshot;
 use crate::voice_notes::VoiceNoteSession;
 use serde_json::json;
@@ -76,6 +79,7 @@ pub struct VoipHost {
     lifecycle: LifecycleState,
     call: CallSession,
     voice_note: VoiceNoteSession,
+    message_store: MessageStore,
     last_message: Option<MessageSessionState>,
     outbound_message_ids: OutboundMessageIds,
 }
@@ -89,6 +93,7 @@ impl Default for VoipHost {
             lifecycle: LifecycleState::default(),
             call: CallSession::default(),
             voice_note: VoiceNoteSession::default(),
+            message_store: MessageStore::default(),
             last_message: None,
             outbound_message_ids: OutboundMessageIds::default(),
         }
@@ -97,6 +102,7 @@ impl Default for VoipHost {
 
 impl VoipHost {
     pub fn configure(&mut self, config: VoipConfig) {
+        self.message_store = MessageStore::open(&config.message_store_dir, 200);
         self.config = Some(config);
         self.registered = false;
         self.registration_state = "none".to_string();
@@ -145,6 +151,7 @@ impl VoipHost {
             voice_note: &self.voice_note,
             last_message: self.last_message.as_ref(),
             pending_outbound_messages: self.outbound_message_ids.len(),
+            message_store: &self.message_store,
         }
         .payload()
     }
@@ -239,6 +246,23 @@ impl VoipHost {
         let backend_id = backend.send_text_message(sip_address, text)?;
         self.outbound_message_ids
             .remember(&backend_id, client_id, "voip text message")?;
+        let sender_sip_address = self.local_identity();
+        if let Err(error) = self.message_store.upsert(MessageRecord {
+            message_id: client_id.to_string(),
+            peer_sip_address: sip_address.to_string(),
+            sender_sip_address,
+            recipient_sip_address: sip_address.to_string(),
+            kind: "text".to_string(),
+            direction: "outgoing".to_string(),
+            delivery_state: "sending".to_string(),
+            text: text.to_string(),
+            local_file_path: String::new(),
+            mime_type: String::new(),
+            duration_ms: 0,
+            unread: false,
+        }) {
+            eprintln!("failed to persist accepted outgoing VoIP text message: {error}");
+        }
         Ok(client_id.to_string())
     }
 
@@ -285,7 +309,28 @@ impl VoipHost {
             .remember(&backend_id, client_id, "voip voice note")?;
         self.voice_note
             .start_sending(file_path, duration_ms, mime_type, client_id);
+        let sender_sip_address = self.local_identity();
+        if let Err(error) = self.message_store.upsert(MessageRecord {
+            message_id: client_id.to_string(),
+            peer_sip_address: sip_address.to_string(),
+            sender_sip_address,
+            recipient_sip_address: sip_address.to_string(),
+            kind: "voice_note".to_string(),
+            direction: "outgoing".to_string(),
+            delivery_state: "sending".to_string(),
+            text: String::new(),
+            local_file_path: file_path.to_string(),
+            mime_type: mime_type.to_string(),
+            duration_ms,
+            unread: false,
+        }) {
+            eprintln!("failed to persist accepted outgoing VoIP voice note: {error}");
+        }
         Ok(client_id.to_string())
+    }
+
+    pub fn mark_voice_notes_seen(&mut self, sip_address: &str) -> Result<(), String> {
+        self.message_store.mark_contact_seen(sip_address)
     }
 
     pub fn poll_backend_events<B: CallBackend>(
@@ -332,6 +377,9 @@ impl VoipHost {
                 self.outbound_message_ids.clear();
             }
             BackendEvent::MessageReceived { message } => {
+                if let Err(error) = self.message_store.upsert(message.clone()) {
+                    eprintln!("failed to persist received VoIP message: {error}");
+                }
                 self.last_message = Some(MessageSessionState::received(message));
             }
             BackendEvent::MessageDeliveryChanged {
@@ -346,6 +394,12 @@ impl VoipHost {
                     local_file_path,
                     error,
                 ));
+                if let Err(store_error) =
+                    self.message_store
+                        .update_delivery(message_id, delivery_state, local_file_path)
+                {
+                    eprintln!("failed to persist VoIP delivery update: {store_error}");
+                }
                 self.voice_note
                     .apply_delivery(message_id, delivery_state, local_file_path);
             }
@@ -358,11 +412,20 @@ impl VoipHost {
                     message_id,
                     local_file_path,
                 ));
+                if let Err(error) =
+                    self.message_store
+                        .update_download(message_id, local_file_path, mime_type)
+                {
+                    eprintln!("failed to persist VoIP download update: {error}");
+                }
                 self.voice_note
                     .apply_download(message_id, local_file_path, mime_type);
             }
             BackendEvent::MessageFailed { message_id, reason } => {
                 self.last_message = Some(MessageSessionState::failed(message_id, reason));
+                if let Err(error) = self.message_store.update_delivery(message_id, "failed", "") {
+                    eprintln!("failed to persist VoIP failure update: {error}");
+                }
                 self.voice_note.fail(message_id);
             }
         }
@@ -372,6 +435,7 @@ impl VoipHost {
         match event {
             BackendEvent::MessageReceived { mut message } => {
                 message.message_id = self.translate_message_id(&message.message_id, false);
+                let message = normalize_message_record(message);
                 BackendEvent::MessageReceived { message }
             }
             BackendEvent::MessageDeliveryChanged {
@@ -407,5 +471,12 @@ impl VoipHost {
 
     fn translate_message_id(&mut self, backend_id: &str, terminal: bool) -> String {
         self.outbound_message_ids.translate(backend_id, terminal)
+    }
+
+    fn local_identity(&self) -> String {
+        self.config
+            .as_ref()
+            .map(|config| config.sip_identity.clone())
+            .unwrap_or_default()
     }
 }

--- a/yoyopod_rs/voip-host/src/lib.rs
+++ b/yoyopod_rs/voip-host/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod events;
 pub mod host;
 pub mod lifecycle;
+pub mod message_store;
 pub mod messages;
 pub mod protocol;
 pub mod runtime_snapshot;

--- a/yoyopod_rs/voip-host/src/message_store.rs
+++ b/yoyopod_rs/voip-host/src/message_store.rs
@@ -1,0 +1,304 @@
+use crate::messages::{normalize_message_record, MessageRecord};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+const DEFAULT_MAX_ENTRIES: usize = 200;
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct StoredMessage {
+    id: String,
+    peer_sip_address: String,
+    sender_sip_address: String,
+    recipient_sip_address: String,
+    kind: String,
+    direction: String,
+    delivery_state: String,
+    created_at: String,
+    updated_at: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    local_file_path: String,
+    #[serde(default)]
+    mime_type: String,
+    #[serde(default)]
+    duration_ms: i32,
+    #[serde(default)]
+    unread: bool,
+    #[serde(default)]
+    display_name: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct StorePayload {
+    #[serde(default)]
+    messages: Vec<StoredMessage>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MessageStore {
+    store_dir: Option<PathBuf>,
+    max_entries: usize,
+    messages: Vec<StoredMessage>,
+}
+
+impl Default for MessageStore {
+    fn default() -> Self {
+        Self::memory(DEFAULT_MAX_ENTRIES)
+    }
+}
+
+impl MessageStore {
+    pub fn memory(max_entries: usize) -> Self {
+        Self {
+            store_dir: None,
+            max_entries: max_entries.max(1),
+            messages: Vec::new(),
+        }
+    }
+
+    pub fn open(store_dir: impl AsRef<Path>, max_entries: usize) -> Self {
+        let store_dir = store_dir.as_ref();
+        if store_dir.as_os_str().is_empty() {
+            return Self::memory(max_entries);
+        }
+
+        let mut store = Self {
+            store_dir: Some(store_dir.to_path_buf()),
+            max_entries: max_entries.max(1),
+            messages: Vec::new(),
+        };
+        store.load();
+        store
+    }
+
+    pub fn upsert(&mut self, message: MessageRecord) -> Result<(), String> {
+        let message = normalize_message_record(message);
+        let previous = self.take_message(&message.message_id);
+        let now = now_timestamp();
+        let stored = StoredMessage {
+            id: message.message_id,
+            peer_sip_address: message.peer_sip_address,
+            sender_sip_address: message.sender_sip_address,
+            recipient_sip_address: message.recipient_sip_address,
+            kind: message.kind,
+            direction: message.direction,
+            delivery_state: message.delivery_state,
+            created_at: previous
+                .as_ref()
+                .map(|message| message.created_at.clone())
+                .unwrap_or_else(|| now.clone()),
+            updated_at: now,
+            text: message.text,
+            local_file_path: message.local_file_path,
+            mime_type: message.mime_type,
+            duration_ms: message.duration_ms.max(0),
+            unread: message.unread,
+            display_name: previous
+                .map(|message| message.display_name)
+                .unwrap_or_default(),
+        };
+        self.messages.insert(0, stored);
+        self.truncate();
+        self.save()
+    }
+
+    pub fn update_delivery(
+        &mut self,
+        message_id: &str,
+        delivery_state: &str,
+        local_file_path: &str,
+    ) -> Result<(), String> {
+        if let Some(message) = self.find_mut(message_id) {
+            message.delivery_state = delivery_state.to_string();
+            if !local_file_path.is_empty() {
+                message.local_file_path = local_file_path.to_string();
+            }
+            message.updated_at = now_timestamp();
+            self.reorder_message(message_id);
+            return self.save();
+        }
+        Ok(())
+    }
+
+    pub fn update_download(
+        &mut self,
+        message_id: &str,
+        local_file_path: &str,
+        mime_type: &str,
+    ) -> Result<(), String> {
+        if let Some(message) = self.find_mut(message_id) {
+            if !local_file_path.is_empty() {
+                message.local_file_path = local_file_path.to_string();
+            }
+            if !mime_type.is_empty() {
+                message.mime_type = mime_type.to_string();
+            }
+            message.updated_at = now_timestamp();
+            self.reorder_message(message_id);
+            return self.save();
+        }
+        Ok(())
+    }
+
+    pub fn mark_contact_seen(&mut self, sip_address: &str) -> Result<(), String> {
+        let mut changed = false;
+        let now = now_timestamp();
+        for message in &mut self.messages {
+            if message.peer_sip_address == sip_address
+                && message.direction == "incoming"
+                && message.unread
+            {
+                message.unread = false;
+                message.updated_at = now.clone();
+                changed = true;
+            }
+        }
+        if changed {
+            return self.save();
+        }
+        Ok(())
+    }
+
+    pub fn summary_payload(&self) -> Value {
+        json!({
+            "unread_voice_notes": self.unread_voice_note_count(),
+            "unread_voice_notes_by_contact": self.unread_voice_note_counts_by_contact(),
+            "latest_voice_note_by_contact": self.latest_voice_note_by_contact(),
+        })
+    }
+
+    fn load(&mut self) {
+        let Some(index_file) = self.index_file() else {
+            self.messages.clear();
+            return;
+        };
+        let Ok(contents) = fs::read_to_string(index_file) else {
+            self.messages.clear();
+            return;
+        };
+        match serde_json::from_str::<StorePayload>(&contents) {
+            Ok(mut payload) => {
+                payload.messages.truncate(self.max_entries);
+                self.messages = payload.messages;
+            }
+            Err(error) => {
+                eprintln!("failed to load VoIP message store: {error}");
+                self.messages.clear();
+            }
+        }
+    }
+
+    fn save(&self) -> Result<(), String> {
+        let Some(store_dir) = &self.store_dir else {
+            return Ok(());
+        };
+        fs::create_dir_all(store_dir).map_err(|error| error.to_string())?;
+        let index_file = store_dir.join("messages.json");
+        let payload = StorePayload {
+            messages: self
+                .messages
+                .iter()
+                .take(self.max_entries)
+                .cloned()
+                .collect(),
+        };
+        let encoded = serde_json::to_string_pretty(&payload).map_err(|error| error.to_string())?;
+        fs::write(index_file, encoded).map_err(|error| error.to_string())
+    }
+
+    fn index_file(&self) -> Option<PathBuf> {
+        self.store_dir
+            .as_ref()
+            .map(|store_dir| store_dir.join("messages.json"))
+    }
+
+    fn unread_voice_note_count(&self) -> usize {
+        self.messages
+            .iter()
+            .filter(|message| is_unread_incoming_voice_note(message))
+            .count()
+    }
+
+    fn unread_voice_note_counts_by_contact(&self) -> BTreeMap<String, usize> {
+        let mut counts = BTreeMap::new();
+        for message in &self.messages {
+            if is_unread_incoming_voice_note(message) && !message.peer_sip_address.is_empty() {
+                *counts.entry(message.peer_sip_address.clone()).or_insert(0) += 1;
+            }
+        }
+        counts
+    }
+
+    fn latest_voice_note_by_contact(&self) -> BTreeMap<String, Value> {
+        let mut latest = BTreeMap::new();
+        for message in &self.messages {
+            if message.kind != "voice_note"
+                || message.peer_sip_address.is_empty()
+                || latest.contains_key(&message.peer_sip_address)
+            {
+                continue;
+            }
+            latest.insert(
+                message.peer_sip_address.clone(),
+                json!({
+                    "message_id": message.id,
+                    "direction": message.direction,
+                    "delivery_state": message.delivery_state,
+                    "local_file_path": message.local_file_path,
+                    "duration_ms": message.duration_ms.max(0),
+                    "unread": message.unread,
+                    "display_name": message.display_name,
+                }),
+            );
+        }
+        latest
+    }
+
+    fn take_message(&mut self, message_id: &str) -> Option<StoredMessage> {
+        let index = self
+            .messages
+            .iter()
+            .position(|message| message.id == message_id)?;
+        Some(self.messages.remove(index))
+    }
+
+    fn find_mut(&mut self, message_id: &str) -> Option<&mut StoredMessage> {
+        self.messages
+            .iter_mut()
+            .find(|message| message.id == message_id)
+    }
+
+    fn reorder_message(&mut self, message_id: &str) {
+        if let Some(message) = self.take_message(message_id) {
+            self.messages.insert(0, message);
+            self.truncate();
+        }
+    }
+
+    fn truncate(&mut self) {
+        self.messages.truncate(self.max_entries);
+    }
+}
+
+fn is_unread_incoming_voice_note(message: &StoredMessage) -> bool {
+    message.kind == "voice_note" && message.direction == "incoming" && message.unread
+}
+
+fn now_timestamp() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| fallback_timestamp())
+}
+
+fn fallback_timestamp() -> String {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    format!("1970-01-01T00:00:{:02}Z", seconds % 60)
+}

--- a/yoyopod_rs/voip-host/src/messages.rs
+++ b/yoyopod_rs/voip-host/src/messages.rs
@@ -1,6 +1,8 @@
 use serde_json::json;
 use std::collections::HashMap;
 
+const RCS_FT_HTTP_MIME: &str = "application/vnd.gsma.rcs-ft-http+xml";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MessageRecord {
     pub message_id: String,
@@ -131,4 +133,53 @@ impl OutboundMessageIds {
 
 pub fn is_terminal_delivery_state(value: &str) -> bool {
     matches!(value, "delivered" | "failed")
+}
+
+pub fn normalize_message_record(mut message: MessageRecord) -> MessageRecord {
+    if message.mime_type != RCS_FT_HTTP_MIME || message.text.is_empty() {
+        return message;
+    }
+
+    let voice_note_envelope = message.kind == "voice_note"
+        || (message.kind == "text" && is_voice_recording_envelope(&message.text));
+    if !voice_note_envelope {
+        return message;
+    }
+
+    message.kind = "voice_note".to_string();
+    message.mime_type =
+        extract_voice_note_payload_mime(&message.text).unwrap_or_else(|| "audio/wav".to_string());
+    if message.duration_ms <= 0 {
+        message.duration_ms = extract_voice_note_duration_ms(&message.text);
+    }
+    message.text.clear();
+    message
+}
+
+fn is_voice_recording_envelope(xml_text: &str) -> bool {
+    xml_text.contains("voice-recording=yes")
+}
+
+fn extract_voice_note_payload_mime(xml_text: &str) -> Option<String> {
+    let content_type = extract_tag_text(xml_text, "<content-type>", "</content-type>")?;
+    let mime_type = content_type.split(';').next().unwrap_or("").trim();
+    if mime_type.is_empty() {
+        None
+    } else {
+        Some(mime_type.to_string())
+    }
+}
+
+fn extract_voice_note_duration_ms(xml_text: &str) -> i32 {
+    extract_tag_text(xml_text, "<am:playing-length>", "</am:playing-length>")
+        .and_then(|duration| duration.parse::<i32>().ok())
+        .unwrap_or_default()
+        .max(0)
+}
+
+fn extract_tag_text<'a>(xml_text: &'a str, opening: &str, closing: &str) -> Option<&'a str> {
+    let start = xml_text.find(opening)? + opening.len();
+    let rest = &xml_text[start..];
+    let end = rest.find(closing)?;
+    Some(&rest[..end])
 }

--- a/yoyopod_rs/voip-host/src/runtime_snapshot.rs
+++ b/yoyopod_rs/voip-host/src/runtime_snapshot.rs
@@ -1,5 +1,6 @@
 use crate::calls::CallSession;
 use crate::lifecycle::LifecycleState;
+use crate::message_store::MessageStore;
 use crate::messages::MessageSessionState;
 use crate::voice_notes::VoiceNoteSession;
 use serde_json::json;
@@ -13,6 +14,7 @@ pub struct RuntimeSnapshot<'a> {
     pub voice_note: &'a VoiceNoteSession,
     pub last_message: Option<&'a MessageSessionState>,
     pub pending_outbound_messages: usize,
+    pub message_store: &'a MessageStore,
 }
 
 impl RuntimeSnapshot<'_> {
@@ -21,6 +23,7 @@ impl RuntimeSnapshot<'_> {
             .last_message
             .map(MessageSessionState::payload)
             .unwrap_or(serde_json::Value::Null);
+        let message_summary = self.message_store.summary_payload();
 
         json!({
             "configured": self.configured,
@@ -35,6 +38,9 @@ impl RuntimeSnapshot<'_> {
             "pending_outbound_messages": self.pending_outbound_messages,
             "voice_note": self.voice_note.payload(),
             "last_message": last_message,
+            "unread_voice_notes": message_summary["unread_voice_notes"].clone(),
+            "unread_voice_notes_by_contact": message_summary["unread_voice_notes_by_contact"].clone(),
+            "latest_voice_note_by_contact": message_summary["latest_voice_note_by_contact"].clone(),
         })
     }
 }

--- a/yoyopod_rs/voip-host/src/worker.rs
+++ b/yoyopod_rs/voip-host/src/worker.rs
@@ -334,6 +334,32 @@ pub fn handle_command(
                 write_session_snapshot(host)?;
             }
         }
+        "voip.mark_voice_notes_seen" => {
+            let uri = envelope
+                .payload
+                .get("uri")
+                .or_else(|| envelope.payload.get("sip_address"))
+                .and_then(|value| value.as_str())
+                .unwrap_or("")
+                .trim();
+            if uri.is_empty() {
+                write_envelope(&WorkerEnvelope::error(
+                    "voip.error",
+                    envelope.request_id,
+                    "invalid_command",
+                    "voip.mark_voice_notes_seen requires uri",
+                ))?;
+            } else {
+                host.mark_voice_notes_seen(uri)
+                    .map_err(|error| anyhow!(error))?;
+                write_envelope(&WorkerEnvelope::result(
+                    "voip.mark_voice_notes_seen",
+                    envelope.request_id,
+                    json!({"marked_seen": true}),
+                ))?;
+                write_session_snapshot(host)?;
+            }
+        }
         "voip.shutdown" | "worker.stop" => {
             if let Some(mut backend_ref) = backend.take() {
                 host.unregister(&mut backend_ref);

--- a/yoyopod_rs/voip-host/tests/host.rs
+++ b/yoyopod_rs/voip-host/tests/host.rs
@@ -1,7 +1,9 @@
 mod support;
 
+use std::fs;
+
 use serde_json::Value;
-use support::{config, FakeBackend};
+use support::{config, config_with_message_store, FakeBackend};
 use yoyopod_voip_host::config::VoipConfig;
 use yoyopod_voip_host::host::{BackendEvent, MessageRecord, VoipHost};
 
@@ -134,6 +136,104 @@ fn session_snapshot_tracks_call_message_and_voice_note_state() {
 }
 
 #[test]
+fn session_snapshot_tracks_rust_owned_voice_note_summary() {
+    let store_dir = support::temp_store_dir("host-message-summary");
+    let mut host = VoipHost::default();
+    host.configure(config_with_message_store(&store_dir));
+
+    poll_one(
+        &mut host,
+        BackendEvent::MessageReceived {
+            message: MessageRecord {
+                message_id: "incoming-mom-1".to_string(),
+                peer_sip_address: "sip:mom@example.com".to_string(),
+                sender_sip_address: "sip:mom@example.com".to_string(),
+                recipient_sip_address: "sip:alice@example.com".to_string(),
+                kind: "voice_note".to_string(),
+                direction: "incoming".to_string(),
+                delivery_state: "delivered".to_string(),
+                text: String::new(),
+                local_file_path: "/tmp/mom.wav".to_string(),
+                mime_type: "audio/wav".to_string(),
+                duration_ms: 1800,
+                unread: true,
+            },
+        },
+    );
+
+    let snapshot = host.session_snapshot_payload();
+    assert_eq!(snapshot["unread_voice_notes"], 1);
+    assert_eq!(
+        snapshot["unread_voice_notes_by_contact"]["sip:mom@example.com"],
+        1
+    );
+    assert_eq!(
+        snapshot["latest_voice_note_by_contact"]["sip:mom@example.com"]["message_id"],
+        "incoming-mom-1"
+    );
+
+    host.mark_voice_notes_seen("sip:mom@example.com")
+        .expect("mark seen");
+
+    let snapshot = host.session_snapshot_payload();
+    assert_eq!(snapshot["unread_voice_notes"], 0);
+    assert!(snapshot["unread_voice_notes_by_contact"]
+        .as_object()
+        .expect("counts object")
+        .is_empty());
+}
+
+#[test]
+fn message_received_normalizes_rcs_voice_note_envelope_for_event_and_snapshot() {
+    let store_dir = support::temp_store_dir("host-message-envelope");
+    let mut host = VoipHost::default();
+    host.configure(config_with_message_store(&store_dir));
+    let mut backend = FakeBackend {
+        events: vec![BackendEvent::MessageReceived {
+            message: MessageRecord {
+                message_id: "incoming-envelope-1".to_string(),
+                peer_sip_address: "sip:mom@example.com".to_string(),
+                sender_sip_address: "sip:mom@example.com".to_string(),
+                recipient_sip_address: "sip:alice@example.com".to_string(),
+                kind: "text".to_string(),
+                direction: "incoming".to_string(),
+                delivery_state: "delivered".to_string(),
+                text: (r#"<?xml version="1.0" encoding="UTF-8"?>"#.to_string()
+                    + r#"<file xmlns="urn:gsma:params:xml:ns:rcs:rcs:fthttp" "#
+                    + r#"xmlns:am="urn:gsma:params:xml:ns:rcs:rcs:rram">"#
+                    + r#"<file-info type="file">"#
+                    + r#"<content-type>audio/ogg;voice-recording=yes</content-type>"#
+                    + r#"<am:playing-length>4046</am:playing-length>"#
+                    + r#"</file-info></file>"#),
+                local_file_path: "/tmp/incoming-envelope.mka".to_string(),
+                mime_type: "application/vnd.gsma.rcs-ft-http+xml".to_string(),
+                duration_ms: 0,
+                unread: true,
+            },
+        }],
+        ..FakeBackend::default()
+    };
+
+    let events = host.poll_backend_events(&mut backend).expect("poll event");
+
+    let BackendEvent::MessageReceived { message } = &events[0] else {
+        panic!("expected normalized message received event");
+    };
+    assert_eq!(message.kind, "voice_note");
+    assert_eq!(message.mime_type, "audio/ogg");
+    assert_eq!(message.duration_ms, 4046);
+    assert_eq!(message.text, "");
+
+    let snapshot = host.session_snapshot_payload();
+    assert_eq!(snapshot["last_message"]["kind"], "voice_note");
+    assert_eq!(snapshot["unread_voice_notes"], 1);
+    assert_eq!(
+        snapshot["latest_voice_note_by_contact"]["sip:mom@example.com"]["duration_ms"],
+        4046
+    );
+}
+
+#[test]
 fn call_session_snapshot_tracks_direction_terminal_outcome_and_duration() {
     let mut host = VoipHost::default();
     let mut backend = FakeBackend::default();
@@ -199,7 +299,10 @@ fn outgoing_terminal_call_state_finalizes_session_when_event_uses_peer_address()
     assert_eq!(snapshot["active_call_peer"], "");
     assert_eq!(snapshot["call_session"]["active"], false);
     assert_eq!(snapshot["call_session"]["session_id"], "call-outgoing");
-    assert_eq!(snapshot["call_session"]["peer_sip_address"], "sip:bob@example.com");
+    assert_eq!(
+        snapshot["call_session"]["peer_sip_address"],
+        "sip:bob@example.com"
+    );
     assert_eq!(snapshot["call_session"]["terminal_state"], "released");
     assert_eq!(snapshot["call_session"]["history_outcome"], "cancelled");
 }
@@ -392,6 +495,26 @@ fn send_text_message_returns_client_id_and_maps_delivery_back_to_client_id() {
 }
 
 #[test]
+fn send_text_message_returns_client_id_when_message_store_save_fails() {
+    let store_path = support::temp_store_dir("host-text-store-file");
+    fs::write(&store_path, b"not a directory").expect("store blocker");
+    let mut host = VoipHost::default();
+    host.configure(config_with_message_store(&store_path));
+    let mut backend = FakeBackend::default();
+    host.register(&mut backend).unwrap();
+
+    let message_id = host
+        .send_text_message(&mut backend, "sip:bob@example.com", "hello", "client-msg-1")
+        .expect("send text remains accepted");
+
+    assert_eq!(message_id, "client-msg-1");
+    assert_eq!(
+        backend.calls,
+        vec!["start", "text:sip:bob@example.com:hello"]
+    );
+}
+
+#[test]
 fn voice_note_recording_commands_forward_to_backend() {
     let mut host = VoipHost::default();
     let mut backend = FakeBackend::default();
@@ -467,6 +590,36 @@ fn send_voice_note_returns_client_id_and_maps_delivery_back_to_client_id() {
             local_file_path: "/tmp/a.wav".to_string(),
             error: "".to_string(),
         }]
+    );
+}
+
+#[test]
+fn send_voice_note_returns_client_id_when_message_store_save_fails() {
+    let store_path = support::temp_store_dir("host-voice-store-file");
+    fs::write(&store_path, b"not a directory").expect("store blocker");
+    let mut host = VoipHost::default();
+    host.configure(config_with_message_store(&store_path));
+    let mut backend = FakeBackend::default();
+    host.register(&mut backend).unwrap();
+
+    let message_id = host
+        .send_voice_note(
+            &mut backend,
+            "sip:bob@example.com",
+            "/tmp/a.wav",
+            1250,
+            "audio/wav",
+            "client-vn-1",
+        )
+        .expect("send voice note remains accepted");
+
+    assert_eq!(message_id, "client-vn-1");
+    assert_eq!(
+        backend.calls,
+        vec![
+            "start",
+            "voice:sip:bob@example.com:/tmp/a.wav:1250:audio/wav"
+        ]
     );
 }
 

--- a/yoyopod_rs/voip-host/tests/message_store.rs
+++ b/yoyopod_rs/voip-host/tests/message_store.rs
@@ -1,0 +1,207 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+use yoyopod_voip_host::message_store::MessageStore;
+use yoyopod_voip_host::messages::MessageRecord;
+
+fn temp_store_dir(test_name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("yoyopod-{test_name}-{unique}"))
+}
+
+fn voice_note(
+    id: &str,
+    peer_sip_address: &str,
+    direction: &str,
+    delivery_state: &str,
+    unread: bool,
+    local_file_path: &str,
+) -> MessageRecord {
+    MessageRecord {
+        message_id: id.to_string(),
+        peer_sip_address: peer_sip_address.to_string(),
+        sender_sip_address: if direction == "incoming" {
+            peer_sip_address.to_string()
+        } else {
+            "sip:alice@example.com".to_string()
+        },
+        recipient_sip_address: if direction == "incoming" {
+            "sip:alice@example.com".to_string()
+        } else {
+            peer_sip_address.to_string()
+        },
+        kind: "voice_note".to_string(),
+        direction: direction.to_string(),
+        delivery_state: delivery_state.to_string(),
+        text: String::new(),
+        local_file_path: local_file_path.to_string(),
+        mime_type: "audio/wav".to_string(),
+        duration_ms: 1250,
+        unread,
+    }
+}
+
+#[test]
+fn message_store_persists_python_compatible_voice_note_summary() {
+    let store_dir = temp_store_dir("message-summary");
+    let mut store = MessageStore::open(&store_dir, 200);
+
+    store
+        .upsert(voice_note(
+            "incoming-mom-1",
+            "sip:mom@example.com",
+            "incoming",
+            "delivered",
+            true,
+            "/tmp/mom-1.wav",
+        ))
+        .expect("upsert incoming mom");
+    store
+        .upsert(voice_note(
+            "incoming-dad-1",
+            "sip:dad@example.com",
+            "incoming",
+            "delivered",
+            true,
+            "/tmp/dad-1.wav",
+        ))
+        .expect("upsert incoming dad");
+    store
+        .upsert(voice_note(
+            "outgoing-mom-2",
+            "sip:mom@example.com",
+            "outgoing",
+            "sent",
+            false,
+            "/tmp/mom-2.wav",
+        ))
+        .expect("upsert outgoing mom");
+
+    let summary = store.summary_payload();
+
+    assert_eq!(summary["unread_voice_notes"], 2);
+    assert_eq!(
+        summary["unread_voice_notes_by_contact"]["sip:mom@example.com"],
+        1
+    );
+    assert_eq!(
+        summary["unread_voice_notes_by_contact"]["sip:dad@example.com"],
+        1
+    );
+    assert_eq!(
+        summary["latest_voice_note_by_contact"]["sip:mom@example.com"]["message_id"],
+        "outgoing-mom-2"
+    );
+    assert_eq!(
+        summary["latest_voice_note_by_contact"]["sip:mom@example.com"]["direction"],
+        "outgoing"
+    );
+
+    let payload: Value = serde_json::from_str(
+        &fs::read_to_string(store_dir.join("messages.json")).expect("messages file"),
+    )
+    .expect("message store json");
+    assert_eq!(payload["messages"][0]["id"], "outgoing-mom-2");
+    assert_eq!(payload["messages"][0]["kind"], "voice_note");
+
+    let loaded = MessageStore::open(&store_dir, 200);
+    assert_eq!(loaded.summary_payload(), summary);
+}
+
+#[test]
+fn message_store_normalizes_rcs_voice_note_text_envelope() {
+    let store_dir = temp_store_dir("message-envelope");
+    let mut store = MessageStore::open(&store_dir, 200);
+
+    store
+        .upsert(MessageRecord {
+            message_id: "incoming-envelope-1".to_string(),
+            peer_sip_address: "sip:mom@example.com".to_string(),
+            sender_sip_address: "sip:mom@example.com".to_string(),
+            recipient_sip_address: "sip:alice@example.com".to_string(),
+            kind: "text".to_string(),
+            direction: "incoming".to_string(),
+            delivery_state: "delivered".to_string(),
+            text: (r#"<?xml version="1.0" encoding="UTF-8"?>"#.to_string()
+                + r#"<file xmlns="urn:gsma:params:xml:ns:rcs:rcs:fthttp" "#
+                + r#"xmlns:am="urn:gsma:params:xml:ns:rcs:rcs:rram">"#
+                + r#"<file-info type="file">"#
+                + r#"<content-type>audio/ogg;voice-recording=yes</content-type>"#
+                + r#"<am:playing-length>4046</am:playing-length>"#
+                + r#"</file-info></file>"#),
+            local_file_path: "/tmp/incoming-envelope.mka".to_string(),
+            mime_type: "application/vnd.gsma.rcs-ft-http+xml".to_string(),
+            duration_ms: 0,
+            unread: true,
+        })
+        .expect("upsert RCS envelope");
+
+    let summary = store.summary_payload();
+    assert_eq!(summary["unread_voice_notes"], 1);
+    assert_eq!(
+        summary["latest_voice_note_by_contact"]["sip:mom@example.com"]["duration_ms"],
+        4046
+    );
+
+    let payload: Value = serde_json::from_str(
+        &fs::read_to_string(store_dir.join("messages.json")).expect("messages file"),
+    )
+    .expect("message store json");
+    assert_eq!(payload["messages"][0]["kind"], "voice_note");
+    assert_eq!(payload["messages"][0]["mime_type"], "audio/ogg");
+    assert_eq!(payload["messages"][0]["duration_ms"], 4046);
+    assert_eq!(payload["messages"][0]["text"], "");
+}
+
+#[test]
+fn message_store_updates_delivery_downloads_and_mark_seen() {
+    let store_dir = temp_store_dir("message-updates");
+    let mut store = MessageStore::open(&store_dir, 200);
+
+    store
+        .upsert(voice_note(
+            "incoming-mom-1",
+            "sip:mom@example.com",
+            "incoming",
+            "delivered",
+            true,
+            "",
+        ))
+        .expect("upsert incoming");
+    store
+        .upsert(voice_note(
+            "outgoing-mom-1",
+            "sip:mom@example.com",
+            "outgoing",
+            "sending",
+            false,
+            "/tmp/outgoing.wav",
+        ))
+        .expect("upsert outgoing");
+
+    store
+        .update_delivery("outgoing-mom-1", "delivered", "/tmp/sent.wav")
+        .expect("delivery update");
+    store
+        .update_download("incoming-mom-1", "/tmp/downloaded.wav", "audio/ogg")
+        .expect("download update");
+    store
+        .mark_contact_seen("sip:mom@example.com")
+        .expect("mark seen");
+
+    let summary = store.summary_payload();
+    assert_eq!(summary["unread_voice_notes"], 0);
+    assert_eq!(
+        summary["latest_voice_note_by_contact"]["sip:mom@example.com"]["delivery_state"],
+        "delivered"
+    );
+    assert_eq!(
+        summary["latest_voice_note_by_contact"]["sip:mom@example.com"]["local_file_path"],
+        "/tmp/downloaded.wav"
+    );
+}

--- a/yoyopod_rs/voip-host/tests/runtime_snapshot.rs
+++ b/yoyopod_rs/voip-host/tests/runtime_snapshot.rs
@@ -1,5 +1,6 @@
 use yoyopod_voip_host::calls::CallSession;
 use yoyopod_voip_host::lifecycle::LifecycleState;
+use yoyopod_voip_host::message_store::MessageStore;
 use yoyopod_voip_host::messages::MessageSessionState;
 use yoyopod_voip_host::runtime_snapshot::RuntimeSnapshot;
 use yoyopod_voip_host::voice_notes::VoiceNoteSession;
@@ -18,6 +19,7 @@ fn runtime_snapshot_composes_canonical_voip_payload() {
 
     let last_message =
         MessageSessionState::delivery_changed("client-vn-1", "delivered", "/tmp/note.wav", "");
+    let message_store = MessageStore::memory(200);
 
     let payload = RuntimeSnapshot {
         configured: true,
@@ -28,6 +30,7 @@ fn runtime_snapshot_composes_canonical_voip_payload() {
         voice_note: &voice_note,
         last_message: Some(&last_message),
         pending_outbound_messages: 1,
+        message_store: &message_store,
     }
     .payload();
 
@@ -42,4 +45,9 @@ fn runtime_snapshot_composes_canonical_voip_payload() {
     assert_eq!(payload["voice_note"]["message_id"], "client-vn-1");
     assert_eq!(payload["last_message"]["message_id"], "client-vn-1");
     assert_eq!(payload["pending_outbound_messages"], 1);
+    assert_eq!(payload["unread_voice_notes"], 0);
+    assert!(payload["latest_voice_note_by_contact"]
+        .as_object()
+        .expect("summary object")
+        .is_empty());
 }

--- a/yoyopod_rs/voip-host/tests/support/mod.rs
+++ b/yoyopod_rs/voip-host/tests/support/mod.rs
@@ -1,4 +1,6 @@
 use serde_json::json;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 use yoyopod_voip_host::config::VoipConfig;
 use yoyopod_voip_host::host::{BackendEvent, CallBackend};
 
@@ -8,6 +10,25 @@ pub fn config() -> VoipConfig {
         "sip_identity": "sip:alice@example.com"
     }))
     .expect("config")
+}
+
+#[allow(dead_code)]
+pub fn config_with_message_store(store_dir: &Path) -> VoipConfig {
+    VoipConfig::from_payload(&json!({
+        "sip_server": "sip.example.com",
+        "sip_identity": "sip:alice@example.com",
+        "message_store_dir": store_dir.to_string_lossy()
+    }))
+    .expect("config")
+}
+
+#[allow(dead_code)]
+pub fn temp_store_dir(test_name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("yoyopod-{test_name}-{unique}"))
 }
 
 #[derive(Default)]

--- a/yoyopod_rs/voip-host/tests/worker.rs
+++ b/yoyopod_rs/voip-host/tests/worker.rs
@@ -114,3 +114,53 @@ fn worker_stop_uses_shutdown_path() {
         yoyopod_voip_host::worker::LoopAction::Shutdown
     ));
 }
+
+#[test]
+fn mark_voice_notes_seen_command_updates_snapshot_summary() {
+    let mut host = VoipHost::default();
+    host.configure(config());
+    let mut backend = FakeBackend {
+        events: vec![BackendEvent::MessageReceived {
+            message: MessageRecord {
+                message_id: "note-1".to_string(),
+                peer_sip_address: "sip:mom@example.com".to_string(),
+                sender_sip_address: "sip:mom@example.com".to_string(),
+                recipient_sip_address: "sip:alice@example.com".to_string(),
+                kind: "voice_note".to_string(),
+                direction: "incoming".to_string(),
+                delivery_state: "delivered".to_string(),
+                text: String::new(),
+                local_file_path: "/tmp/note.wav".to_string(),
+                mime_type: "audio/wav".to_string(),
+                duration_ms: 1000,
+                unread: true,
+            },
+        }],
+        ..FakeBackend::default()
+    };
+    host.poll_backend_events(&mut backend)
+        .expect("incoming message");
+    let mut backend = None;
+
+    let action = handle_command(
+        WorkerEnvelope {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Command,
+            message_type: "voip.mark_voice_notes_seen".to_string(),
+            request_id: Some("mark-seen-1".to_string()),
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload: json!({"uri": "sip:mom@example.com"}),
+        },
+        &mut host,
+        &mut backend,
+        None,
+    )
+    .expect("mark seen should be handled");
+
+    assert!(matches!(
+        action,
+        yoyopod_voip_host::worker::LoopAction::Continue
+    ));
+    assert_eq!(host.session_snapshot_payload()["unread_voice_notes"], 0);
+}


### PR DESCRIPTION
## Summary
- Add a Rust VoIP message store that persists Python-compatible `messages.json` metadata and owns unread/latest voice-note summaries.
- Include unread counts and latest voice-note summaries in Rust `voip.snapshot` payloads, plus a `voip.mark_voice_notes_seen` worker command.
- Wire Python Rust-host mode to consume Rust snapshot summaries and avoid repopulating the legacy Python message store when Rust owns runtime snapshots.

## Validation
- `cargo test --workspace --locked`
- `cargo test --workspace --locked --features whisplay-hardware`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q` (`1917 passed, 22 skipped`)

## Notes
- `bazel test //yoyopod_rs/voip-host/...` was not run locally because neither `bazel` nor `bazelisk` is installed in this environment.