### PR TITLE
Move voice-note facade to Rust runtime ownership

### DIFF
--- a/tests/backends/test_voip_backend.py
+++ b/tests/backends/test_voip_backend.py
@@ -645,6 +645,29 @@ def test_voip_manager_ignores_direct_delivery_events_when_rust_owns_voice_notes(
     assert manager._message_store.get("mock-note-1") is None
 
 
+def test_voip_manager_marks_rust_owned_voice_note_failed_from_command_error(
+    tmp_path: Path,
+) -> None:
+    """Rust command failures should unblock the active compatibility draft."""
+
+    backend = SnapshotOwnedMockVoIPBackend()
+    manager = VoIPManager(build_config(tmp_path), backend=backend)
+
+    assert manager.start()
+    assert manager.start_voice_note_recording("sip:mom@example.com", recipient_name="Mom")
+    assert manager.stop_voice_note_recording() is not None
+    assert manager.send_active_voice_note() is True
+
+    backend.emit(MessageFailed(message_id="mock-note-1", reason="Upload failed"))
+
+    active = manager.get_active_voice_note()
+    assert active is not None
+    assert active.send_state == "failed"
+    assert active.status_text == "Upload failed"
+    assert active.send_started_at == 0.0
+    assert manager._message_store.get("mock-note-1") is None
+
+
 def test_voip_manager_skips_python_send_timeout_when_rust_owns_voice_notes(
     tmp_path: Path,
 ) -> None:

--- a/tests/backends/test_voip_backend.py
+++ b/tests/backends/test_voip_backend.py
@@ -564,6 +564,109 @@ def test_voip_manager_does_not_persist_rust_owned_message_events_to_python_store
     assert manager._message_store.get("incoming-note-1") is None
 
 
+def test_voip_manager_derives_rust_owned_active_voice_note_from_snapshot() -> None:
+    """Rust snapshots should be enough to expose active voice-note UI state."""
+
+    backend = SnapshotOwnedMockVoIPBackend()
+    manager = VoIPManager(build_config(), backend=backend)
+
+    assert manager.start()
+    snapshot = VoIPRuntimeSnapshot(
+        configured=True,
+        registered=True,
+        registration_state=RegistrationState.OK,
+        lifecycle=VoIPLifecycleSnapshot(
+            state="registered",
+            reason="registered",
+            backend_available=True,
+        ),
+        voice_note=VoIPVoiceNoteSnapshot(
+            state="recording",
+            file_path="/tmp/rust-note.wav",
+            mime_type="audio/wav",
+        ),
+    )
+    backend.runtime_snapshot = snapshot
+    backend.emit(VoIPRuntimeSnapshotChanged(snapshot=snapshot))
+
+    active = manager.get_active_voice_note()
+    assert active is not None
+    assert active.file_path == "/tmp/rust-note.wav"
+    assert active.send_state == "recording"
+    assert active.status_text == "Recording..."
+
+
+def test_voip_manager_sends_rust_owned_voice_note_without_python_message_store(
+    tmp_path: Path,
+) -> None:
+    """Rust-owned voice-note sends should not create Python message records."""
+
+    backend = SnapshotOwnedMockVoIPBackend()
+    manager = VoIPManager(build_config(tmp_path), backend=backend)
+
+    assert manager.start()
+    assert manager.start_voice_note_recording("sip:mom@example.com", recipient_name="Mom")
+    draft = manager.stop_voice_note_recording()
+    assert draft is not None
+
+    assert manager.send_active_voice_note() is True
+
+    assert backend.commands == [
+        f"record-start {draft.file_path}",
+        "record-stop",
+        f"voice-note sip:mom@example.com {Path(draft.file_path).name} 1500 audio/wav",
+    ]
+    assert manager.get_active_voice_note().send_state == "sending"
+    assert manager._message_store.get("mock-note-1") is None
+
+
+def test_voip_manager_ignores_direct_delivery_events_when_rust_owns_voice_notes(
+    tmp_path: Path,
+) -> None:
+    """Rust-owned voice-note delivery state should change only through snapshots."""
+
+    backend = SnapshotOwnedMockVoIPBackend()
+    manager = VoIPManager(build_config(tmp_path), backend=backend)
+
+    assert manager.start()
+    assert manager.start_voice_note_recording("sip:mom@example.com", recipient_name="Mom")
+    assert manager.stop_voice_note_recording() is not None
+    assert manager.send_active_voice_note() is True
+
+    backend.emit(
+        MessageDeliveryChanged(
+            message_id="mock-note-1",
+            delivery_state=MessageDeliveryState.SENT,
+            local_file_path="/tmp/rust-note.wav",
+        )
+    )
+
+    assert manager.get_active_voice_note().send_state == "sending"
+    assert manager._message_store.get("mock-note-1") is None
+
+
+def test_voip_manager_skips_python_send_timeout_when_rust_owns_voice_notes(
+    tmp_path: Path,
+) -> None:
+    """Rust runtime recovery owns stuck voice-note sends in snapshot mode."""
+
+    backend = SnapshotOwnedMockVoIPBackend()
+    manager = VoIPManager(build_config(tmp_path), backend=backend)
+
+    assert manager.start()
+    assert manager.start_voice_note_recording("sip:mom@example.com", recipient_name="Mom")
+    assert manager.stop_voice_note_recording() is not None
+    assert manager.send_active_voice_note() is True
+
+    active = manager.get_active_voice_note()
+    assert active is not None
+    active.send_started_at = time.monotonic() - 30.0
+
+    assert manager.iterate() == 0
+    assert manager.get_active_voice_note().send_state == "sending"
+    assert manager._message_store.get("mock-note-1") is None
+
+
 def test_voip_manager_derives_availability_from_rust_lifecycle_snapshots() -> None:
     """Rust lifecycle snapshots should drive recovery availability without side events."""
 

--- a/yoyopod/integrations/call/manager.py
+++ b/yoyopod/integrations/call/manager.py
@@ -93,6 +93,7 @@ class VoIPManager:
             | None
         ) = None
         self._pending_terminal_action: str | None = None
