### PR TITLE
[codex] Recover playlists after Rust snapshot boot

### DIFF
--- a/tests/backends/test_rust_host_music.py
+++ b/tests/backends/test_rust_host_music.py
@@ -246,6 +246,7 @@ def test_snapshot_updates_cached_state_and_fires_callbacks() -> None:
     )
 
     assert backend.is_connected is True
+    assert backend.library_state_ready is True
     assert backend.get_playback_state() == "playing"
     assert backend.get_time_position() == 4200
     assert backend.get_volume() == 70

--- a/tests/backends/test_rust_host_music.py
+++ b/tests/backends/test_rust_host_music.py
@@ -321,6 +321,29 @@ def test_wrong_domain_worker_messages_are_ignored() -> None:
     assert backend.get_current_track() is None
 
 
+def test_correlated_runtime_command_error_does_not_stop_backend() -> None:
+    supervisor = _FakeSupervisor()
+    backend = RustHostBackend(_config(), worker_supervisor=supervisor, worker_path="/bin/media")
+
+    assert backend.start() is True
+    assert backend.load_playlist_file("/music/missing.m3u") is True
+
+    request_id = supervisor.request_ids[-1]
+    assert request_id is not None
+
+    backend.handle_worker_message(
+        _reply(
+            "error",
+            "media.error",
+            {"code": "command_failed", "message": "playlist missing"},
+            request_id=request_id,
+        )
+    )
+
+    assert backend.running is True
+    assert supervisor.stopped == []
+
+
 def test_prepare_remote_playback_asset_waits_for_worker_result() -> None:
     supervisor = _FakeSupervisor()
     backend = RustHostBackend(

--- a/tests/integrations/test_local_music_service.py
+++ b/tests/integrations/test_local_music_service.py
@@ -42,7 +42,14 @@ class StubScreenManager:
 class _SnapshotOwnedBackend:
     owns_library_state = True
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        connected: bool = True,
+        library_state_ready: bool = True,
+    ) -> None:
+        self._connected = connected
+        self.library_state_ready = library_state_ready
         self.playlists = [Playlist(uri="/music/rust.m3u", name="Rust", track_count=4)]
         self.recent_tracks = [
             RecentTrackEntry(
@@ -59,7 +66,7 @@ class _SnapshotOwnedBackend:
 
     @property
     def is_connected(self) -> bool:
-        return True
+        return self._connected
 
     def list_playlists(self, fetch_track_counts: bool = False) -> list[Playlist]:
         assert fetch_track_counts is True
@@ -204,6 +211,24 @@ def test_local_music_service_delegates_library_queries_to_snapshot_owned_backend
     assert service.playlist_count() == 1
     assert service.list_recent_tracks() == backend.recent_tracks
     assert service.menu_items() == backend.menu
+
+
+def test_local_music_service_is_available_when_snapshot_owned_backend_library_state_is_ready(
+    tmp_path: Path,
+) -> None:
+    backend = _SnapshotOwnedBackend(connected=False, library_state_ready=True)
+    service = LocalMusicService(backend, music_dir=tmp_path / "Music")
+
+    assert service.is_available is True
+
+
+def test_local_music_service_is_unavailable_until_snapshot_owned_library_state_arrives(
+    tmp_path: Path,
+) -> None:
+    backend = _SnapshotOwnedBackend(connected=False, library_state_ready=False)
+    service = LocalMusicService(backend, music_dir=tmp_path / "Music")
+
+    assert service.is_available is False
 
 
 def test_local_music_service_uses_backend_owned_recent_and_shuffle_actions(tmp_path: Path) -> None:

--- a/tests/ui/test_playlist_lvgl_view.py
+++ b/tests/ui/test_playlist_lvgl_view.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from yoyopod.core import AppContext
-from yoyopod.backends.music import MockMusicBackend
+from yoyopod.backends.music import MockMusicBackend, Playlist
 from yoyopod.integrations.music import LocalMusicService
 from yoyopod.ui.input import InteractionProfile
 from yoyopod.ui.screens.music.playlist import PlaylistScreen
+from yoyopod.ui.screens.manager import ScreenManager, VisibleTickRefreshResult
 
 
 class FakeLvglBinding:
@@ -54,6 +55,21 @@ class FakeLvglDisplay:
 
     def is_portrait(self) -> bool:
         return True
+
+
+class SnapshotOwnedPlaylistBackend:
+    owns_library_state = True
+
+    def __init__(self, *, library_state_ready: bool) -> None:
+        self.library_state_ready = library_state_ready
+
+    @property
+    def is_connected(self) -> bool:
+        return False
+
+    def list_playlists(self, fetch_track_counts: bool = False) -> list[Playlist]:
+        assert fetch_track_counts is True
+        return [Playlist(uri="/music/Alpha.m3u", name="Alpha", track_count=3)]
 
 
 def _write_playlist(path: Path, track_count: int) -> None:
@@ -229,5 +245,31 @@ def test_playlist_screen_recovers_after_music_backend_connects(tmp_path: Path) -
     backend.start()
     screen.render()
 
+    assert binding.playlist_sync_payloads[-1]["items"] == ["Alpha"]
+    assert binding.playlist_sync_payloads[-1]["badges"] == ["3"]
+
+
+def test_playlist_screen_visible_tick_recovers_after_library_snapshot_arrives() -> None:
+    """PlaylistScreen should repopulate after Rust-owned library state becomes ready."""
+
+    binding = FakeLvglBinding()
+    display = FakeLvglDisplay(binding)
+    backend = SnapshotOwnedPlaylistBackend(library_state_ready=False)
+    screen = PlaylistScreen(
+        display,
+        AppContext(interaction_profile=InteractionProfile.ONE_BUTTON),
+        music_service=LocalMusicService(backend),
+    )
+    manager = ScreenManager(display)
+    manager.register_screen("playlists", screen)
+    manager.push_screen("playlists")
+    assert manager.flush_pending_navigation_refresh() is True
+
+    assert binding.playlist_sync_payloads[-1]["items"] == []
+    assert binding.playlist_sync_payloads[-1]["empty_subtitle"] == "Music offline"
+
+    backend.library_state_ready = True
+
+    assert manager.refresh_current_screen_for_visible_tick() is VisibleTickRefreshResult.RENDERED
     assert binding.playlist_sync_payloads[-1]["items"] == ["Alpha"]
     assert binding.playlist_sync_payloads[-1]["badges"] == ["3"]

--- a/yoyopod/backends/music/rust_host.py
+++ b/yoyopod/backends/music/rust_host.py
@@ -75,6 +75,7 @@ class RustHostBackend:
         self._playback_state = "stopped"
         self._time_position_ms = 0
         self._volume_percent = 100
+        self._library_state_ready = False
         self._playlists: list[Playlist] = []
         self._recent_tracks: list[Any] = []
         self._menu_items: list[Any] = []
@@ -178,6 +179,7 @@ class RustHostBackend:
             self._current_track = None
             self._playback_state = "stopped"
             self._time_position_ms = 0
+            self._library_state_ready = False
 
     @property
     def is_connected(self) -> bool:
@@ -189,6 +191,10 @@ class RustHostBackend:
         return self._starting or self._warm_start_pending or (
             thread is not None and thread.is_alive()
         )
+
+    @property
+    def library_state_ready(self) -> bool:
+        return self._library_state_ready
 
     def play(self) -> bool:
         return self._send("media.play", {})
@@ -520,6 +526,7 @@ class RustHostBackend:
         self._starting = False
         self._warm_start_pending = False
         self.running = False
+        self._library_state_ready = False
         for pending in pending_requests:
             self._complete_pending_request_once(
                 pending,
@@ -546,6 +553,7 @@ class RustHostBackend:
         self._time_position_ms = next_time_position_ms
         if next_volume >= 0:
             self._volume_percent = next_volume
+        self._library_state_ready = True
         self._playlists = next_playlists
         self._recent_tracks = next_recent_tracks
         self._menu_items = next_menu_items

--- a/yoyopod/integrations/music/library.py
+++ b/yoyopod/integrations/music/library.py
@@ -39,8 +39,15 @@ class LocalMusicService:
 
     @property
     def is_available(self) -> bool:
-        """Return True when the music backend is connected."""
-        return bool(self.music_backend and self.music_backend.is_connected)
+        """Return True when local-library browsing can use the active backend."""
+        if self.music_backend is None:
+            return False
+        if self._backend_owns_library_state():
+            return bool(
+                getattr(self.music_backend, "library_state_ready", False)
+                or self.music_backend.is_connected
+            )
+        return bool(self.music_backend.is_connected)
 
     def is_local_track_uri(self, uri: str) -> bool:
         """Return True when the URI is a path under the music directory."""

--- a/yoyopod/ui/screens/music/playlist.py
+++ b/yoyopod/ui/screens/music/playlist.py
@@ -181,6 +181,16 @@ class PlaylistScreen(Screen):
             raise RuntimeError("PlaylistScreen requires an initialized LVGL backend")
         lvgl_view.sync()
 
+    def wants_visible_tick_refresh(self) -> bool:
+        """Opt into visible-tick refreshes while an offline playlist fetch can recover."""
+
+        return not self.loading and not self.playlists and self.error_message == "Music offline"
+
+    def should_render_for_visible_tick(self) -> bool:
+        """Render only when Rust-owned library state becomes available."""
+
+        return self._should_retry_offline_fetch()
+
     def select_next(self) -> None:
         """Move to the next playlist."""
         if self.playlists and self.selected_index < len(self.playlists) - 1:

--- a/yoyopod_rs/media-host/src/worker.rs
+++ b/yoyopod_rs/media-host/src/worker.rs
@@ -98,6 +98,7 @@ where
                             continue;
                         }
 
+                        let request_id = envelope.request_id.clone();
                         match handle_command(envelope, &mut host) {
                             Ok(outcome) => {
                                 for envelope in &outcome.envelopes {
@@ -114,7 +115,7 @@ where
                                     output,
                                     &WorkerEnvelope::error(
                                         "media.error",
-                                        None,
+                                        request_id,
                                         "command_failed",
                                         error.to_string(),
                                     ),

--- a/yoyopod_rs/media-host/tests/worker.rs
+++ b/yoyopod_rs/media-host/tests/worker.rs
@@ -31,6 +31,32 @@ fn run_emits_ready_event_before_processing_input() {
 }
 
 #[test]
+fn command_failures_preserve_request_id() {
+    let input = std::io::Cursor::new(
+        br#"{"schema_version":1,"kind":"command","type":"media.load_playlist","request_id":"playlist-1","payload":{}}
+"#
+        .to_vec(),
+    );
+    let mut output = Vec::new();
+    let mut errors = Vec::new();
+
+    run_io(input, &mut output, &mut errors).expect("worker run");
+
+    let stdout = String::from_utf8(output).expect("utf8");
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines.len() >= 2, "expected ready event and command error");
+
+    let command_error = WorkerEnvelope::decode(lines[1].as_bytes()).expect("decode error envelope");
+    assert_eq!(command_error.kind, EnvelopeKind::Error);
+    assert_eq!(command_error.request_id.as_deref(), Some("playlist-1"));
+    assert_eq!(command_error.payload["code"], "command_failed");
+    assert_eq!(
+        command_error.payload["message"],
+        "media.load_playlist requires path"
+    );
+}
+
+#[test]
 fn health_command_reports_ready_and_unconfigured_state() {
     let mut host = MediaHost::default();
     let outcome = handle_command(


### PR DESCRIPTION
## What changed
- treat Rust-owned media library snapshots as browse-ready before playback transport reports connected
- let the playlist screen retry its offline fetch on visible ticks so it recovers as soon as the Rust snapshot lands
- add regression coverage for Rust media snapshot readiness and playlist recovery

## Why
After the Rust media host cutover, Listen could briefly show `Music offline` during boot because Python gated playlist browsing on transport connectivity only. The Rust worker already had library state by then, so the visible behavior was stricter than the real backend state.

## Root cause
`LocalMusicService.is_available` only mirrored `music_backend.is_connected`, and `PlaylistScreen` had no visible-tick recovery path for a Rust snapshot-owned library becoming ready before the transport connection callback fired.

## Validation
- `uv run python scripts/quality.py gate`
- `uv run pytest -q`
- hardware validation on `tifo@rpi-zero` using CI artifact `yoyopod-media-host-6f4b64bd376d23c352cba0f3953e2063c4d9dda0`
  - `uv run yoyopod remote --branch codex/rust-media-host validate --sha 6f4b64bd376d23c352cba0f3953e2063c4d9dda0 --with-music`
  - result: pass
  - key log signal: playlists were fetched before `Music backend connected (connected)`

## Notes
- This PR is now a one-commit hardening fix on top of current `main`; the earlier Rust media-host ownership work is already in `main` via `#421`.
