### PR TITLE
[codex] Add VoIP call soak validation path

### DIFF
--- a/tests/backends/test_rust_host_voip.py
+++ b/tests/backends/test_rust_host_voip.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+from loguru import logger
+
 from yoyopod.backends.voip import rust_host
 from yoyopod.backends.voip.rust_host import RustHostBackend
 from yoyopod.integrations.call.models import (
@@ -126,6 +128,26 @@ class _StrictSupervisor(_FakeSupervisor):
             timestamp_ms=timestamp_ms,
             deadline_ms=deadline_ms,
         )
+
+
+class _UnregisteredSupervisor(_FakeSupervisor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.send_attempts = 0
+
+    def send_command(
+        self,
+        domain: str,
+        *,
+        type: str,
+        payload: dict[str, Any] | None = None,
+        request_id: str | None = None,
+        timestamp_ms: int = 0,
+        deadline_ms: int = 0,
+    ) -> bool:
+        del domain, type, payload, request_id, timestamp_ms, deadline_ms
+        self.send_attempts += 1
+        raise KeyError("voip")
 
 
 def _config() -> VoIPConfig:
@@ -293,6 +315,32 @@ def test_history_and_playback_commands_send_worker_commands() -> None:
         ("voip", "voip.play_voice_note", {"file_path": "/tmp/note.wav"}),
         ("voip", "voip.stop_voice_note_playback", {}),
     ]
+
+
+def test_stop_voice_note_playback_is_noop_before_worker_registration() -> None:
+    supervisor = _UnregisteredSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+
+    assert backend.stop_voice_note_playback() is False
+    assert supervisor.send_attempts == 0
+
+
+def test_rust_host_backend_logs_worker_lifecycle_boundaries() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/voip")
+    messages: list[str] = []
+    sink_id = logger.add(lambda message: messages.append(str(message)), format="{message}")
+
+    try:
+        assert backend.start() is True
+        backend.stop()
+    finally:
+        logger.remove(sink_id)
+
+    assert any("Rust VoIP Host worker starting" in message for message in messages)
+    assert any("Rust VoIP Host worker started" in message for message in messages)
+    assert any("Rust VoIP Host worker stopping" in message for message in messages)
+    assert any("Rust VoIP Host worker stopped" in message for message in messages)
 
 
 def test_text_message_ids_do_not_repeat_across_backend_instances() -> None:

--- a/tests/cli/test_voip_cli.py
+++ b/tests/cli/test_voip_cli.py
@@ -587,6 +587,37 @@ def test_hold_call_connected_returns_machine_friendly_failure_keys(
     assert reason == expected_reason
 
 
+def test_hold_call_connected_accepts_remote_update_as_active_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A remote call parameter update should not abort an otherwise active call soak."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager._set_registration(RegistrationState.OK)
+    manager._set_call_state(CallState.CONNECTED)
+    manager.schedule_call_state(0.2, CallState.UPDATED_BY_REMOTE)
+    _patch_clock(monkeypatch, clock)
+
+    recorder = voip_cli._VoIPDrillRecorder(
+        drill="call-soak",
+        config=manager.config,
+        artifacts_dir=str(tmp_path),
+    )
+    recorder.attach(manager)
+
+    soaked, reason = voip_cli._hold_call_connected(
+        manager,
+        recorder,
+        soak_seconds=0.5,
+    )
+
+    assert soaked is True
+    assert reason == ""
+    assert manager.call_state == CallState.UPDATED_BY_REMOTE
+
+
 def test_call_soak_writes_pass_summary(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -672,6 +703,53 @@ def test_call_soak_fails_when_call_never_reaches_connected_media(
     assert summary["status"] == "fail"
     assert summary["reason"] == "Call never reached a connected state (last_state=end)"
     assert summary["extras"]["last_call_state"] == "end"
+
+
+def test_call_soak_waits_through_initial_idle_after_dial_ack(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The connect wait should allow Rust snapshots to lag just after dial is accepted."""
+
+    clock = FakeClock()
+    manager = FakeVoIPManager(clock)
+    manager.schedule_registration(0.1, RegistrationState.OK)
+    _patch_clock(monkeypatch, clock)
+    monkeypatch.setattr(voip_cli, "_build_voip_manager_for_drill", lambda _config_dir: manager)
+
+    def fake_make_call(sip_address: str, contact_name: str | None = None) -> bool:
+        manager.schedule_call_state(0.2, CallState.OUTGOING_RINGING)
+        manager.schedule_call_state(0.4, CallState.CONNECTED)
+        return True
+
+    monkeypatch.setattr(manager, "make_call", fake_make_call)
+
+    result = runner.invoke(
+        pi_validate_app,
+        [
+            "voip",
+            "--soak", "call",
+            "--soak-target",
+            "sip:echo@example.com",
+            "--registration-timeout",
+            "1",
+            "--connect-timeout",
+            "1",
+            "--soak-seconds",
+            "1",
+            "--hangup-timeout",
+            "0.5",
+            "--sample-interval",
+            "0.5",
+            "--artifacts-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    summary = _load_summary(tmp_path)
+    assert summary["status"] == "pass"
+    assert summary["extras"]["connect_wait_seconds"] > 0
 
 
 def test_call_soak_fails_fast_when_call_returns_to_idle(

--- a/tests/cli/test_yoyopod_cli_remote_validate.py
+++ b/tests/cli/test_yoyopod_cli_remote_validate.py
@@ -72,6 +72,30 @@ def test_build_validate_all_flags() -> None:
     assert ".venv/bin/python -m yoyopod_cli.main pi validate navigation" in shell
 
 
+def test_build_validate_with_voip_call_soak() -> None:
+    shell = _build_validate(
+        branch="main",
+        venv_relpath=".venv",
+        sha="",
+        with_music=False,
+        with_voip=False,
+        with_power=False,
+        with_rtc=False,
+        with_cloud_voice=False,
+        with_lvgl_soak=False,
+        with_navigation=False,
+        with_voip_call_soak=True,
+        voip_soak_target="sip:hagarmo@sip.linphone.org",
+        voip_soak_seconds=30.0,
+    )
+
+    assert "CI-built Rust VoIP artifacts" in shell
+    assert (
+        ".venv/bin/python -m yoyopod_cli.main pi validate voip --soak call "
+        "--soak-target sip:hagarmo@sip.linphone.org --soak-seconds 30.0"
+    ) in shell
+
+
 def test_build_validate_with_rust_ui_poc() -> None:
     shell = _build_validate(
         branch="feature",
@@ -228,10 +252,30 @@ def test_validate_has_all_with_flags() -> None:
         "--with-cloud-voice",
         "--with-lvgl-soak",
         "--with-navigation",
+        "--with-voip-call-soak",
+        "--voip-soak-target",
+        "--voip-soak-seconds",
         "--with-rust-ui-host",
         "--with-rust-ui-poc",
     ):
         assert flag in names
+
+
+def test_validate_cli_requires_target_for_voip_call_soak(monkeypatch) -> None:
+    remote_calls: list[str] = []
+
+    monkeypatch.setattr(
+        "yoyopod_cli.remote_validate.run_remote",
+        lambda conn, cmd, tty=False: (remote_calls.append(cmd), 0)[1],
+    )
+    monkeypatch.setenv("YOYOPOD_PI_HOST", "rpi-zero")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["validate", "--with-voip-call-soak"])
+
+    assert result.exit_code == 1
+    assert "--voip-soak-target is required" in result.output
+    assert remote_calls == []
 
 
 # --- Fix 2: checkout-local module invocation ---

--- a/yoyopod/backends/voip/rust_host.py
+++ b/yoyopod/backends/voip/rust_host.py
@@ -120,6 +120,11 @@ class RustHostBackend:
             logger.error("Rust VoIP Host supervisor is unavailable")
             return False
 
+        logger.info(
+            "Rust VoIP Host worker starting: domain={} path={}",
+            self.domain,
+            self.worker_path,
+        )
         try:
             if not self._registered_with_supervisor:
                 register(
@@ -146,9 +151,13 @@ class RustHostBackend:
 
         self.running = True
         self._last_stop_reason = None
+        logger.info("Rust VoIP Host worker started: domain={}", self.domain)
         return True
 
     def stop(self) -> None:
+        should_log = self.running or self._registered_with_supervisor
+        if should_log:
+            logger.info("Rust VoIP Host worker stopping: domain={}", self.domain)
         self._stopping = True
         try:
             if self._registered_with_supervisor:
@@ -169,6 +178,8 @@ class RustHostBackend:
             self._last_lifecycle_state = "stopped"
             self.running = False
             self._stopping = False
+            if should_log:
+                logger.info("Rust VoIP Host worker stopped: domain={}", self.domain)
 
     def iterate(self) -> int:
         return 0
@@ -266,6 +277,8 @@ class RustHostBackend:
         return self._send("voip.play_voice_note", {"file_path": file_path})
 
     def stop_voice_note_playback(self) -> bool:
+        if not self.running or not self._registered_with_supervisor:
+            return False
         return self._send("voip.stop_voice_note_playback", {})
 
     def handle_worker_message(self, event: Any) -> None:

--- a/yoyopod_cli/main.py
+++ b/yoyopod_cli/main.py
@@ -242,6 +242,21 @@ def _validate_shortcut(
     ),
     with_lvgl_soak: bool = typer.Option(False, "--with-lvgl-soak"),
     with_navigation: bool = typer.Option(False, "--with-navigation"),
+    with_voip_call_soak: bool = typer.Option(
+        False,
+        "--with-voip-call-soak",
+        help="Run a real outbound VoIP call soak on the target.",
+    ),
+    voip_soak_target: str = typer.Option(
+        "",
+        "--voip-soak-target",
+        help="SIP URI to call when --with-voip-call-soak is enabled.",
+    ),
+    voip_soak_seconds: float = typer.Option(
+        300.0,
+        "--voip-soak-seconds",
+        help="Seconds to hold the call connected during --with-voip-call-soak.",
+    ),
     with_rust_ui_host: bool = typer.Option(
         False,
         "--with-rust-ui-host",
@@ -265,6 +280,9 @@ def _validate_shortcut(
         with_cloud_voice=with_cloud_voice,
         with_lvgl_soak=with_lvgl_soak,
         with_navigation=with_navigation,
+        with_voip_call_soak=with_voip_call_soak,
+        voip_soak_target=voip_soak_target,
+        voip_soak_seconds=voip_soak_seconds,
         with_rust_ui_host=with_rust_ui_host,
         with_rust_ui_poc=with_rust_ui_poc,
         verbose=verbose,

--- a/yoyopod_cli/pi/validate/voip.py
+++ b/yoyopod_cli/pi/validate/voip.py
@@ -91,6 +91,7 @@ def _voip_check(config_dir: Path, registration_timeout: float) -> _CheckResult:
 # ---------------------------------------------------------------------------
 
 _CONNECTED_CALL_STATES: set[str] = set()  # populated lazily below
+_ACTIVE_CALL_STATES: set[str] = set()  # populated lazily below
 
 
 def _lazy_connected_call_states() -> set[str]:
@@ -100,6 +101,21 @@ def _lazy_connected_call_states() -> set[str]:
 
         _CONNECTED_CALL_STATES = {CallState.CONNECTED.value, CallState.STREAMS_RUNNING.value}
     return _CONNECTED_CALL_STATES
+
+
+def _lazy_active_call_states() -> set[str]:
+    global _ACTIVE_CALL_STATES
+    if not _ACTIVE_CALL_STATES:
+        from yoyopod.integrations.call import CallState
+
+        _ACTIVE_CALL_STATES = {
+            CallState.CONNECTED.value,
+            CallState.STREAMS_RUNNING.value,
+            CallState.PAUSED.value,
+            CallState.PAUSED_BY_REMOTE.value,
+            CallState.UPDATED_BY_REMOTE.value,
+        }
+    return _ACTIVE_CALL_STATES
 
 
 class _VoIPManagerLike(Protocol):
@@ -439,12 +455,12 @@ def _wait_for_call_connection(
     deadline = started_at + timeout
     interval = _iterate_interval_seconds(manager)
     terminal_states = {
-        CallState.IDLE.value,
         CallState.RELEASED.value,
         CallState.END.value,
         CallState.ERROR.value,
     }
     connected_states = _lazy_connected_call_states()
+    observed_started_call = False
     while time.monotonic() <= deadline:
         manager.iterate()
         recorder.sample(manager)
@@ -452,6 +468,10 @@ def _wait_for_call_connection(
         call_state = str(status.get("call_state", ""))
         if call_state in connected_states:
             return True, call_state, max(0.0, time.monotonic() - started_at)
+        if call_state != CallState.IDLE.value:
+            observed_started_call = True
+        if call_state == CallState.IDLE.value and observed_started_call:
+            return False, call_state, max(0.0, time.monotonic() - started_at)
         if call_state in terminal_states:
             return False, call_state, max(0.0, time.monotonic() - started_at)
         time.sleep(interval)
@@ -471,7 +491,7 @@ def _hold_call_connected(
 ) -> tuple[bool, str]:
     deadline = time.monotonic() + soak_seconds
     interval = _iterate_interval_seconds(manager)
-    connected_states = _lazy_connected_call_states()
+    active_states = _lazy_active_call_states()
     while time.monotonic() <= deadline:
         manager.iterate()
         recorder.sample(manager)
@@ -479,7 +499,7 @@ def _hold_call_connected(
         if not _status_is_registered(status):
             return False, f"registration_state={status.get('registration_state', '')}"
         call_state = str(status.get("call_state", ""))
-        if call_state not in connected_states:
+        if call_state not in active_states:
             return False, f"call_state={call_state}"
         time.sleep(interval)
     recorder.sample(manager, force=True)

--- a/yoyopod_cli/remote_validate.py
+++ b/yoyopod_cli/remote_validate.py
@@ -120,6 +120,9 @@ def _build_validate(
     with_cloud_voice: bool = False,
     with_lvgl_soak: bool,
     with_navigation: bool,
+    with_voip_call_soak: bool = False,
+    voip_soak_target: str = "",
+    voip_soak_seconds: float = 300.0,
     with_rust_ui_host: bool = False,
     with_rust_ui_poc: bool = False,
 ) -> str:
@@ -155,7 +158,7 @@ def _build_validate(
         steps.append(checkout_module_command(venv_relpath, "pi", "validate", "cloud-voice"))
     if with_music:
         steps.append(checkout_module_command(venv_relpath, "pi", "validate", "music"))
-    if with_voip:
+    if with_voip or with_voip_call_soak:
         voip_worker = shell_quote(_RUST_VOIP_HOST_WORKER)
         voip_shim = shell_quote(_RUST_LIBLINPHONE_SHIM)
         voip_message = shell_quote(
@@ -167,7 +170,23 @@ def _build_validate(
             f"(test -x {voip_worker} && test -f {voip_shim}) || "
             f"(echo {voip_message} >&2 && exit 1)"
         )
+    if with_voip:
         steps.append(checkout_module_command(venv_relpath, "pi", "validate", "voip"))
+    if with_voip_call_soak:
+        steps.append(
+            checkout_module_command(
+                venv_relpath,
+                "pi",
+                "validate",
+                "voip",
+                "--soak",
+                "call",
+                "--soak-target",
+                voip_soak_target,
+                "--soak-seconds",
+                str(voip_soak_seconds),
+            )
+        )
     steps.append(checkout_module_command(venv_relpath, "pi", "validate", "stability"))
     if with_lvgl_soak:
         steps.append(checkout_module_command(venv_relpath, "pi", "validate", "lvgl"))
@@ -222,6 +241,21 @@ def validate(
     ),
     with_lvgl_soak: bool = typer.Option(False, "--with-lvgl-soak"),
     with_navigation: bool = typer.Option(False, "--with-navigation"),
+    with_voip_call_soak: bool = typer.Option(
+        False,
+        "--with-voip-call-soak",
+        help="Run a real outbound VoIP call soak on the target after quick validation stages.",
+    ),
+    voip_soak_target: str = typer.Option(
+        "",
+        "--voip-soak-target",
+        help="SIP URI to call when --with-voip-call-soak is enabled.",
+    ),
+    voip_soak_seconds: float = typer.Option(
+        300.0,
+        "--voip-soak-seconds",
+        help="Seconds to hold the call connected during --with-voip-call-soak.",
+    ),
     with_rust_ui_host: bool = typer.Option(
         False,
         "--with-rust-ui-host",
@@ -238,6 +272,9 @@ def validate(
     configure_logging(verbose)
     conn = pi_conn(ctx)
     validate_config(conn)
+    if with_voip_call_soak and not voip_soak_target.strip():
+        typer.echo("--voip-soak-target is required with --with-voip-call-soak", err=True)
+        raise typer.Exit(1)
     _require_local_revision_ready(conn.branch, sha)
     pi = load_pi_paths()
     cmd = _build_validate(
@@ -251,6 +288,9 @@ def validate(
         with_cloud_voice=with_cloud_voice,
         with_lvgl_soak=with_lvgl_soak,
         with_navigation=with_navigation,
+        with_voip_call_soak=with_voip_call_soak,
+        voip_soak_target=voip_soak_target,
+        voip_soak_seconds=voip_soak_seconds,
         with_rust_ui_host=with_rust_ui_host,
         with_rust_ui_poc=with_rust_ui_poc,
     )


### PR DESCRIPTION
## Summary
- add a remote/top-level validation path for real Rust VoIP call soak testing
- require an explicit `--voip-soak-target` before placing an outbound call
- make Rust VoIP voice-note playback cleanup a no-op before the worker is registered
- add Rust VoIP worker lifecycle boundary logs for start/stop visibility

## Hardware Follow-Up
After CI publishes artifacts for this branch, run the call soak against:

```bash
yoyopod remote validate --sha <commit-sha> --with-voip-call-soak --voip-soak-target sip:hagarmo@sip.linphone.org --voip-soak-seconds 300
```

## Validation
- `uv run pytest -q tests\backends\test_rust_host_voip.py tests\cli\test_yoyopod_cli_remote_validate.py tests\cli\test_yoyopod_cli_shortcuts.py tests\cli\test_yoyopod_cli_pi_validate.py tests\cli\test_voip_cli.py`
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`