+        self._rust_active_voice_note: VoiceNoteDraft | None = None
         self._message_store = message_store or self._build_message_store()
         self._messaging_service = MessagingService(
             config=self.config,
@@ -180,7 +181,8 @@ class VoIPManager:
         drained_events = 0
         if self.running:
             drained_events = self.backend.iterate()
-        self._check_active_voice_note_timeout()
+        if not self._backend_owns_runtime_snapshot():
+            self._check_active_voice_note_timeout()
         return drained_events
 
     @property
@@ -241,6 +243,8 @@ class VoIPManager:
     def poll_housekeeping(self) -> None:
         """Run lightweight coordinator-thread-only maintenance alongside background iterate."""
 
+        if self._backend_owns_runtime_snapshot():
+            return
         self._check_active_voice_note_timeout()
 
     def make_call(self, sip_address: str, contact_name: str | None = None) -> bool:
@@ -323,23 +327,40 @@ class VoIPManager:
                 self.call_state.value,
             )
             return False
+        if self._backend_owns_runtime_snapshot():
+            return self._start_rust_voice_note_recording(recipient_address, recipient_name)
         return self._voice_note_service.start_voice_note_recording(
             recipient_address, recipient_name
         )
 
     def stop_voice_note_recording(self) -> VoiceNoteDraft | None:
+        if self._backend_owns_runtime_snapshot():
+            return self._stop_rust_voice_note_recording()
         return self._voice_note_service.stop_voice_note_recording()
 
     def cancel_voice_note_recording(self) -> bool:
+        if self._backend_owns_runtime_snapshot():
+            success = self.backend.cancel_voice_note_recording()
+            self._rust_active_voice_note = None
+            return success
         return self._voice_note_service.cancel_voice_note_recording()
 
     def send_active_voice_note(self) -> bool:
+        if self._backend_owns_runtime_snapshot():
+            return self._send_rust_active_voice_note()
         return self._voice_note_service.send_active_voice_note()
 
     def get_active_voice_note(self) -> VoiceNoteDraft | None:
+        if self._backend_owns_runtime_snapshot():
+            if self._rust_active_voice_note is None:
+                self._refresh_rust_voice_note_snapshot()
+            return self._rust_active_voice_note
         return self._voice_note_service.get_active_voice_note()
 
     def discard_active_voice_note(self) -> None:
+        if self._backend_owns_runtime_snapshot():
+            self._rust_active_voice_note = None
+            return
         self._voice_note_service.discard_active_voice_note()
 
     def latest_voice_note_for_contact(self, sip_address: str) -> VoIPMessageRecord | None:
@@ -623,9 +644,9 @@ class VoIPManager:
             self._messaging_service.handle_message_received(event.message)
             return
         if isinstance(event, MessageDeliveryChanged):
-            self._voice_note_service.handle_message_delivery_changed(event)
             if self._backend_owns_runtime_snapshot():
                 return
+            self._voice_note_service.handle_message_delivery_changed(event)
             self._messaging_service.handle_message_delivery_changed(event)
             return
         if isinstance(event, MessageDownloadCompleted):
@@ -634,9 +655,9 @@ class VoIPManager:
             self._messaging_service.handle_message_download_completed(event)
             return
         if isinstance(event, MessageFailed):
-            self._voice_note_service.handle_message_failed(event)
             if self._backend_owns_runtime_snapshot():
                 return
+            self._voice_note_service.handle_message_failed(event)
             self._messaging_service.handle_message_failed(event)
 
     def _apply_runtime_snapshot(self, snapshot: VoIPRuntimeSnapshot) -> None:
@@ -652,12 +673,134 @@ class VoIPManager:
         self.is_muted = snapshot.muted
         self._update_call_state(snapshot.call_state)
         self._notify_lifecycle_availability_from_snapshot(snapshot)
-        self._voice_note_service.apply_runtime_snapshot(snapshot)
         if self._backend_owns_runtime_snapshot():
+            self._apply_rust_voice_note_snapshot(snapshot)
             self._notify_rust_message_summary_change(snapshot)
         else:
+            self._voice_note_service.apply_runtime_snapshot(snapshot)
             self._messaging_service.apply_runtime_snapshot(snapshot)
         self._notify_runtime_snapshot_change(snapshot)
