### PR TITLE
[codex] Add Rust cloud host

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,8 @@ __pycache__/
 build/
 !yoyopod_rs/ui-host/build/
 !yoyopod_rs/ui-host/build/**
+!yoyopod_rs/cloud-host/build/
+!yoyopod_rs/cloud-host/build/**
 !yoyopod_rs/media-host/build/
 !yoyopod_rs/media-host/build/**
 !yoyopod_rs/voip-host/build/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           sudo apt-get install -y pkg-config liblinphone-dev libudev-dev
 
       - name: Run Bazel Rust host tests
-        run: bazel test --action_env=PATH //yoyopod_rs/ui-host/... //yoyopod_rs/media-host/... //yoyopod_rs/voip-host/... //yoyopod_rs/network-host/... //yoyopod_rs/runtime/...
+        run: bazel test --action_env=PATH //yoyopod_rs/ui-host/... //yoyopod_rs/cloud-host/... //yoyopod_rs/media-host/... //yoyopod_rs/voip-host/... //yoyopod_rs/network-host/... //yoyopod_rs/runtime/...
 
       - name: Run Rust workspace tests
         working-directory: yoyopod_rs
@@ -155,6 +155,7 @@ jobs:
           cargo build --release --locked \
             -p yoyopod-runtime \
             -p yoyopod-ui-host \
+            -p yoyopod-cloud-host \
             -p yoyopod-media-host \
             -p yoyopod-voip-host \
             -p yoyopod-network-host \
@@ -166,11 +167,13 @@ jobs:
           mkdir -p \
             "${bundle_root}/yoyopod_rs/runtime/build" \
             "${bundle_root}/yoyopod_rs/ui-host/build" \
+            "${bundle_root}/yoyopod_rs/cloud-host/build" \
             "${bundle_root}/yoyopod_rs/media-host/build" \
             "${bundle_root}/yoyopod_rs/voip-host/build" \
             "${bundle_root}/yoyopod_rs/network-host/build"
           cp target/release/yoyopod-runtime "${bundle_root}/yoyopod_rs/runtime/build/yoyopod-runtime"
           cp target/release/yoyopod-ui-host "${bundle_root}/yoyopod_rs/ui-host/build/yoyopod-ui-host"
+          cp target/release/yoyopod-cloud-host "${bundle_root}/yoyopod_rs/cloud-host/build/yoyopod-cloud-host"
           cp target/release/yoyopod-media-host "${bundle_root}/yoyopod_rs/media-host/build/yoyopod-media-host"
           cp target/release/yoyopod-voip-host "${bundle_root}/yoyopod_rs/voip-host/build/yoyopod-voip-host"
           cp target/release/yoyopod-network-host "${bundle_root}/yoyopod_rs/network-host/build/yoyopod-network-host"

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ data/communication/
 data/cloud/
 data/media/
 data/people/
+yoyopod_rs/cloud-host/data/
 
 # OS files
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Current Runtime Status
   - `yoyopod_rs/media-host/` for local music/mpv ownership
   - `yoyopod_rs/voip-host/` for Liblinphone/SIP ownership
   - `yoyopod_rs/network-host/` for SIM7600/PPP/GPS ownership
+  - `yoyopod_rs/cloud-host/` for cloud MQTT telemetry/command transport
 - The Rust UI host now contains native Rust LVGL scene controllers for the main
   screen set. The C LVGL shim and LVGL native library still exist as display
   infrastructure during the transition.
@@ -76,6 +77,7 @@ Pi Lanes And Bootstrap
 
 Source Of Truth
 - `yoyopod_rs/runtime/`
+- `yoyopod_rs/cloud-host/`
 - `yoyopod_rs/ui-host/`
 - `yoyopod_rs/media-host/`
 - `yoyopod_rs/voip-host/`

--- a/tests/deploy/test_ci_workflows.py
+++ b/tests/deploy/test_ci_workflows.py
@@ -39,8 +39,9 @@ def test_rust_ci_builds_arm64_device_bundle_artifact() -> None:
     assert "Install native Rust host dependencies" in workflow
     assert "pkg-config liblinphone-dev libudev-dev" in workflow
     assert (
-        "bazel test --action_env=PATH //yoyopod_rs/ui-host/... //yoyopod_rs/media-host/... "
-        "//yoyopod_rs/voip-host/... //yoyopod_rs/network-host/... //yoyopod_rs/runtime/..."
+        "bazel test --action_env=PATH //yoyopod_rs/ui-host/... //yoyopod_rs/cloud-host/... "
+        "//yoyopod_rs/media-host/... //yoyopod_rs/voip-host/... //yoyopod_rs/network-host/... "
+        "//yoyopod_rs/runtime/..."
     ) in workflow
     assert "cargo test --workspace --locked --features whisplay-hardware,native-lvgl" in workflow
     assert (
@@ -49,6 +50,7 @@ def test_rust_ci_builds_arm64_device_bundle_artifact() -> None:
     )
     assert "-p yoyopod-runtime" in workflow
     assert "-p yoyopod-ui-host" in workflow
+    assert "-p yoyopod-cloud-host" in workflow
     assert "-p yoyopod-media-host" in workflow
     assert "-p yoyopod-voip-host" in workflow
     assert "-p yoyopod-network-host" in workflow
@@ -60,6 +62,7 @@ def test_rust_ci_builds_arm64_device_bundle_artifact() -> None:
     assert "name: yoyopod-rust-device-arm64-${{ env.RUST_ARTIFACT_SHA }}" in workflow
     assert "yoyopod-rust-device-arm64-${{ env.RUST_ARTIFACT_SHA }}.tar.gz" in workflow
     assert "yoyopod_rs/ui-host/build/yoyopod-ui-host" in workflow
+    assert "yoyopod_rs/cloud-host/build/yoyopod-cloud-host" in workflow
     assert "yoyopod_rs/media-host/build/yoyopod-media-host" in workflow
     assert "yoyopod_rs/voip-host/build/yoyopod-voip-host" in workflow
     assert "yoyopod_rs/network-host/build/yoyopod-network-host" in workflow
@@ -99,6 +102,7 @@ def test_rust_bazel_feature_folder_layout_is_checked_in() -> None:
     assert (REPO_ROOT / "yoyopod_rs" / "BUILD.bazel").exists()
     assert (REPO_ROOT / "yoyopod_rs" / "ui-host" / "BUILD.bazel").exists()
     assert (REPO_ROOT / "yoyopod_rs" / "ui-host" / "tests" / "README.md").exists()
+    assert (REPO_ROOT / "yoyopod_rs" / "cloud-host" / "BUILD.bazel").exists()
     assert (REPO_ROOT / "yoyopod_rs" / "voip-host" / "BUILD.bazel").exists()
     assert (REPO_ROOT / "yoyopod_rs" / "voip-host" / "tests" / "README.md").exists()
     assert (REPO_ROOT / "yoyopod_rs" / "network-host" / "BUILD.bazel").exists()
@@ -175,6 +179,7 @@ def test_dockerignore_preserves_rust_artifact_build_dirs_for_slot_builder() -> N
 
     for artifact_dir in (
         "yoyopod_rs/ui-host/build",
+        "yoyopod_rs/cloud-host/build",
         "yoyopod_rs/media-host/build",
         "yoyopod_rs/voip-host/build",
         "yoyopod_rs/network-host/build",

--- a/yoyopod_cli/remote_validate.py
+++ b/yoyopod_cli/remote_validate.py
@@ -23,6 +23,7 @@ app = build_remote_app("validate_app", "Validate commit + health on the Pi.")
 
 _RUST_UI_HOST_WORKER = "yoyopod_rs/ui-host/build/yoyopod-ui-host"
 _RUST_UI_POC_WORKER = _RUST_UI_HOST_WORKER
+_RUST_CLOUD_HOST_WORKER = "yoyopod_rs/cloud-host/build/yoyopod-cloud-host"
 _RUST_MEDIA_HOST_WORKER = "yoyopod_rs/media-host/build/yoyopod-media-host"
 _RUST_VOIP_HOST_WORKER = "yoyopod_rs/voip-host/build/yoyopod-voip-host"
 
@@ -148,6 +149,14 @@ def _build_validate(
         steps.append(f"git reset --hard {origin_br}")
     steps.append("git clean -fd")
     media_worker = shell_quote(_RUST_MEDIA_HOST_WORKER)
+    cloud_worker = shell_quote(_RUST_CLOUD_HOST_WORKER)
+    cloud_message = shell_quote(
+        "Missing executable CI-built Rust cloud binary at "
+        f"{_RUST_CLOUD_HOST_WORKER}. Download and extract the GitHub Actions "
+        "artifact yoyopod-rust-device-arm64-<sha> "
+        "for this exact commit before Pi validation; do not build Rust binaries on the Pi."
+    )
+    steps.append(f"test -x {cloud_worker} || (echo {cloud_message} >&2 && exit 1)")
     media_message = shell_quote(
         "Missing executable CI-built Rust media binary at "
         f"{_RUST_MEDIA_HOST_WORKER}. Download and extract the GitHub Actions "

--- a/yoyopod_cli/setup.py
+++ b/yoyopod_cli/setup.py
@@ -44,6 +44,7 @@ HOST_REMOTE_TOOLS: tuple[str, ...] = ("ssh", "rsync")
 HOST_DEV_MODULES: tuple[str, ...] = ("pytest", "black", "ruff", "mypy", "typer")
 NATIVE_ARTIFACTS: tuple[Path, ...] = (
     REPO_ROOT / "yoyopod" / "ui" / "lvgl_binding" / "native" / "build" / "libyoyopod_lvgl_shim.so",
+    REPO_ROOT / "yoyopod_rs" / "cloud-host" / "build" / "yoyopod-cloud-host",
     REPO_ROOT / "yoyopod_rs" / "media-host" / "build" / "yoyopod-media-host",
     REPO_ROOT / "yoyopod_rs" / "voip-host" / "build" / "yoyopod-voip-host",
 )

--- a/yoyopod_cli/slot_contract.py
+++ b/yoyopod_cli/slot_contract.py
@@ -13,6 +13,7 @@ SLOT_VOICE_WORKER_ARTIFACT = Path("workers") / "voice" / "go" / "build" / "yoyop
 APP_NATIVE_RUNTIME_ARTIFACTS: tuple[Path, ...] = (
     Path("yoyopod") / "ui" / "lvgl_binding" / "native" / "build" / "libyoyopod_lvgl_shim.so",
     Path("yoyopod") / "ui" / "lvgl_binding" / "native" / "build" / "lvgl" / "lib" / "liblvgl.so.9",
+    Path("yoyopod_rs") / "cloud-host" / "build" / "yoyopod-cloud-host",
     Path("yoyopod_rs") / "media-host" / "build" / "yoyopod-media-host",
     Path("yoyopod_rs") / "voip-host" / "build" / "yoyopod-voip-host",
     Path("yoyopod_rs") / "network-host" / "build" / "yoyopod-network-host",

--- a/yoyopod_rs/BUILD.bazel
+++ b/yoyopod_rs/BUILD.bazel
@@ -6,6 +6,11 @@ alias(
 )
 
 alias(
+    name = "cloud-host",
+    actual = "//yoyopod_rs/cloud-host:yoyopod-cloud-host",
+)
+
+alias(
     name = "ui-host",
     actual = "//yoyopod_rs/ui-host:yoyopod-ui-host",
 )

--- a/yoyopod_rs/Cargo.lock
+++ b/yoyopod_rs/Cargo.lock
@@ -59,10 +59,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-tungstenite"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0f7efedeac57d9b26170f72965ecfd31473ca52ca7a64e925b0b6f5f079886"
+dependencies = [
+ "atomic-waker",
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+]
+
+[[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version",
+ "tokio",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "az"
@@ -113,12 +173,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -236,6 +304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +350,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "embedded-graphics"
@@ -340,12 +420,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -361,6 +458,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -386,13 +577,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -417,6 +620,22 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icu_collections"
@@ -562,6 +781,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +857,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +891,17 @@ name = "micromath"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "nix"
@@ -729,10 +978,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -800,6 +1071,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -811,8 +1088,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -822,7 +1109,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -832,6 +1129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -867,6 +1173,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumqttc"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0feff8d882bff0b2fddaf99355a10336d43dd3ed44204f85ece28cf9626ab519"
+dependencies = [
+ "async-tungstenite",
+ "bytes",
+ "fixedbitset",
+ "flume",
+ "futures-util",
+ "http",
+ "log",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "ws_stream_tungstenite",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,13 +1225,35 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -905,10 +1267,22 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -921,10 +1295,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1008,6 +1414,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,10 +1442,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1147,6 +1589,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1763,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -1495,6 +2053,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "ws_stream_tungstenite"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c9c55940d22313a53398bfeb9438c5f519de475fa37ed7ff068f8c1ca8eb45"
+dependencies = [
+ "async-tungstenite",
+ "async_io_stream",
+ "bitflags 2.11.1",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-util",
+ "pharos",
+ "rustc_version",
+ "tokio",
+ "tracing",
+ "tungstenite",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,13 +2096,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoyopod-cloud-host"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "rumqttc",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+]
+
+[[package]]
 name = "yoyopod-media-host"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
  "filetime",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",

--- a/yoyopod_rs/Cargo.toml
+++ b/yoyopod_rs/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "cloud-host",
     "media-host",
     "ui-host",
     "voip-host",

--- a/yoyopod_rs/cloud-host/BUILD.bazel
+++ b/yoyopod_rs/cloud-host/BUILD.bazel
@@ -1,0 +1,32 @@
+load(
+    "//:defs.bzl",
+    "yoyopod_rust_host_binary",
+    "yoyopod_rust_host_integration_tests",
+    "yoyopod_rust_host_library",
+)
+
+yoyopod_rust_host_library(
+    name = "cloud_host_lib",
+    srcs = glob(
+        ["src/**/*.rs"],
+        exclude = ["src/main.rs"],
+    ),
+    crate_name = "yoyopod_cloud_host",
+)
+
+yoyopod_rust_host_binary(
+    name = "yoyopod-cloud-host",
+    srcs = ["src/main.rs"],
+    deps = [":cloud_host_lib"],
+)
+
+CLOUD_HOST_TESTS = [
+    "config",
+    "worker",
+]
+
+yoyopod_rust_host_integration_tests(
+    name = "tests",
+    tests = CLOUD_HOST_TESTS,
+    deps = [":cloud_host_lib"],
+)

