### PR TITLE
Collapse VoIP manager around Rust runtime

### DIFF
--- a/tests/backends/test_voip_backend.py
+++ b/tests/backends/test_voip_backend.py
@@ -67,6 +67,10 @@ class BackgroundIterateMockVoIPBackend(MockVoIPBackend):
         self.metrics_error = metrics_error
         self.iterate_calls = 0
         self.iterate_started = threading.Event()
+        self.runtime_snapshot: VoIPRuntimeSnapshot | None = None
+
+    def get_runtime_snapshot(self) -> VoIPRuntimeSnapshot | None:
+        return self.runtime_snapshot
 
     def iterate(self) -> int:
         self.iterate_started.set()
@@ -139,6 +143,24 @@ def test_voip_manager_requires_explicit_backend_in_rust_only_runtime() -> None:
         VoIPManager(build_config())
 
 
+def test_voip_manager_requires_rust_runtime_snapshot_backend() -> None:
+    """Production VoIPManager should not accept a Python-owned runtime backend."""
+
+    with pytest.raises(ValueError, match="Rust runtime snapshot"):
+        VoIPManager(build_config(), backend=MockVoIPBackend())
+
+
+def test_voip_manager_does_not_construct_python_runtime_owners() -> None:
+    """The app-facing facade should not own Python message or voice-note stores."""
+
+    manager = VoIPManager(build_config(), backend=SnapshotOwnedMockVoIPBackend())
+
+    assert manager.owns_runtime_snapshot() is True
+    assert not hasattr(manager, "_message_store")
+    assert not hasattr(manager, "_messaging_service")
+    assert not hasattr(manager, "_voice_note_service")
+
+
 def wait_for_condition(predicate: Callable[[], bool], *, timeout_seconds: float = 1.0) -> bool:
     """Poll a test condition until it becomes true or the timeout expires."""
 
@@ -153,7 +175,7 @@ def wait_for_condition(predicate: Callable[[], bool], *, timeout_seconds: float 
 def test_voip_manager_skips_backend_start_when_identity_missing() -> None:
     """VoIPManager should fail fast before touching the backend when SIP identity is absent."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     config = build_config()
     config.sip_identity = ""
     manager = VoIPManager(config, backend=backend)
@@ -166,7 +188,7 @@ def test_voip_manager_skips_backend_start_when_identity_missing() -> None:
 def test_voip_manager_applies_backend_events_and_resolves_contact_names() -> None:
     """VoIPManager should stay app-facing while backend events remain typed and low-level."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     people_directory = FakePeopleDirectory({"sip:parent@example.com": "Parent"})
     manager = VoIPManager(build_config(), people_directory=people_directory, backend=backend)
 
@@ -194,7 +216,7 @@ def test_voip_manager_applies_backend_events_and_resolves_contact_names() -> Non
 def test_voip_manager_mirrors_rust_runtime_snapshot_without_duplicate_callbacks() -> None:
     """Rust-owned runtime snapshots should become the app-facing live VoIP state."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     people_directory = FakePeopleDirectory({"sip:bob@example.com": "Bob"})
     manager = VoIPManager(build_config(), people_directory=people_directory, backend=backend)
     registration_states: list[RegistrationState] = []
@@ -235,7 +257,7 @@ def test_voip_manager_mirrors_rust_runtime_snapshot_without_duplicate_callbacks(
 def test_voip_manager_delegates_outgoing_commands_to_backend() -> None:
     """Outgoing commands should not invent local call phases before backend events arrive."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     manager = VoIPManager(build_config(), backend=backend)
     call_states: list[CallState] = []
 
@@ -246,7 +268,7 @@ def test_voip_manager_delegates_outgoing_commands_to_backend() -> None:
     assert backend.commands == ["call sip:bob@example.com"]
     assert call_states == []
     assert manager.call_state == CallState.IDLE
-    assert manager.get_caller_info()["display_name"] == "Bob"
+    assert manager.get_caller_info()["display_name"] == "Unknown"
 
 
 def test_voip_manager_waits_for_rust_snapshot_before_call_identity() -> None:
@@ -561,7 +583,7 @@ def test_voip_manager_does_not_persist_rust_owned_message_events_to_python_store
         )
     )
 
-    assert manager._message_store.get("incoming-note-1") is None
+    assert not hasattr(manager, "_message_store")
 
 
 def test_voip_manager_derives_rust_owned_active_voice_note_from_snapshot() -> None:
@@ -617,7 +639,7 @@ def test_voip_manager_sends_rust_owned_voice_note_without_python_message_store(
         f"voice-note sip:mom@example.com {Path(draft.file_path).name} 1500 audio/wav",
     ]
     assert manager.get_active_voice_note().send_state == "sending"