+
+    def _start_rust_voice_note_recording(
+        self,
+        recipient_address: str,
+        recipient_name: str,
+    ) -> bool:
+        if not recipient_address:
+            logger.error("Cannot start voice-note recording without a recipient address")
+            return False
+
+        file_path = VoiceNoteService.build_recording_file_path(self.config)
+        if not self.backend.start_voice_note_recording(file_path):
+            return False
+
+        self._rust_active_voice_note = VoiceNoteDraft(
+            recipient_address=recipient_address,
+            recipient_name=recipient_name or self._lookup_contact_name(recipient_address),
+            file_path=file_path,
+            send_state="recording",
+            status_text="Recording...",
+        )
+        return True
+
+    def _stop_rust_voice_note_recording(self) -> VoiceNoteDraft | None:
+        draft = self.get_active_voice_note()
+        if draft is None:
+            return None
+
+        duration_ms = self.backend.stop_voice_note_recording()
+        if duration_ms is None:
+            return None
+
+        draft.duration_ms = max(0, int(duration_ms))
+        draft.send_state = "review"
+        draft.status_text = "Ready to send"
+        return draft
+
+    def _send_rust_active_voice_note(self) -> bool:
+        draft = self.get_active_voice_note()
+        if draft is None:
+            return False
+        if not draft.recipient_address:
+            logger.error("Cannot send Rust-owned voice note without a recipient address")
+            return False
+
+        draft.send_state = "sending"
+        draft.status_text = "Sending..."
+        draft.send_started_at = time.monotonic()
+        message_id = self.backend.send_voice_note(
+            draft.recipient_address,
+            file_path=draft.file_path,
+            duration_ms=draft.duration_ms,
+            mime_type=draft.mime_type,
+        )
+        if not message_id:
+            draft.send_state = "failed"
+            draft.status_text = "Couldn't send"
+            draft.send_started_at = 0.0
+            return False
+
+        draft.message_id = message_id
+        return True
+
+    def _refresh_rust_voice_note_snapshot(self) -> None:
+        get_snapshot = getattr(self.backend, "get_runtime_snapshot", None)
+        if not callable(get_snapshot):
+            return
+        snapshot = cast(VoIPRuntimeSnapshot | None, get_snapshot())
+        if snapshot is None:
+            return
+        self._runtime_snapshot = snapshot
+        self._apply_rust_voice_note_snapshot(snapshot)
+
+    def _apply_rust_voice_note_snapshot(self, snapshot: VoIPRuntimeSnapshot) -> None:
+        voice_note = snapshot.voice_note
+        state = voice_note.state.strip().lower() or "idle"
+        if state == "idle":
+            return
+
+        draft = self._rust_active_voice_note
+        if draft is None:
+            draft = VoiceNoteDraft(
+                recipient_address="",
+                recipient_name="",
+                file_path=voice_note.file_path,
+                mime_type=voice_note.mime_type or "audio/wav",
+            )
+            self._rust_active_voice_note = draft
+
+        if voice_note.file_path:
+            draft.file_path = voice_note.file_path
+        if voice_note.duration_ms > 0:
+            draft.duration_ms = voice_note.duration_ms
+        if voice_note.mime_type:
+            draft.mime_type = voice_note.mime_type
+        if voice_note.message_id:
+            draft.message_id = voice_note.message_id
+
+        if state == "recording":
+            draft.send_state = "recording"
+            draft.status_text = "Recording..."
+            return
+        if state == "recorded":
+            draft.send_state = "review"
+            draft.status_text = "Ready to send"
+            return
+        if state == "sending":
+            draft.send_state = "sending"
+            draft.status_text = "Sending..."
+            if draft.send_started_at <= 0.0:
+                draft.send_started_at = time.monotonic()
+            return
+        if state == "sent":
+            draft.send_state = "sent"
+            draft.status_text = "Sent"
+            draft.send_started_at = 0.0
+            return
+        if state == "failed":
+            draft.send_state = "failed"
+            draft.status_text = _snapshot_failure_text(snapshot)
+            draft.send_started_at = 0.0
 
     def _notify_rust_message_summary_change(self, snapshot: VoIPRuntimeSnapshot) -> None:
         summary = {

--- a/yoyopod/integrations/call/manager.py
+++ b/yoyopod/integrations/call/manager.py
@@ -656,6 +656,7 @@ class VoIPManager:
             return
         if isinstance(event, MessageFailed):
             if self._backend_owns_runtime_snapshot():
+                self._handle_rust_voice_note_failed(event)
                 return
             self._voice_note_service.handle_message_failed(event)
             self._messaging_service.handle_message_failed(event)
@@ -801,6 +802,17 @@ class VoIPManager:
             draft.send_state = "failed"
             draft.status_text = _snapshot_failure_text(snapshot)
             draft.send_started_at = 0.0
+
+    def _handle_rust_voice_note_failed(self, event: MessageFailed) -> None:
+        draft = self._rust_active_voice_note
+        if draft is None:
+            return
+        if event.message_id and draft.message_id != event.message_id:
+            return
+
+        draft.send_state = "failed"
+        draft.status_text = event.reason or "Couldn't send"
+        draft.send_started_at = 0.0
 
     def _notify_rust_message_summary_change(self, snapshot: VoIPRuntimeSnapshot) -> None:
         summary = {

--- a/yoyopod/integrations/call/voice_notes.py
+++ b/yoyopod/integrations/call/voice_notes.py
@@ -72,11 +72,7 @@ class VoiceNoteService:
             return False
 
         self.discard_active_voice_note()
-        voice_note_dir = Path(self.config.voice_note_store_dir)
-        voice_note_dir.mkdir(parents=True, exist_ok=True)
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-        file_name = f"voice-note-{timestamp}.wav"
-        file_path = str(voice_note_dir / file_name)
+        file_path = self.build_recording_file_path(self.config)
 
         if not self.backend.start_voice_note_recording(file_path):
             return False
@@ -313,6 +309,13 @@ class VoiceNoteService:
         if draft.message_id:
             self._message_store.update_delivery(draft.message_id, MessageDeliveryState.FAILED)
         self._notify_message_summary_change()
+
+    @staticmethod
+    def build_recording_file_path(config: VoIPConfig) -> str:
+        voice_note_dir = Path(config.voice_note_store_dir)
+        voice_note_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        return str(voice_note_dir / f"voice-note-{timestamp}.wav")
 
     @staticmethod
     def build_voice_note_playback_command(file_path: str) -> list[str]:


### PR DESCRIPTION
## Summary
- route Rust-snapshot voice-note record/stop/send commands directly through the Rust backend path
- keep only a UI compatibility draft in Python while Rust owns active voice-note snapshots and delivery state
- stop Python message-store writes, direct delivery-event mutation, and Python send-timeouts for Rust-owned voice notes

## Validation
- uv run pytest -q tests\backends\test_voip_backend.py tests\integrations\test_voip_services.py tests\integrations\test_call.py
- uv run python scripts/quality.py gate
- uv run pytest -q