--- a/yoyopod_rs/cloud-host/Cargo.toml
+++ b/yoyopod_rs/cloud-host/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "yoyopod-cloud-host"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[[bin]]
+name = "yoyopod-cloud-host"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+rumqttc = { version = "0.25", features = ["websocket", "url"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.9"
+thiserror = "2.0"

--- a/yoyopod_rs/cloud-host/src/config.rs
+++ b/yoyopod_rs/cloud-host/src/config.rs
@@ -1,0 +1,357 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_yaml::{Mapping, Value};
+
+const CLOUD_BACKEND_CONFIG: &str = "cloud/backend.yaml";
+const CLOUD_SECRETS_CONFIG: &str = "cloud/device.secrets.yaml";
+const SYSTEM_CLOUD_SECRETS_FILE: &str = "/etc/yoyopod/cloud/device.secrets.yaml";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct CloudHostConfig {
+    pub api_base_url: String,
+    pub auth_path: String,
+    pub refresh_path: String,
+    pub config_path_template: String,
+    pub contacts_bootstrap_path_template: String,
+    pub timeout_seconds: f64,
+    pub config_poll_interval_seconds: u64,
+    pub claim_retry_seconds: u64,
+    pub cache_file: String,
+    pub status_file: String,
+    pub mqtt_broker_host: String,
+    pub mqtt_broker_port: u16,
+    pub mqtt_use_tls: bool,
+    pub mqtt_transport: String,
+    pub mqtt_username: String,
+    pub mqtt_password: String,
+    pub battery_report_interval_seconds: u64,
+    pub device_id: String,
+    pub device_secret: String,
+    pub runtime_root: String,
+    pub secrets_source: String,
+    pub secrets_error: String,
+}
+
+impl Default for CloudHostConfig {
+    fn default() -> Self {
+        Self {
+            api_base_url: "https://yoyopod.moraouf.net".to_string(),
+            auth_path: "/v1/auth/device".to_string(),
+            refresh_path: "/v1/auth/device/refresh".to_string(),
+            config_path_template: "/v1/devices/{device_id}/config".to_string(),
+            contacts_bootstrap_path_template: "/v1/devices/{device_id}/contacts/bootstrap"
+                .to_string(),
+            timeout_seconds: 3.0,
+            config_poll_interval_seconds: 300,
+            claim_retry_seconds: 60,
+            cache_file: "data/cloud/config_cache.json".to_string(),
+            status_file: "data/cloud/status.json".to_string(),
+            mqtt_broker_host: "yoyopod.moraouf.net".to_string(),
+            mqtt_broker_port: 1883,
+            mqtt_use_tls: false,
+            mqtt_transport: "tcp".to_string(),
+            mqtt_username: String::new(),
+            mqtt_password: String::new(),
+            battery_report_interval_seconds: 60,
+            device_id: String::new(),
+            device_secret: String::new(),
+            runtime_root: String::new(),
+            secrets_source: String::new(),
+            secrets_error: String::new(),
+        }
+    }
+}
+
+impl CloudHostConfig {
+    pub fn load(config_dir: impl AsRef<Path>) -> Result<Self> {
+        let config_dir = config_dir.as_ref();
+        let runtime_root = runtime_root_for_config_dir(config_dir);
+        let mut config = Self {
+            runtime_root: runtime_root.to_string_lossy().to_string(),
+            ..Self::default()
+        };
+
+        let backend = load_yaml_mapping(&config_dir.join(CLOUD_BACKEND_CONFIG))?;
+        let backend = nested_mapping(&backend, "backend").unwrap_or(&backend);
+        apply_backend_mapping(&mut config, backend);
+
+        let secrets_path = resolve_secrets_path(config_dir);
+        if secrets_path.exists() {
+            match load_yaml_mapping(&secrets_path) {
+                Ok(raw_secrets) => {
+                    let secrets = nested_mapping(&raw_secrets, "secrets").unwrap_or(&raw_secrets);
+                    config.device_id = string_key(secrets, "device_id", "");
+                    config.device_secret = string_key(secrets, "device_secret", "");
+                    config.secrets_source = secrets_path.to_string_lossy().to_string();
+                }
+                Err(error) => {
+                    config.secrets_source = secrets_path.to_string_lossy().to_string();
+                    config.secrets_error = format!("Failed to load cloud provisioning: {error}");
+                }
+            }
+        }
+
+        apply_env_overrides(&mut config)?;
+        if (config.device_id.trim().is_empty() && !config.device_secret.trim().is_empty())
+            || (!config.device_id.trim().is_empty() && config.device_secret.trim().is_empty())
+        {
+            config.secrets_error =
+                "Provisioning file must contain both device_id and device_secret".to_string();
+        }
+        Ok(config)
+    }
+
+    pub fn default_for_config_dir(config_dir: impl AsRef<Path>) -> Self {
+        let runtime_root = runtime_root_for_config_dir(config_dir.as_ref());
+        Self {
+            runtime_root: runtime_root.to_string_lossy().to_string(),
+            ..Self::default()
+        }
+    }
+
+    pub fn status_path(&self) -> PathBuf {
+        resolve_runtime_path(&self.runtime_root, &self.status_file)
+    }
+
+    pub fn device_event_topic(&self) -> String {
+        format!("yoyopod/{}/evt", self.device_id.trim())
+    }
+
+    pub fn device_ack_topic(&self) -> String {
+        format!("yoyopod/{}/ack", self.device_id.trim())
+    }
+
+    pub fn device_command_topic(&self) -> String {
+        format!("yoyopod/{}/cmd", self.device_id.trim())
+    }
+
+    pub fn mqtt_configured(&self) -> bool {
+        !self.mqtt_broker_host.trim().is_empty() && !self.device_id.trim().is_empty()
+    }
+
+    pub fn provisioned(&self) -> bool {
+        self.secrets_error.trim().is_empty()
+            && !self.device_id.trim().is_empty()
+            && !self.device_secret.trim().is_empty()
+    }
+}
+
+fn apply_backend_mapping(config: &mut CloudHostConfig, backend: &Mapping) {
+    config.api_base_url = string_key(backend, "api_base_url", &config.api_base_url);
+    config.auth_path = string_key(backend, "auth_path", &config.auth_path);
+    config.refresh_path = string_key(backend, "refresh_path", &config.refresh_path);
+    config.config_path_template = string_key(
+        backend,
+        "config_path_template",
+        &config.config_path_template,
+    );
+    config.contacts_bootstrap_path_template = string_key(
+        backend,
+        "contacts_bootstrap_path_template",
+        &config.contacts_bootstrap_path_template,
+    );
+    config.timeout_seconds = f64_key(backend, "timeout_seconds", config.timeout_seconds);
+    config.config_poll_interval_seconds = u64_key(
+        backend,
+        "config_poll_interval_seconds",
+        config.config_poll_interval_seconds,
+    );
+    config.claim_retry_seconds =
+        u64_key(backend, "claim_retry_seconds", config.claim_retry_seconds);
+    config.cache_file = string_key(backend, "cache_file", &config.cache_file);
+    config.status_file = string_key(backend, "status_file", &config.status_file);
+    config.mqtt_broker_host = string_key(backend, "mqtt_broker_host", &config.mqtt_broker_host);
+    config.mqtt_broker_port = u16_key(backend, "mqtt_broker_port", config.mqtt_broker_port);
+    config.mqtt_use_tls = bool_key(backend, "mqtt_use_tls", config.mqtt_use_tls);
+    config.mqtt_transport = string_key(backend, "mqtt_transport", &config.mqtt_transport);
+    config.mqtt_username = string_key(backend, "mqtt_username", &config.mqtt_username);
+    config.mqtt_password = string_key(backend, "mqtt_password", &config.mqtt_password);
+    config.battery_report_interval_seconds = u64_key(
+        backend,
+        "battery_report_interval_seconds",
+        config.battery_report_interval_seconds,
+    );
+}
+
+fn apply_env_overrides(config: &mut CloudHostConfig) -> Result<()> {
+    if let Some(value) = env_string("YOYOPOD_CLOUD_API_BASE_URL") {
+        config.api_base_url = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_TIMEOUT_SECONDS") {
+        config.timeout_seconds = value
+            .parse()
+            .with_context(|| format!("parse YOYOPOD_CLOUD_TIMEOUT_SECONDS={value}"))?;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_CONFIG_POLL_INTERVAL_SECONDS") {
+        config.config_poll_interval_seconds = value
+            .parse()
+            .with_context(|| format!("parse YOYOPOD_CLOUD_CONFIG_POLL_INTERVAL_SECONDS={value}"))?;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_CACHE_FILE") {
+        config.cache_file = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_STATUS_FILE") {
+        config.status_file = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_MQTT_BROKER_HOST") {
+        config.mqtt_broker_host = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_MQTT_BROKER_PORT") {
+        config.mqtt_broker_port = value
+            .parse()
+            .with_context(|| format!("parse YOYOPOD_CLOUD_MQTT_BROKER_PORT={value}"))?;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_MQTT_USE_TLS") {
+        config.mqtt_use_tls = parse_bool("YOYOPOD_CLOUD_MQTT_USE_TLS", &value)?;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_MQTT_TRANSPORT") {
+        config.mqtt_transport = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_MQTT_USERNAME") {
+        config.mqtt_username = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_MQTT_PASSWORD") {
+        config.mqtt_password = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_BATTERY_REPORT_INTERVAL_SECONDS") {
+        config.battery_report_interval_seconds = value.parse().with_context(|| {
+            format!("parse YOYOPOD_CLOUD_BATTERY_REPORT_INTERVAL_SECONDS={value}")
+        })?;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_DEVICE_ID") {
+        config.device_id = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_CLOUD_DEVICE_SECRET") {
+        config.device_secret = value;
+    }
+    Ok(())
+}
+
+fn load_yaml_mapping(path: &Path) -> Result<Mapping> {
+    if !path.exists() {
+        return Ok(Mapping::new());
+    }
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let value: Value =
+        serde_yaml::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
+    Ok(match value {
+        Value::Mapping(mapping) => mapping,
+        _ => Mapping::new(),
+    })
+}
+
+fn nested_mapping<'a>(mapping: &'a Mapping, key: &str) -> Option<&'a Mapping> {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(Value::as_mapping)
+}
+
+fn string_key(mapping: &Mapping, key: &str, default: &str) -> String {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(default)
+        .to_string()
+}
+
+fn u64_key(mapping: &Mapping, key: &str, default: u64) -> u64 {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(|value| {
+            value
+                .as_u64()
+                .or_else(|| value.as_str()?.trim().parse::<u64>().ok())
+        })
+        .unwrap_or(default)
+}
+
+fn u16_key(mapping: &Mapping, key: &str, default: u16) -> u16 {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(|value| {
+            value
+                .as_u64()
+                .and_then(|value| u16::try_from(value).ok())
+                .or_else(|| value.as_str()?.trim().parse::<u16>().ok())
+        })
+        .unwrap_or(default)
+}
+
+fn f64_key(mapping: &Mapping, key: &str, default: f64) -> f64 {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse::<f64>().ok())
+        })
+        .unwrap_or(default)
+}
+
+fn bool_key(mapping: &Mapping, key: &str, default: bool) -> bool {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(|value| {
+            value
+                .as_bool()
+                .or_else(|| parse_bool(key, value.as_str()?).ok())
+        })
+        .unwrap_or(default)
+}
+
+fn env_string(name: &str) -> Option<String> {
+    let value = env::var(name).ok()?;
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn parse_bool(name: &str, value: &str) -> Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => anyhow::bail!("invalid boolean for {name}: {value}"),
+    }
+}
+
+fn resolve_secrets_path(config_dir: &Path) -> PathBuf {
+    let local = config_dir.join(CLOUD_SECRETS_CONFIG);
+    if local.exists() {
+        local
+    } else {
+        PathBuf::from(SYSTEM_CLOUD_SECRETS_FILE)
+    }
+}
+
+fn runtime_root_for_config_dir(config_dir: &Path) -> PathBuf {
+    let config_dir = if config_dir.is_absolute() {
+        config_dir.to_path_buf()
+    } else {
+        env::current_dir()
+            .map(|cwd| cwd.join(config_dir))
+            .unwrap_or_else(|_| config_dir.to_path_buf())
+    };
+    config_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or(config_dir)
+}
+
+fn resolve_runtime_path(runtime_root: &str, raw_path: &str) -> PathBuf {
+    let path = Path::new(raw_path);
+    if path.is_absolute() || raw_path.starts_with('/') {
+        path.to_path_buf()
+    } else {
+        Path::new(runtime_root).join(path)
+    }
+}

--- a/yoyopod_rs/cloud-host/src/host.rs
+++ b/yoyopod_rs/cloud-host/src/host.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -7,14 +7,24 @@ use crate::config::CloudHostConfig;
 use crate::mqtt::{CloudMqttBackend, MqttRuntimeEvent};
 use crate::snapshot::{current_epoch_seconds, current_millis, persist_status, CloudStatusSnapshot};
 
+const MAX_PENDING_PUBLISHES: usize = 32;
+
 pub struct CloudHost<B: CloudMqttBackend> {
     config_dir: String,
     config: CloudHostConfig,
     mqtt: B,
     snapshot: CloudStatusSnapshot,
+    pending_publishes: VecDeque<PendingPublish>,
+    mqtt_started: bool,
     last_telemetry_payloads: BTreeMap<String, Value>,
     last_connectivity_type: Option<String>,
     next_battery_report_at_ms: u64,
+}
+
+struct PendingPublish {
+    topic: String,
+    payload: String,
+    qos: u8,
 }
 
 impl<B: CloudMqttBackend> CloudHost<B> {
@@ -25,6 +35,8 @@ impl<B: CloudMqttBackend> CloudHost<B> {
             config,
             mqtt,
             snapshot,
+            pending_publishes: VecDeque::new(),
+            mqtt_started: false,
             last_telemetry_payloads: BTreeMap::new(),
             last_connectivity_type: None,
             next_battery_report_at_ms: 0,
@@ -68,12 +80,14 @@ impl<B: CloudMqttBackend> CloudHost<B> {
             self.snapshot.mark_degraded(error.to_string());
             self.persist_status();
         })?;
+        self.mqtt_started = true;
         self.persist_status();
         Ok(())
     }
 
     pub fn stop(&mut self) {
         self.mqtt.stop();
+        self.mqtt_started = false;
         self.snapshot.mark_disconnected("stopped");
         self.persist_status();
     }