-    assert manager._message_store.get("mock-note-1") is None
+    assert not hasattr(manager, "_message_store")
 
 
 def test_voip_manager_ignores_direct_delivery_events_when_rust_owns_voice_notes(
@@ -642,7 +664,7 @@ def test_voip_manager_ignores_direct_delivery_events_when_rust_owns_voice_notes(
     )
 
     assert manager.get_active_voice_note().send_state == "sending"
-    assert manager._message_store.get("mock-note-1") is None
+    assert not hasattr(manager, "_message_store")
 
 
 def test_voip_manager_marks_rust_owned_voice_note_failed_from_command_error(
@@ -665,7 +687,7 @@ def test_voip_manager_marks_rust_owned_voice_note_failed_from_command_error(
     assert active.send_state == "failed"
     assert active.status_text == "Upload failed"
     assert active.send_started_at == 0.0
-    assert manager._message_store.get("mock-note-1") is None
+    assert not hasattr(manager, "_message_store")
 
 
 def test_voip_manager_skips_python_send_timeout_when_rust_owns_voice_notes(
@@ -687,7 +709,7 @@ def test_voip_manager_skips_python_send_timeout_when_rust_owns_voice_notes(
 
     assert manager.iterate() == 0
     assert manager.get_active_voice_note().send_state == "sending"
-    assert manager._message_store.get("mock-note-1") is None
+    assert not hasattr(manager, "_message_store")
 
 
 def test_voip_manager_derives_availability_from_rust_lifecycle_snapshots() -> None:
@@ -743,7 +765,7 @@ def test_voip_manager_derives_availability_from_rust_lifecycle_snapshots() -> No
 def test_voip_manager_starts_timer_on_streams_running_without_connected() -> None:
     """Streams-running callbacks should start live duration tracking on their own."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     manager = VoIPManager(build_config(), backend=backend)
     started: list[bool] = []
     manager._start_call_timer = lambda: started.append(True)  # type: ignore[method-assign]
@@ -760,7 +782,7 @@ def test_voip_manager_derives_live_call_duration_without_worker_thread(
 ) -> None:
     """Call duration should come from the current clock and stored start time."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     manager = VoIPManager(build_config(), backend=backend)
     now = 1_000.9
     monkeypatch.setattr(time, "time", lambda: now)
@@ -775,7 +797,7 @@ def test_voip_manager_derives_live_call_duration_without_worker_thread(
 def test_voip_manager_tracks_voice_note_send_and_delivery() -> None:
     """Voice-note record/send flow should update the active draft and summary state."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     manager = VoIPManager(build_config(), backend=backend)
 
     assert manager.start()
@@ -789,10 +811,16 @@ def test_voip_manager_tracks_voice_note_send_and_delivery() -> None:
     assert manager.get_active_voice_note().send_state == "sending"
 
     backend.emit(
-        MessageDeliveryChanged(
-            message_id="mock-note-1",
-            delivery_state=MessageDeliveryState.SENT,
-            local_file_path="data/voice.wav",
+        VoIPRuntimeSnapshotChanged(
+            snapshot=VoIPRuntimeSnapshot(
+                voice_note=VoIPVoiceNoteSnapshot(
+                    state="sent",
+                    file_path=draft.file_path,
+                    duration_ms=draft.duration_ms,
+                    mime_type=draft.mime_type,
+                    message_id=draft.message_id,
+                )
+            )
         )
     )
 
@@ -802,7 +830,7 @@ def test_voip_manager_tracks_voice_note_send_and_delivery() -> None:
 def test_voip_manager_routes_rust_runtime_snapshot_to_voice_note_and_message_mirrors() -> None:
     """VoIPManager should fan Rust snapshots into its compatibility services."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     manager = VoIPManager(build_config(), backend=backend)
 
     assert manager.start()
@@ -829,6 +857,16 @@ def test_voip_manager_routes_rust_runtime_snapshot_to_voice_note_and_message_mir
                     delivery_state=MessageDeliveryState.DELIVERED,
                     local_file_path=draft.file_path,
                 ),
+                latest_voice_note_by_contact={
+                    "sip:mom@example.com": {
+                        "message_id": draft.message_id,
+                        "direction": MessageDirection.OUTGOING.value,
+                        "delivery_state": MessageDeliveryState.DELIVERED.value,
+                        "local_file_path": draft.file_path,
+                        "duration_ms": draft.duration_ms,
+                        "display_name": "Mom",
+                    }
+                },
             )
         )
     )
@@ -841,10 +879,10 @@ def test_voip_manager_routes_rust_runtime_snapshot_to_voice_note_and_message_mir
     assert stored.delivery_state == MessageDeliveryState.DELIVERED
 
 
-def test_voip_manager_fails_voice_note_send_without_transfer_server() -> None:
-    """Voice-note sending should fail immediately when file transfer is not configured."""
+def test_voip_manager_delegates_voice_note_send_without_transfer_server() -> None:
+    """Rust owns transfer-server validation instead of a Python preflight."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     config = build_config()
     config.file_transfer_server_url = ""
     manager = VoIPManager(config, backend=backend)
@@ -853,9 +891,8 @@ def test_voip_manager_fails_voice_note_send_without_transfer_server() -> None:
     assert manager.start_voice_note_recording("sip:mom@example.com", recipient_name="Mom")
     assert manager.stop_voice_note_recording() is not None
 
-    assert manager.send_active_voice_note() is False
-    assert manager.get_active_voice_note().send_state == "failed"
-    assert manager.get_active_voice_note().status_text == "Voice notes unavailable"
+    assert manager.send_active_voice_note() is True
+    assert manager.get_active_voice_note().send_state == "sending"
 
 
 def test_voip_manager_allows_voice_note_send_for_hosted_linphone_account_without_explicit_url() -> (
@@ -863,7 +900,7 @@ def test_voip_manager_allows_voice_note_send_for_hosted_linphone_account_without
 ):
     """Hosted Linphone accounts should use inferred upload settings instead of failing immediately."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     config = build_config()
     config.sip_server = "sip.linphone.org"
     config.file_transfer_server_url = ""
@@ -876,10 +913,10 @@ def test_voip_manager_allows_voice_note_send_for_hosted_linphone_account_without
     assert manager.get_active_voice_note().send_state == "sending"
 
 
-def test_voip_manager_times_out_stuck_voice_note_send() -> None:
-    """Voice-note sends should not remain in sending forever without delivery callbacks."""
+def test_voip_manager_does_not_timeout_rust_owned_voice_note_send() -> None:
+    """Rust runtime recovery owns stuck voice-note sends."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     config = build_config()
     config.file_transfer_server_url = "https://transfer.example.com"
     manager = VoIPManager(config, backend=backend)
@@ -892,15 +929,14 @@ def test_voip_manager_times_out_stuck_voice_note_send() -> None:
     manager.get_active_voice_note().send_started_at = time.monotonic() - 30.0
     drained_events = manager.iterate()
 
-    assert manager.get_active_voice_note().send_state == "failed"
-    assert manager.get_active_voice_note().status_text == "Send timed out"
+    assert manager.get_active_voice_note().send_state == "sending"
     assert drained_events == 0
 
 
 def test_voip_manager_rejects_voice_note_recording_during_active_call() -> None:
     """Voice-note recording should be blocked while a call is active."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     manager = VoIPManager(build_config(), backend=backend)
     manager.call_state = CallState.CONNECTED
 
@@ -911,20 +947,18 @@ def test_voip_manager_rejects_voice_note_recording_during_active_call() -> None:
 def test_voip_manager_stops_voice_note_playback_when_call_enters_active_state() -> None:
     """Incoming or active call phases should stop any local voice-note playback."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     manager = VoIPManager(build_config(), backend=backend)
-    stopped: list[str] = []
-    manager._voice_note_service.stop_voice_note_playback = lambda: stopped.append("stop")
 
     manager._update_call_state(CallState.INCOMING)
 
-    assert stopped == ["stop"]
+    assert backend.stopped_playback == 1
 
 
 def test_voip_manager_queues_backend_events_back_to_main_thread(tmp_path: Path) -> None:
     """App-mode VoIP events should be marshaled back through the main-thread scheduler."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     config = build_config()
     config.message_store_dir = str(tmp_path / "messages")
     config.voice_note_store_dir = str(tmp_path / "voice_notes")
@@ -1046,7 +1080,7 @@ def test_voip_manager_background_iterate_worker_surfaces_unexpected_failure(
 def test_voip_manager_surfaces_voice_note_failure_reason() -> None:
     """Voice-note send failures should preserve the backend reason for the UI."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     manager = VoIPManager(build_config(), backend=backend)
 
     assert manager.start()
@@ -1060,14 +1094,14 @@ def test_voip_manager_surfaces_voice_note_failure_reason() -> None:
     assert manager.get_active_voice_note().status_text == "Upload failed"
 
 
-def test_voip_manager_receives_incoming_voice_note_and_updates_summary(tmp_path: Path) -> None:
-    """Incoming voice notes should be persisted and exposed through Talk summaries."""
+def test_voip_manager_receives_voice_note_summary_from_runtime_snapshot(tmp_path: Path) -> None:
+    """Incoming voice notes should be exposed through Rust-owned snapshot summaries."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     config = build_config()
     config.message_store_dir = str(tmp_path / "messages")
     manager = VoIPManager(config, backend=backend)
-    summary_events: list[tuple[int, dict[str, dict[str, str]]]] = []
+    summary_events: list[tuple[int, dict[str, dict[str, object]]]] = []
     manager.on_message_summary_change(
         lambda unread, summary: summary_events.append((unread, summary))
     )
@@ -1075,20 +1109,21 @@ def test_voip_manager_receives_incoming_voice_note_and_updates_summary(tmp_path:
     assert manager.start()
 
     backend.emit(
-        MessageReceived(
-            message=VoIPMessageRecord(
-                id="incoming-1",
-                peer_sip_address="sip:mom@example.com",
-                sender_sip_address="sip:mom@example.com",
-                recipient_sip_address="sip:alice@example.com",
-                kind=MessageKind.VOICE_NOTE,
-                direction=MessageDirection.INCOMING,
-                delivery_state=MessageDeliveryState.DELIVERED,
-                created_at="2026-04-06T00:00:00+00:00",
-                updated_at="2026-04-06T00:00:00+00:00",
-                local_file_path="data/voice_notes/incoming.wav",
-                duration_ms=2000,
-                unread=True,
+        VoIPRuntimeSnapshotChanged(
+            snapshot=VoIPRuntimeSnapshot(
+                unread_voice_notes=1,
+                unread_voice_notes_by_contact={"sip:mom@example.com": 1},
+                latest_voice_note_by_contact={
+                    "sip:mom@example.com": {
+                        "message_id": "incoming-1",
+                        "direction": MessageDirection.INCOMING.value,
+                        "delivery_state": MessageDeliveryState.DELIVERED.value,
+                        "local_file_path": "data/voice_notes/incoming.wav",
+                        "duration_ms": 2000,
+                        "unread": True,
+                        "display_name": "Mom",
+                    }
+                },
             )
         )
     )
@@ -1121,12 +1156,12 @@ def test_voip_manager_uses_ffplay_for_containerized_voice_notes() -> None:
     ]
 
 
-def test_voip_manager_coerces_rcs_voice_note_envelope_into_voice_note_record(
+def test_voip_manager_ignores_raw_incoming_message_events_without_snapshot(
     tmp_path: Path,
 ) -> None:
-    """Incoming GSMA file-transfer envelopes for voice recordings should not be stored as plain text."""
+    """Rust snapshots, not Python message parsing, own incoming message state."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     config = build_config()
     config.message_store_dir = str(tmp_path / "messages")
     manager = VoIPManager(config, backend=backend)
@@ -1162,31 +1197,26 @@ def test_voip_manager_coerces_rcs_voice_note_envelope_into_voice_note_record(
         )
     )
 
-    latest = manager.latest_voice_note_for_contact("sip:mom@example.com")
-    assert latest is not None
-    assert latest.kind == MessageKind.VOICE_NOTE
-    assert latest.mime_type == "audio/wav"
-    assert latest.duration_ms == 4046
-    assert latest.text == ""
-    assert latest.local_file_path == "/tmp/incoming-envelope.mka"
+    assert manager.latest_voice_note_for_contact("sip:mom@example.com") is None
+    assert manager.latest_voice_note_summary() == {}
 
 
-def test_voip_manager_builds_message_store_under_directory(tmp_path: Path) -> None:
-    """The configured message store path should be treated as a directory, not a file."""
+def test_voip_manager_leaves_message_store_directory_to_rust(tmp_path: Path) -> None:
+    """The Python facade should not create a legacy message-store directory."""
 
     config = build_config()
     config.message_store_dir = str(tmp_path / "messages")
 
-    manager = VoIPManager(config, backend=MockVoIPBackend())
+    manager = VoIPManager(config, backend=SnapshotOwnedMockVoIPBackend())
 
-    assert manager._message_store.store_dir == tmp_path / "messages"
-    assert manager._message_store.index_file == tmp_path / "messages" / "messages.json"
+    assert not hasattr(manager, "_message_store")
+    assert not (tmp_path / "messages").exists()
 
 
 def test_voip_manager_handles_backend_stop_event() -> None:
     """Unexpected backend stop should clear availability and registration state."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     manager = VoIPManager(build_config(), backend=backend)
 
     assert manager.start()
@@ -1201,7 +1231,7 @@ def test_voip_manager_handles_backend_stop_event() -> None:
 def test_voip_manager_marks_available_after_backend_recovery() -> None:
     """A recovered worker should restore availability after an unexpected stop."""
 
-    backend = MockVoIPBackend()
+    backend = SnapshotOwnedMockVoIPBackend()
     manager = VoIPManager(build_config(), backend=backend)
     availability_changes: list[tuple[bool, str, RegistrationState]] = []
     manager.on_availability_change(

--- a/yoyopod/integrations/call/__init__.py
+++ b/yoyopod/integrations/call/__init__.py
@@ -265,7 +265,6 @@ def setup(
         actual_config,
         people_directory=actual_people_directory,
         backend=backend,
-        message_store=message_store,
         event_scheduler=app.scheduler.run_on_main,
         background_iterate_enabled=background_iterate_enabled,
     )

--- a/yoyopod/integrations/call/manager.py
+++ b/yoyopod/integrations/call/manager.py
@@ -12,21 +12,16 @@ from typing import TYPE_CHECKING, Callable, cast
 from loguru import logger
 
 from yoyopod.backends.voip.protocol import VoIPBackend
-from yoyopod.integrations.call.messaging import MessagingService
-from yoyopod.integrations.call.message_store import VoIPMessageStore
 from yoyopod.integrations.call.models import (
     BackendRecovered,
     BackendStopped,
     CallState,
     CallStateChanged,
     IncomingCallDetected,
-    MessageDeliveryChanged,
     MessageDeliveryState,
     MessageDirection,
-    MessageDownloadCompleted,
     MessageFailed,
     MessageKind,
-    MessageReceived,
     RegistrationState,
     RegistrationStateChanged,
     VoIPConfig,
@@ -35,10 +30,12 @@ from yoyopod.integrations.call.models import (
     VoIPRuntimeSnapshot,
     VoIPRuntimeSnapshotChanged,
 )
-from yoyopod.integrations.call.voice_notes import VoiceNoteDraft, VoiceNoteService
+from yoyopod.integrations.call.voice_notes import VoiceNoteDraft
 
 if TYPE_CHECKING:
     from yoyopod.integrations.contacts.directory import PeopleManager
+
+VOICE_NOTE_CONTAINER_GAIN_DB = 12.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,7 +62,6 @@ class VoIPManager:
         config: VoIPConfig,
         people_directory: "PeopleManager | None" = None,
         backend: VoIPBackend | None = None,
-        message_store: VoIPMessageStore | None = None,
         event_scheduler: Callable[[Callable[[], None]], None] | None = None,
         background_iterate_enabled: bool = False,
     ) -> None:
@@ -73,6 +69,8 @@ class VoIPManager:
         self.people_directory = people_directory
         if backend is None:
             raise ValueError("VoIPManager requires an explicit VoIP backend")
+        if not callable(getattr(backend, "get_runtime_snapshot", None)):
+            raise ValueError("VoIPManager requires a Rust runtime snapshot backend")
         self.backend = backend
         self.running = False
         self.registered = False
@@ -94,26 +92,18 @@ class VoIPManager:
         ) = None
         self._pending_terminal_action: str | None = None
         self._rust_active_voice_note: VoiceNoteDraft | None = None
-        self._message_store = message_store or self._build_message_store()
-        self._messaging_service = MessagingService(
-            config=self.config,
-            backend=self.backend,
-            message_store=self._message_store,
-            lookup_contact_name=self._lookup_contact_name,
-        )
-        self._voice_note_service = VoiceNoteService(
-            config=self.config,
-            backend=self.backend,
-            message_store=self._message_store,
-            lookup_contact_name=self._lookup_contact_name,
-            notify_message_summary_change=self._notify_message_summary_change,
-        )
 
         self.registration_callbacks: list[Callable[[RegistrationState], None]] = []
         self.call_state_callbacks: list[Callable[[CallState], None]] = []
         self.incoming_call_callbacks: list[Callable[[str, str], None]] = []
         self.availability_callbacks: list[Callable[[bool, str, RegistrationState], None]] = []
         self.runtime_snapshot_callbacks: list[Callable[[VoIPRuntimeSnapshot], None]] = []
+        self.message_received_callbacks: list[Callable[[VoIPMessageRecord], None]] = []
+        self.message_delivery_callbacks: list[Callable[[VoIPMessageRecord], None]] = []
+        self.message_failure_callbacks: list[Callable[[str, str], None]] = []
+        self.message_summary_callbacks: list[
+            Callable[[int, dict[str, dict[str, object]]], None]
+        ] = []
         self._last_lifecycle_availability: tuple[bool, str, RegistrationState] | None = None
         self._event_scheduler = event_scheduler
         self._background_iterate_enabled = bool(background_iterate_enabled and event_scheduler)
@@ -136,11 +126,6 @@ class VoIPManager:
         self.backend.on_event(self._dispatch_backend_event)
         logger.info("VoIPManager initialized (server: {})", config.sip_server)
 
-    def _build_message_store(self) -> VoIPMessageStore:
-        store_dir = Path(self.config.message_store_dir)
-        store_dir.mkdir(parents=True, exist_ok=True)
-        return VoIPMessageStore(store_dir)
-
     def start(self) -> bool:
         if self.running:
             return True
@@ -149,7 +134,7 @@ class VoIPManager:
             logger.warning("VoIP start skipped: SIP identity/server not configured")
             self._update_registration_state(RegistrationState.FAILED)
             self._notify_availability_change(False, "start_unconfigured")
-            self._notify_message_summary_change()
+            self._notify_message_summary_change(0, {})
             return False
 
         self.running = self.backend.start()
@@ -158,8 +143,6 @@ class VoIPManager:
         self._notify_availability_change(
             self.running, "started" if self.running else "start_failed"
         )
-        if not self._backend_owns_runtime_snapshot():
-            self._notify_message_summary_change()
         return self.running
 
     def stop(self, notify_events: bool = True) -> None:
@@ -181,8 +164,6 @@ class VoIPManager:
         drained_events = 0
         if self.running:
             drained_events = self.backend.iterate()
-        if not self._backend_owns_runtime_snapshot():
-            self._check_active_voice_note_timeout()
         return drained_events
 
     @property
@@ -238,14 +219,12 @@ class VoIPManager:
     def owns_runtime_snapshot(self) -> bool:
         """Return whether the backend is the source of truth for live runtime facts."""
 
-        return self._backend_owns_runtime_snapshot()
+        return True
 
     def poll_housekeeping(self) -> None:
         """Run lightweight coordinator-thread-only maintenance alongside background iterate."""
 
-        if self._backend_owns_runtime_snapshot():
-            return
-        self._check_active_voice_note_timeout()
+        return
 
     def make_call(self, sip_address: str, contact_name: str | None = None) -> bool:
         if not self.registered:
@@ -257,9 +236,6 @@ class VoIPManager:
         if not self.backend.make_call(sip_address):
             return False
 
-        if not self._backend_owns_runtime_snapshot():
-            self.caller_address = sip_address
-            self.caller_name = resolved_name
         self._pending_terminal_action = None
         return True
 
@@ -287,20 +263,12 @@ class VoIPManager:
     def mute(self) -> bool:
         if self.is_muted:
             return False
-        if self.backend.mute():
-            if not self._backend_owns_runtime_snapshot():
-                self.is_muted = True
-            return True
-        return False
+        return bool(self.backend.mute())
 
     def unmute(self) -> bool:
         if not self.is_muted:
             return False
-        if self.backend.unmute():
-            if not self._backend_owns_runtime_snapshot():
-                self.is_muted = False
-            return True
-        return False
+        return bool(self.backend.unmute())
 
     def toggle_mute(self) -> bool:
         if self.is_muted:
@@ -310,10 +278,8 @@ class VoIPManager:
         return True
 
     def send_text_message(self, sip_address: str, text: str, display_name: str = "") -> bool:
-        if self._backend_owns_runtime_snapshot():
-            message_id = self.backend.send_text_message(sip_address, text)
-            return bool(message_id)
-        return self._messaging_service.send_text_message(sip_address, text, display_name)
+        message_id = self.backend.send_text_message(sip_address, text)
+        return bool(message_id)
 
     def start_voice_note_recording(self, recipient_address: str, recipient_name: str = "") -> bool:
         if self.call_state not in (
@@ -327,80 +293,60 @@ class VoIPManager:
                 self.call_state.value,
             )
             return False
-        if self._backend_owns_runtime_snapshot():
-            return self._start_rust_voice_note_recording(recipient_address, recipient_name)
-        return self._voice_note_service.start_voice_note_recording(
-            recipient_address, recipient_name
-        )
+        return self._start_rust_voice_note_recording(recipient_address, recipient_name)
 
     def stop_voice_note_recording(self) -> VoiceNoteDraft | None:
-        if self._backend_owns_runtime_snapshot():
-            return self._stop_rust_voice_note_recording()
-        return self._voice_note_service.stop_voice_note_recording()
+        return self._stop_rust_voice_note_recording()
 
     def cancel_voice_note_recording(self) -> bool:
-        if self._backend_owns_runtime_snapshot():
-            success = self.backend.cancel_voice_note_recording()
-            self._rust_active_voice_note = None
-            return success
-        return self._voice_note_service.cancel_voice_note_recording()
+        success = self.backend.cancel_voice_note_recording()
+        self._rust_active_voice_note = None
+        return success
 
     def send_active_voice_note(self) -> bool:
-        if self._backend_owns_runtime_snapshot():
-            return self._send_rust_active_voice_note()
-        return self._voice_note_service.send_active_voice_note()
+        return self._send_rust_active_voice_note()
 
     def get_active_voice_note(self) -> VoiceNoteDraft | None:
-        if self._backend_owns_runtime_snapshot():
-            if self._rust_active_voice_note is None:
-                self._refresh_rust_voice_note_snapshot()
-            return self._rust_active_voice_note
-        return self._voice_note_service.get_active_voice_note()
+        if self._rust_active_voice_note is None:
+            self._refresh_rust_voice_note_snapshot()
+        return self._rust_active_voice_note
 
     def discard_active_voice_note(self) -> None:
-        if self._backend_owns_runtime_snapshot():
-            self._rust_active_voice_note = None
-            return
-        self._voice_note_service.discard_active_voice_note()
+        self._rust_active_voice_note = None
 
     def latest_voice_note_for_contact(self, sip_address: str) -> VoIPMessageRecord | None:
-        if self._backend_owns_runtime_snapshot():
-            return self._runtime_voice_note_record_for_contact(sip_address)
-        return self._voice_note_service.latest_voice_note_for_contact(sip_address)
+        return self._runtime_voice_note_record_for_contact(sip_address)
 
     def unread_voice_note_count(self) -> int:
-        if self._backend_owns_runtime_snapshot() and self._runtime_snapshot is not None:
+        if self._runtime_snapshot is not None:
             return max(0, int(self._runtime_snapshot.unread_voice_notes))
-        return self._voice_note_service.unread_voice_note_count()
+        return 0
 
     def unread_voice_note_counts_by_contact(self) -> dict[str, int]:
-        if self._backend_owns_runtime_snapshot() and self._runtime_snapshot is not None:
+        if self._runtime_snapshot is not None:
             return dict(self._runtime_snapshot.unread_voice_notes_by_contact)
-        return self._voice_note_service.unread_voice_note_counts_by_contact()
+        return {}
 
     def latest_voice_note_summary(self) -> dict[str, dict[str, object]]:
-        if self._backend_owns_runtime_snapshot() and self._runtime_snapshot is not None:
+        if self._runtime_snapshot is not None:
             return {
                 str(address): dict(summary)
                 for address, summary in self._runtime_snapshot.latest_voice_note_by_contact.items()
             }
-        return self._voice_note_service.latest_voice_note_summary()
+        return {}
 
     def mark_voice_notes_seen(self, sip_address: str) -> None:
-        if self._backend_owns_runtime_snapshot():
-            mark_seen = getattr(self.backend, "mark_voice_notes_seen", None)
-            if callable(mark_seen):
-                mark_seen(sip_address)
-            return
-        self._voice_note_service.mark_voice_notes_seen(sip_address)
+        mark_seen = getattr(self.backend, "mark_voice_notes_seen", None)
+        if callable(mark_seen):
+            mark_seen(sip_address)
 
     def call_history_unread_count(self) -> int:
-        if self._backend_owns_runtime_snapshot() and self._runtime_snapshot is not None:
+        if self._runtime_snapshot is not None:
             return max(0, int(self._runtime_snapshot.unseen_call_history))
         return 0
 
     def call_history_recent_preview(self) -> tuple[str, ...]:
-        if not self._backend_owns_runtime_snapshot() or self._runtime_snapshot is None:
+        if self._runtime_snapshot is None:
             return ()
         preview: list[str] = []
         for raw_entry in self._runtime_snapshot.recent_call_history:
@@ -412,28 +358,22 @@ class VoIPManager:
         return tuple(preview)
 
     def mark_call_history_seen(self, sip_address: str = "") -> bool:
-        if not self._backend_owns_runtime_snapshot():
-            return False
         mark_seen = getattr(self.backend, "mark_call_history_seen", None)
         if not callable(mark_seen):
             return False
         return bool(mark_seen(sip_address))
 
     def play_latest_voice_note(self, sip_address: str) -> bool:
-        if self._backend_owns_runtime_snapshot():
-            record = self._runtime_voice_note_record_for_contact(sip_address)
-            if record is None or not record.local_file_path:
-                return False
-            return self.play_voice_note(record.local_file_path)
-        return self._voice_note_service.play_latest_voice_note(sip_address)
+        record = self._runtime_voice_note_record_for_contact(sip_address)
+        if record is None or not record.local_file_path:
+            return False
+        return self.play_voice_note(record.local_file_path)
 
     def play_voice_note(self, file_path: str) -> bool:
-        if self._backend_owns_runtime_snapshot():
-            play = getattr(self.backend, "play_voice_note", None)
-            if callable(play):
-                return bool(play(file_path))
-            return False
-        return self._voice_note_service.play_voice_note(file_path)
+        play = getattr(self.backend, "play_voice_note", None)
+        if callable(play):
+            return bool(play(file_path))
+        return False
 
     def on_registration_change(self, callback: Callable[[RegistrationState], None]) -> None:
         self.registration_callbacks.append(callback)
@@ -457,19 +397,19 @@ class VoIPManager:
         self.runtime_snapshot_callbacks.append(callback)
 
     def on_message_received(self, callback: Callable[[VoIPMessageRecord], None]) -> None:
-        self._messaging_service.on_message_received(callback)
+        self.message_received_callbacks.append(callback)
 
     def on_message_delivery_change(self, callback: Callable[[VoIPMessageRecord], None]) -> None:
-        self._messaging_service.on_message_delivery_change(callback)
+        self.message_delivery_callbacks.append(callback)
 
     def on_message_failure(self, callback: Callable[[str, str], None]) -> None:
-        self._messaging_service.on_message_failure(callback)
+        self.message_failure_callbacks.append(callback)
 
     def on_message_summary_change(
         self,
         callback: Callable[[int, dict[str, dict[str, object]]], None],
     ) -> None:
-        self._messaging_service.on_message_summary_change(callback)
+        self.message_summary_callbacks.append(callback)
 
     def get_status(self) -> dict:
         return {
@@ -638,28 +578,9 @@ class VoIPManager:
         if isinstance(event, VoIPRuntimeSnapshotChanged):
             self._apply_runtime_snapshot(event.snapshot)
             return
-        if isinstance(event, MessageReceived):
-            if self._backend_owns_runtime_snapshot():
-                return
-            self._messaging_service.handle_message_received(event.message)
-            return
-        if isinstance(event, MessageDeliveryChanged):
-            if self._backend_owns_runtime_snapshot():
-                return
-            self._voice_note_service.handle_message_delivery_changed(event)
-            self._messaging_service.handle_message_delivery_changed(event)
-            return
-        if isinstance(event, MessageDownloadCompleted):
-            if self._backend_owns_runtime_snapshot():
-                return
-            self._messaging_service.handle_message_download_completed(event)
-            return
         if isinstance(event, MessageFailed):
-            if self._backend_owns_runtime_snapshot():
-                self._handle_rust_voice_note_failed(event)
-                return
-            self._voice_note_service.handle_message_failed(event)
-            self._messaging_service.handle_message_failed(event)
+            self._handle_rust_voice_note_failed(event)
+            return
 
     def _apply_runtime_snapshot(self, snapshot: VoIPRuntimeSnapshot) -> None:
         self._runtime_snapshot = snapshot
@@ -674,12 +595,8 @@ class VoIPManager:
         self.is_muted = snapshot.muted
         self._update_call_state(snapshot.call_state)
         self._notify_lifecycle_availability_from_snapshot(snapshot)
-        if self._backend_owns_runtime_snapshot():
-            self._apply_rust_voice_note_snapshot(snapshot)
-            self._notify_rust_message_summary_change(snapshot)
-        else:
-            self._voice_note_service.apply_runtime_snapshot(snapshot)
-            self._messaging_service.apply_runtime_snapshot(snapshot)
+        self._apply_rust_voice_note_snapshot(snapshot)
+        self._notify_rust_message_summary_change(snapshot)
         self._notify_runtime_snapshot_change(snapshot)
 
     def _start_rust_voice_note_recording(
@@ -691,7 +608,7 @@ class VoIPManager:
             logger.error("Cannot start voice-note recording without a recipient address")
             return False
 
-        file_path = VoiceNoteService.build_recording_file_path(self.config)
+        file_path = _build_recording_file_path(self.config)
         if not self.backend.start_voice_note_recording(file_path):
             return False
 
@@ -813,6 +730,7 @@ class VoIPManager:
         draft.send_state = "failed"
         draft.status_text = event.reason or "Couldn't send"
         draft.send_started_at = 0.0
+        self._notify_message_failure(event.message_id, draft.status_text)
 
     def _notify_rust_message_summary_change(self, snapshot: VoIPRuntimeSnapshot) -> None:
         summary = {
@@ -827,10 +745,7 @@ class VoIPManager:
         if self._last_rust_message_summary_key == key:
             return
         self._last_rust_message_summary_key = key
-        self._messaging_service.notify_external_message_summary_change(
-            max(0, int(snapshot.unread_voice_notes)),
-            summary,
-        )
+        self._notify_message_summary_change(max(0, int(snapshot.unread_voice_notes)), summary)
 
     def _runtime_voice_note_record_for_contact(
         self,
@@ -893,11 +808,23 @@ class VoIPManager:
             self.caller_address = None
             self.caller_name = None
 
-    def _backend_owns_runtime_snapshot(self) -> bool:
-        return callable(getattr(self.backend, "get_runtime_snapshot", None))
+    def _notify_message_summary_change(
+        self,
+        unread_voice_notes: int,
+        latest_voice_note_by_contact: dict[str, dict[str, object]],
+    ) -> None:
+        for callback in self.message_summary_callbacks:
+            try:
+                callback(unread_voice_notes, latest_voice_note_by_contact)
+            except Exception as exc:
+                logger.error("Error in message summary callback: {}", exc)
 
-    def _notify_message_summary_change(self) -> None:
-        self._messaging_service.notify_message_summary_change()
+    def _notify_message_failure(self, message_id: str, reason: str) -> None:
+        for callback in self.message_failure_callbacks:
+            try:
+                callback(message_id, reason)
+            except Exception as exc:
+                logger.error("Error in message failure callback: {}", exc)
 
     def _handle_incoming_call_event(self, caller_address: str) -> None:
         self.caller_address = caller_address
@@ -1031,19 +958,13 @@ class VoIPManager:
                 logger.error("Error in runtime snapshot callback: {}", exc)
 
     def _stop_voice_note_playback(self) -> None:
-        if self._backend_owns_runtime_snapshot():
-            stop = getattr(self.backend, "stop_voice_note_playback", None)
-            if callable(stop):
-                stop()
-            return
-        self._voice_note_service.stop_voice_note_playback()
+        stop = getattr(self.backend, "stop_voice_note_playback", None)
+        if callable(stop):
+            stop()
 
     @staticmethod
     def _build_voice_note_playback_command(file_path: str) -> list[str]:
-        return VoiceNoteService.build_voice_note_playback_command(file_path)
-
-    def _check_active_voice_note_timeout(self) -> None:
-        self._voice_note_service.check_active_voice_note_timeout()
+        return _voice_note_playback_command(file_path)
 
 
 def _message_summary_key(
@@ -1073,6 +994,29 @@ def _message_summary_key(
         ),
         latest_key,
     )
+
+
+def _build_recording_file_path(config: VoIPConfig) -> str:
+    voice_note_dir = Path(config.voice_note_store_dir)
+    voice_note_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return str(voice_note_dir / f"voice-note-{timestamp}.wav")
+
+
+def _voice_note_playback_command(file_path: str) -> list[str]:
+    suffix = Path(file_path).suffix.lower()
+    if suffix in {".mka", ".mkv", ".ogg", ".opus", ".mp3", ".m4a"}:
+        return [
+            "ffplay",
+            "-nodisp",
+            "-autoexit",
+            "-loglevel",
+            "error",
+            "-af",
+            f"volume={VOICE_NOTE_CONTAINER_GAIN_DB}dB",
+            file_path,
+        ]
+    return ["aplay", "-q", file_path]
 
 
 __all__ = ["VoIPIterateSnapshot", "VoIPManager"]


### PR DESCRIPTION
## Summary
- make `VoIPManager` require a Rust runtime-snapshot backend instead of accepting Python-owned runtime backends
- remove Python message-store, messaging-service, and voice-note-service ownership from the app-facing manager
- keep manager callbacks and UI compatibility draft state while sourcing summaries/history/voice-note facts from Rust snapshots
- update manager tests around Rust-owned message, voice-note, playback, and call-state behavior

## Validation
- uv run pytest -q tests\backends\test_voip_backend.py tests\integrations\test_call.py tests\integrations\test_voip_services.py tests\core\test_bootstrap.py
- uv run pytest -q
- uv run python scripts/quality.py gate
- uv run python scripts/quality.py gate
- uv run pytest -q