@@ -84,6 +98,12 @@ impl<B: CloudMqttBackend> CloudHost<B> {
             match event {
                 MqttRuntimeEvent::Connected => {
                     self.snapshot.mark_connected();
+                    if let Err(error) = self.flush_pending_publishes() {
+                        let message = error.to_string();
+                        self.snapshot.mark_degraded(message.clone());
+                        self.persist_status();
+                        events.push(CloudRuntimeEvent::Error(message));
+                    }
                     self.persist_status();
                     events.push(CloudRuntimeEvent::Snapshot(self.snapshot.clone()));
                 }
@@ -176,17 +196,13 @@ impl<B: CloudMqttBackend> CloudHost<B> {
     }
 
     pub fn publish_device_event(&mut self, event_type: &str, payload: Value) -> Result<bool> {
-        if !self.snapshot.mqtt_connected && !self.mqtt.is_connected() {
-            return Ok(false);
-        }
         let topic = self.config.device_event_topic();
         let message = json!({
             "type": event_type,
             "payload": payload,
             "ts": current_epoch_seconds(),
         });
-        self.mqtt
-            .publish(&topic, &serde_json::to_string(&message)?, 1)
+        self.publish_or_queue(&topic, serde_json::to_string(&message)?, 1)
             .with_context(|| format!("publish cloud event {event_type}"))
     }
 
@@ -196,9 +212,6 @@ impl<B: CloudMqttBackend> CloudHost<B> {
         payload: Value,
         qos: u8,
     ) -> Result<bool> {
-        if !self.snapshot.mqtt_connected && !self.mqtt.is_connected() {
-            return Ok(false);
-        }
         let topic_suffix = topic_suffix.trim().trim_matches('/');
         if topic_suffix.is_empty() {
             return Ok(false);
@@ -213,7 +226,7 @@ impl<B: CloudMqttBackend> CloudHost<B> {
         }
         let topic = format!("yoyopod/telemetry/{topic_suffix}");
         let encoded = serde_json::to_string(&payload)?;
-        let published = self.mqtt.publish(&topic, &encoded, qos)?;
+        let published = self.publish_or_queue(&topic, encoded, qos)?;
         if published {
             self.last_telemetry_payloads.insert(key, payload);
         }
@@ -227,9 +240,6 @@ impl<B: CloudMqttBackend> CloudHost<B> {
         reason: Option<&str>,
         payload: Value,
     ) -> Result<bool> {
-        if !self.snapshot.mqtt_connected && !self.mqtt.is_connected() {
-            return Ok(false);
-        }
         let command_id = command_id.trim();
         if command_id.is_empty() {
             return Ok(false);
@@ -242,17 +252,54 @@ impl<B: CloudMqttBackend> CloudHost<B> {
         if let Some(reason) = reason.filter(|value| !value.trim().is_empty()) {
             message["reason"] = json!(reason);
         }
-        self.mqtt
-            .publish(
-                &self.config.device_ack_topic(),
-                &serde_json::to_string(&message)?,
-                1,
-            )
-            .with_context(|| format!("publish cloud ack {command_id}"))
+        self.publish_or_queue(
+            &self.config.device_ack_topic(),
+            serde_json::to_string(&message)?,
+            1,
+        )
+        .with_context(|| format!("publish cloud ack {command_id}"))
     }
 
     pub fn persist_status(&self) {
         persist_status(&self.config, &self.snapshot);
+    }
+
+    fn publish_or_queue(&mut self, topic: &str, payload: String, qos: u8) -> Result<bool> {
+        if self.snapshot.mqtt_connected || self.mqtt.is_connected() {
+            return self.mqtt.publish(topic, &payload, qos);
+        }
+        if !self.mqtt_started || !self.config.provisioned() || !self.config.mqtt_configured() {
+            return Ok(false);
+        }
+        if self.pending_publishes.len() == MAX_PENDING_PUBLISHES {
+            let _ = self.pending_publishes.pop_front();
+        }
+        self.pending_publishes.push_back(PendingPublish {
+            topic: topic.to_string(),
+            payload,
+            qos,
+        });
+        Ok(true)
+    }
+
+    fn flush_pending_publishes(&mut self) -> Result<()> {
+        while let Some(pending) = self.pending_publishes.pop_front() {
+            match self
+                .mqtt
+                .publish(&pending.topic, &pending.payload, pending.qos)
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    self.pending_publishes.push_front(pending);
+                    break;
+                }
+                Err(error) => {
+                    self.pending_publishes.push_front(pending);
+                    return Err(error);
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/yoyopod_rs/cloud-host/src/host.rs
+++ b/yoyopod_rs/cloud-host/src/host.rs
@@ -1,0 +1,274 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+
+use crate::config::CloudHostConfig;
+use crate::mqtt::{CloudMqttBackend, MqttRuntimeEvent};
+use crate::snapshot::{current_epoch_seconds, current_millis, persist_status, CloudStatusSnapshot};
+
+pub struct CloudHost<B: CloudMqttBackend> {
+    config_dir: String,
+    config: CloudHostConfig,
+    mqtt: B,
+    snapshot: CloudStatusSnapshot,
+    last_telemetry_payloads: BTreeMap<String, Value>,
+    last_connectivity_type: Option<String>,
+    next_battery_report_at_ms: u64,
+}
+
+impl<B: CloudMqttBackend> CloudHost<B> {
+    pub fn new(config_dir: impl Into<String>, config: CloudHostConfig, mqtt: B) -> Self {
+        let snapshot = CloudStatusSnapshot::from_config(&config);
+        Self {
+            config_dir: config_dir.into(),
+            config,
+            mqtt,
+            snapshot,
+            last_telemetry_payloads: BTreeMap::new(),
+            last_connectivity_type: None,
+            next_battery_report_at_ms: 0,
+        }
+    }
+
+    pub fn config_dir(&self) -> &str {
+        &self.config_dir
+    }
+
+    pub fn snapshot(&self) -> &CloudStatusSnapshot {
+        &self.snapshot
+    }
+
+    pub fn mark_config_load_failed(&mut self, error: impl Into<String>) {
+        self.snapshot.mark_config_load_failed(error);
+        self.persist_status();
+    }
+
+    pub fn start(&mut self) -> Result<()> {
+        if self.snapshot.provisioning_state == "invalid_provisioning" {
+            self.persist_status();
+            return Ok(());
+        }
+        if !self.config.provisioned() {
+            self.snapshot.provisioning_state = "unprovisioned".to_string();
+            self.snapshot.cloud_state = "offline".to_string();
+            self.persist_status();
+            return Ok(());
+        }
+        self.snapshot.provisioning_state = "provisioned".to_string();
+        if !self.config.mqtt_configured() {
+            self.snapshot.cloud_state = "offline".to_string();
+            self.snapshot.last_error_summary = "MQTT broker host not configured".to_string();
+            self.persist_status();
+            return Ok(());
+        }
+
+        self.snapshot.mark_connecting();
+        self.mqtt.start(&self.config).inspect_err(|error| {
+            self.snapshot.mark_degraded(error.to_string());
+            self.persist_status();
+        })?;
+        self.persist_status();
+        Ok(())
+    }
+
+    pub fn stop(&mut self) {
+        self.mqtt.stop();
+        self.snapshot.mark_disconnected("stopped");
+        self.persist_status();
+    }
+
+    pub fn drain_runtime_events(&mut self) -> Vec<CloudRuntimeEvent> {
+        let mut events = Vec::new();
+        for event in self.mqtt.drain_events() {
+            match event {
+                MqttRuntimeEvent::Connected => {
+                    self.snapshot.mark_connected();
+                    self.persist_status();
+                    events.push(CloudRuntimeEvent::Snapshot(self.snapshot.clone()));
+                }
+                MqttRuntimeEvent::Disconnected(reason) => {
+                    self.snapshot.mark_disconnected(reason);
+                    self.persist_status();
+                    events.push(CloudRuntimeEvent::Snapshot(self.snapshot.clone()));
+                }
+                MqttRuntimeEvent::Command(command) => {
+                    self.snapshot
+                        .mark_command(command_type(&command).unwrap_or_default());
+                    self.persist_status();
+                    events.push(CloudRuntimeEvent::Command(command));
+                    events.push(CloudRuntimeEvent::Snapshot(self.snapshot.clone()));
+                }
+                MqttRuntimeEvent::Error(message) => {
+                    self.snapshot.mark_degraded(message.clone());
+                    self.persist_status();
+                    events.push(CloudRuntimeEvent::Error(message));
+                    events.push(CloudRuntimeEvent::Snapshot(self.snapshot.clone()));
+                }
+            }
+        }
+        if self.mqtt.is_connected() && !self.snapshot.mqtt_connected {
+            self.snapshot.mark_connected();
+            self.persist_status();
+            events.push(CloudRuntimeEvent::Snapshot(self.snapshot.clone()));
+        }
+        events
+    }
+
+    pub fn health_payload(&self) -> Value {
+        json!({ "snapshot": self.snapshot })
+    }
+
+    pub fn publish_heartbeat(&mut self, firmware_version: Option<&str>) -> Result<bool> {
+        let mut payload = json!({});
+        if let Some(firmware_version) = firmware_version.filter(|value| !value.trim().is_empty()) {
+            payload["firmware_version"] = json!(firmware_version);
+        }
+        self.publish_device_event("heartbeat", payload)
+    }
+
+    pub fn publish_battery(&mut self, level: i64, charging: bool) -> Result<bool> {
+        let now = current_millis();
+        if now < self.next_battery_report_at_ms {
+            return Ok(false);
+        }
+        let level = level.clamp(0, 100);
+        let published = self.publish_device_event(
+            "battery",
+            json!({
+                "level": level,
+                "charging": charging,
+            }),
+        )?;
+        if published {
+            self.next_battery_report_at_ms =
+                now + self.config.battery_report_interval_seconds.max(1) * 1000;
+        }
+        Ok(published)
+    }
+
+    pub fn publish_connectivity(&mut self, connection_type: &str) -> Result<bool> {
+        let connection_type = connection_type.trim();
+        if connection_type.is_empty() {
+            return Ok(false);
+        }
+        if self
+            .last_connectivity_type
+            .as_deref()
+            .is_some_and(|last| last == connection_type)
+        {
+            return Ok(false);
+        }
+        let published = self.publish_device_event(
+            "connectivity",
+            json!({
+                "type": connection_type,
+            }),
+        )?;
+        if published {
+            self.last_connectivity_type = Some(connection_type.to_string());
+        }
+        Ok(published)
+    }
+
+    pub fn publish_playback_event(&mut self, payload: Value) -> Result<bool> {
+        self.publish_device_event("playback", payload)
+    }
+
+    pub fn publish_device_event(&mut self, event_type: &str, payload: Value) -> Result<bool> {
+        if !self.snapshot.mqtt_connected && !self.mqtt.is_connected() {
+            return Ok(false);
+        }
+        let topic = self.config.device_event_topic();
+        let message = json!({
+            "type": event_type,
+            "payload": payload,
+            "ts": current_epoch_seconds(),
+        });
+        self.mqtt
+            .publish(&topic, &serde_json::to_string(&message)?, 1)
+            .with_context(|| format!("publish cloud event {event_type}"))
+    }
+
+    pub fn publish_telemetry(
+        &mut self,
+        topic_suffix: &str,
+        payload: Value,
+        qos: u8,
+    ) -> Result<bool> {
+        if !self.snapshot.mqtt_connected && !self.mqtt.is_connected() {
+            return Ok(false);
+        }
+        let topic_suffix = topic_suffix.trim().trim_matches('/');
+        if topic_suffix.is_empty() {
+            return Ok(false);
+        }
+        let key = format!("telemetry/{topic_suffix}");
+        if self
+            .last_telemetry_payloads
+            .get(&key)
+            .is_some_and(|last| last == &payload)
+        {
+            return Ok(false);
+        }
+        let topic = format!("yoyopod/telemetry/{topic_suffix}");
+        let encoded = serde_json::to_string(&payload)?;
+        let published = self.mqtt.publish(&topic, &encoded, qos)?;
+        if published {
+            self.last_telemetry_payloads.insert(key, payload);
+        }
+        Ok(published)
+    }
+
+    pub fn publish_ack(
+        &mut self,
+        command_id: &str,
+        ok: bool,
+        reason: Option<&str>,
+        payload: Value,
+    ) -> Result<bool> {
+        if !self.snapshot.mqtt_connected && !self.mqtt.is_connected() {
+            return Ok(false);
+        }
+        let command_id = command_id.trim();
+        if command_id.is_empty() {
+            return Ok(false);
+        }
+        let mut message = json!({
+            "command_id": command_id,
+            "status": if ok { "ack" } else { "nack" },
+            "payload": payload,
+        });
+        if let Some(reason) = reason.filter(|value| !value.trim().is_empty()) {
+            message["reason"] = json!(reason);
+        }
+        self.mqtt
+            .publish(
+                &self.config.device_ack_topic(),
+                &serde_json::to_string(&message)?,
+                1,
+            )
+            .with_context(|| format!("publish cloud ack {command_id}"))
+    }
+
+    pub fn persist_status(&self) {
+        persist_status(&self.config, &self.snapshot);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CloudRuntimeEvent {
+    Snapshot(CloudStatusSnapshot),
+    Command(Value),
+    Error(String),
+}
+
+fn command_type(command: &Value) -> Option<String> {
+    command
+        .get("command")
+        .or_else(|| command.get("type"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}

--- a/yoyopod_rs/cloud-host/src/lib.rs
+++ b/yoyopod_rs/cloud-host/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod config;
+pub mod host;
+pub mod mqtt;
+pub mod protocol;
+pub mod snapshot;
+pub mod worker;

--- a/yoyopod_rs/cloud-host/src/main.rs
+++ b/yoyopod_rs/cloud-host/src/main.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[command(name = "yoyopod-cloud-host")]
+#[command(about = "YoYoPod Rust Cloud Host")]
+struct Args {
+    #[arg(long, default_value = "config")]
+    config_dir: String,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    yoyopod_cloud_host::worker::run(&args.config_dir)
+}

--- a/yoyopod_rs/cloud-host/src/mqtt.rs
+++ b/yoyopod_rs/cloud-host/src/mqtt.rs
@@ -1,0 +1,198 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use rumqttc::{Client, Event, Incoming, MqttOptions, QoS, Transport};
+use serde_json::Value;
+
+use crate::config::CloudHostConfig;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MqttRuntimeEvent {
+    Connected,
+    Disconnected(String),
+    Command(Value),
+    Error(String),
+}
+
+pub trait CloudMqttBackend {
+    fn start(&mut self, config: &CloudHostConfig) -> Result<()>;
+    fn stop(&mut self);
+    fn is_connected(&self) -> bool;
+    fn publish(&mut self, topic: &str, payload: &str, qos: u8) -> Result<bool>;
+    fn drain_events(&mut self) -> Vec<MqttRuntimeEvent>;
+}
+
+#[derive(Default)]
+pub struct DisabledMqttBackend;
+
+impl CloudMqttBackend for DisabledMqttBackend {
+    fn start(&mut self, _config: &CloudHostConfig) -> Result<()> {
+        Ok(())
+    }
+
+    fn stop(&mut self) {}
+
+    fn is_connected(&self) -> bool {
+        false
+    }
+
+    fn publish(&mut self, _topic: &str, _payload: &str, _qos: u8) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn drain_events(&mut self) -> Vec<MqttRuntimeEvent> {
+        Vec::new()
+    }
+}
+
+#[derive(Default)]
+pub struct RumqttBackend {
+    client: Option<Client>,
+    connected: Arc<AtomicBool>,
+    events: Option<Receiver<MqttRuntimeEvent>>,
+}
+
+impl CloudMqttBackend for RumqttBackend {
+    fn start(&mut self, config: &CloudHostConfig) -> Result<()> {
+        self.stop();
+        let mut options = mqtt_options(config)?;
+        options.set_keep_alive(Duration::from_secs(60));
+        options.set_clean_session(true);
+        if !config.mqtt_username.trim().is_empty() {
+            options.set_credentials(config.mqtt_username.clone(), config.mqtt_password.clone());
+        }
+
+        let (client, mut connection) = Client::new(options, 16);
+        client
+            .subscribe(config.device_command_topic(), QoS::AtLeastOnce)
+            .context("subscribe cloud command topic")?;
+
+        let (tx, rx) = mpsc::channel();
+        let connected = Arc::new(AtomicBool::new(false));
+        let connected_for_thread = Arc::clone(&connected);
+        thread::spawn(move || {
+            for notification in connection.iter() {
+                match notification {
+                    Ok(Event::Incoming(Incoming::ConnAck(_))) => {
+                        connected_for_thread.store(true, Ordering::SeqCst);
+                        let _ = tx.send(MqttRuntimeEvent::Connected);
+                    }
+                    Ok(Event::Incoming(Incoming::Disconnect)) => {
+                        connected_for_thread.store(false, Ordering::SeqCst);
+                        let _ = tx.send(MqttRuntimeEvent::Disconnected("broker disconnect".into()));
+                    }
+                    Ok(Event::Incoming(Incoming::Publish(publish))) => {
+                        match serde_json::from_slice::<Value>(&publish.payload) {
+                            Ok(payload) => {
+                                let _ = tx.send(MqttRuntimeEvent::Command(payload));
+                            }
+                            Err(error) => {
+                                let _ = tx.send(MqttRuntimeEvent::Error(format!(
+                                    "invalid MQTT command payload: {error}"
+                                )));
+                            }
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        connected_for_thread.store(false, Ordering::SeqCst);
+                        let _ = tx.send(MqttRuntimeEvent::Disconnected(error.to_string()));
+                    }
+                }
+            }
+        });
+
+        self.client = Some(client);
+        self.connected = connected;
+        self.events = Some(rx);
+        Ok(())
+    }
+
+    fn stop(&mut self) {
+        self.connected.store(false, Ordering::SeqCst);
+        if let Some(client) = &self.client {
+            let _ = client.disconnect();
+        }
+        self.client = None;
+        self.events = None;
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected.load(Ordering::SeqCst)
+    }
+
+    fn publish(&mut self, topic: &str, payload: &str, qos: u8) -> Result<bool> {
+        let Some(client) = &self.client else {
+            return Ok(false);
+        };
+        client
+            .publish(topic, qos_from_u8(qos), false, payload.as_bytes())
+            .with_context(|| format!("publish MQTT topic {topic}"))?;
+        Ok(true)
+    }
+
+    fn drain_events(&mut self) -> Vec<MqttRuntimeEvent> {
+        let Some(rx) = &self.events else {
+            return Vec::new();
+        };
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+        events
+    }
+}
+
+fn mqtt_options(config: &CloudHostConfig) -> Result<MqttOptions> {
+    let client_id = format!("yoyopod-{}", config.device_id.trim());
+    let transport = config.mqtt_transport.trim().to_ascii_lowercase();
+    let mut options = if matches!(
+        transport.as_str(),
+        "websocket" | "websockets" | "ws" | "wss"
+    ) {
+        let broker_url = websocket_broker_url(config);
+        MqttOptions::new(client_id, broker_url, config.mqtt_broker_port)
+    } else {
+        MqttOptions::new(
+            client_id,
+            config.mqtt_broker_host.trim(),
+            config.mqtt_broker_port,
+        )
+    };
+
+    if matches!(
+        transport.as_str(),
+        "websocket" | "websockets" | "ws" | "wss"
+    ) {
+        if config.mqtt_use_tls || transport == "wss" {
+            options.set_transport(Transport::wss_with_default_config());
+        } else {
+            options.set_transport(Transport::ws());
+        }
+    } else if config.mqtt_use_tls {
+        options.set_transport(Transport::tls_with_default_config());
+    }
+
+    Ok(options)
+}
+
+fn websocket_broker_url(config: &CloudHostConfig) -> String {
+    let host = config.mqtt_broker_host.trim();
+    if host.starts_with("ws://") || host.starts_with("wss://") {
+        return host.to_string();
+    }
+    let scheme = if config.mqtt_use_tls { "wss" } else { "ws" };
+    format!("{scheme}://{host}:{}/mqtt", config.mqtt_broker_port)
+}
+
+fn qos_from_u8(qos: u8) -> QoS {
+    match qos {
+        0 => QoS::AtMostOnce,
+        2 => QoS::ExactlyOnce,
+        _ => QoS::AtLeastOnce,
+    }
+}

--- a/yoyopod_rs/cloud-host/src/protocol.rs
+++ b/yoyopod_rs/cloud-host/src/protocol.rs
@@ -1,0 +1,188 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use thiserror::Error;
+
+use crate::snapshot::CloudStatusSnapshot;
+
+pub const SUPPORTED_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvelopeKind {
+    Command,
+    Event,
+    Result,
+    Error,
+    Heartbeat,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkerEnvelope {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u16,
+    pub kind: EnvelopeKind,
+    #[serde(rename = "type")]
+    pub message_type: String,
+    #[serde(default)]
+    pub request_id: Option<String>,
+    #[serde(default)]
+    pub timestamp_ms: u64,
+    #[serde(default)]
+    pub deadline_ms: u64,
+    #[serde(default = "empty_payload")]
+    pub payload: Value,
+}
+
+#[derive(Debug, Error)]
+pub enum ProtocolError {
+    #[error("invalid JSON worker envelope: {0}")]
+    InvalidJson(#[from] serde_json::Error),
+    #[error("unsupported schema_version {actual}; expected {expected}")]
+    UnsupportedSchema { actual: u16, expected: u16 },
+    #[error("invalid worker envelope: {0}")]
+    InvalidEnvelope(String),
+}
+
+fn default_schema_version() -> u16 {
+    SUPPORTED_SCHEMA_VERSION
+}
+
+fn empty_payload() -> Value {
+    json!({})
+}
+
+impl WorkerEnvelope {
+    pub fn decode(line: &[u8]) -> Result<Self, ProtocolError> {
+        let envelope: WorkerEnvelope = serde_json::from_slice(line)?;
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, ProtocolError> {
+        self.validate()?;
+        let mut encoded = serde_json::to_vec(self)?;
+        encoded.push(b'\n');
+        Ok(encoded)
+    }
+
+    pub fn event(message_type: impl Into<String>, payload: Value) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Event,
+            message_type: message_type.into(),
+            request_id: None,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload,
+        }
+    }
+
+    pub fn result(
+        message_type: impl Into<String>,
+        request_id: Option<String>,
+        payload: Value,
+    ) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Result,
+            message_type: message_type.into(),
+            request_id,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload,
+        }
+    }
+
+    pub fn error(
+        message_type: impl Into<String>,
+        request_id: Option<String>,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Error,
+            message_type: message_type.into(),
+            request_id,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload: json!({
+                "code": code.into(),
+                "message": message.into(),
+            }),
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), ProtocolError> {
+        if self.schema_version != SUPPORTED_SCHEMA_VERSION {
+            return Err(ProtocolError::UnsupportedSchema {
+                actual: self.schema_version,
+                expected: SUPPORTED_SCHEMA_VERSION,
+            });
+        }
+        if self.message_type.trim().is_empty() {
+            return Err(ProtocolError::InvalidEnvelope(
+                "type must be a non-empty string".to_string(),
+            ));
+        }
+        if !self.payload.is_object() {
+            return Err(ProtocolError::InvalidEnvelope(
+                "payload must be an object".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub fn ready_event(config_dir: &str) -> WorkerEnvelope {
+    WorkerEnvelope::event(
+        "cloud.ready",
+        json!({
+            "config_dir": config_dir,
+            "capabilities": [
+                "mqtt",
+                "telemetry",
+                "heartbeat",
+                "battery",
+                "connectivity",
+                "ack",
+                "command_subscribe"
+            ],
+        }),
+    )
+}
+
+pub fn snapshot_event(snapshot: &CloudStatusSnapshot) -> WorkerEnvelope {
+    WorkerEnvelope::event(
+        "cloud.snapshot",
+        serde_json::to_value(snapshot).expect("cloud snapshot should serialize"),
+    )
+}
+
+pub fn snapshot_result(
+    request_id: Option<String>,
+    snapshot: &CloudStatusSnapshot,
+) -> WorkerEnvelope {
+    WorkerEnvelope::result(
+        "cloud.health",
+        request_id,
+        json!({
+            "snapshot": snapshot,
+        }),
+    )
+}
+
+pub fn stopped_event(reason: &str) -> WorkerEnvelope {
+    WorkerEnvelope::event("cloud.stopped", json!({ "reason": reason }))
+}
+
+pub fn stopped_result(request_id: Option<String>, reason: &str) -> WorkerEnvelope {
+    WorkerEnvelope::result(
+        "cloud.stopped",
+        request_id,
+        json!({
+            "shutdown": true,
+            "reason": reason,
+        }),
+    )
+}

--- a/yoyopod_rs/cloud-host/src/snapshot.rs
+++ b/yoyopod_rs/cloud-host/src/snapshot.rs
@@ -1,0 +1,134 @@
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::CloudHostConfig;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CloudStatusSnapshot {
+    pub device_id: String,
+    pub provisioning_state: String,
+    pub cloud_state: String,
+    pub mqtt_connected: bool,
+    pub mqtt_broker_host: String,
+    pub mqtt_broker_port: u16,
+    pub mqtt_transport: String,
+    pub config_source: String,
+    pub config_version: u64,
+    pub backend_reachable: Option<bool>,
+    pub last_successful_sync: Option<String>,
+    pub last_error_summary: String,
+    pub unapplied_keys: Vec<String>,
+    pub last_command_type: String,
+    pub updated_at_ms: u64,
+}
+
+impl CloudStatusSnapshot {
+    pub fn from_config(config: &CloudHostConfig) -> Self {
+        let provisioning_state = if !config.secrets_error.trim().is_empty() {
+            "invalid_provisioning"
+        } else if config.device_id.trim().is_empty() && config.device_secret.trim().is_empty() {
+            "unprovisioned"
+        } else if config.device_id.trim().is_empty() || config.device_secret.trim().is_empty() {
+            "invalid_provisioning"
+        } else {
+            "provisioned"
+        };
+        let cloud_state = if provisioning_state == "invalid_provisioning" {
+            "degraded"
+        } else {
+            "offline"
+        };
+        let last_error_summary = if provisioning_state == "invalid_provisioning" {
+            config.secrets_error.clone()
+        } else {
+            String::new()
+        };
+
+        Self {
+            device_id: config.device_id.trim().to_string(),
+            provisioning_state: provisioning_state.to_string(),
+            cloud_state: cloud_state.to_string(),
+            mqtt_connected: false,
+            mqtt_broker_host: config.mqtt_broker_host.clone(),
+            mqtt_broker_port: config.mqtt_broker_port,
+            mqtt_transport: config.mqtt_transport.clone(),
+            config_source: "none".to_string(),
+            config_version: 0,
+            backend_reachable: None,
+            last_successful_sync: None,
+            last_error_summary,
+            unapplied_keys: Vec::new(),
+            last_command_type: String::new(),
+            updated_at_ms: current_millis(),
+        }
+    }
+
+    pub fn mark_config_load_failed(&mut self, error: impl Into<String>) {
+        self.provisioning_state = "invalid_provisioning".to_string();
+        self.cloud_state = "degraded".to_string();
+        self.last_error_summary = error.into();
+        self.refresh_timestamp();
+    }
+
+    pub fn mark_connecting(&mut self) {
+        self.cloud_state = "connecting".to_string();
+        self.last_error_summary.clear();
+        self.refresh_timestamp();
+    }
+
+    pub fn mark_connected(&mut self) {
+        self.mqtt_connected = true;
+        self.cloud_state = "ready".to_string();
+        self.last_error_summary.clear();
+        self.refresh_timestamp();
+    }
+
+    pub fn mark_disconnected(&mut self, reason: impl Into<String>) {
+        self.mqtt_connected = false;
+        self.cloud_state = "offline".to_string();
+        self.last_error_summary = reason.into();
+        self.refresh_timestamp();
+    }
+
+    pub fn mark_degraded(&mut self, reason: impl Into<String>) {
+        self.mqtt_connected = false;
+        self.cloud_state = "degraded".to_string();
+        self.last_error_summary = reason.into();
+        self.refresh_timestamp();
+    }
+
+    pub fn mark_command(&mut self, command_type: impl Into<String>) {
+        self.last_command_type = command_type.into();
+        self.refresh_timestamp();
+    }
+
+    pub fn refresh_timestamp(&mut self) {
+        self.updated_at_ms = current_millis();
+    }
+}
+
+pub fn persist_status(config: &CloudHostConfig, snapshot: &CloudStatusSnapshot) {
+    let path = config.status_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    if let Ok(payload) = serde_json::to_string_pretty(snapshot) {
+        let _ = fs::write(path, payload);
+    }
+}
+
+pub fn current_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default()
+}
+
+pub fn current_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
+}

--- a/yoyopod_rs/cloud-host/src/worker.rs
+++ b/yoyopod_rs/cloud-host/src/worker.rs
@@ -65,11 +65,27 @@ where
     W: Write,
     B: CloudMqttBackend,
 {
-    emit(output, &ready_event(host.config_dir()))?;
-    if let Err(error) = host.start() {
+    let started = match host.start() {
+        Ok(()) => true,
+        Err(error) => {
+            emit(
+                output,
+                &WorkerEnvelope::error("cloud.error", None, "startup_failed", error.to_string()),
+            )?;
+            false
+        }
+    };
+    if started {
+        emit(output, &ready_event(host.config_dir()))?;
+    } else {
         emit(
             output,
-            &WorkerEnvelope::error("cloud.error", None, "startup_failed", error.to_string()),
+            &WorkerEnvelope::error(
+                "cloud.error",
+                None,
+                "not_ready",
+                "cloud MQTT startup failed before ready",
+            ),
         )?;
     }
     emit(output, &snapshot_event(host.snapshot()))?;

--- a/yoyopod_rs/cloud-host/src/worker.rs
+++ b/yoyopod_rs/cloud-host/src/worker.rs
@@ -1,0 +1,325 @@
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+
+use crate::config::CloudHostConfig;
+use crate::host::{CloudHost, CloudRuntimeEvent};
+use crate::mqtt::{CloudMqttBackend, RumqttBackend};
+use crate::protocol::{
+    ready_event, snapshot_event, snapshot_result, stopped_event, stopped_result, EnvelopeKind,
+    WorkerEnvelope,
+};
+
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+pub fn run(config_dir: &str) -> Result<()> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+    run_with_backend(config_dir, stdin, &mut stdout, RumqttBackend::default())
+}
+
+pub fn run_with_io<R, W>(config_dir: &str, input: R, output: &mut W) -> Result<()>
+where
+    R: Read + Send + 'static,
+    W: Write,
+{
+    run_with_backend(config_dir, input, output, RumqttBackend::default())
+}
+
+pub fn run_with_backend<R, W, B>(
+    config_dir: &str,
+    input: R,
+    output: &mut W,
+    backend: B,
+) -> Result<()>
+where
+    R: Read + Send + 'static,
+    W: Write,
+    B: CloudMqttBackend,
+{
+    let (config, load_error) = match CloudHostConfig::load(config_dir) {
+        Ok(config) => (config, None),
+        Err(error) => (
+            CloudHostConfig::default_for_config_dir(config_dir),
+            Some(error.to_string()),
+        ),
+    };
+    let mut host = CloudHost::new(config_dir, config, backend);
+    if let Some(error) = load_error {
+        host.mark_config_load_failed(error);
+    }
+    run_host_loop(host, input, output, DEFAULT_POLL_INTERVAL)
+}
+
+pub fn run_host_loop<R, W, B>(
+    mut host: CloudHost<B>,
+    input: R,
+    output: &mut W,
+    poll_interval: Duration,
+) -> Result<()>
+where
+    R: Read + Send + 'static,
+    W: Write,
+    B: CloudMqttBackend,
+{
+    emit(output, &ready_event(host.config_dir()))?;
+    if let Err(error) = host.start() {
+        emit(
+            output,
+            &WorkerEnvelope::error("cloud.error", None, "startup_failed", error.to_string()),
+        )?;
+    }
+    emit(output, &snapshot_event(host.snapshot()))?;
+
+    let (stdin_tx, stdin_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(input);
+        for line in reader.lines() {
+            if stdin_tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    loop {
+        match stdin_rx.recv_timeout(poll_interval) {
+            Ok(Ok(line)) => {
+                if line.trim().is_empty() {
+                    emit_runtime_events(output, &mut host)?;
+                    continue;
+                }
+                let envelope = match WorkerEnvelope::decode(line.as_bytes()) {
+                    Ok(envelope) => envelope,
+                    Err(error) => {
+                        emit(
+                            output,
+                            &WorkerEnvelope::error(
+                                "cloud.error",
+                                None,
+                                "protocol_error",
+                                error.to_string(),
+                            ),
+                        )?;
+                        continue;
+                    }
+                };
+                if envelope.kind != EnvelopeKind::Command {
+                    emit(
+                        output,
+                        &WorkerEnvelope::error(
+                            "cloud.error",
+                            envelope.request_id,
+                            "invalid_kind",
+                            "cloud worker accepts commands only",
+                        ),
+                    )?;
+                    continue;
+                }
+
+                match handle_command(&mut host, envelope)? {
+                    LoopControl::Continue(envelopes) => {
+                        for envelope in envelopes {
+                            emit(output, &envelope)?;
+                        }
+                        emit_runtime_events(output, &mut host)?;
+                    }
+                    LoopControl::Shutdown(envelopes) => {
+                        for envelope in envelopes {
+                            emit(output, &envelope)?;
+                        }
+                        emit_runtime_events(output, &mut host)?;
+                        emit(output, &stopped_event("shutdown"))?;
+                        break;
+                    }
+                }
+            }
+            Ok(Err(error)) => {
+                host.stop();
+                emit(output, &stopped_event("input_error"))?;
+                return Err(error.into());
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                emit_runtime_events(output, &mut host)?;
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                host.stop();
+                emit(output, &stopped_event("input_closed"))?;
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+enum LoopControl {
+    Continue(Vec<WorkerEnvelope>),
+    Shutdown(Vec<WorkerEnvelope>),
+}
+
+fn handle_command<B: CloudMqttBackend>(
+    host: &mut CloudHost<B>,
+    envelope: WorkerEnvelope,
+) -> Result<LoopControl> {
+    let request_id = envelope.request_id.clone();
+    let result = match envelope.message_type.as_str() {
+        "cloud.health" => snapshot_result(request_id, host.snapshot()),
+        "cloud.publish_heartbeat" => {
+            let firmware_version = string_field(&envelope.payload, "firmware_version");
+            let published = host.publish_heartbeat(firmware_version.as_deref())?;
+            publish_result(envelope.message_type, request_id, published)
+        }
+        "cloud.publish_battery" => {
+            let level = envelope
+                .payload
+                .get("level")
+                .and_then(Value::as_i64)
+                .ok_or_else(|| anyhow!("cloud.publish_battery requires level"))?;
+            let charging = envelope
+                .payload
+                .get("charging")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let published = host.publish_battery(level, charging)?;
+            publish_result(envelope.message_type, request_id, published)
+        }
+        "cloud.publish_connectivity" => {
+            let connection_type = string_field(&envelope.payload, "connection_type")
+                .or_else(|| string_field(&envelope.payload, "type"))
+                .unwrap_or_else(|| "unknown".to_string());
+            let published = host.publish_connectivity(&connection_type)?;
+            publish_result(envelope.message_type, request_id, published)
+        }
+        "cloud.publish_playback_event" => {
+            let payload = envelope
+                .payload
+                .get("payload")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let published = host.publish_playback_event(payload)?;
+            publish_result(envelope.message_type, request_id, published)
+        }
+        "cloud.publish_event" => {
+            let event_type = string_field(&envelope.payload, "event_type")
+                .or_else(|| string_field(&envelope.payload, "type"))
+                .ok_or_else(|| anyhow!("cloud.publish_event requires event_type"))?;
+            let payload = envelope
+                .payload
+                .get("payload")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let published = host.publish_device_event(&event_type, payload)?;
+            publish_result(envelope.message_type, request_id, published)
+        }
+        "cloud.publish_telemetry" => {
+            let topic_suffix = string_field(&envelope.payload, "topic_suffix")
+                .or_else(|| string_field(&envelope.payload, "entity"))
+                .ok_or_else(|| anyhow!("cloud.publish_telemetry requires topic_suffix"))?;
+            let payload = envelope
+                .payload
+                .get("payload")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let qos = envelope
+                .payload
+                .get("qos")
+                .and_then(Value::as_u64)
+                .and_then(|value| u8::try_from(value).ok())
+                .unwrap_or(0);
+            let published = host.publish_telemetry(&topic_suffix, payload, qos)?;
+            publish_result(envelope.message_type, request_id, published)
+        }
+        "cloud.ack" => {
+            let command_id = string_field(&envelope.payload, "command_id")
+                .or_else(|| string_field(&envelope.payload, "commandId"))
+                .ok_or_else(|| anyhow!("cloud.ack requires command_id"))?;
+            let ok = envelope
+                .payload
+                .get("ok")
+                .and_then(Value::as_bool)
+                .unwrap_or(true);
+            let reason = string_field(&envelope.payload, "reason");
+            let payload = envelope
+                .payload
+                .get("payload")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let published = host.publish_ack(&command_id, ok, reason.as_deref(), payload)?;
+            publish_result(envelope.message_type, request_id, published)
+        }
+        "cloud.shutdown" | "worker.stop" => {
+            host.stop();
+            return Ok(LoopControl::Shutdown(vec![stopped_result(
+                request_id, "shutdown",
+            )]));
+        }
+        _ => WorkerEnvelope::error(
+            "cloud.error",
+            request_id,
+            "unsupported_command",
+            format!("unsupported command {}", envelope.message_type),
+        ),
+    };
+
+    Ok(LoopControl::Continue(vec![
+        result,
+        snapshot_event(host.snapshot()),
+    ]))
+}
+
+fn emit_runtime_events<W: Write, B: CloudMqttBackend>(
+    output: &mut W,
+    host: &mut CloudHost<B>,
+) -> Result<()> {
+    for event in host.drain_runtime_events() {
+        match event {
+            CloudRuntimeEvent::Snapshot(snapshot) => emit(output, &snapshot_event(&snapshot))?,
+            CloudRuntimeEvent::Command(command) => emit(
+                output,
+                &WorkerEnvelope::event(
+                    "cloud.command",
+                    json!({
+                        "command": command,
+                    }),
+                ),
+            )?,
+            CloudRuntimeEvent::Error(message) => emit(
+                output,
+                &WorkerEnvelope::error("cloud.error", None, "mqtt_error", message),
+            )?,
+        }
+    }
+    Ok(())
+}
+
+fn publish_result(
+    message_type: String,
+    request_id: Option<String>,
+    published: bool,
+) -> WorkerEnvelope {
+    WorkerEnvelope::result(
+        message_type,
+        request_id,
+        json!({
+            "published": published,
+        }),
+    )
+}
+
+fn emit(output: &mut dyn Write, envelope: &WorkerEnvelope) -> Result<()> {
+    output.write_all(&envelope.encode()?)?;
+    output.flush()?;
+    Ok(())
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}

--- a/yoyopod_rs/cloud-host/tests/config.rs
+++ b/yoyopod_rs/cloud-host/tests/config.rs
@@ -1,0 +1,81 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use yoyopod_cloud_host::config::CloudHostConfig;
+
+#[test]
+fn loads_cloud_backend_and_runtime_secrets() {
+    let dir = temp_dir("cloud-config");
+    write(
+        &dir.join("cloud/backend.yaml"),
+        r#"
+backend:
+  mqtt_broker_host: "mqtt.example.test"
+  mqtt_broker_port: 443
+  mqtt_use_tls: true
+  mqtt_transport: "websockets"
+  mqtt_username: "device-user"
+  mqtt_password: "device-pass"
+  battery_report_interval_seconds: 12
+  status_file: "data/cloud/status.json"
+"#,
+    );
+    write(
+        &dir.join("cloud/device.secrets.yaml"),
+        r#"
+secrets:
+  device_id: "device-123"
+  device_secret: "secret-456"
+"#,
+    );
+
+    let config = CloudHostConfig::load(&dir).expect("load cloud config");
+
+    assert_eq!(config.mqtt_broker_host, "mqtt.example.test");
+    assert_eq!(config.mqtt_broker_port, 443);
+    assert!(config.mqtt_use_tls);
+    assert_eq!(config.mqtt_transport, "websockets");
+    assert_eq!(config.mqtt_username, "device-user");
+    assert_eq!(config.mqtt_password, "device-pass");
+    assert_eq!(config.battery_report_interval_seconds, 12);
+    assert_eq!(config.device_id, "device-123");
+    assert_eq!(config.device_secret, "secret-456");
+    assert!(config.provisioned());
+    assert_eq!(config.device_event_topic(), "yoyopod/device-123/evt");
+    assert_eq!(config.device_ack_topic(), "yoyopod/device-123/ack");
+    assert_eq!(config.device_command_topic(), "yoyopod/device-123/cmd");
+}
+
+#[test]
+fn partial_provisioning_is_marked_invalid() {
+    let dir = temp_dir("partial-secrets");
+    write(
+        &dir.join("cloud/device.secrets.yaml"),
+        r#"
+device_id: "device-only"
+"#,
+    );
+
+    let config = CloudHostConfig::load(&dir).expect("load cloud config");
+
+    assert!(!config.provisioned());
+    assert!(config
+        .secrets_error
+        .contains("both device_id and device_secret"));
+}
+
+fn temp_dir(test_name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("yoyopod-cloud-host-{test_name}-{unique}"))
+}
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir");
+    }
+    fs::write(path, contents).expect("write file");
+}

--- a/yoyopod_rs/cloud-host/tests/worker.rs
+++ b/yoyopod_rs/cloud-host/tests/worker.rs
@@ -87,11 +87,61 @@ fn worker_surfaces_backend_commands_as_cloud_command_events() {
     assert!(output.contains(r#""last_command_type":"fetch_config""#));
 }
 
-#[derive(Default)]
+#[test]
+fn worker_queues_publish_commands_until_mqtt_connected() {
+    let shared = Arc::new(Mutex::new(FakeMqttState {
+        connect_on_start: false,
+        events: vec![MqttRuntimeEvent::Connected],
+        ..FakeMqttState::default()
+    }));
+    let backend = FakeMqttBackend::new(shared.clone());
+    let host = CloudHost::new(
+        "config",
+        provisioned_config("queue-until-connected"),
+        backend,
+    );
+    let input = Cursor::new(format!(
+        "{}{}",
+        command(
+            "cloud.publish_heartbeat",
+            json!({"firmware_version": "test-fw"})
+        ),
+        command("worker.stop", json!({})),
+    ));
+    let mut output = Vec::new();
+
+    run_host_loop(
+        host,
+        input,
+        &mut output,
+        std::time::Duration::from_millis(1),
+    )
+    .expect("worker loop");
+
+    let published = &shared.lock().expect("fake mqtt state").published;
+    assert_eq!(published.len(), 1);
+    assert_eq!(published[0].0, "yoyopod/device-123/evt");
+    let heartbeat: Value = serde_json::from_str(&published[0].1).expect("heartbeat json");
+    assert_eq!(heartbeat["type"], "heartbeat");
+    assert_eq!(heartbeat["payload"]["firmware_version"], "test-fw");
+}
+
 struct FakeMqttState {
     published: Vec<(String, String, u8)>,
     events: Vec<MqttRuntimeEvent>,
     connected: bool,
+    connect_on_start: bool,
+}
+
+impl Default for FakeMqttState {
+    fn default() -> Self {
+        Self {
+            published: Vec::new(),
+            events: Vec::new(),
+            connected: false,
+            connect_on_start: true,
+        }
+    }
 }
 
 struct FakeMqttBackend {
@@ -106,7 +156,8 @@ impl FakeMqttBackend {
 
 impl CloudMqttBackend for FakeMqttBackend {
     fn start(&mut self, _config: &CloudHostConfig) -> Result<()> {
-        self.state.lock().expect("fake state").connected = true;
+        let mut state = self.state.lock().expect("fake state");
+        state.connected = state.connect_on_start;
         Ok(())
     }
 

--- a/yoyopod_rs/cloud-host/tests/worker.rs
+++ b/yoyopod_rs/cloud-host/tests/worker.rs
@@ -1,0 +1,165 @@
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use serde_json::{json, Value};
+use yoyopod_cloud_host::config::CloudHostConfig;
+use yoyopod_cloud_host::host::CloudHost;
+use yoyopod_cloud_host::mqtt::{CloudMqttBackend, MqttRuntimeEvent};
+use yoyopod_cloud_host::protocol::{EnvelopeKind, WorkerEnvelope};
+use yoyopod_cloud_host::worker::run_host_loop;
+
+#[test]
+fn worker_publishes_python_compatible_mqtt_events_and_acks() {
+    let shared = Arc::new(Mutex::new(FakeMqttState::default()));
+    let backend = FakeMqttBackend::new(shared.clone());
+    let host = CloudHost::new("config", provisioned_config("publish-events"), backend);
+    let input = Cursor::new(format!(
+        "{}{}{}",
+        command(
+            "cloud.publish_heartbeat",
+            json!({"firmware_version": "test-fw"})
+        ),
+        command(
+            "cloud.ack",
+            json!({"command_id": "cmd-1", "ok": false, "reason": "invalid_command"})
+        ),
+        command("worker.stop", json!({})),
+    ));
+    let mut output = Vec::new();
+
+    run_host_loop(
+        host,
+        input,
+        &mut output,
+        std::time::Duration::from_millis(1),
+    )
+    .expect("worker loop");
+
+    let published = &shared.lock().expect("fake mqtt state").published;
+    assert_eq!(published.len(), 2);
+    assert_eq!(published[0].0, "yoyopod/device-123/evt");
+    assert_eq!(published[0].2, 1);
+    let heartbeat: Value = serde_json::from_str(&published[0].1).expect("heartbeat json");
+    assert_eq!(heartbeat["type"], "heartbeat");
+    assert_eq!(heartbeat["payload"]["firmware_version"], "test-fw");
+    assert!(heartbeat["ts"].as_u64().is_some());
+
+    assert_eq!(published[1].0, "yoyopod/device-123/ack");
+    let ack: Value = serde_json::from_str(&published[1].1).expect("ack json");
+    assert_eq!(ack["command_id"], "cmd-1");
+    assert_eq!(ack["status"], "nack");
+    assert_eq!(ack["reason"], "invalid_command");
+
+    let output = String::from_utf8(output).expect("worker utf8 output");
+    assert!(output.contains(r#""type":"cloud.ready""#));
+    assert!(output.contains(r#""type":"cloud.snapshot""#));
+    assert!(output.contains(r#""type":"cloud.stopped""#));
+}
+
+#[test]
+fn worker_surfaces_backend_commands_as_cloud_command_events() {
+    let shared = Arc::new(Mutex::new(FakeMqttState {
+        events: vec![MqttRuntimeEvent::Command(json!({
+            "command": "fetch_config",
+            "commandId": "cmd-2"
+        }))],
+        ..FakeMqttState::default()
+    }));
+    let backend = FakeMqttBackend::new(shared);
+    let host = CloudHost::new("config", provisioned_config("backend-commands"), backend);
+    let input = Cursor::new(command("worker.stop", json!({})));
+    let mut output = Vec::new();
+
+    run_host_loop(
+        host,
+        input,
+        &mut output,
+        std::time::Duration::from_millis(1),
+    )
+    .expect("worker loop");
+
+    let output = String::from_utf8(output).expect("worker utf8 output");
+    assert!(output.contains(r#""type":"cloud.command""#));
+    assert!(output.contains(r#""command":"fetch_config""#));
+    assert!(output.contains(r#""last_command_type":"fetch_config""#));
+}
+
+#[derive(Default)]
+struct FakeMqttState {
+    published: Vec<(String, String, u8)>,
+    events: Vec<MqttRuntimeEvent>,
+    connected: bool,
+}
+
+struct FakeMqttBackend {
+    state: Arc<Mutex<FakeMqttState>>,
+}
+
+impl FakeMqttBackend {
+    fn new(state: Arc<Mutex<FakeMqttState>>) -> Self {
+        Self { state }
+    }
+}
+
+impl CloudMqttBackend for FakeMqttBackend {
+    fn start(&mut self, _config: &CloudHostConfig) -> Result<()> {
+        self.state.lock().expect("fake state").connected = true;
+        Ok(())
+    }
+
+    fn stop(&mut self) {
+        self.state.lock().expect("fake state").connected = false;
+    }
+
+    fn is_connected(&self) -> bool {
+        self.state.lock().expect("fake state").connected
+    }
+
+    fn publish(&mut self, topic: &str, payload: &str, qos: u8) -> Result<bool> {
+        self.state.lock().expect("fake state").published.push((
+            topic.to_string(),
+            payload.to_string(),
+            qos,
+        ));
+        Ok(true)
+    }
+
+    fn drain_events(&mut self) -> Vec<MqttRuntimeEvent> {
+        std::mem::take(&mut self.state.lock().expect("fake state").events)
+    }
+}
+
+fn provisioned_config(test_name: &str) -> CloudHostConfig {
+    CloudHostConfig {
+        mqtt_broker_host: "mqtt.example.test".to_string(),
+        mqtt_broker_port: 1883,
+        device_id: "device-123".to_string(),
+        device_secret: "secret-456".to_string(),
+        runtime_root: temp_dir(test_name).to_string_lossy().to_string(),
+        ..CloudHostConfig::default()
+    }
+}
+
+fn temp_dir(test_name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("yoyopod-cloud-host-worker-{test_name}-{unique}"))
+}
+
+fn command(message_type: &str, payload: Value) -> String {
+    let envelope = WorkerEnvelope {
+        schema_version: 1,
+        kind: EnvelopeKind::Command,
+        message_type: message_type.to_string(),
+        request_id: None,
+        timestamp_ms: 0,
+        deadline_ms: 0,
+        payload,
+    };
+    String::from_utf8(envelope.encode().expect("encode command")).expect("utf8 command")
+}

--- a/yoyopod_rs/runtime/src/cli.rs
+++ b/yoyopod_rs/runtime/src/cli.rs
@@ -110,6 +110,32 @@ fn start_workers(
     }
     state.mark_worker(WorkerDomain::Ui, WorkerState::Running, "ready");
 
+    state.mark_worker(WorkerDomain::Cloud, WorkerState::Starting, "starting");
+    if workers.start(WorkerSpec::new(
+        WorkerDomain::Cloud,
+        config.worker_paths.cloud.clone(),
+        [
+            "--config-dir".to_string(),
+            config_dir.to_string_lossy().to_string(),
+        ],
+    )) {
+        if workers.wait_for_ready(WorkerDomain::Cloud, "cloud.ready", Duration::from_secs(3)) {
+            state.mark_worker(WorkerDomain::Cloud, WorkerState::Running, "ready");
+        } else {
+            state.mark_worker(
+                WorkerDomain::Cloud,
+                WorkerState::Degraded,
+                "timed out waiting for cloud.ready",
+            );
+        }
+    } else {
+        state.mark_worker(
+            WorkerDomain::Cloud,
+            WorkerState::Degraded,
+            "failed to start",
+        );
+    }
+
     if workers.start(WorkerSpec::new(
         WorkerDomain::Media,
         config.worker_paths.media.clone(),
@@ -208,6 +234,17 @@ fn send_startup_commands(workers: &mut WorkerSupervisor, config: &RuntimeConfig)
         WorkerDomain::Ui,
         "ui.set_backlight",
         json!({"brightness": config.ui.brightness}),
+    );
+    workers.send_command(WorkerDomain::Cloud, "cloud.health", json!({}));
+    workers.send_command(
+        WorkerDomain::Cloud,
+        "cloud.publish_heartbeat",
+        json!({"firmware_version": env!("CARGO_PKG_VERSION")}),
+    );
+    workers.send_command(
+        WorkerDomain::Cloud,
+        "cloud.publish_battery",
+        json!({"level": 100, "charging": false}),
     );
     workers.send_command(WorkerDomain::Network, "network.health", json!({}));
     workers.send_command(WorkerDomain::Network, "network.query_gps", json!({}));

--- a/yoyopod_rs/runtime/src/config.rs
+++ b/yoyopod_rs/runtime/src/config.rs
@@ -13,6 +13,7 @@ const LINPHONE_HOSTED_FILE_TRANSFER_SERVER_URL: &str = "https://files.linphone.o
 const LINPHONE_HOSTED_LIME_SERVER_URL: &str =
     "https://lime.linphone.org/lime-server/lime-server.php";
 const RUST_UI_HOST_DEFAULT_WORKER: &str = "yoyopod_rs/ui-host/build/yoyopod-ui-host";
+const RUST_CLOUD_HOST_DEFAULT_WORKER: &str = "yoyopod_rs/cloud-host/build/yoyopod-cloud-host";
 const RUST_NETWORK_HOST_DEFAULT_WORKER: &str = "yoyopod_rs/network-host/build/yoyopod-network-host";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -87,6 +88,7 @@ pub struct VoipRuntimeConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkerPaths {
     pub ui: String,
+    pub cloud: String,
     pub media: String,
     pub voip: String,
     pub network: String,
@@ -318,6 +320,10 @@ impl RuntimeConfig {
             },
             worker_paths: WorkerPaths {
                 ui: ui_worker_path(),
+                cloud: env_or_default(
+                    "YOYOPOD_RUST_CLOUD_HOST_WORKER",
+                    RUST_CLOUD_HOST_DEFAULT_WORKER,
+                ),
                 media: env_or_default(
                     "YOYOPOD_RUST_MEDIA_HOST_WORKER",
                     "yoyopod_rs/media-host/build/yoyopod-media-host",

--- a/yoyopod_rs/runtime/src/event.rs
+++ b/yoyopod_rs/runtime/src/event.rs
@@ -42,6 +42,12 @@ pub enum RuntimeCommand {
         domain: WorkerDomain,
         envelope: WorkerEnvelope,
     },
+    WorkerCommandWithAck {
+        domain: WorkerDomain,
+        envelope: WorkerEnvelope,
+        success_ack: WorkerEnvelope,
+        failure_ack: WorkerEnvelope,
+    },
     Shutdown,
 }
 
@@ -574,23 +580,40 @@ fn remote_media_control(
     command_id: Option<String>,
     command_type: &str,
 ) -> Vec<RuntimeCommand> {
-    let mut commands = vec![worker_command(
-        WorkerDomain::Media,
-        media_message_type,
-        empty_payload(),
-    )];
-    if let Some(command_id) = command_id {
-        commands.push(worker_command(
-            WorkerDomain::Cloud,
+    let media_command = WorkerEnvelope::command(media_message_type, None, empty_payload());
+    let Some(command_id) = command_id else {
+        return vec![RuntimeCommand::WorkerCommand {
+            domain: WorkerDomain::Media,
+            envelope: media_command,
+        }];
+    };
+
+    vec![RuntimeCommand::WorkerCommandWithAck {
+        domain: WorkerDomain::Media,
+        envelope: media_command,
+        success_ack: WorkerEnvelope::command(
             "cloud.ack",
+            None,
             json!({
                 "command_id": command_id,
                 "ok": true,
                 "payload": {"command": command_type}
             }),
-        ));
-    }
-    commands
+        ),
+        failure_ack: WorkerEnvelope::command(
+            "cloud.ack",
+            None,
+            json!({
+                "command_id": command_id,
+                "ok": false,
+                "reason": "media_dispatch_failed",
+                "payload": {
+                    "command": command_type,
+                    "media_command": media_message_type
+                }
+            }),
+        ),
+    }]
 }
 
 fn commands_for_media_snapshot(snapshot: &Value) -> Vec<RuntimeCommand> {

--- a/yoyopod_rs/runtime/src/event.rs
+++ b/yoyopod_rs/runtime/src/event.rs
@@ -10,6 +10,8 @@ pub enum RuntimeEvent {
     WorkerReady {
         domain: WorkerDomain,
     },
+    CloudSnapshot(Value),
+    CloudCommand(Value),
     MediaSnapshot(Value),
     VoipSnapshot(Value),
     NetworkSnapshot(Value),
@@ -49,6 +51,8 @@ impl RuntimeEvent {
             Self::WorkerReady { domain } => {
                 state.mark_worker(*domain, WorkerState::Running, "ready");
             }
+            Self::CloudSnapshot(snapshot) => state.apply_cloud_snapshot(snapshot),
+            Self::CloudCommand(_) => {}
             Self::MediaSnapshot(snapshot) => state.apply_media_snapshot(snapshot),
             Self::VoipSnapshot(snapshot) => state.apply_voip_snapshot(snapshot),
             Self::NetworkSnapshot(snapshot) => state.apply_network_snapshot(snapshot),
@@ -108,11 +112,13 @@ pub fn commands_for_event(state: &RuntimeState, event: &RuntimeEvent) -> Vec<Run
             payload,
         } => commands_for_ui_intent(state, domain, action, payload),
         RuntimeEvent::UiInput(payload) => commands_for_ui_input(state, payload),
+        RuntimeEvent::CloudCommand(command) => commands_for_cloud_command(command),
+        RuntimeEvent::MediaSnapshot(snapshot) => commands_for_media_snapshot(snapshot),
         RuntimeEvent::VoipSnapshot(snapshot) => commands_for_voip_snapshot(state, snapshot),
+        RuntimeEvent::NetworkSnapshot(snapshot) => commands_for_network_snapshot(snapshot),
         RuntimeEvent::Shutdown => vec![RuntimeCommand::Shutdown],
         RuntimeEvent::WorkerReady { .. }
-        | RuntimeEvent::MediaSnapshot(_)
-        | RuntimeEvent::NetworkSnapshot(_)
+        | RuntimeEvent::CloudSnapshot(_)
         | RuntimeEvent::UiScreenChanged { .. }
         | RuntimeEvent::WorkerError { .. }
         | RuntimeEvent::WorkerExited { .. }
@@ -134,6 +140,7 @@ fn runtime_event_from_message(
 
     match domain {
         WorkerDomain::Ui => ui_event_from_message(message_type, payload),
+        WorkerDomain::Cloud => cloud_event_from_message(message_type, payload),
         WorkerDomain::Media => media_event_from_message(message_type, payload),
         WorkerDomain::Voip => voip_event_from_message(message_type, payload),
         WorkerDomain::Network => network_event_from_message(message_type, payload),
@@ -151,6 +158,25 @@ fn runtime_event_from_message(
             "voice.ready",
             "voice.error",
         ),
+    }
+}
+
+fn cloud_event_from_message(message_type: &str, payload: Value) -> RuntimeEvent {
+    match message_type {
+        "cloud.ready" => RuntimeEvent::WorkerReady {
+            domain: WorkerDomain::Cloud,
+        },
+        "cloud.snapshot" | "cloud.health" => RuntimeEvent::CloudSnapshot(payload),
+        "cloud.command" => payload
+            .get("command")
+            .cloned()
+            .map(RuntimeEvent::CloudCommand)
+            .unwrap_or(RuntimeEvent::Ignored),
+        "cloud.error" => RuntimeEvent::WorkerError {
+            domain: WorkerDomain::Cloud,
+            message: worker_error_message(message_type, &payload),
+        },
+        _ => RuntimeEvent::Ignored,
     }
 }
 
@@ -496,9 +522,111 @@ fn commands_for_ui_input(state: &RuntimeState, payload: &Value) -> Vec<RuntimeCo
     Vec::new()
 }
 
+fn commands_for_cloud_command(command: &Value) -> Vec<RuntimeCommand> {
+    let command_type = string_field(command, "command")
+        .or_else(|| string_field(command, "type"))
+        .unwrap_or_default();
+    let command_id =
+        string_field(command, "commandId").or_else(|| string_field(command, "command_id"));
+
+    match normalized(&command_type).as_str() {
+        "pause" => remote_media_control("media.pause", command_id, "pause"),
+        "resume" => remote_media_control("media.resume", command_id, "resume"),
+        "stop" => remote_media_control("media.stop_playback", command_id, "stop"),
+        "fetch_config" => Vec::new(),
+        "play_track" | "store_media" => command_id
+            .map(|command_id| {
+                vec![worker_command(
+                    WorkerDomain::Cloud,
+                    "cloud.ack",
+                    json!({
+                        "command_id": command_id,
+                        "ok": false,
+                        "reason": "unsupported_command",
+                        "payload": {
+                            "command": command_type.clone(),
+                            "rust_runtime": true
+                        }
+                    }),
+                )]
+            })
+            .unwrap_or_default(),
+        _ if !command_type.trim().is_empty() => command_id
+            .map(|command_id| {
+                vec![worker_command(
+                    WorkerDomain::Cloud,
+                    "cloud.ack",
+                    json!({
+                        "command_id": command_id,
+                        "ok": false,
+                        "reason": "unsupported_command",
+                        "payload": {"command": command_type.clone()}
+                    }),
+                )]
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+fn remote_media_control(
+    media_message_type: &str,
+    command_id: Option<String>,
+    command_type: &str,
+) -> Vec<RuntimeCommand> {
+    let mut commands = vec![worker_command(
+        WorkerDomain::Media,
+        media_message_type,
+        empty_payload(),
+    )];
+    if let Some(command_id) = command_id {
+        commands.push(worker_command(
+            WorkerDomain::Cloud,
+            "cloud.ack",
+            json!({
+                "command_id": command_id,
+                "ok": true,
+                "payload": {"command": command_type}
+            }),
+        ));
+    }
+    commands
+}
+
+fn commands_for_media_snapshot(snapshot: &Value) -> Vec<RuntimeCommand> {
+    let playback_state =
+        string_field(snapshot, "playback_state").unwrap_or_else(|| "stopped".to_string());
+    let mut attrs = json!({
+        "playback_state": playback_state.clone(),
+    });
+    if let Some(track) = snapshot.get("current_track") {
+        attrs["track"] = track.clone();
+    }
+    vec![cloud_telemetry_command(
+        "music.state",
+        json!({
+            "entity": "music.state",
+            "value": playback_state,
+            "attrs": attrs,
+            "ts": current_epoch_seconds(),
+        }),
+    )]
+}
+
 fn commands_for_voip_snapshot(state: &RuntimeState, snapshot: &Value) -> Vec<RuntimeCommand> {
+    let mut commands = Vec::new();
+    let call_state = string_field(snapshot, "call_state").unwrap_or_else(|| "idle".to_string());
+    commands.push(cloud_telemetry_command(
+        "call.state",
+        json!({
+            "entity": "call.state",
+            "value": call_state,
+            "attrs": snapshot,
+            "ts": current_epoch_seconds(),
+        }),
+    ));
     if !is_music_playing(state) {
-        return Vec::new();
+        return commands;
     }
 
     let mut snapshot_state = RuntimeState::default();
@@ -507,14 +635,88 @@ fn commands_for_voip_snapshot(state: &RuntimeState, snapshot: &Value) -> Vec<Run
         snapshot_state.call.state,
         CallState::Incoming | CallState::Outgoing | CallState::Active
     ) {
-        return vec![worker_command(
+        commands.push(worker_command(
             WorkerDomain::Media,
             "media.pause",
             empty_payload(),
-        )];
+        ));
     }
 
-    Vec::new()
+    commands
+}
+
+fn commands_for_network_snapshot(snapshot: &Value) -> Vec<RuntimeCommand> {
+    let snapshot = snapshot.get("snapshot").unwrap_or(snapshot);
+    let app_state = snapshot.get("app_state").unwrap_or(snapshot);
+    let connected = app_state
+        .get("connected")
+        .or_else(|| snapshot.get("connected"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let connection_type = string_field(app_state, "connection_type")
+        .or_else(|| string_field(snapshot, "connection_type"))
+        .unwrap_or_else(|| "none".to_string());
+    let signal_bars = app_state
+        .get("signal_bars")
+        .or_else(|| app_state.get("signal_strength"))
+        .and_then(Value::as_i64)
+        .or_else(|| {
+            snapshot
+                .get("signal")
+                .and_then(|signal| signal.get("bars"))
+                .and_then(Value::as_i64)
+        })
+        .unwrap_or(0)
+        .clamp(0, 4);
+    let gps_has_fix = app_state
+        .get("gps_has_fix")
+        .or_else(|| snapshot.get("gps_has_fix"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let mut commands = vec![
+        cloud_telemetry_command(
+            "network.ppp_up",
+            json!({
+                "entity": "network.ppp_up",
+                "value": connected,
+                "attrs": {
+                    "connection_type": connection_type.clone(),
+                },
+                "ts": current_epoch_seconds(),
+            }),
+        ),
+        cloud_telemetry_command(
+            "network.signal_bars",
+            json!({
+                "entity": "network.signal_bars",
+                "value": signal_bars,
+                "attrs": {
+                    "connection_type": connection_type.clone(),
+                },
+                "ts": current_epoch_seconds(),
+            }),
+        ),
+        cloud_telemetry_command(
+            "location.fix",
+            json!({
+                "entity": "location.fix",
+                "value": gps_has_fix,
+                "attrs": snapshot.get("gps").cloned().unwrap_or_else(empty_payload),
+                "ts": current_epoch_seconds(),
+            }),
+        ),
+    ];
+    if connected && connection_type != "none" {
+        commands.push(worker_command(
+            WorkerDomain::Cloud,
+            "cloud.publish_connectivity",
+            json!({
+                "connection_type": connection_type,
+            }),
+        ));
+    }
+    commands
 }
 
 fn worker_command(
@@ -526,6 +728,18 @@ fn worker_command(
         domain,
         envelope: WorkerEnvelope::command(message_type, None, payload),
     }
+}
+
+fn cloud_telemetry_command(topic_suffix: &str, payload: Value) -> RuntimeCommand {
+    worker_command(
+        WorkerDomain::Cloud,
+        "cloud.publish_telemetry",
+        json!({
+            "topic_suffix": topic_suffix,
+            "payload": payload,
+            "qos": 0,
+        }),
+    )
 }
 
 fn is_music_playing(state: &RuntimeState) -> bool {
@@ -569,6 +783,13 @@ fn new_voice_note_client_id() -> String {
         .map(|duration| duration.as_millis())
         .unwrap_or_default();
     format!("runtime-vn-{}-{millis}", std::process::id())
+}
+
+fn current_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
 }
 
 fn normalized(value: &str) -> String {

--- a/yoyopod_rs/runtime/src/runtime_loop.rs
+++ b/yoyopod_rs/runtime/src/runtime_loop.rs
@@ -94,6 +94,19 @@ impl RuntimeLoop {
             RuntimeCommand::WorkerCommand { domain, envelope } => {
                 let _ = io.send_worker_envelope(domain, envelope);
             }
+            RuntimeCommand::WorkerCommandWithAck {
+                domain,
+                envelope,
+                success_ack,
+                failure_ack,
+            } => {
+                let ack = if io.send_worker_envelope(domain, envelope) {
+                    success_ack
+                } else {
+                    failure_ack
+                };
+                let _ = io.send_worker_envelope(WorkerDomain::Cloud, ack);
+            }
             RuntimeCommand::Shutdown => {
                 self.shutdown_requested = true;
             }

--- a/yoyopod_rs/runtime/src/runtime_loop.rs
+++ b/yoyopod_rs/runtime/src/runtime_loop.rs
@@ -8,8 +8,9 @@ use crate::protocol::WorkerEnvelope;
 use crate::state::{RuntimeState, WorkerDomain, WorkerState};
 use crate::worker::{WorkerProtocolError, WorkerSupervisor};
 
-const WORKER_DOMAINS: [WorkerDomain; 6] = [
+const WORKER_DOMAINS: [WorkerDomain; 7] = [
     WorkerDomain::Ui,
+    WorkerDomain::Cloud,
     WorkerDomain::Media,
     WorkerDomain::Voip,
     WorkerDomain::Network,

--- a/yoyopod_rs/runtime/src/state.rs
+++ b/yoyopod_rs/runtime/src/state.rs
@@ -7,6 +7,7 @@ use serde_json::{json, Value};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum WorkerDomain {
     Ui,
+    Cloud,
     Media,
     Voip,
     Network,
@@ -18,6 +19,7 @@ impl WorkerDomain {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Ui => "ui",
+            Self::Cloud => "cloud",
             Self::Media => "media",
             Self::Voip => "voip",
             Self::Network => "network",
@@ -308,6 +310,27 @@ impl Default for NetworkRuntimeState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloudRuntimeState {
+    pub device_id: String,
+    pub provisioning_state: String,
+    pub cloud_state: String,
+    pub mqtt_connected: bool,
+    pub last_error_summary: String,
+}
+
+impl Default for CloudRuntimeState {
+    fn default() -> Self {
+        Self {
+            device_id: String::new(),
+            provisioning_state: "unprovisioned".to_string(),
+            cloud_state: "offline".to_string(),
+            mqtt_connected: false,
+            last_error_summary: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetupRow {
     pub label: String,
     pub value: String,
@@ -333,7 +356,9 @@ pub struct RuntimeState {
     pub call: CallRuntimeState,
     pub voice: VoiceRuntimeState,
     pub network: NetworkRuntimeState,
+    pub cloud: CloudRuntimeState,
     pub ui: WorkerHealth,
+    pub cloud_worker: WorkerHealth,
     pub media_worker: WorkerHealth,
     pub voip_worker: WorkerHealth,
     pub network_worker: WorkerHealth,
@@ -351,7 +376,9 @@ impl Default for RuntimeState {
             call: CallRuntimeState::default(),
             voice: VoiceRuntimeState::default(),
             network: NetworkRuntimeState::default(),
+            cloud: CloudRuntimeState::default(),
             ui: WorkerHealth::default(),
+            cloud_worker: WorkerHealth::default(),
             media_worker: WorkerHealth::default(),
             voip_worker: WorkerHealth::default(),
             network_worker: WorkerHealth::default(),
@@ -400,6 +427,7 @@ impl RuntimeState {
     fn worker_health_mut(&mut self, domain: WorkerDomain) -> &mut WorkerHealth {
         match domain {
             WorkerDomain::Ui => &mut self.ui,
+            WorkerDomain::Cloud => &mut self.cloud_worker,
             WorkerDomain::Media => &mut self.media_worker,
             WorkerDomain::Voip => &mut self.voip_worker,
             WorkerDomain::Network => &mut self.network_worker,
@@ -654,6 +682,25 @@ impl RuntimeState {
         }
     }
 
+    pub fn apply_cloud_snapshot(&mut self, snapshot: &Value) {
+        let snapshot = snapshot.get("snapshot").unwrap_or(snapshot);
+        if let Some(device_id) = string_field(snapshot, "device_id") {
+            self.cloud.device_id = device_id;
+        }
+        if let Some(provisioning_state) = string_field(snapshot, "provisioning_state") {
+            self.cloud.provisioning_state = provisioning_state;
+        }
+        if let Some(cloud_state) = string_field(snapshot, "cloud_state") {
+            self.cloud.cloud_state = cloud_state;
+        }
+        if let Some(mqtt_connected) = snapshot.get("mqtt_connected").and_then(Value::as_bool) {
+            self.cloud.mqtt_connected = mqtt_connected;
+        }
+        if let Some(last_error_summary) = string_field(snapshot, "last_error_summary") {
+            self.cloud.last_error_summary = last_error_summary;
+        }
+    }
+
     pub fn ui_snapshot_payload(&self) -> Value {
         json!({
             "app_state": self.current_screen,
@@ -701,6 +748,13 @@ impl RuntimeState {
                 "signal_strength": self.network.signal_strength,
                 "gps_has_fix": self.network.gps_has_fix,
             },
+            "cloud": {
+                "device_id": self.cloud.device_id,
+                "provisioning_state": self.cloud.provisioning_state,
+                "cloud_state": self.cloud.cloud_state,
+                "mqtt_connected": self.cloud.mqtt_connected,
+                "last_error_summary": self.cloud.last_error_summary,
+            },
             "overlay": {
                 "loading": false,
                 "error": "",
@@ -708,6 +762,7 @@ impl RuntimeState {
             },
             "workers": {
                 WorkerDomain::Ui.as_str(): worker_payload(&self.ui),
+                WorkerDomain::Cloud.as_str(): worker_payload(&self.cloud_worker),
                 WorkerDomain::Media.as_str(): worker_payload(&self.media_worker),
                 WorkerDomain::Voip.as_str(): worker_payload(&self.voip_worker),
                 WorkerDomain::Network.as_str(): worker_payload(&self.network_worker),
@@ -909,8 +964,15 @@ impl RuntimeState {
                 "peer_address": self.call.peer_address,
                 "muted": self.call.muted,
             },
+            "cloud": {
+                "provisioning_state": self.cloud.provisioning_state,
+                "cloud_state": self.cloud.cloud_state,
+                "mqtt_connected": self.cloud.mqtt_connected,
+                "last_error_summary": self.cloud.last_error_summary,
+            },
             "workers": {
                 WorkerDomain::Ui.as_str(): worker_payload(&self.ui),
+                WorkerDomain::Cloud.as_str(): worker_payload(&self.cloud_worker),
                 WorkerDomain::Media.as_str(): worker_payload(&self.media_worker),
                 WorkerDomain::Voip.as_str(): worker_payload(&self.voip_worker),
                 WorkerDomain::Network.as_str(): worker_payload(&self.network_worker),

--- a/yoyopod_rs/runtime/src/worker.rs
+++ b/yoyopod_rs/runtime/src/worker.rs
@@ -368,9 +368,10 @@ fn preserve_ready_backlog(backlog: &mut VecDeque<WorkerEnvelope>, message: Worke
     backlog.push_back(message);
 }
 
-fn all_worker_domains() -> [WorkerDomain; 6] {
+fn all_worker_domains() -> [WorkerDomain; 7] {
     [
         WorkerDomain::Ui,
+        WorkerDomain::Cloud,
         WorkerDomain::Media,
         WorkerDomain::Voip,
         WorkerDomain::Network,

--- a/yoyopod_rs/runtime/tests/cli.rs
+++ b/yoyopod_rs/runtime/tests/cli.rs
@@ -254,6 +254,54 @@ logging:
     assert!(captured_ui.contains(r#"Fix: Yes"#));
 }
 
+#[test]
+fn boot_starts_cloud_worker_and_sends_startup_telemetry_commands() {
+    let _guard = env_lock();
+    let dir = temp_dir("cloud-worker");
+    let config_dir = dir.join("config");
+    let ui_stdin = dir.join("ui-stdin.ndjson");
+    let cloud_args = dir.join("cloud-args.txt");
+    let cloud_stdin = dir.join("cloud-stdin.ndjson");
+    let ui_worker = write_ui_worker_script(&dir, &ui_stdin);
+    let cloud_worker = write_cloud_worker_script(&dir, &cloud_args, &cloud_stdin);
+    write(
+        &config_dir.join("app/core.yaml"),
+        &format!(
+            r#"
+logging:
+  pid_file: "{}"
+  file: "{}"
+"#,
+            yaml_path(&dir.join("run/yoyopod.pid")),
+            yaml_path(&dir.join("logs/yoyopod.log"))
+        ),
+    );
+    std::env::set_var("YOYOPOD_RUST_UI_HOST_WORKER", &ui_worker);
+    std::env::set_var("YOYOPOD_RUST_CLOUD_HOST_WORKER", &cloud_worker);
+
+    let result = run(Args {
+        config_dir: config_dir.clone(),
+        dry_run: false,
+        hardware: "whisplay".to_string(),
+    });
+    std::env::remove_var("YOYOPOD_RUST_UI_HOST_WORKER");
+    std::env::remove_var("YOYOPOD_RUST_CLOUD_HOST_WORKER");
+    result.expect("runtime exits after UI shutdown intent");
+
+    let captured_ui = wait_for_file(&ui_stdin);
+    let captured_cloud_args = wait_for_file(&cloud_args);
+    let captured_cloud_stdin = wait_for_file(&cloud_stdin);
+    let normalized_cloud_args = captured_cloud_args.replace('\\', "/");
+
+    assert!(captured_cloud_args.contains("--config-dir"));
+    assert!(normalized_cloud_args.contains(&yaml_path(&config_dir)));
+    assert!(captured_cloud_stdin.contains(r#""type":"cloud.health""#));
+    assert!(captured_cloud_stdin.contains(r#""type":"cloud.publish_heartbeat""#));
+    assert!(captured_cloud_stdin.contains(r#""type":"cloud.publish_battery""#));
+    assert!(captured_ui.contains(r#""cloud""#));
+    assert!(captured_ui.contains(r#""state":"running""#));
+}
+
 fn temp_dir(test_name: &str) -> PathBuf {
     let unique = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -415,6 +463,70 @@ Set-Content -LiteralPath '{}' -Value $lines
         ),
     );
     let command_path = dir.join("network-worker.cmd");
+    write(
+        &command_path,
+        &format!(
+            "@echo off\r\npowershell -NoProfile -ExecutionPolicy Bypass -File \"{}\" %*\r\n",
+            script_path.to_string_lossy()
+        ),
+    );
+    command_path
+}
+
+fn write_cloud_worker_script(dir: &Path, args_path: &Path, stdin_path: &Path) -> PathBuf {
+    let ready = r#"{"schema_version":1,"kind":"event","type":"cloud.ready","payload":{"capabilities":["mqtt","telemetry"]}}"#;
+    let snapshot = r#"{"schema_version":1,"kind":"event","type":"cloud.snapshot","payload":{"device_id":"device-123","provisioning_state":"provisioned","cloud_state":"ready","mqtt_connected":true,"mqtt_broker_host":"mqtt.example.test","mqtt_broker_port":1883,"mqtt_transport":"tcp","config_source":"none","config_version":0,"backend_reachable":null,"last_successful_sync":null,"last_error_summary":"","unapplied_keys":[],"last_command_type":"","updated_at_ms":1}}"#;
+
+    if !cfg!(windows) {
+        let script_path = dir.join("cloud-worker.sh");
+        write(
+            &script_path,
+            &format!(
+                r#"#!/bin/sh
+printf '%s\n' "$@" > {}
+printf '%s\n' '{}'
+printf '%s\n' '{}'
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> {}
+  case "$line" in
+    *'"type":"worker.stop"'*) break ;;
+  esac
+done
+"#,
+                shell_single_quote(args_path),
+                ready,
+                snapshot,
+                shell_single_quote(stdin_path)
+            ),
+        );
+        make_executable(&script_path);
+        return script_path;
+    }
+
+    let script_path = dir.join("cloud-worker.ps1");
+    write(
+        &script_path,
+        &format!(
+            r#"
+Set-Content -LiteralPath '{}' -Value ($args -join "`n")
+Write-Output '{}'
+Write-Output '{}'
+$lines = @()
+while (($line = [Console]::In.ReadLine()) -ne $null) {{
+  $lines += $line
+  if ($line -match '"type":"worker.stop"') {{
+    break
+  }}
+}}
+Set-Content -LiteralPath '{}' -Value $lines
+"#,
+            args_path.to_string_lossy().replace('\'', "''"),
+            ready.replace('\'', "''"),
+            snapshot.replace('\'', "''"),
+            stdin_path.to_string_lossy().replace('\'', "''")
+        ),
+    );
+    let command_path = dir.join("cloud-worker.cmd");
     write(
         &command_path,
         &format!(

--- a/yoyopod_rs/runtime/tests/config.rs
+++ b/yoyopod_rs/runtime/tests/config.rs
@@ -43,6 +43,7 @@ const CONFIG_ENV_KEYS: &[&str] = &[
     "YOYOPOD_ALSA_DEVICE",
     "YOYOPOD_RUST_UI_HOST_WORKER",
     "YOYOPOD_RUST_UI_WORKER",
+    "YOYOPOD_RUST_CLOUD_HOST_WORKER",
     "YOYOPOD_RUST_MEDIA_HOST_WORKER",
     "YOYOPOD_RUST_VOIP_HOST_WORKER",
     "YOYOPOD_RUST_NETWORK_HOST_WORKER",
@@ -190,6 +191,10 @@ secrets:
     assert_eq!(
         config.worker_paths.ui,
         "yoyopod_rs/ui-host/build/yoyopod-ui-host"
+    );
+    assert_eq!(
+        config.worker_paths.cloud,
+        "yoyopod_rs/cloud-host/build/yoyopod-cloud-host"
     );
     assert_eq!(
         config.worker_paths.network,
@@ -616,4 +621,18 @@ fn network_worker_path_can_be_overridden_by_env() {
     let config = RuntimeConfig::load(&dir).expect("load runtime config");
 
     assert_eq!(config.worker_paths.network, "/host/yoyopod-network-host");
+}
+
+#[test]
+fn cloud_worker_path_can_be_overridden_by_env() {
+    let _lock = lock_env();
+    let _env = clean_config_env();
+    let dir = temp_config_dir("cloud-worker-env");
+    fs::create_dir_all(&dir).expect("config dir");
+
+    std::env::set_var("YOYOPOD_RUST_CLOUD_HOST_WORKER", "/host/yoyopod-cloud-host");
+
+    let config = RuntimeConfig::load(&dir).expect("load runtime config");
+
+    assert_eq!(config.worker_paths.cloud, "/host/yoyopod-cloud-host");
 }

--- a/yoyopod_rs/runtime/tests/event.rs
+++ b/yoyopod_rs/runtime/tests/event.rs
@@ -884,20 +884,39 @@ fn cloud_command_routes_remote_pause_to_media_and_ack() {
 
     let commands = commands_for_event(&RuntimeState::default(), &event);
 
+    let [RuntimeCommand::WorkerCommandWithAck {
+        domain,
+        envelope,
+        success_ack,
+        failure_ack,
+    }] = commands.as_slice()
+    else {
+        panic!("expected conditional media command with cloud ack");
+    };
+    assert_eq!(*domain, WorkerDomain::Media);
+    assert_eq!(envelope.message_type, "media.pause");
+    assert_eq!(envelope.payload, json!({}));
+    assert_eq!(success_ack.message_type, "cloud.ack");
     assert_eq!(
-        commands,
-        vec![
-            worker_command(WorkerDomain::Media, "media.pause", json!({})),
-            worker_command(
-                WorkerDomain::Cloud,
-                "cloud.ack",
-                json!({
-                    "command_id": "cmd-1",
-                    "ok": true,
-                    "payload": {"command": "pause"}
-                })
-            )
-        ]
+        success_ack.payload,
+        json!({
+            "command_id": "cmd-1",
+            "ok": true,
+            "payload": {"command": "pause"}
+        })
+    );
+    assert_eq!(failure_ack.message_type, "cloud.ack");
+    assert_eq!(
+        failure_ack.payload,
+        json!({
+            "command_id": "cmd-1",
+            "ok": false,
+            "reason": "media_dispatch_failed",
+            "payload": {
+                "command": "pause",
+                "media_command": "media.pause"
+            }
+        })
     );
 }
 

--- a/yoyopod_rs/runtime/tests/event.rs
+++ b/yoyopod_rs/runtime/tests/event.rs
@@ -121,6 +121,7 @@ fn worker_error_marks_worker_degraded() {
 #[test]
 fn health_only_worker_domains_decode_ready_and_error_events() {
     for (domain, ready_type, error_type) in [
+        (WorkerDomain::Cloud, "cloud.ready", "cloud.error"),
         (WorkerDomain::Network, "network.ready", "network.error"),
         (WorkerDomain::Power, "power.ready", "power.error"),
         (WorkerDomain::Voice, "voice.ready", "voice.error"),
@@ -758,14 +759,16 @@ fn incoming_call_routes_media_pause_when_music_is_playing() {
 
     let commands = commands_for_event(&state, &event);
 
-    assert_eq!(
-        commands,
-        vec![worker_command(
-            WorkerDomain::Media,
-            "media.pause",
-            json!({})
-        )]
-    );
+    assert!(commands.contains(&worker_command(
+        WorkerDomain::Media,
+        "media.pause",
+        json!({})
+    )));
+    assert!(commands.iter().any(|command| matches!(
+        command,
+        RuntimeCommand::WorkerCommand { domain: WorkerDomain::Cloud, envelope }
+            if envelope.message_type == "cloud.publish_telemetry"
+    )));
 }
 
 #[test]
@@ -785,14 +788,11 @@ fn active_raw_voip_snapshot_routes_media_pause_when_music_is_playing() {
 
     let commands = commands_for_event(&state, &event);
 
-    assert_eq!(
-        commands,
-        vec![worker_command(
-            WorkerDomain::Media,
-            "media.pause",
-            json!({})
-        )]
-    );
+    assert!(commands.contains(&worker_command(
+        WorkerDomain::Media,
+        "media.pause",
+        json!({})
+    )));
 }
 
 #[test]
@@ -812,14 +812,11 @@ fn outgoing_raw_voip_snapshot_routes_media_pause_when_music_is_playing() {
 
     let commands = commands_for_event(&state, &event);
 
-    assert_eq!(
-        commands,
-        vec![worker_command(
-            WorkerDomain::Media,
-            "media.pause",
-            json!({})
-        )]
-    );
+    assert!(commands.contains(&worker_command(
+        WorkerDomain::Media,
+        "media.pause",
+        json!({})
+    )));
 }
 
 #[test]
@@ -837,7 +834,17 @@ fn idle_voip_snapshot_does_not_pause_music() {
     let mut state = RuntimeState::default();
     state.apply_media_snapshot(&json!({"playback_state": "playing"}));
 
-    assert_eq!(commands_for_event(&state, &event), Vec::new());
+    let commands = commands_for_event(&state, &event);
+    assert!(!commands.contains(&worker_command(
+        WorkerDomain::Media,
+        "media.pause",
+        json!({})
+    )));
+    assert!(commands.iter().any(|command| matches!(
+        command,
+        RuntimeCommand::WorkerCommand { domain: WorkerDomain::Cloud, envelope }
+            if envelope.message_type == "cloud.publish_telemetry"
+    )));
 }
 
 #[test]
@@ -857,6 +864,75 @@ fn voip_snapshot_event_apply_uses_runtime_state_normalization() {
     event.apply(&mut state);
 
     assert_eq!(state.call.state, CallState::Active);
+}
+
+#[test]
+fn cloud_command_routes_remote_pause_to_media_and_ack() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Cloud,
+        event_envelope(
+            "cloud.command",
+            json!({
+                "command": {
+                    "command": "pause",
+                    "commandId": "cmd-1"
+                }
+            }),
+        ),
+    )
+    .expect("event");
+
+    let commands = commands_for_event(&RuntimeState::default(), &event);
+
+    assert_eq!(
+        commands,
+        vec![
+            worker_command(WorkerDomain::Media, "media.pause", json!({})),
+            worker_command(
+                WorkerDomain::Cloud,
+                "cloud.ack",
+                json!({
+                    "command_id": "cmd-1",
+                    "ok": true,
+                    "payload": {"command": "pause"}
+                })
+            )
+        ]
+    );
+}
+
+#[test]
+fn network_snapshot_routes_cloud_connectivity_and_telemetry() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Network,
+        event_envelope(
+            "network.snapshot",
+            json!({
+                "app_state": {
+                    "connected": true,
+                    "connection_type": "4g",
+                    "signal_bars": 3,
+                    "gps_has_fix": true
+                }
+            }),
+        ),
+    )
+    .expect("event");
+
+    let commands = commands_for_event(&RuntimeState::default(), &event);
+
+    assert!(commands.iter().any(|command| matches!(
+        command,
+        RuntimeCommand::WorkerCommand { domain: WorkerDomain::Cloud, envelope }
+            if envelope.message_type == "cloud.publish_connectivity"
+                && envelope.payload["connection_type"] == "4g"
+    )));
+    assert!(commands.iter().any(|command| matches!(
+        command,
+        RuntimeCommand::WorkerCommand { domain: WorkerDomain::Cloud, envelope }
+            if envelope.message_type == "cloud.publish_telemetry"
+                && envelope.payload["topic_suffix"] == "network.signal_bars"
+    )));
 }
 
 fn event_envelope(message_type: &str, payload: Value) -> WorkerEnvelope {

--- a/yoyopod_rs/runtime/tests/runtime_loop.rs
+++ b/yoyopod_rs/runtime/tests/runtime_loop.rs
@@ -133,6 +133,7 @@ fn protocol_error_remains_visible_after_same_iteration_ready_event() {
         .into_iter()
         .collect(),
         sent: Vec::new(),
+        ..FakeLoopIo::default()
     };
 
     let processed = runtime_loop.run_once(&mut io);
@@ -191,10 +192,85 @@ fn incoming_voip_snapshot_pauses_media_before_applying_call_state() {
     assert!(pause_index < snapshot_index);
 }
 
+#[test]
+fn cloud_remote_media_command_acks_after_media_dispatch_succeeds() {
+    let mut runtime_loop = RuntimeLoop::new(RuntimeState::default());
+    let mut io = FakeLoopIo::with_messages([(
+        WorkerDomain::Cloud,
+        event_envelope(
+            "cloud.command",
+            json!({
+                "command": {
+                    "command": "pause",
+                    "commandId": "cmd-1"
+                }
+            }),
+        ),
+    )]);
+
+    let processed = runtime_loop.run_once(&mut io);
+
+    assert_eq!(processed, 1);
+    let pause = sent_to(&io, WorkerDomain::Media, "media.pause");
+    assert_eq!(pause.payload, json!({}));
+    let ack = sent_to(&io, WorkerDomain::Cloud, "cloud.ack");
+    assert_eq!(
+        ack.payload,
+        json!({
+            "command_id": "cmd-1",
+            "ok": true,
+            "payload": {"command": "pause"}
+        })
+    );
+}
+
+#[test]
+fn cloud_remote_media_command_nacks_when_media_dispatch_fails() {
+    let mut runtime_loop = RuntimeLoop::new(RuntimeState::default());
+    let mut io = FakeLoopIo::with_messages([(
+        WorkerDomain::Cloud,
+        event_envelope(
+            "cloud.command",
+            json!({
+                "command": {
+                    "command": "stop",
+                    "commandId": "cmd-2"
+                }
+            }),
+        ),
+    )]);
+    io.fail_sends
+        .push_back((WorkerDomain::Media, "media.stop_playback".to_string()));
+
+    let processed = runtime_loop.run_once(&mut io);
+
+    assert_eq!(processed, 1);
+    assert!(sent_optional(&io, WorkerDomain::Media, "media.stop_playback").is_none());
+    assert_eq!(
+        io.failed_sends,
+        vec![(WorkerDomain::Media, "media.stop_playback".to_string())]
+    );
+    let ack = sent_to(&io, WorkerDomain::Cloud, "cloud.ack");
+    assert_eq!(
+        ack.payload,
+        json!({
+            "command_id": "cmd-2",
+            "ok": false,
+            "reason": "media_dispatch_failed",
+            "payload": {
+                "command": "stop",
+                "media_command": "media.stop_playback"
+            }
+        })
+    );
+}
+
 #[derive(Default)]
 struct FakeLoopIo {
     messages: VecDeque<(WorkerDomain, WorkerEnvelope)>,
     protocol_errors: VecDeque<(WorkerDomain, WorkerProtocolError)>,
+    fail_sends: VecDeque<(WorkerDomain, String)>,
+    failed_sends: Vec<(WorkerDomain, String)>,
     sent: Vec<(WorkerDomain, WorkerEnvelope)>,
 }
 
@@ -226,6 +302,17 @@ impl LoopIo for FakeLoopIo {
     }
 
     fn send_worker_envelope(&mut self, domain: WorkerDomain, envelope: WorkerEnvelope) -> bool {
+        if self
+            .fail_sends
+            .front()
+            .is_some_and(|(failed_domain, message_type)| {
+                *failed_domain == domain && message_type == &envelope.message_type
+            })
+        {
+            let failed = self.fail_sends.pop_front().expect("checked failed send");
+            self.failed_sends.push(failed);
+            return false;
+        }
         self.sent.push((domain, envelope));
         true
     }

--- a/yoyopod_rs/runtime/tests/state.rs
+++ b/yoyopod_rs/runtime/tests/state.rs
@@ -295,6 +295,28 @@ fn network_snapshot_updates_status_bar_payload_and_power_row() {
 }
 
 #[test]
+fn cloud_snapshot_updates_runtime_status_payload() {
+    let mut state = RuntimeState::default();
+
+    state.apply_cloud_snapshot(&json!({
+        "device_id": "device-123",
+        "provisioning_state": "provisioned",
+        "cloud_state": "ready",
+        "mqtt_connected": true,
+        "last_error_summary": ""
+    }));
+
+    let ui = state.ui_snapshot_payload();
+    assert_eq!(ui["cloud"]["provisioning_state"], "provisioned");
+    assert_eq!(ui["cloud"]["cloud_state"], "ready");
+    assert_eq!(ui["cloud"]["mqtt_connected"], true);
+
+    let status = state.status_payload();
+    assert_eq!(status["cloud"]["cloud_state"], "ready");
+    assert_eq!(status["cloud"]["mqtt_connected"], true);
+}
+
+#[test]
 fn network_setup_projection_feeds_setup_pages() {
     let mut state = RuntimeState::default();
 


### PR DESCRIPTION
## Summary

- Add `yoyopod-cloud-host`, a Rust worker for cloud/MQTT signaling that follows the existing host protocol pattern.
- Wire the cloud worker into `yoyopod-runtime` supervision, health/state projection, startup telemetry, and MQTT-backed command/event routing.
- Update CI/artifact/deploy validation so the cloud host binary is built and required with the Rust runtime bundle.

## Notes

- Cloud pause/resume/stop commands are routed through the runtime and ACKed.
- Remote media transfer commands are surfaced but currently NACKed as unsupported until the next media command slice wires the full transfer path.

## Verification

- `cargo test --manifest-path yoyopod_rs\Cargo.toml --workspace --locked`
- `git diff --cached --check` before commit
