### PR TITLE
[codex] Port power domain to Rust runtime

### DIFF
--- a/yoyopod_rs/BUILD.bazel
+++ b/yoyopod_rs/BUILD.bazel
@@ -11,6 +11,11 @@ alias(
 )
 
 alias(
+    name = "power-host",
+    actual = "//yoyopod_rs/power-host:yoyopod-power-host",
+)
+
+alias(
     name = "ui-host",
     actual = "//yoyopod_rs/ui-host:yoyopod-ui-host",
 )

--- a/yoyopod_rs/Cargo.lock
+++ b/yoyopod_rs/Cargo.lock
@@ -2140,6 +2140,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoyopod-power-host"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+]
+
+[[package]]
 name = "yoyopod-runtime"
 version = "0.1.0"
 dependencies = [

--- a/yoyopod_rs/Cargo.toml
+++ b/yoyopod_rs/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "cloud-host",
     "media-host",
+    "power-host",
     "ui-host",
     "voip-host",
     "network-host",

--- a/yoyopod_rs/power-host/BUILD.bazel
+++ b/yoyopod_rs/power-host/BUILD.bazel
@@ -1,0 +1,33 @@
+load(
+    "//:defs.bzl",
+    "yoyopod_rust_host_binary",
+    "yoyopod_rust_host_integration_tests",
+    "yoyopod_rust_host_library",
+)
+
+yoyopod_rust_host_library(
+    name = "power_host_lib",
+    srcs = glob(
+        ["src/**/*.rs"],
+        exclude = ["src/main.rs"],
+    ),
+    crate_name = "yoyopod_power_host",
+)
+
+yoyopod_rust_host_binary(
+    name = "yoyopod-power-host",
+    srcs = ["src/main.rs"],
+    deps = [":power_host_lib"],
+)
+
+POWER_HOST_TESTS = [
+    "config",
+    "snapshot",
+    "worker",
+]
+
+yoyopod_rust_host_integration_tests(
+    name = "tests",
+    tests = POWER_HOST_TESTS,
+    deps = [":power_host_lib"],
+)

--- a/yoyopod_rs/power-host/Cargo.toml
+++ b/yoyopod_rs/power-host/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "yoyopod-power-host"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[[bin]]
+name = "yoyopod-power-host"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.9"
+thiserror = "2.0"

--- a/yoyopod_rs/power-host/src/config.rs
+++ b/yoyopod_rs/power-host/src/config.rs
@@ -1,0 +1,312 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_yaml::{Mapping, Value};
+
+const POWER_BACKEND_CONFIG: &str = "power/backend.yaml";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct PowerHostConfig {
+    pub enabled: bool,
+    pub backend: String,
+    pub transport: String,
+    pub socket_path: String,
+    pub tcp_host: String,
+    pub tcp_port: u16,
+    pub timeout_seconds: f64,
+    pub poll_interval_seconds: f64,
+    pub runtime_root: String,
+    pub watchdog: PowerWatchdogConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct PowerWatchdogConfig {
+    pub enabled: bool,
+    pub timeout_seconds: u64,
+    pub feed_interval_seconds: f64,
+    pub i2c_bus: u8,
+    pub i2c_address: u16,
+    pub command_timeout_seconds: f64,
+}
+
+impl Default for PowerHostConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            backend: "pisugar".to_string(),
+            transport: "auto".to_string(),
+            socket_path: "/tmp/pisugar-server.sock".to_string(),
+            tcp_host: "127.0.0.1".to_string(),
+            tcp_port: 8423,
+            timeout_seconds: 2.0,
+            poll_interval_seconds: 30.0,
+            runtime_root: String::new(),
+            watchdog: PowerWatchdogConfig::default(),
+        }
+    }
+}
+
+impl Default for PowerWatchdogConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            timeout_seconds: 60,
+            feed_interval_seconds: 15.0,
+            i2c_bus: 1,
+            i2c_address: 0x57,
+            command_timeout_seconds: 5.0,
+        }
+    }
+}
+
+impl PowerHostConfig {
+    pub fn load(config_dir: impl AsRef<Path>) -> Result<Self> {
+        let config_dir = config_dir.as_ref();
+        let runtime_root = runtime_root_for_config_dir(config_dir);
+        let mut config = Self {
+            runtime_root: runtime_root.to_string_lossy().to_string(),
+            ..Self::default()
+        };
+
+        let raw = load_yaml_mapping(&config_dir.join(POWER_BACKEND_CONFIG))?;
+        let power = nested_mapping(&raw, "power").unwrap_or(&raw);
+        apply_power_mapping(&mut config, power);
+        apply_env_overrides(&mut config)?;
+        Ok(config)
+    }
+
+    pub fn default_for_config_dir(config_dir: impl AsRef<Path>) -> Self {
+        let runtime_root = runtime_root_for_config_dir(config_dir.as_ref());
+        Self {
+            runtime_root: runtime_root.to_string_lossy().to_string(),
+            ..Self::default()
+        }
+    }
+}
+
+fn apply_power_mapping(config: &mut PowerHostConfig, power: &Mapping) {
+    config.enabled = bool_key(power, "enabled", config.enabled);
+    config.backend = string_key(power, "backend", &config.backend);
+    config.transport = string_key(power, "transport", &config.transport);
+    config.socket_path = string_key(power, "socket_path", &config.socket_path);
+    config.tcp_host = string_key(power, "tcp_host", &config.tcp_host);
+    config.tcp_port = u16_key(power, "tcp_port", config.tcp_port);
+    config.timeout_seconds = f64_key(power, "timeout_seconds", config.timeout_seconds);
+    config.poll_interval_seconds =
+        f64_key(power, "poll_interval_seconds", config.poll_interval_seconds);
+    config.watchdog.enabled = bool_key(power, "watchdog_enabled", config.watchdog.enabled);
+    config.watchdog.timeout_seconds = u64_key(
+        power,
+        "watchdog_timeout_seconds",
+        config.watchdog.timeout_seconds,
+    );
+    config.watchdog.feed_interval_seconds = f64_key(
+        power,
+        "watchdog_feed_interval_seconds",
+        config.watchdog.feed_interval_seconds,
+    );
+    config.watchdog.i2c_bus = u8_key(power, "watchdog_i2c_bus", config.watchdog.i2c_bus);
+    config.watchdog.i2c_address =
+        u16_key(power, "watchdog_i2c_address", config.watchdog.i2c_address);
+    config.watchdog.command_timeout_seconds = f64_key(
+        power,
+        "watchdog_command_timeout_seconds",
+        config.watchdog.command_timeout_seconds,
+    );
+}
+
+fn apply_env_overrides(config: &mut PowerHostConfig) -> Result<()> {
+    if let Some(value) = env_string("YOYOPOD_POWER_ENABLED") {
+        config.enabled = parse_bool("YOYOPOD_POWER_ENABLED", &value)?;
+    }
+    if let Some(value) = env_string("YOYOPOD_POWER_BACKEND") {
+        config.backend = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_POWER_TRANSPORT") {
+        config.transport = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_PISUGAR_SOCKET_PATH") {
+        config.socket_path = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_PISUGAR_HOST") {
+        config.tcp_host = value;
+    }
+    if let Some(value) = env_string("YOYOPOD_PISUGAR_PORT") {
+        config.tcp_port = value
+            .parse()
+            .with_context(|| format!("parse YOYOPOD_PISUGAR_PORT={value}"))?;
+    }
+    if let Some(value) = env_string("YOYOPOD_POWER_TIMEOUT_SECONDS") {
+        config.timeout_seconds = value
+            .parse()
+            .with_context(|| format!("parse YOYOPOD_POWER_TIMEOUT_SECONDS={value}"))?;
+    }
+    if let Some(value) = env_string("YOYOPOD_POWER_POLL_INTERVAL_SECONDS") {
+        config.poll_interval_seconds = value
+            .parse()
+            .with_context(|| format!("parse YOYOPOD_POWER_POLL_INTERVAL_SECONDS={value}"))?;
+    }
+    if let Some(value) = env_string("YOYOPOD_POWER_WATCHDOG_ENABLED") {
+        config.watchdog.enabled = parse_bool("YOYOPOD_POWER_WATCHDOG_ENABLED", &value)?;
+    }
+    if let Some(value) = env_string("YOYOPOD_POWER_WATCHDOG_TIMEOUT_SECONDS") {
+        config.watchdog.timeout_seconds = value
+            .parse()
+            .with_context(|| format!("parse YOYOPOD_POWER_WATCHDOG_TIMEOUT_SECONDS={value}"))?;
+    }
+    if let Some(value) = env_string("YOYOPOD_POWER_WATCHDOG_FEED_INTERVAL_SECONDS") {
+        config.watchdog.feed_interval_seconds = value.parse().with_context(|| {
+            format!("parse YOYOPOD_POWER_WATCHDOG_FEED_INTERVAL_SECONDS={value}")
+        })?;
+    }
+    if let Some(value) = env_string("YOYOPOD_POWER_WATCHDOG_I2C_BUS") {
+        config.watchdog.i2c_bus = value
+            .parse()
+            .with_context(|| format!("parse YOYOPOD_POWER_WATCHDOG_I2C_BUS={value}"))?;
+    }
+    if let Some(value) = env_string("YOYOPOD_POWER_WATCHDOG_I2C_ADDRESS") {
+        config.watchdog.i2c_address = parse_u16(&value)
+            .with_context(|| format!("parse YOYOPOD_POWER_WATCHDOG_I2C_ADDRESS={value}"))?;
+    }
+    if let Some(value) = env_string("YOYOPOD_POWER_WATCHDOG_COMMAND_TIMEOUT_SECONDS") {
+        config.watchdog.command_timeout_seconds = value.parse().with_context(|| {
+            format!("parse YOYOPOD_POWER_WATCHDOG_COMMAND_TIMEOUT_SECONDS={value}")
+        })?;
+    }
+    Ok(())
+}
+
+fn load_yaml_mapping(path: &Path) -> Result<Mapping> {
+    if !path.exists() {
+        return Ok(Mapping::new());
+    }
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let value: Value =
+        serde_yaml::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
+    Ok(match value {
+        Value::Mapping(mapping) => mapping,
+        _ => Mapping::new(),
+    })
+}
+
+fn nested_mapping<'a>(mapping: &'a Mapping, key: &str) -> Option<&'a Mapping> {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(Value::as_mapping)
+}
+
+fn string_key(mapping: &Mapping, key: &str, default: &str) -> String {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(default)
+        .to_string()
+}
+
+fn u16_key(mapping: &Mapping, key: &str, default: u16) -> u16 {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(|value| {
+            value
+                .as_u64()
+                .and_then(|value| u16::try_from(value).ok())
+                .or_else(|| parse_u16(value.as_str()?).ok())
+        })
+        .unwrap_or(default)
+}
+
+fn u8_key(mapping: &Mapping, key: &str, default: u8) -> u8 {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(|value| {
+            value
+                .as_u64()
+                .and_then(|value| u8::try_from(value).ok())
+                .or_else(|| value.as_str()?.trim().parse::<u8>().ok())
+        })
+        .unwrap_or(default)
+}
+
+fn u64_key(mapping: &Mapping, key: &str, default: u64) -> u64 {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(|value| {
+            value
+                .as_u64()
+                .or_else(|| value.as_str()?.trim().parse::<u64>().ok())
+        })
+        .unwrap_or(default)
+}
+
+fn f64_key(mapping: &Mapping, key: &str, default: f64) -> f64 {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse::<f64>().ok())
+        })
+        .unwrap_or(default)
+}
+
+fn bool_key(mapping: &Mapping, key: &str, default: bool) -> bool {
+    mapping
+        .get(Value::String(key.to_string()))
+        .and_then(|value| {
+            value
+                .as_bool()
+                .or_else(|| parse_bool(key, value.as_str()?).ok())
+        })
+        .unwrap_or(default)
+}
+
+fn env_string(name: &str) -> Option<String> {
+    let value = env::var(name).ok()?;
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn parse_bool(name: &str, value: &str) -> Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => anyhow::bail!("invalid boolean for {name}: {value}"),
+    }
+}
+
+fn parse_u16(value: &str) -> Result<u16> {
+    let trimmed = value.trim();
+    if let Some(hex) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        Ok(u16::from_str_radix(hex, 16)?)
+    } else {
+        Ok(trimmed.parse::<u16>()?)
+    }
+}
+
+fn runtime_root_for_config_dir(config_dir: &Path) -> PathBuf {
+    let config_dir = if config_dir.is_absolute() {
+        config_dir.to_path_buf()
+    } else {
+        env::current_dir()
+            .map(|cwd| cwd.join(config_dir))
+            .unwrap_or_else(|_| config_dir.to_path_buf())
+    };
+    config_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or(config_dir)
+}

--- a/yoyopod_rs/power-host/src/host.rs
+++ b/yoyopod_rs/power-host/src/host.rs
@@ -1,0 +1,678 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use thiserror::Error;
+
+use crate::config::{PowerHostConfig, PowerWatchdogConfig};
+use crate::snapshot::{
+    current_millis, BatterySnapshot, PowerDeviceSnapshot, PowerStatusSnapshot, RtcSnapshot,
+    ShutdownSnapshot,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PowerControlCommand {
+    SyncTimeToRtc,
+    SyncTimeFromRtc,
+    SetRtcAlarm { when: String, repeat_mask: i32 },
+    DisableRtcAlarm,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PowerWatchdogCommand {
+    Enable { timeout_seconds: u64 },
+    Feed,
+    Disable,
+}
+
+impl PowerControlCommand {
+    fn pisugar_command(&self) -> String {
+        match self {
+            Self::SyncTimeToRtc => "rtc_pi2rtc".to_string(),
+            Self::SyncTimeFromRtc => "rtc_rtc2pi".to_string(),
+            Self::SetRtcAlarm { when, repeat_mask } => {
+                format!("rtc_alarm_set {} {}", when, repeat_mask)
+            }
+            Self::DisableRtcAlarm => "rtc_alarm_disable".to_string(),
+        }
+    }
+}
+
+pub trait PowerBackend {
+    fn refresh_snapshot(&mut self) -> PowerStatusSnapshot;
+
+    fn execute_control(
+        &mut self,
+        _command: PowerControlCommand,
+    ) -> Result<PowerStatusSnapshot, String> {
+        Err("power control unsupported".to_string())
+    }
+
+    fn execute_watchdog(&mut self, _command: PowerWatchdogCommand) -> Result<(), String> {
+        Err("power watchdog unsupported".to_string())
+    }
+}
+
+pub struct PowerHost<B: PowerBackend> {
+    backend: B,
+    snapshot: PowerStatusSnapshot,
+}
+
+impl<B: PowerBackend> PowerHost<B> {
+    pub fn new(backend: B) -> Self {
+        Self {
+            backend,
+            snapshot: PowerStatusSnapshot::default(),
+        }
+    }
+
+    pub fn snapshot(&self) -> &PowerStatusSnapshot {
+        &self.snapshot
+    }
+
+    pub fn refresh(&mut self) -> &PowerStatusSnapshot {
+        self.snapshot = self.backend.refresh_snapshot();
+        &self.snapshot
+    }
+
+    pub fn execute_control(
+        &mut self,
+        command: PowerControlCommand,
+    ) -> Result<PowerStatusSnapshot, String> {
+        let snapshot = self.backend.execute_control(command)?;
+        self.snapshot = snapshot.clone();
+        Ok(snapshot)
+    }
+
+    pub fn execute_watchdog(&mut self, command: PowerWatchdogCommand) -> Result<(), String> {
+        self.backend.execute_watchdog(command)
+    }
+}
+
+pub struct DisabledPowerBackend {
+    reason: String,
+}
+
+impl DisabledPowerBackend {
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+impl PowerBackend for DisabledPowerBackend {
+    fn refresh_snapshot(&mut self) -> PowerStatusSnapshot {
+        PowerStatusSnapshot {
+            available: false,
+            checked_at_ms: current_millis(),
+            error: self.reason.clone(),
+            ..PowerStatusSnapshot::default()
+        }
+    }
+
+    fn execute_control(
+        &mut self,
+        _command: PowerControlCommand,
+    ) -> Result<PowerStatusSnapshot, String> {
+        Err(self.reason.clone())
+    }
+
+    fn execute_watchdog(&mut self, _command: PowerWatchdogCommand) -> Result<(), String> {
+        Err(self.reason.clone())
+    }
+}
+
+pub struct PiSugarBackend {
+    config: PowerHostConfig,
+}
+
+impl PiSugarBackend {
+    pub fn new(config: PowerHostConfig) -> Self {
+        Self { config }
+    }
+
+    fn get_snapshot(&self) -> PowerStatusSnapshot {
+        if !self.config.enabled {
+            return PowerStatusSnapshot {
+                available: false,
+                checked_at_ms: current_millis(),
+                error: "power backend disabled".to_string(),
+                ..PowerStatusSnapshot::default()
+            };
+        }
+        if self.config.backend.trim() != "pisugar" {
+            return PowerStatusSnapshot {
+                available: false,
+                checked_at_ms: current_millis(),
+                error: format!("unsupported power backend {}", self.config.backend),
+                ..PowerStatusSnapshot::default()
+            };
+        }
+
+        let mut telemetry_success_count = 0;
+        let mut errors = Vec::<String>::new();
+        let device = PowerDeviceSnapshot {
+            model: self.read_string(
+                "get model",
+                false,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            firmware_version: self.read_string(
+                "get firmware_version",
+                false,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+        };
+        let battery = BatterySnapshot {
+            level_percent: self.read_float(
+                "get battery",
+                true,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            voltage_volts: self.read_float(
+                "get battery_v",
+                true,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            charging: self.read_bool(
+                "get battery_charging",
+                true,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            power_plugged: self.read_bool(
+                "get battery_power_plugged",
+                true,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            allow_charging: self.read_bool(
+                "get battery_allow_charging",
+                true,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            output_enabled: self.read_bool(
+                "get battery_output_enabled",
+                true,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            temperature_celsius: self.read_float(
+                "get temperature",
+                true,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+        };
+        let rtc = RtcSnapshot {
+            time: self.read_string(
+                "get rtc_time",
+                true,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            alarm_enabled: self.read_bool(
+                "get rtc_alarm_enabled",
+                true,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            alarm_time: self.read_string(
+                "get rtc_alarm_time",
+                false,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            alarm_repeat_mask: self.read_i32(
+                "get alarm_repeat",
+                false,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            adjust_ppm: self.read_float(
+                "get rtc_adjust_ppm",
+                false,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+        };
+        let shutdown = ShutdownSnapshot {
+            safe_shutdown_level_percent: self.read_float(
+                "get safe_shutdown_level",
+                false,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+            safe_shutdown_delay_seconds: self.read_i32(
+                "get safe_shutdown_delay",
+                false,
+                &mut telemetry_success_count,
+                &mut errors,
+            ),
+        };
+
+        PowerStatusSnapshot {
+            available: telemetry_success_count > 0,
+            checked_at_ms: current_millis(),
+            source: "pisugar".to_string(),
+            device,
+            battery,
+            rtc,
+            shutdown,
+            error: errors.join("; "),
+        }
+    }
+
+    fn query(&self, command: &str) -> Result<String, PowerTransportError> {
+        let response = self.send_command(command)?;
+        extract_response_value(command, &response)
+    }
+
+    fn execute_control_command(&self, command: &str) -> Result<String, PowerTransportError> {
+        let response = self.send_command(command)?.trim().to_string();
+        if response.is_empty() {
+            return Err(PowerTransportError::Transport(format!(
+                "Empty response for {command:?}"
+            )));
+        }
+        if response.to_ascii_lowercase().starts_with("error") {
+            return Err(PowerTransportError::Transport(format!(
+                "PiSugar command failed for {command:?}: {response}"
+            )));
+        }
+        Ok(response)
+    }
+
+    fn read_string(
+        &self,
+        command: &str,
+        counts_as_telemetry: bool,
+        telemetry_success_count: &mut usize,
+        errors: &mut Vec<String>,
+    ) -> Option<String> {
+        match self.query(command) {
+            Ok(value) => {
+                if counts_as_telemetry {
+                    *telemetry_success_count += 1;
+                }
+                Some(value)
+            }
+            Err(error) => {
+                errors.push(format!("{command}: {error}"));
+                None
+            }
+        }
+    }
+
+    fn read_float(
+        &self,
+        command: &str,
+        counts_as_telemetry: bool,
+        telemetry_success_count: &mut usize,
+        errors: &mut Vec<String>,
+    ) -> Option<f64> {
+        self.read_string(
+            command,
+            counts_as_telemetry,
+            telemetry_success_count,
+            errors,
+        )
+        .and_then(|value| match value.parse::<f64>() {
+            Ok(parsed) => Some(parsed),
+            Err(error) => {
+                errors.push(format!("{command}: {error}"));
+                None
+            }
+        })
+    }
+
+    fn read_i32(
+        &self,
+        command: &str,
+        counts_as_telemetry: bool,
+        telemetry_success_count: &mut usize,
+        errors: &mut Vec<String>,
+    ) -> Option<i32> {
+        self.read_float(
+            command,
+            counts_as_telemetry,
+            telemetry_success_count,
+            errors,
+        )
+        .and_then(|value| i32::try_from(value as i64).ok())
+    }
+
+    fn read_bool(
+        &self,
+        command: &str,
+        counts_as_telemetry: bool,
+        telemetry_success_count: &mut usize,
+        errors: &mut Vec<String>,
+    ) -> Option<bool> {
+        self.read_string(
+            command,
+            counts_as_telemetry,
+            telemetry_success_count,
+            errors,
+        )
+        .and_then(|value| match parse_bool(&value) {
+            Some(parsed) => Some(parsed),
+            None => {
+                errors.push(format!("{command}: cannot coerce {value:?} to bool"));
+                None
+            }
+        })
+    }
+
+    fn send_command(&self, command: &str) -> Result<String, PowerTransportError> {
+        match self.config.transport.trim() {
+            "socket" => send_unix_command(
+                &self.config.socket_path,
+                self.config.timeout_seconds,
+                command,
+            ),
+            "tcp" => send_tcp_command(
+                &self.config.tcp_host,
+                self.config.tcp_port,
+                self.config.timeout_seconds,
+                command,
+            ),
+            _ => send_auto_command(&self.config, command),
+        }
+    }
+
+    fn execute_watchdog_command(
+        &self,
+        command: PowerWatchdogCommand,
+    ) -> Result<(), PowerTransportError> {
+        let watchdog = PiSugarWatchdog::new(&self.config.watchdog);
+        watchdog.execute(command)
+    }
+}
+
+impl PowerBackend for PiSugarBackend {
+    fn refresh_snapshot(&mut self) -> PowerStatusSnapshot {
+        self.get_snapshot()
+    }
+
+    fn execute_control(
+        &mut self,
+        command: PowerControlCommand,
+    ) -> Result<PowerStatusSnapshot, String> {
+        self.execute_control_command(&command.pisugar_command())
+            .map_err(|error| error.to_string())?;
+        Ok(self.get_snapshot())
+    }
+
+    fn execute_watchdog(&mut self, command: PowerWatchdogCommand) -> Result<(), String> {
+        self.execute_watchdog_command(command)
+            .map_err(|error| error.to_string())
+    }
+}
+
+struct PiSugarWatchdog<'a> {
+    config: &'a PowerWatchdogConfig,
+}
+
+impl<'a> PiSugarWatchdog<'a> {
+    const CONTROL_REGISTER: u8 = 0x06;
+    const TIMEOUT_REGISTER: u8 = 0x07;
+    const ENABLE_MASK: u8 = 0x80;
+    const FEED_MASK: u8 = 0x20;
+
+    fn new(config: &'a PowerWatchdogConfig) -> Self {
+        Self { config }
+    }
+
+    fn execute(&self, command: PowerWatchdogCommand) -> Result<(), PowerTransportError> {
+        match command {
+            PowerWatchdogCommand::Enable { timeout_seconds } => {
+                let timeout_value = coerce_watchdog_timeout(timeout_seconds)?;
+                let control_value = self.read_register(Self::CONTROL_REGISTER)?;
+                self.write_register(Self::TIMEOUT_REGISTER, timeout_value)?;
+                self.write_register(
+                    Self::CONTROL_REGISTER,
+                    control_value | Self::ENABLE_MASK | Self::FEED_MASK,
+                )
+            }
+            PowerWatchdogCommand::Feed => {
+                let control_value = self.read_register(Self::CONTROL_REGISTER)?;
+                self.write_register(
+                    Self::CONTROL_REGISTER,
+                    control_value | Self::ENABLE_MASK | Self::FEED_MASK,
+                )
+            }
+            PowerWatchdogCommand::Disable => {
+                let control_value = self.read_register(Self::CONTROL_REGISTER)?;
+                self.write_register(
+                    Self::CONTROL_REGISTER,
+                    control_value & !Self::ENABLE_MASK & !Self::FEED_MASK,
+                )
+            }
+        }
+    }
+
+    fn read_register(&self, register: u8) -> Result<u8, PowerTransportError> {
+        let output = self.run_i2c_command(&[
+            "i2cget".to_string(),
+            "-y".to_string(),
+            self.config.i2c_bus.to_string(),
+            format!("0x{:x}", self.config.i2c_address),
+            format!("0x{register:x}"),
+        ])?;
+        parse_watchdog_register(&output, register)
+    }
+
+    fn write_register(&self, register: u8, value: u8) -> Result<(), PowerTransportError> {
+        self.run_i2c_command(&[
+            "i2cset".to_string(),
+            "-y".to_string(),
+            self.config.i2c_bus.to_string(),
+            format!("0x{:x}", self.config.i2c_address),
+            format!("0x{register:x}"),
+            format!("0x{value:x}"),
+        ])?;
+        Ok(())
+    }
+
+    fn run_i2c_command(&self, command: &[String]) -> Result<String, PowerTransportError> {
+        let Some((program, args)) = command.split_first() else {
+            return Err(PowerTransportError::Transport(
+                "empty watchdog command".to_string(),
+            ));
+        };
+        let output = Command::new(program).args(args).output().map_err(|error| {
+            PowerTransportError::Transport(format!("watchdog command failed to start: {error}"))
+        })?;
+        if !output.status.success() {
+            return Err(PowerTransportError::Transport(format!(
+                "watchdog command failed ({}): {}; stderr={}",
+                output
+                    .status
+                    .code()
+                    .map(|code| code.to_string())
+                    .unwrap_or_else(|| "signal".to_string()),
+                command.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+}
+
+#[derive(Debug, Error)]
+enum PowerTransportError {
+    #[error("{0}")]
+    Transport(String),
+}
+
+fn send_auto_command(
+    config: &PowerHostConfig,
+    command: &str,
+) -> Result<String, PowerTransportError> {
+    let mut errors = Vec::new();
+    match send_unix_command(&config.socket_path, config.timeout_seconds, command) {
+        Ok(response) => return Ok(response),
+        Err(error) => errors.push(error.to_string()),
+    }
+    match send_tcp_command(
+        &config.tcp_host,
+        config.tcp_port,
+        config.timeout_seconds,
+        command,
+    ) {
+        Ok(response) => Ok(response),
+        Err(error) => {
+            errors.push(error.to_string());
+            Err(PowerTransportError::Transport(errors.join("; ")))
+        }
+    }
+}
+
+fn send_tcp_command(
+    host: &str,
+    port: u16,
+    timeout_seconds: f64,
+    command: &str,
+) -> Result<String, PowerTransportError> {
+    let timeout = timeout(timeout_seconds);
+    let address = format!("{host}:{port}");
+    let mut stream = TcpStream::connect(&address)
+        .map_err(|error| PowerTransportError::Transport(format!("TCP {address}: {error}")))?;
+    stream.set_read_timeout(Some(timeout)).ok();
+    stream.set_write_timeout(Some(timeout)).ok();
+    stream
+        .write_all(format!("{}\n", command.trim()).as_bytes())
+        .map_err(|error| PowerTransportError::Transport(format!("TCP write {address}: {error}")))?;
+    let _ = stream.shutdown(std::net::Shutdown::Write);
+    read_stream_response(stream)
+}
+
+#[cfg(unix)]
+fn send_unix_command(
+    socket_path: &str,
+    timeout_seconds: f64,
+    command: &str,
+) -> Result<String, PowerTransportError> {
+    use std::os::unix::net::UnixStream;
+
+    let path = Path::new(socket_path);
+    if !path.exists() {
+        return Err(PowerTransportError::Transport(format!(
+            "Unix socket not found: {}",
+            path.display()
+        )));
+    }
+    let timeout = timeout(timeout_seconds);
+    let mut stream = UnixStream::connect(path).map_err(|error| {
+        PowerTransportError::Transport(format!("Unix {}: {error}", path.display()))
+    })?;
+    stream.set_read_timeout(Some(timeout)).ok();
+    stream.set_write_timeout(Some(timeout)).ok();
+    stream
+        .write_all(format!("{}\n", command.trim()).as_bytes())
+        .map_err(|error| {
+            PowerTransportError::Transport(format!("Unix write {}: {error}", path.display()))
+        })?;
+    let _ = stream.shutdown(std::net::Shutdown::Write);
+    read_stream_response(stream)
+}
+
+#[cfg(not(unix))]
+fn send_unix_command(
+    socket_path: &str,
+    _timeout_seconds: f64,
+    _command: &str,
+) -> Result<String, PowerTransportError> {
+    let path = Path::new(socket_path);
+    Err(PowerTransportError::Transport(format!(
+        "Unix socket unsupported on this platform: {}",
+        path.display()
+    )))
+}
+
+fn read_stream_response(mut stream: impl Read) -> Result<String, PowerTransportError> {
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .map_err(|error| PowerTransportError::Transport(format!("read response: {error}")))?;
+    let response = response.trim().to_string();
+    if response.is_empty() {
+        Err(PowerTransportError::Transport(
+            "No response from PiSugar server".to_string(),
+        ))
+    } else {
+        Ok(response)
+    }
+}
+
+fn extract_response_value(command: &str, response: &str) -> Result<String, PowerTransportError> {
+    let Some(line) = response
+        .lines()
+        .map(str::trim)
+        .rfind(|line| !line.is_empty())
+    else {
+        return Err(PowerTransportError::Transport(format!(
+            "Empty response for {command:?}"
+        )));
+    };
+    let value = line
+        .split_once(':')
+        .map(|(_, value)| value)
+        .unwrap_or(line)
+        .trim();
+    if value.is_empty() {
+        Err(PowerTransportError::Transport(format!(
+            "Malformed response for {command:?}: {response:?}"
+        )))
+    } else {
+        Ok(value.to_string())
+    }
+}
+
+fn coerce_watchdog_timeout(timeout_seconds: u64) -> Result<u8, PowerTransportError> {
+    if timeout_seconds == 0 {
+        return Err(PowerTransportError::Transport(
+            "Watchdog timeout must be positive".to_string(),
+        ));
+    }
+    let units = timeout_seconds.div_ceil(2).clamp(1, 255);
+    Ok(units as u8)
+}
+
+fn parse_watchdog_register(output: &str, register: u8) -> Result<u8, PowerTransportError> {
+    let output = output.trim();
+    let parsed = if let Some(hex) = output
+        .strip_prefix("0x")
+        .or_else(|| output.strip_prefix("0X"))
+    {
+        u8::from_str_radix(hex, 16)
+    } else {
+        output.parse::<u8>()
+    };
+    parsed.map_err(|error| {
+        PowerTransportError::Transport(format!(
+            "Unexpected i2cget output for register 0x{register:x}: {output:?}: {error}"
+        ))
+    })
+}
+
+fn parse_bool(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Some(true),
+        "false" | "0" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+fn timeout(timeout_seconds: f64) -> Duration {
+    Duration::from_secs_f64(timeout_seconds.max(0.1))
+}

--- a/yoyopod_rs/power-host/src/lib.rs
+++ b/yoyopod_rs/power-host/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod config;
+pub mod host;
+pub mod protocol;
+pub mod snapshot;
+pub mod worker;

--- a/yoyopod_rs/power-host/src/main.rs
+++ b/yoyopod_rs/power-host/src/main.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[command(name = "yoyopod-power-host")]
+#[command(about = "YoYoPod Rust Power Host")]
+struct Args {
+    #[arg(long, default_value = "config")]
+    config_dir: String,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    yoyopod_power_host::worker::run(&args.config_dir)
+}

--- a/yoyopod_rs/power-host/src/protocol.rs
+++ b/yoyopod_rs/power-host/src/protocol.rs
@@ -1,0 +1,199 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use thiserror::Error;
+
+use crate::snapshot::PowerStatusSnapshot;
+
+pub const SUPPORTED_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvelopeKind {
+    Command,
+    Event,
+    Result,
+    Error,
+    Heartbeat,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkerEnvelope {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u16,
+    pub kind: EnvelopeKind,
+    #[serde(rename = "type")]
+    pub message_type: String,
+    #[serde(default)]
+    pub request_id: Option<String>,
+    #[serde(default)]
+    pub timestamp_ms: u64,
+    #[serde(default)]
+    pub deadline_ms: u64,
+    #[serde(default = "empty_payload")]
+    pub payload: Value,
+}
+
+#[derive(Debug, Error)]
+pub enum ProtocolError {
+    #[error("invalid JSON worker envelope: {0}")]
+    InvalidJson(#[from] serde_json::Error),
+    #[error("unsupported schema_version {actual}; expected {expected}")]
+    UnsupportedSchema { actual: u16, expected: u16 },
+    #[error("invalid worker envelope: {0}")]
+    InvalidEnvelope(String),
+}
+
+impl WorkerEnvelope {
+    pub fn decode(line: &[u8]) -> Result<Self, ProtocolError> {
+        let envelope: WorkerEnvelope = serde_json::from_slice(line)?;
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, ProtocolError> {
+        self.validate()?;
+        let mut encoded = serde_json::to_vec(self)?;
+        encoded.push(b'\n');
+        Ok(encoded)
+    }
+
+    pub fn event(message_type: impl Into<String>, payload: Value) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Event,
+            message_type: message_type.into(),
+            request_id: None,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload,
+        }
+    }
+
+    pub fn result(
+        message_type: impl Into<String>,
+        request_id: Option<String>,
+        payload: Value,
+    ) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Result,
+            message_type: message_type.into(),
+            request_id,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload,
+        }
+    }
+
+    pub fn error(
+        message_type: impl Into<String>,
+        request_id: Option<String>,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            kind: EnvelopeKind::Error,
+            message_type: message_type.into(),
+            request_id,
+            timestamp_ms: 0,
+            deadline_ms: 0,
+            payload: json!({
+                "code": code.into(),
+                "message": message.into(),
+            }),
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), ProtocolError> {
+        if self.schema_version != SUPPORTED_SCHEMA_VERSION {
+            return Err(ProtocolError::UnsupportedSchema {
+                actual: self.schema_version,
+                expected: SUPPORTED_SCHEMA_VERSION,
+            });
+        }
+        if self.message_type.trim().is_empty() {
+            return Err(ProtocolError::InvalidEnvelope(
+                "type must be a non-empty string".to_string(),
+            ));
+        }
+        if !self.payload.is_object() {
+            return Err(ProtocolError::InvalidEnvelope(
+                "payload must be an object".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub fn ready_event() -> WorkerEnvelope {
+    WorkerEnvelope::event(
+        "power.ready",
+        json!({
+            "capabilities": [
+                "telemetry",
+                "battery",
+                "rtc",
+                "rtc_control",
+                "watchdog",
+                "health"
+            ],
+        }),
+    )
+}
+
+pub fn snapshot_event(snapshot: &PowerStatusSnapshot) -> WorkerEnvelope {
+    WorkerEnvelope::event(
+        "power.snapshot",
+        serde_json::to_value(snapshot).expect("power snapshot should serialize"),
+    )
+}
+
+pub fn snapshot_result(
+    request_id: Option<String>,
+    snapshot: &PowerStatusSnapshot,
+) -> WorkerEnvelope {
+    WorkerEnvelope::result(
+        "power.health",
+        request_id,
+        serde_json::to_value(snapshot).expect("power snapshot should serialize"),
+    )
+}
+
+pub fn control_result(
+    message_type: impl Into<String>,
+    request_id: Option<String>,
+    snapshot: &PowerStatusSnapshot,
+) -> WorkerEnvelope {
+    WorkerEnvelope::result(
+        message_type,
+        request_id,
+        json!({
+            "ok": true,
+            "snapshot": snapshot,
+        }),
+    )
+}
+
+pub fn stopped_event(reason: &str) -> WorkerEnvelope {
+    WorkerEnvelope::event("power.stopped", json!({ "reason": reason }))
+}
+
+pub fn stopped_result(request_id: Option<String>, reason: &str) -> WorkerEnvelope {
+    WorkerEnvelope::result(
+        "power.stopped",
+        request_id,
+        json!({
+            "shutdown": true,
+            "reason": reason,
+        }),
+    )
+}
+
+fn default_schema_version() -> u16 {
+    SUPPORTED_SCHEMA_VERSION
+}
+
+fn empty_payload() -> Value {
+    json!({})
+}

--- a/yoyopod_rs/power-host/src/snapshot.rs
+++ b/yoyopod_rs/power-host/src/snapshot.rs
@@ -1,0 +1,69 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PowerStatusSnapshot {
+    pub available: bool,
+    pub checked_at_ms: u64,
+    pub source: String,
+    pub device: PowerDeviceSnapshot,
+    pub battery: BatterySnapshot,
+    pub rtc: RtcSnapshot,
+    pub shutdown: ShutdownSnapshot,
+    pub error: String,
+}
+
+impl Default for PowerStatusSnapshot {
+    fn default() -> Self {
+        Self {
+            available: false,
+            checked_at_ms: current_millis(),
+            source: "pisugar".to_string(),
+            device: PowerDeviceSnapshot::default(),
+            battery: BatterySnapshot::default(),
+            rtc: RtcSnapshot::default(),
+            shutdown: ShutdownSnapshot::default(),
+            error: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct PowerDeviceSnapshot {
+    pub model: Option<String>,
+    pub firmware_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct BatterySnapshot {
+    pub level_percent: Option<f64>,
+    pub voltage_volts: Option<f64>,
+    pub charging: Option<bool>,
+    pub power_plugged: Option<bool>,
+    pub allow_charging: Option<bool>,
+    pub output_enabled: Option<bool>,
+    pub temperature_celsius: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct RtcSnapshot {
+    pub time: Option<String>,
+    pub alarm_enabled: Option<bool>,
+    pub alarm_time: Option<String>,
+    pub alarm_repeat_mask: Option<i32>,
+    pub adjust_ppm: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ShutdownSnapshot {
+    pub safe_shutdown_level_percent: Option<f64>,
+    pub safe_shutdown_delay_seconds: Option<i32>,
+}
+
+pub fn current_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default()
+}

--- a/yoyopod_rs/power-host/src/worker.rs
+++ b/yoyopod_rs/power-host/src/worker.rs
@@ -1,0 +1,504 @@
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::config::{PowerHostConfig, PowerWatchdogConfig};
+use crate::host::{
+    DisabledPowerBackend, PiSugarBackend, PowerBackend, PowerControlCommand, PowerHost,
+    PowerWatchdogCommand,
+};
+use crate::protocol::{
+    control_result, ready_event, snapshot_event, snapshot_result, stopped_event, stopped_result,
+    EnvelopeKind, WorkerEnvelope,
+};
+
+pub fn run(config_dir: &str) -> Result<()> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+    run_with_io(config_dir, stdin, &mut stdout)
+}
+
+pub fn run_with_io<R, W>(config_dir: &str, input: R, output: &mut W) -> Result<()>
+where
+    R: Read + Send + 'static,
+    W: Write,
+{
+    let config = PowerHostConfig::load(config_dir)
+        .unwrap_or_else(|_| PowerHostConfig::default_for_config_dir(config_dir));
+    let poll_interval = Duration::from_secs_f64(config.poll_interval_seconds.max(0.1));
+    let watchdog = config.watchdog.clone();
+    if config.enabled && config.backend.trim() == "pisugar" {
+        run_host_loop_with_watchdog(
+            PowerHost::new(PiSugarBackend::new(config)),
+            input,
+            output,
+            poll_interval,
+            watchdog,
+        )
+    } else {
+        let reason = if config.enabled {
+            format!("unsupported power backend {}", config.backend)
+        } else {
+            "power backend disabled".to_string()
+        };
+        run_host_loop_with_watchdog(
+            PowerHost::new(DisabledPowerBackend::new(reason)),
+            input,
+            output,
+            poll_interval,
+            watchdog,
+        )
+    }
+}
+
+pub fn run_host_loop<R, W, B>(
+    host: PowerHost<B>,
+    input: R,
+    output: &mut W,
+    poll_interval: Duration,
+) -> Result<()>
+where
+    R: Read + Send + 'static,
+    W: Write,
+    B: PowerBackend,
+{
+    run_host_loop_with_watchdog(
+        host,
+        input,
+        output,
+        poll_interval,
+        PowerWatchdogConfig::default(),
+    )
+}
+
+pub fn run_host_loop_with_watchdog<R, W, B>(
+    mut host: PowerHost<B>,
+    input: R,
+    output: &mut W,
+    poll_interval: Duration,
+    watchdog_config: PowerWatchdogConfig,
+) -> Result<()>
+where
+    R: Read + Send + 'static,
+    W: Write,
+    B: PowerBackend,
+{
+    emit(output, &ready_event())?;
+    host.refresh();
+    emit(output, &snapshot_event(host.snapshot()))?;
+    let mut watchdog = WatchdogRuntime::new(watchdog_config);
+    watchdog.start(&mut host, output)?;
+
+    let (stdin_tx, stdin_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(input);
+        for line in reader.lines() {
+            if stdin_tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut next_poll = Instant::now() + poll_interval;
+    loop {
+        let now = Instant::now();
+        let next_deadline = watchdog
+            .next_feed_at()
+            .map(|deadline| deadline.min(next_poll))
+            .unwrap_or(next_poll);
+        let timeout = next_deadline
+            .checked_duration_since(now)
+            .unwrap_or_else(|| Duration::from_millis(0));
+        match stdin_rx.recv_timeout(timeout) {
+            Ok(Ok(line)) => {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let envelope = match WorkerEnvelope::decode(line.as_bytes()) {
+                    Ok(envelope) => envelope,
+                    Err(error) => {
+                        emit(
+                            output,
+                            &WorkerEnvelope::error(
+                                "power.error",
+                                None,
+                                "protocol_error",
+                                error.to_string(),
+                            ),
+                        )?;
+                        continue;
+                    }
+                };
+                if envelope.kind != EnvelopeKind::Command {
+                    emit(
+                        output,
+                        &WorkerEnvelope::error(
+                            "power.error",
+                            envelope.request_id,
+                            "invalid_kind",
+                            "power worker accepts commands only",
+                        ),
+                    )?;
+                    continue;
+                }
+                match handle_command(&mut host, &mut watchdog, envelope) {
+                    LoopControl::Continue(envelopes) => {
+                        for envelope in envelopes {
+                            emit(output, &envelope)?;
+                        }
+                    }
+                    LoopControl::Shutdown(envelopes) => {
+                        watchdog.disable_for_stop(&mut host, output)?;
+                        for envelope in envelopes {
+                            emit(output, &envelope)?;
+                        }
+                        emit(output, &stopped_event("shutdown"))?;
+                        break;
+                    }
+                }
+            }
+            Ok(Err(error)) => {
+                emit(output, &stopped_event("input_error"))?;
+                return Err(error.into());
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                let now = Instant::now();
+                if watchdog.feed_due(now) {
+                    watchdog.feed(&mut host, output, now)?;
+                }
+                if now >= next_poll {
+                    host.refresh();
+                    emit(output, &snapshot_event(host.snapshot()))?;
+                    next_poll = Instant::now() + poll_interval;
+                }
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                emit(output, &stopped_event("input_closed"))?;
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+struct WatchdogRuntime {
+    config: PowerWatchdogConfig,
+    active: bool,
+    suppressed: bool,
+    next_feed_at: Option<Instant>,
+}
+
+impl WatchdogRuntime {
+    fn new(config: PowerWatchdogConfig) -> Self {
+        Self {
+            config,
+            active: false,
+            suppressed: false,
+            next_feed_at: None,
+        }
+    }
+
+    fn start<B: PowerBackend>(
+        &mut self,
+        host: &mut PowerHost<B>,
+        output: &mut dyn Write,
+    ) -> Result<()> {
+        if !self.config.enabled {
+            return Ok(());
+        }
+        self.enable(host, output, None, "power.watchdog_enable")
+    }
+
+    fn enable<B: PowerBackend>(
+        &mut self,
+        host: &mut PowerHost<B>,
+        output: &mut dyn Write,
+        request_id: Option<String>,
+        message_type: &str,
+    ) -> Result<()> {
+        let timeout_seconds = self.config.timeout_seconds.max(1);
+        match host.execute_watchdog(PowerWatchdogCommand::Enable { timeout_seconds }) {
+            Ok(()) => {
+                self.active = true;
+                self.suppressed = false;
+                self.next_feed_at = Some(Instant::now() + self.feed_interval());
+                if request_id.is_some() {
+                    emit(output, &watchdog_result(message_type, request_id, self))?;
+                }
+            }
+            Err(message) => emit(
+                output,
+                &WorkerEnvelope::error("power.error", request_id, "watchdog_failed", message),
+            )?,
+        }
+        Ok(())
+    }
+
+    fn feed<B: PowerBackend>(
+        &mut self,
+        host: &mut PowerHost<B>,
+        output: &mut dyn Write,
+        now: Instant,
+    ) -> Result<()> {
+        if !self.active || self.suppressed {
+            return Ok(());
+        }
+        match host.execute_watchdog(PowerWatchdogCommand::Feed) {
+            Ok(()) => {
+                self.next_feed_at = Some(now + self.feed_interval());
+            }
+            Err(message) => {
+                self.next_feed_at = Some(now + self.feed_interval().min(Duration::from_secs(5)));
+                emit(
+                    output,
+                    &WorkerEnvelope::error("power.error", None, "watchdog_failed", message),
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn disable<B: PowerBackend>(
+        &mut self,
+        host: &mut PowerHost<B>,
+        output: &mut dyn Write,
+        request_id: Option<String>,
+        message_type: &str,
+    ) -> Result<()> {
+        if !self.active {
+            if request_id.is_some() {
+                emit(output, &watchdog_result(message_type, request_id, self))?;
+            }
+            return Ok(());
+        }
+        match host.execute_watchdog(PowerWatchdogCommand::Disable) {
+            Ok(()) => {
+                self.active = false;
+                self.suppressed = false;
+                self.next_feed_at = None;
+                if request_id.is_some() {
+                    emit(output, &watchdog_result(message_type, request_id, self))?;
+                }
+            }
+            Err(message) => emit(
+                output,
+                &WorkerEnvelope::error("power.error", request_id, "watchdog_failed", message),
+            )?,
+        }
+        Ok(())
+    }
+
+    fn disable_for_stop<B: PowerBackend>(
+        &mut self,
+        host: &mut PowerHost<B>,
+        output: &mut dyn Write,
+    ) -> Result<()> {
+        if self.active && !self.suppressed {
+            self.disable(host, output, None, "power.watchdog_disable")?;
+        }
+        Ok(())
+    }
+
+    fn suppress(&mut self) {
+        if self.active {
+            self.suppressed = true;
+            self.next_feed_at = None;
+        }
+    }
+
+    fn feed_due(&self, now: Instant) -> bool {
+        self.active
+            && !self.suppressed
+            && self
+                .next_feed_at
+                .is_some_and(|next_feed_at| now >= next_feed_at)
+    }
+
+    fn next_feed_at(&self) -> Option<Instant> {
+        if self.active && !self.suppressed {
+            self.next_feed_at
+        } else {
+            None
+        }
+    }
+
+    fn feed_interval(&self) -> Duration {
+        Duration::from_secs_f64(self.config.feed_interval_seconds.max(0.001))
+    }
+}
+
+enum LoopControl {
+    Continue(Vec<WorkerEnvelope>),
+    Shutdown(Vec<WorkerEnvelope>),
+}
+
+fn handle_command<B: PowerBackend>(
+    host: &mut PowerHost<B>,
+    watchdog: &mut WatchdogRuntime,
+    envelope: WorkerEnvelope,
+) -> LoopControl {
+    let request_id = envelope.request_id.clone();
+    match envelope.message_type.as_str() {
+        "power.health" => LoopControl::Continue(vec![snapshot_result(request_id, host.snapshot())]),
+        "power.refresh" => {
+            host.refresh();
+            LoopControl::Continue(vec![
+                snapshot_result(request_id, host.snapshot()),
+                snapshot_event(host.snapshot()),
+            ])
+        }
+        "power.sync_time_to_rtc" => control_command(
+            host,
+            envelope.message_type,
+            request_id,
+            PowerControlCommand::SyncTimeToRtc,
+        ),
+        "power.sync_time_from_rtc" => control_command(
+            host,
+            envelope.message_type,
+            request_id,
+            PowerControlCommand::SyncTimeFromRtc,
+        ),
+        "power.set_rtc_alarm" => match set_alarm_command(&envelope.payload) {
+            Ok(command) => control_command(host, envelope.message_type, request_id, command),
+            Err(message) => LoopControl::Continue(vec![WorkerEnvelope::error(
+                "power.error",
+                request_id,
+                "invalid_payload",
+                message,
+            )]),
+        },
+        "power.disable_rtc_alarm" => control_command(
+            host,
+            envelope.message_type,
+            request_id,
+            PowerControlCommand::DisableRtcAlarm,
+        ),
+        "power.watchdog_enable" => {
+            let mut output = Vec::new();
+            let result = watchdog.enable(host, &mut output, request_id, "power.watchdog_enable");
+            watchdog_command_result(result, output)
+        }
+        "power.watchdog_feed" => {
+            let mut output = Vec::new();
+            let now = Instant::now();
+            let result = if watchdog.active && !watchdog.suppressed {
+                watchdog.feed(host, &mut output, now).and_then(|()| {
+                    emit(
+                        &mut output,
+                        &watchdog_result("power.watchdog_feed", request_id, watchdog),
+                    )
+                })
+            } else {
+                emit(
+                    &mut output,
+                    &watchdog_result("power.watchdog_feed", request_id, watchdog),
+                )
+            };
+            watchdog_command_result(result, output)
+        }
+        "power.watchdog_disable" => {
+            let mut output = Vec::new();
+            let result = watchdog.disable(host, &mut output, request_id, "power.watchdog_disable");
+            watchdog_command_result(result, output)
+        }
+        "power.watchdog_suppress" => {
+            watchdog.suppress();
+            LoopControl::Continue(vec![watchdog_result(
+                "power.watchdog_suppress",
+                request_id,
+                watchdog,
+            )])
+        }
+        "power.shutdown" | "worker.stop" => {
+            LoopControl::Shutdown(vec![stopped_result(request_id, "shutdown")])
+        }
+        _ => LoopControl::Continue(vec![WorkerEnvelope::error(
+            "power.error",
+            request_id,
+            "unsupported_command",
+            format!("unsupported command {}", envelope.message_type),
+        )]),
+    }
+}
+
+fn watchdog_command_result(result: Result<()>, output: Vec<u8>) -> LoopControl {
+    let envelopes = String::from_utf8_lossy(&output)
+        .lines()
+        .filter_map(|line| WorkerEnvelope::decode(line.as_bytes()).ok())
+        .collect::<Vec<_>>();
+    match result {
+        Ok(()) => LoopControl::Continue(envelopes),
+        Err(error) => LoopControl::Continue(vec![WorkerEnvelope::error(
+            "power.error",
+            None,
+            "watchdog_failed",
+            error.to_string(),
+        )]),
+    }
+}
+
+fn watchdog_result(
+    message_type: impl Into<String>,
+    request_id: Option<String>,
+    watchdog: &WatchdogRuntime,
+) -> WorkerEnvelope {
+    WorkerEnvelope::result(
+        message_type,
+        request_id,
+        serde_json::json!({
+            "ok": true,
+            "active": watchdog.active,
+            "suppressed": watchdog.suppressed,
+        }),
+    )
+}
+
+fn control_command<B: PowerBackend>(
+    host: &mut PowerHost<B>,
+    message_type: String,
+    request_id: Option<String>,
+    command: PowerControlCommand,
+) -> LoopControl {
+    match host.execute_control(command) {
+        Ok(snapshot) => LoopControl::Continue(vec![
+            control_result(message_type, request_id, &snapshot),
+            snapshot_event(&snapshot),
+        ]),
+        Err(message) => LoopControl::Continue(vec![WorkerEnvelope::error(
+            "power.error",
+            request_id,
+            "control_failed",
+            message,
+        )]),
+    }
+}
+
+fn set_alarm_command(payload: &Value) -> Result<PowerControlCommand, String> {
+    let when = payload
+        .get("when")
+        .or_else(|| payload.get("alarm_time"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "power.set_rtc_alarm requires when".to_string())?
+        .to_string();
+    let repeat_mask = payload
+        .get("repeat_mask")
+        .and_then(Value::as_i64)
+        .unwrap_or(127);
+    let repeat_mask = i32::try_from(repeat_mask)
+        .map_err(|_| "power.set_rtc_alarm repeat_mask must fit in i32".to_string())?;
+
+    Ok(PowerControlCommand::SetRtcAlarm { when, repeat_mask })
+}
+
+fn emit(output: &mut dyn Write, envelope: &WorkerEnvelope) -> Result<()> {
+    output.write_all(&envelope.encode()?)?;
+    output.flush()?;
+    Ok(())
+}

--- a/yoyopod_rs/power-host/tests/config.rs
+++ b/yoyopod_rs/power-host/tests/config.rs
@@ -1,0 +1,155 @@
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use yoyopod_power_host::config::PowerHostConfig;
+
+const CONFIG_ENV_KEYS: &[&str] = &[
+    "YOYOPOD_POWER_ENABLED",
+    "YOYOPOD_POWER_BACKEND",
+    "YOYOPOD_POWER_TRANSPORT",
+    "YOYOPOD_PISUGAR_SOCKET_PATH",
+    "YOYOPOD_PISUGAR_HOST",
+    "YOYOPOD_PISUGAR_PORT",
+    "YOYOPOD_POWER_TIMEOUT_SECONDS",
+    "YOYOPOD_POWER_POLL_INTERVAL_SECONDS",
+    "YOYOPOD_POWER_WATCHDOG_ENABLED",
+    "YOYOPOD_POWER_WATCHDOG_TIMEOUT_SECONDS",
+    "YOYOPOD_POWER_WATCHDOG_FEED_INTERVAL_SECONDS",
+    "YOYOPOD_POWER_WATCHDOG_I2C_BUS",
+    "YOYOPOD_POWER_WATCHDOG_I2C_ADDRESS",
+    "YOYOPOD_POWER_WATCHDOG_COMMAND_TIMEOUT_SECONDS",
+];
+
+struct EnvSnapshot {
+    values: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl Drop for EnvSnapshot {
+    fn drop(&mut self) {
+        for (key, value) in self.values.drain(..) {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn lock_env() -> MutexGuard<'static, ()> {
+    env_lock().lock().unwrap_or_else(|error| error.into_inner())
+}
+
+fn clean_config_env() -> EnvSnapshot {
+    let values = CONFIG_ENV_KEYS
+        .iter()
+        .map(|key| (*key, std::env::var_os(key)))
+        .collect();
+    for key in CONFIG_ENV_KEYS {
+        std::env::remove_var(key);
+    }
+    EnvSnapshot { values }
+}
+
+fn temp_config_dir(test_name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("yoyopod-power-host-config-{test_name}-{unique}"))
+}
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir");
+    }
+    fs::write(path, contents).expect("write config");
+}
+
+#[test]
+fn loads_power_backend_yaml_with_python_defaults() {
+    let _lock = lock_env();
+    let _env = clean_config_env();
+    let dir = temp_config_dir("yaml");
+    write(
+        &dir.join("power/backend.yaml"),
+        r#"
+power:
+  enabled: false
+  backend: "pisugar"
+  transport: "tcp"
+  socket_path: "/tmp/custom-pisugar.sock"
+  tcp_host: "10.0.0.2"
+  tcp_port: 18423
+  timeout_seconds: 1.5
+  poll_interval_seconds: 12.5
+  watchdog_enabled: true
+  watchdog_timeout_seconds: 44
+  watchdog_feed_interval_seconds: 8.5
+  watchdog_i2c_bus: 2
+  watchdog_i2c_address: 0x58
+  watchdog_command_timeout_seconds: 3.25
+"#,
+    );
+
+    let config = PowerHostConfig::load(&dir).expect("load power config");
+
+    assert!(!config.enabled);
+    assert_eq!(config.backend, "pisugar");
+    assert_eq!(config.transport, "tcp");
+    assert_eq!(config.socket_path, "/tmp/custom-pisugar.sock");
+    assert_eq!(config.tcp_host, "10.0.0.2");
+    assert_eq!(config.tcp_port, 18423);
+    assert_eq!(config.timeout_seconds, 1.5);
+    assert_eq!(config.poll_interval_seconds, 12.5);
+    assert!(config.watchdog.enabled);
+    assert_eq!(config.watchdog.timeout_seconds, 44);
+    assert_eq!(config.watchdog.feed_interval_seconds, 8.5);
+    assert_eq!(config.watchdog.i2c_bus, 2);
+    assert_eq!(config.watchdog.i2c_address, 0x58);
+    assert_eq!(config.watchdog.command_timeout_seconds, 3.25);
+}
+
+#[test]
+fn env_overrides_power_connection_settings() {
+    let _lock = lock_env();
+    let _env = clean_config_env();
+    let dir = temp_config_dir("env");
+    fs::create_dir_all(&dir).expect("config dir");
+    std::env::set_var("YOYOPOD_POWER_ENABLED", "false");
+    std::env::set_var("YOYOPOD_POWER_TRANSPORT", "socket");
+    std::env::set_var("YOYOPOD_PISUGAR_SOCKET_PATH", "/tmp/env.sock");
+    std::env::set_var("YOYOPOD_PISUGAR_HOST", "192.0.2.55");
+    std::env::set_var("YOYOPOD_PISUGAR_PORT", "8424");
+    std::env::set_var("YOYOPOD_POWER_TIMEOUT_SECONDS", "0.75");
+    std::env::set_var("YOYOPOD_POWER_POLL_INTERVAL_SECONDS", "9.25");
+    std::env::set_var("YOYOPOD_POWER_WATCHDOG_ENABLED", "true");
+    std::env::set_var("YOYOPOD_POWER_WATCHDOG_TIMEOUT_SECONDS", "22");
+    std::env::set_var("YOYOPOD_POWER_WATCHDOG_FEED_INTERVAL_SECONDS", "4.5");
+    std::env::set_var("YOYOPOD_POWER_WATCHDOG_I2C_BUS", "3");
+    std::env::set_var("YOYOPOD_POWER_WATCHDOG_I2C_ADDRESS", "0x59");
+    std::env::set_var("YOYOPOD_POWER_WATCHDOG_COMMAND_TIMEOUT_SECONDS", "2.25");
+
+    let config = PowerHostConfig::load(&dir).expect("load power config");
+
+    assert!(!config.enabled);
+    assert_eq!(config.transport, "socket");
+    assert_eq!(config.socket_path, "/tmp/env.sock");
+    assert_eq!(config.tcp_host, "192.0.2.55");
+    assert_eq!(config.tcp_port, 8424);
+    assert_eq!(config.timeout_seconds, 0.75);
+    assert_eq!(config.poll_interval_seconds, 9.25);
+    assert!(config.watchdog.enabled);
+    assert_eq!(config.watchdog.timeout_seconds, 22);
+    assert_eq!(config.watchdog.feed_interval_seconds, 4.5);
+    assert_eq!(config.watchdog.i2c_bus, 3);
+    assert_eq!(config.watchdog.i2c_address, 0x59);
+    assert_eq!(config.watchdog.command_timeout_seconds, 2.25);
+}

--- a/yoyopod_rs/power-host/tests/snapshot.rs
+++ b/yoyopod_rs/power-host/tests/snapshot.rs
@@ -1,0 +1,30 @@
+use serde_json::json;
+use yoyopod_power_host::snapshot::{BatterySnapshot, PowerStatusSnapshot};
+
+#[test]
+fn power_snapshot_serializes_runtime_compatible_shape() {
+    let snapshot = PowerStatusSnapshot {
+        available: true,
+        checked_at_ms: 1234,
+        source: "pisugar".to_string(),
+        battery: BatterySnapshot {
+            level_percent: Some(87.6),
+            voltage_volts: Some(4.05),
+            charging: Some(true),
+            power_plugged: Some(true),
+            allow_charging: Some(true),
+            output_enabled: Some(true),
+            temperature_celsius: Some(31.5),
+        },
+        error: String::new(),
+        ..PowerStatusSnapshot::default()
+    };
+
+    let payload = serde_json::to_value(snapshot).expect("serialize snapshot");
+
+    assert_eq!(payload["available"], json!(true));
+    assert_eq!(payload["source"], json!("pisugar"));
+    assert_eq!(payload["battery"]["level_percent"], json!(87.6));
+    assert_eq!(payload["battery"]["charging"], json!(true));
+    assert_eq!(payload["battery"]["power_plugged"], json!(true));
+}

--- a/yoyopod_rs/power-host/tests/worker.rs
+++ b/yoyopod_rs/power-host/tests/worker.rs
@@ -1,0 +1,322 @@
+use std::io::{Cursor, Read};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use yoyopod_power_host::config::PowerWatchdogConfig;
+use yoyopod_power_host::host::{
+    PowerBackend, PowerControlCommand, PowerHost, PowerWatchdogCommand,
+};
+use yoyopod_power_host::protocol::WorkerEnvelope;
+use yoyopod_power_host::snapshot::{BatterySnapshot, PowerStatusSnapshot};
+use yoyopod_power_host::worker::{run_host_loop, run_host_loop_with_watchdog};
+
+#[derive(Clone)]
+struct FakeBackend {
+    snapshot: PowerStatusSnapshot,
+    refreshes: Arc<Mutex<usize>>,
+    control_commands: Arc<Mutex<Vec<PowerControlCommand>>>,
+    watchdog_commands: Arc<Mutex<Vec<PowerWatchdogCommand>>>,
+}
+
+impl PowerBackend for FakeBackend {
+    fn refresh_snapshot(&mut self) -> PowerStatusSnapshot {
+        *self.refreshes.lock().expect("refresh lock") += 1;
+        self.snapshot.clone()
+    }
+
+    fn execute_control(
+        &mut self,
+        command: PowerControlCommand,
+    ) -> Result<PowerStatusSnapshot, String> {
+        self.control_commands
+            .lock()
+            .expect("control command lock")
+            .push(command);
+        Ok(self.refresh_snapshot())
+    }
+
+    fn execute_watchdog(&mut self, command: PowerWatchdogCommand) -> Result<(), String> {
+        self.watchdog_commands
+            .lock()
+            .expect("watchdog command lock")
+            .push(command);
+        Ok(())
+    }
+}
+
+#[test]
+fn worker_emits_ready_and_initial_snapshot_then_stops() {
+    let refreshes = Arc::new(Mutex::new(0));
+    let backend = FakeBackend {
+        snapshot: PowerStatusSnapshot {
+            available: true,
+            battery: BatterySnapshot {
+                level_percent: Some(76.0),
+                charging: Some(false),
+                power_plugged: Some(false),
+                ..BatterySnapshot::default()
+            },
+            ..PowerStatusSnapshot::default()
+        },
+        refreshes: Arc::clone(&refreshes),
+        control_commands: Arc::new(Mutex::new(Vec::new())),
+        watchdog_commands: Arc::new(Mutex::new(Vec::new())),
+    };
+    let host = PowerHost::new(backend);
+    let input = Cursor::new(
+        br#"{"schema_version":1,"kind":"command","type":"worker.stop","payload":{}}
+"#
+        .to_vec(),
+    );
+    let mut output = Vec::new();
+
+    run_host_loop(host, input, &mut output, Duration::from_millis(1)).expect("worker loop");
+
+    let lines = String::from_utf8(output).expect("utf8 output");
+    let envelopes = lines
+        .lines()
+        .map(|line| WorkerEnvelope::decode(line.as_bytes()).expect("decode envelope"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(envelopes[0].message_type, "power.ready");
+    assert_eq!(envelopes[1].message_type, "power.snapshot");
+    assert_eq!(envelopes[1].payload["battery"]["level_percent"], 76.0);
+    assert_eq!(
+        envelopes.last().expect("stopped").message_type,
+        "power.stopped"
+    );
+    assert_eq!(*refreshes.lock().expect("refresh lock"), 1);
+}
+
+#[test]
+fn worker_routes_rtc_control_commands_and_emits_fresh_snapshots() {
+    let refreshes = Arc::new(Mutex::new(0));
+    let control_commands = Arc::new(Mutex::new(Vec::new()));
+    let backend = FakeBackend {
+        snapshot: PowerStatusSnapshot {
+            available: true,
+            battery: BatterySnapshot {
+                level_percent: Some(64.0),
+                charging: Some(true),
+                power_plugged: Some(true),
+                ..BatterySnapshot::default()
+            },
+            ..PowerStatusSnapshot::default()
+        },
+        refreshes: Arc::clone(&refreshes),
+        control_commands: Arc::clone(&control_commands),
+        watchdog_commands: Arc::new(Mutex::new(Vec::new())),
+    };
+    let host = PowerHost::new(backend);
+    let input = Cursor::new(
+        br#"{"schema_version":1,"kind":"command","type":"power.sync_time_to_rtc","payload":{}}
+{"schema_version":1,"kind":"command","type":"power.sync_time_from_rtc","payload":{}}
+{"schema_version":1,"kind":"command","type":"power.set_rtc_alarm","payload":{"when":"2026-05-05T07:30:00+00:00","repeat_mask":31}}
+{"schema_version":1,"kind":"command","type":"power.disable_rtc_alarm","payload":{}}
+{"schema_version":1,"kind":"command","type":"worker.stop","payload":{}}
+"#
+        .to_vec(),
+    );
+    let mut output = Vec::new();
+
+    run_host_loop(host, input, &mut output, Duration::from_secs(60)).expect("worker loop");
+
+    assert_eq!(
+        *control_commands.lock().expect("control command lock"),
+        vec![
+            PowerControlCommand::SyncTimeToRtc,
+            PowerControlCommand::SyncTimeFromRtc,
+            PowerControlCommand::SetRtcAlarm {
+                when: "2026-05-05T07:30:00+00:00".to_string(),
+                repeat_mask: 31,
+            },
+            PowerControlCommand::DisableRtcAlarm,
+        ]
+    );
+    assert_eq!(*refreshes.lock().expect("refresh lock"), 5);
+
+    let lines = String::from_utf8(output).expect("utf8 output");
+    let envelopes = lines
+        .lines()
+        .map(|line| WorkerEnvelope::decode(line.as_bytes()).expect("decode envelope"))
+        .collect::<Vec<_>>();
+
+    for message_type in [
+        "power.sync_time_to_rtc",
+        "power.sync_time_from_rtc",
+        "power.set_rtc_alarm",
+        "power.disable_rtc_alarm",
+    ] {
+        let result = envelopes
+            .iter()
+            .find(|envelope| envelope.message_type == message_type)
+            .unwrap_or_else(|| panic!("missing result for {message_type}"));
+        assert_eq!(
+            result.kind,
+            yoyopod_power_host::protocol::EnvelopeKind::Result
+        );
+        assert_eq!(result.payload["ok"], true);
+        assert_eq!(result.payload["snapshot"]["battery"]["level_percent"], 64.0);
+    }
+
+    let snapshot_events = envelopes
+        .iter()
+        .filter(|envelope| envelope.message_type == "power.snapshot")
+        .count();
+    assert_eq!(snapshot_events, 5);
+}
+
+#[test]
+fn worker_rejects_set_rtc_alarm_without_time() {
+    let refreshes = Arc::new(Mutex::new(0));
+    let control_commands = Arc::new(Mutex::new(Vec::new()));
+    let backend = FakeBackend {
+        snapshot: PowerStatusSnapshot::default(),
+        refreshes: Arc::clone(&refreshes),
+        control_commands: Arc::clone(&control_commands),
+        watchdog_commands: Arc::new(Mutex::new(Vec::new())),
+    };
+    let host = PowerHost::new(backend);
+    let input = Cursor::new(
+        br#"{"schema_version":1,"kind":"command","type":"power.set_rtc_alarm","payload":{"repeat_mask":31}}
+{"schema_version":1,"kind":"command","type":"worker.stop","payload":{}}
+"#
+        .to_vec(),
+    );
+    let mut output = Vec::new();
+
+    run_host_loop(host, input, &mut output, Duration::from_secs(60)).expect("worker loop");
+
+    assert!(control_commands
+        .lock()
+        .expect("control command lock")
+        .is_empty());
+    assert_eq!(*refreshes.lock().expect("refresh lock"), 1);
+
+    let lines = String::from_utf8(output).expect("utf8 output");
+    let error = lines
+        .lines()
+        .map(|line| WorkerEnvelope::decode(line.as_bytes()).expect("decode envelope"))
+        .find(|envelope| envelope.message_type == "power.error")
+        .expect("power.error");
+
+    assert_eq!(error.payload["code"], "invalid_payload");
+    assert!(error.payload["message"]
+        .as_str()
+        .expect("error message")
+        .contains("when"));
+}
+
+#[test]
+fn worker_enables_feeds_and_disables_watchdog_when_configured() {
+    let watchdog_commands = Arc::new(Mutex::new(Vec::new()));
+    let backend = FakeBackend {
+        snapshot: PowerStatusSnapshot::default(),
+        refreshes: Arc::new(Mutex::new(0)),
+        control_commands: Arc::new(Mutex::new(Vec::new())),
+        watchdog_commands: Arc::clone(&watchdog_commands),
+    };
+    let host = PowerHost::new(backend);
+    let input = DelayedInput::new(
+        br#"{"schema_version":1,"kind":"command","type":"worker.stop","payload":{}}
+"#
+        .to_vec(),
+        Duration::from_millis(30),
+    );
+    let mut output = Vec::new();
+
+    run_host_loop_with_watchdog(
+        host,
+        input,
+        &mut output,
+        Duration::from_secs(60),
+        PowerWatchdogConfig {
+            enabled: true,
+            timeout_seconds: 60,
+            feed_interval_seconds: 0.005,
+            i2c_bus: 1,
+            i2c_address: 0x57,
+            command_timeout_seconds: 5.0,
+        },
+    )
+    .expect("worker loop");
+
+    let commands = watchdog_commands.lock().expect("watchdog command lock");
+    assert_eq!(
+        commands.first(),
+        Some(&PowerWatchdogCommand::Enable {
+            timeout_seconds: 60
+        })
+    );
+    assert!(commands.contains(&PowerWatchdogCommand::Feed));
+    assert_eq!(commands.last(), Some(&PowerWatchdogCommand::Disable));
+}
+
+#[test]
+fn worker_suppresses_watchdog_disable_for_pending_system_poweroff() {
+    let watchdog_commands = Arc::new(Mutex::new(Vec::new()));
+    let backend = FakeBackend {
+        snapshot: PowerStatusSnapshot::default(),
+        refreshes: Arc::new(Mutex::new(0)),
+        control_commands: Arc::new(Mutex::new(Vec::new())),
+        watchdog_commands: Arc::clone(&watchdog_commands),
+    };
+    let host = PowerHost::new(backend);
+    let input = Cursor::new(
+        br#"{"schema_version":1,"kind":"command","type":"power.watchdog_suppress","payload":{"reason":"pending_system_poweroff"}}
+{"schema_version":1,"kind":"command","type":"worker.stop","payload":{}}
+"#
+        .to_vec(),
+    );
+    let mut output = Vec::new();
+
+    run_host_loop_with_watchdog(
+        host,
+        input,
+        &mut output,
+        Duration::from_secs(60),
+        PowerWatchdogConfig {
+            enabled: true,
+            timeout_seconds: 60,
+            feed_interval_seconds: 15.0,
+            i2c_bus: 1,
+            i2c_address: 0x57,
+            command_timeout_seconds: 5.0,
+        },
+    )
+    .expect("worker loop");
+
+    assert_eq!(
+        *watchdog_commands.lock().expect("watchdog command lock"),
+        vec![PowerWatchdogCommand::Enable {
+            timeout_seconds: 60
+        }]
+    );
+}
+
+struct DelayedInput {
+    payload: Cursor<Vec<u8>>,
+    delay: Duration,
+    delayed: bool,
+}
+
+impl DelayedInput {
+    fn new(payload: Vec<u8>, delay: Duration) -> Self {
+        Self {
+            payload: Cursor::new(payload),
+            delay,
+            delayed: false,
+        }
+    }
+}
+
+impl Read for DelayedInput {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        if !self.delayed {
+            self.delayed = true;
+            thread::sleep(self.delay);
+        }
+        self.payload.read(buffer)
+    }
+}

--- a/yoyopod_rs/runtime/src/cli.rs
+++ b/yoyopod_rs/runtime/src/cli.rs
@@ -96,6 +96,7 @@ fn start_workers(
     let mut state = RuntimeState::default();
     state.seed_contacts(config.people.to_contact_items());
     state.configure_voice_note_store_dir(config.voip.voice_note_store_dir.clone());
+    state.configure_power_safety(config.power.to_safety_config());
     state.mark_worker(WorkerDomain::Ui, WorkerState::Starting, "starting");
 
     if !workers.start(WorkerSpec::new(
@@ -208,6 +209,32 @@ fn start_workers(
         );
     }
 
+    state.mark_worker(WorkerDomain::Power, WorkerState::Starting, "starting");
+    if workers.start(WorkerSpec::new(
+        WorkerDomain::Power,
+        config.worker_paths.power.clone(),
+        [
+            "--config-dir".to_string(),
+            config_dir.to_string_lossy().to_string(),
+        ],
+    )) {
+        if workers.wait_for_ready(WorkerDomain::Power, "power.ready", Duration::from_secs(3)) {
+            state.mark_worker(WorkerDomain::Power, WorkerState::Running, "ready");
+        } else {
+            state.mark_worker(
+                WorkerDomain::Power,
+                WorkerState::Degraded,
+                "timed out waiting for power.ready",
+            );
+        }
+    } else {
+        state.mark_worker(
+            WorkerDomain::Power,
+            WorkerState::Degraded,
+            "failed to start",
+        );
+    }
+
     Ok(state)
 }
 
@@ -241,13 +268,9 @@ fn send_startup_commands(workers: &mut WorkerSupervisor, config: &RuntimeConfig)
         "cloud.publish_heartbeat",
         json!({"firmware_version": env!("CARGO_PKG_VERSION")}),
     );
-    workers.send_command(
-        WorkerDomain::Cloud,
-        "cloud.publish_battery",
-        json!({"level": 100, "charging": false}),
-    );
     workers.send_command(WorkerDomain::Network, "network.health", json!({}));
     workers.send_command(WorkerDomain::Network, "network.query_gps", json!({}));
+    workers.send_command(WorkerDomain::Power, "power.health", json!({}));
     workers.send_command(
         WorkerDomain::Media,
         "media.configure",

--- a/yoyopod_rs/runtime/src/config.rs
+++ b/yoyopod_rs/runtime/src/config.rs
@@ -15,11 +15,13 @@ const LINPHONE_HOSTED_LIME_SERVER_URL: &str =
 const RUST_UI_HOST_DEFAULT_WORKER: &str = "yoyopod_rs/ui-host/build/yoyopod-ui-host";
 const RUST_CLOUD_HOST_DEFAULT_WORKER: &str = "yoyopod_rs/cloud-host/build/yoyopod-cloud-host";
 const RUST_NETWORK_HOST_DEFAULT_WORKER: &str = "yoyopod_rs/network-host/build/yoyopod-network-host";
+const RUST_POWER_HOST_DEFAULT_WORKER: &str = "yoyopod_rs/power-host/build/yoyopod-power-host";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeConfig {
     pub ui: UiConfig,
     pub media: MediaRuntimeConfig,
+    pub power: PowerRuntimeConfig,
     pub voip: VoipRuntimeConfig,
     pub people: PeopleRuntimeConfig,
     pub worker_paths: WorkerPaths,
@@ -45,6 +47,18 @@ pub struct MediaRuntimeConfig {
     pub remote_cache_dir: String,
     pub remote_cache_max_bytes: u64,
     pub auto_resume_after_call: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PowerRuntimeConfig {
+    pub enabled: bool,
+    pub low_battery_warning_percent: f64,
+    pub low_battery_warning_cooldown_seconds: f64,
+    pub auto_shutdown_enabled: bool,
+    pub critical_shutdown_percent: f64,
+    pub shutdown_delay_seconds: f64,
+    pub shutdown_command: String,
+    pub shutdown_state_file: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -92,6 +106,7 @@ pub struct WorkerPaths {
     pub media: String,
     pub voip: String,
     pub network: String,
+    pub power: String,
 }
 
 #[derive(Debug, Error)]
@@ -121,6 +136,7 @@ impl RuntimeConfig {
         let messaging = read_yaml(config_dir.join("communication/messaging.yaml"))?;
         let secrets = read_yaml(config_dir.join("communication/calling.secrets.yaml"))?;
         let people = read_yaml(config_dir.join("people/directory.yaml"))?;
+        let power = read_yaml(config_dir.join("power/backend.yaml"))?;
 
         let default_volume = int_at_env(
             &music,
@@ -195,6 +211,54 @@ impl RuntimeConfig {
                     &["audio", "auto_resume_after_call"],
                     true,
                     "YOYOPOD_AUTO_RESUME_AFTER_CALL",
+                ),
+            },
+            power: PowerRuntimeConfig {
+                enabled: bool_at_env(&power, &["power", "enabled"], true, "YOYOPOD_POWER_ENABLED"),
+                low_battery_warning_percent: f64_at_env(
+                    &power,
+                    &["power", "low_battery_warning_percent"],
+                    20.0,
+                    "YOYOPOD_LOW_BATTERY_WARNING_PERCENT",
+                ),
+                low_battery_warning_cooldown_seconds: f64_at_env(
+                    &power,
+                    &["power", "low_battery_warning_cooldown_seconds"],
+                    300.0,
+                    "YOYOPOD_LOW_BATTERY_WARNING_COOLDOWN_SECONDS",
+                ),
+                auto_shutdown_enabled: bool_at_env(
+                    &power,
+                    &["power", "auto_shutdown_enabled"],
+                    true,
+                    "YOYOPOD_AUTO_SHUTDOWN_ENABLED",
+                ),
+                critical_shutdown_percent: f64_at_env(
+                    &power,
+                    &["power", "critical_shutdown_percent"],
+                    10.0,
+                    "YOYOPOD_CRITICAL_BATTERY_SHUTDOWN_PERCENT",
+                ),
+                shutdown_delay_seconds: f64_at_env(
+                    &power,
+                    &["power", "shutdown_delay_seconds"],
+                    15.0,
+                    "YOYOPOD_POWER_SHUTDOWN_DELAY_SECONDS",
+                ),
+                shutdown_command: string_at_env(
+                    &power,
+                    &["power", "shutdown_command"],
+                    "sudo -n shutdown -h now",
+                    "YOYOPOD_POWER_SHUTDOWN_COMMAND",
+                ),
+                shutdown_state_file: resolve_runtime_path(
+                    &runtime_root,
+                    string_at_env(
+                        &power,
+                        &["power", "shutdown_state_file"],
+                        "data/last_shutdown_state.json",
+                        "YOYOPOD_POWER_SHUTDOWN_STATE_FILE",
+                    ),
                 ),
             },
             voip: VoipRuntimeConfig {
@@ -336,6 +400,10 @@ impl RuntimeConfig {
                     "YOYOPOD_RUST_NETWORK_HOST_WORKER",
                     RUST_NETWORK_HOST_DEFAULT_WORKER,
                 ),
+                power: env_or_default(
+                    "YOYOPOD_RUST_POWER_HOST_WORKER",
+                    RUST_POWER_HOST_DEFAULT_WORKER,
+                ),
             },
             pid_file: resolve_runtime_path(
                 &runtime_root,
@@ -371,6 +439,21 @@ impl MediaRuntimeConfig {
             "remote_cache_dir": self.remote_cache_dir,
             "remote_cache_max_bytes": self.remote_cache_max_bytes,
         })
+    }
+}
+
+impl PowerRuntimeConfig {
+    pub fn to_safety_config(&self) -> crate::state::PowerSafetyConfig {
+        crate::state::PowerSafetyConfig {
+            enabled: self.enabled,
+            low_battery_warning_percent: self.low_battery_warning_percent,
+            low_battery_warning_cooldown_seconds: self.low_battery_warning_cooldown_seconds,
+            auto_shutdown_enabled: self.auto_shutdown_enabled,
+            critical_shutdown_percent: self.critical_shutdown_percent,
+            shutdown_delay_seconds: self.shutdown_delay_seconds,
+            shutdown_command: self.shutdown_command.clone(),
+            shutdown_state_file: self.shutdown_state_file.clone(),
+        }
     }
 }
 
@@ -639,6 +722,12 @@ fn uint_at_env(value: &Value, path: &[&str], default: u64, env: &str) -> u64 {
         .unwrap_or_else(|| uint_at(value, path, default))
 }
 
+fn f64_at_env(value: &Value, path: &[&str], default: f64, env: &str) -> f64 {
+    env_string(env)
+        .and_then(|text| text.parse::<f64>().ok())
+        .unwrap_or_else(|| f64_at(value, path, default))
+}
+
 fn bool_at_env(value: &Value, path: &[&str], default: bool, env: &str) -> bool {
     env_string(env)
         .and_then(|text| parse_bool(&text))
@@ -670,6 +759,16 @@ fn uint_at(value: &Value, path: &[&str], default: u64) -> u64 {
             value
                 .as_u64()
                 .or_else(|| value.as_str()?.trim().parse::<u64>().ok())
+        })
+        .unwrap_or(default)
+}
+
+fn f64_at(value: &Value, path: &[&str], default: f64) -> f64 {
+    at_path(value, path)
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse::<f64>().ok())
         })
         .unwrap_or(default)
 }

--- a/yoyopod_rs/runtime/src/event.rs
+++ b/yoyopod_rs/runtime/src/event.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::{json, Value};
 
 use crate::protocol::{EnvelopeKind, WorkerEnvelope};
-use crate::state::{CallState, RuntimeState, WorkerDomain, WorkerState};
+use crate::state::{CallState, PowerSafetyAction, RuntimeState, WorkerDomain, WorkerState};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum RuntimeEvent {
@@ -15,6 +15,7 @@ pub enum RuntimeEvent {
     MediaSnapshot(Value),
     VoipSnapshot(Value),
     NetworkSnapshot(Value),
+    PowerSnapshot(Value),
     UiInput(Value),
     UiIntent {
         domain: String,
@@ -37,6 +38,7 @@ pub enum RuntimeEvent {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum RuntimeCommand {
     WorkerCommand {
         domain: WorkerDomain,
@@ -62,6 +64,7 @@ impl RuntimeEvent {
             Self::MediaSnapshot(snapshot) => state.apply_media_snapshot(snapshot),
             Self::VoipSnapshot(snapshot) => state.apply_voip_snapshot(snapshot),
             Self::NetworkSnapshot(snapshot) => state.apply_network_snapshot(snapshot),
+            Self::PowerSnapshot(snapshot) => state.apply_power_snapshot(snapshot),
             Self::UiScreenChanged { screen } => {
                 state.current_screen = screen.clone();
             }
@@ -104,6 +107,12 @@ pub fn runtime_event_from_worker(
         {
             Some(RuntimeEvent::NetworkSnapshot(payload))
         }
+        EnvelopeKind::Result
+            if domain == WorkerDomain::Power
+                && matches!(message_type.as_str(), "power.snapshot" | "power.health") =>
+        {
+            Some(RuntimeEvent::PowerSnapshot(payload))
+        }
         EnvelopeKind::Command | EnvelopeKind::Result | EnvelopeKind::Heartbeat => {
             Some(RuntimeEvent::Ignored)
         }
@@ -122,6 +131,7 @@ pub fn commands_for_event(state: &RuntimeState, event: &RuntimeEvent) -> Vec<Run
         RuntimeEvent::MediaSnapshot(snapshot) => commands_for_media_snapshot(snapshot),
         RuntimeEvent::VoipSnapshot(snapshot) => commands_for_voip_snapshot(state, snapshot),
         RuntimeEvent::NetworkSnapshot(snapshot) => commands_for_network_snapshot(snapshot),
+        RuntimeEvent::PowerSnapshot(snapshot) => commands_for_power_snapshot(state, snapshot),
         RuntimeEvent::Shutdown => vec![RuntimeCommand::Shutdown],
         RuntimeEvent::WorkerReady { .. }
         | RuntimeEvent::CloudSnapshot(_)
@@ -150,13 +160,7 @@ fn runtime_event_from_message(
         WorkerDomain::Media => media_event_from_message(message_type, payload),
         WorkerDomain::Voip => voip_event_from_message(message_type, payload),
         WorkerDomain::Network => network_event_from_message(message_type, payload),
-        WorkerDomain::Power => health_only_event_from_message(
-            domain,
-            message_type,
-            &payload,
-            "power.ready",
-            "power.error",
-        ),
+        WorkerDomain::Power => power_event_from_message(message_type, payload),
         WorkerDomain::Voice => health_only_event_from_message(
             domain,
             message_type,
@@ -246,6 +250,20 @@ fn network_event_from_message(message_type: &str, payload: Value) -> RuntimeEven
     }
 }
 
+fn power_event_from_message(message_type: &str, payload: Value) -> RuntimeEvent {
+    match message_type {
+        "power.ready" => RuntimeEvent::WorkerReady {
+            domain: WorkerDomain::Power,
+        },
+        "power.snapshot" | "power.health" => RuntimeEvent::PowerSnapshot(payload),
+        "power.error" => RuntimeEvent::WorkerError {
+            domain: WorkerDomain::Power,
+            message: worker_error_message(message_type, &payload),
+        },
+        _ => RuntimeEvent::Ignored,
+    }
+}
+
 fn health_only_event_from_message(
     domain: WorkerDomain,
     message_type: &str,
@@ -301,6 +319,7 @@ fn commands_for_ui_intent(
         "music" => commands_for_music_intent(state, &action, payload),
         "call" => commands_for_call_intent(state, &action, payload),
         "voice" => commands_for_voice_intent(state, &action, payload),
+        "power" => commands_for_power_intent(&action, payload),
         _ => Vec::new(),
     }
 }
@@ -508,6 +527,52 @@ fn commands_for_voice_intent(
             })
             .unwrap_or_default(),
         "discard" | "again" | "reset" => Vec::new(),
+        _ => Vec::new(),
+    }
+}
+
+fn commands_for_power_intent(action: &str, payload: &Value) -> Vec<RuntimeCommand> {
+    match action {
+        "refresh" | "refresh_snapshot" => vec![worker_command(
+            WorkerDomain::Power,
+            "power.refresh",
+            empty_payload(),
+        )],
+        "sync_time_to_rtc" | "sync_to_rtc" => vec![worker_command(
+            WorkerDomain::Power,
+            "power.sync_time_to_rtc",
+            empty_payload(),
+        )],
+        "sync_time_from_rtc" | "sync_from_rtc" => vec![worker_command(
+            WorkerDomain::Power,
+            "power.sync_time_from_rtc",
+            empty_payload(),
+        )],
+        "set_rtc_alarm" | "set_alarm" => {
+            let Some(when) = string_field(payload, "when")
+                .or_else(|| string_field(payload, "alarm_time"))
+                .filter(|value| !value.trim().is_empty())
+            else {
+                return Vec::new();
+            };
+            let repeat_mask = payload
+                .get("repeat_mask")
+                .and_then(Value::as_i64)
+                .unwrap_or(127);
+            vec![worker_command(
+                WorkerDomain::Power,
+                "power.set_rtc_alarm",
+                json!({
+                    "when": when,
+                    "repeat_mask": repeat_mask,
+                }),
+            )]
+        }
+        "disable_rtc_alarm" | "disable_alarm" => vec![worker_command(
+            WorkerDomain::Power,
+            "power.disable_rtc_alarm",
+            empty_payload(),
+        )],
         _ => Vec::new(),
     }
 }
@@ -742,6 +807,84 @@ fn commands_for_network_snapshot(snapshot: &Value) -> Vec<RuntimeCommand> {
     commands
 }
 
+fn commands_for_power_snapshot(state: &RuntimeState, snapshot: &Value) -> Vec<RuntimeCommand> {
+    let snapshot = snapshot.get("snapshot").unwrap_or(snapshot);
+    let mut commands = Vec::new();
+    let Some(battery) = snapshot
+        .get("battery")
+        .filter(|battery| battery.is_object())
+    else {
+        return commands;
+    };
+    if let Some(level) = f64_field(battery, "level_percent").filter(|level| level.is_finite()) {
+        let charging = battery
+            .get("charging")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let level = (level.round() as i64).clamp(0, 100);
+
+        commands.push(worker_command(
+            WorkerDomain::Cloud,
+            "cloud.publish_battery",
+            json!({
+                "level": level,
+                "charging": charging,
+            }),
+        ));
+    }
+    for action in state.power_safety_actions(snapshot, current_epoch_seconds()) {
+        commands.push(power_safety_event_command(action));
+    }
+    commands
+}
+
+fn power_safety_event_command(action: PowerSafetyAction) -> RuntimeCommand {
+    match action {
+        PowerSafetyAction::LowBatteryWarning {
+            threshold_percent,
+            battery_percent,
+            ..
+        } => worker_command(
+            WorkerDomain::Cloud,
+            "cloud.publish_event",
+            json!({
+                "event_type": "power.low_battery_warning",
+                "payload": {
+                    "threshold_percent": threshold_percent,
+                    "battery_percent": battery_percent,
+                },
+            }),
+        ),
+        PowerSafetyAction::GracefulShutdownRequested {
+            reason,
+            delay_seconds,
+            battery_percent,
+            ..
+        } => worker_command(
+            WorkerDomain::Cloud,
+            "cloud.publish_event",
+            json!({
+                "event_type": "power.graceful_shutdown_requested",
+                "payload": {
+                    "reason": reason,
+                    "delay_seconds": delay_seconds,
+                    "battery_percent": battery_percent,
+                },
+            }),
+        ),
+        PowerSafetyAction::GracefulShutdownCancelled { reason } => worker_command(
+            WorkerDomain::Cloud,
+            "cloud.publish_event",
+            json!({
+                "event_type": "power.graceful_shutdown_cancelled",
+                "payload": {
+                    "reason": reason,
+                },
+            }),
+        ),
+    }
+}
+
 fn worker_command(
     domain: WorkerDomain,
     message_type: impl Into<String>,
@@ -789,6 +932,13 @@ fn string_field(value: &Value, key: &str) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
+}
+
+fn f64_field(value: &Value, key: &str) -> Option<f64> {
+    let value = value.get(key)?;
+    value
+        .as_f64()
+        .or_else(|| value.as_str()?.trim().parse::<f64>().ok())
 }
 
 fn non_empty_string(value: &str) -> Option<String> {

--- a/yoyopod_rs/runtime/src/runtime_loop.rs
+++ b/yoyopod_rs/runtime/src/runtime_loop.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
-use std::time::Instant;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-use serde_json::json;
+use serde_json::{json, Value};
 
 use crate::event::{commands_for_event, runtime_event_from_worker, RuntimeCommand};
 use crate::protocol::WorkerEnvelope;
@@ -23,6 +26,8 @@ pub trait LoopIo {
     fn drain_worker_messages(&mut self) -> Vec<(WorkerDomain, WorkerEnvelope)>;
     fn drain_worker_protocol_errors(&mut self) -> Vec<(WorkerDomain, WorkerProtocolError)>;
     fn send_worker_envelope(&mut self, domain: WorkerDomain, envelope: WorkerEnvelope) -> bool;
+    fn write_power_shutdown_state(&mut self, path: &str, payload: &Value) -> Result<(), String>;
+    fn request_system_shutdown(&mut self, command: &str) -> Result<(), String>;
 }
 
 #[derive(Debug, Clone)]
@@ -84,9 +89,33 @@ impl RuntimeLoop {
 
         self.state.loop_iterations += 1;
         self.state.last_loop_duration_ms = started.elapsed().as_millis() as u64;
+        self.process_pending_power_shutdown(io);
         self.send_tick(io);
 
         processed
+    }
+
+    fn process_pending_power_shutdown(&mut self, io: &mut impl LoopIo) {
+        let now_seconds = current_epoch_seconds();
+        if !self.state.power_shutdown_due(now_seconds) {
+            return;
+        }
+
+        let state_file = self.state.power.safety.config.shutdown_state_file.clone();
+        let command = self.state.power.safety.config.shutdown_command.clone();
+        let payload = self.state.power_shutdown_state_payload(now_seconds);
+        let _ = io.send_worker_envelope(
+            WorkerDomain::Power,
+            WorkerEnvelope::command(
+                "power.watchdog_suppress",
+                None,
+                json!({"reason": "pending_system_poweroff"}),
+            ),
+        );
+        let _ = io.write_power_shutdown_state(&state_file, &payload);
+        let _ = io.request_system_shutdown(&command);
+        self.state.mark_power_shutdown_completed();
+        self.shutdown_requested = true;
     }
 
     fn dispatch_command(&mut self, io: &mut impl LoopIo, command: RuntimeCommand) {
@@ -154,6 +183,14 @@ impl LoopIo for WorkerSupervisor {
     fn send_worker_envelope(&mut self, domain: WorkerDomain, envelope: WorkerEnvelope) -> bool {
         self.send_envelope(domain, envelope)
     }
+
+    fn write_power_shutdown_state(&mut self, path: &str, payload: &Value) -> Result<(), String> {
+        write_shutdown_state_file(path, payload)
+    }
+
+    fn request_system_shutdown(&mut self, command: &str) -> Result<(), String> {
+        run_shutdown_command(command)
+    }
 }
 
 fn protocol_error_reason(error: &WorkerProtocolError) -> String {
@@ -162,4 +199,56 @@ fn protocol_error_reason(error: &WorkerProtocolError) -> String {
     } else {
         format!("protocol error: {} ({})", error.message, error.raw_line)
     }
+}
+
+fn write_shutdown_state_file(path: &str, payload: &Value) -> Result<(), String> {
+    let path = Path::new(path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    let contents = serde_json::to_string_pretty(payload).map_err(|error| error.to_string())?;
+    fs::write(path, contents).map_err(|error| error.to_string())
+}
+
+fn run_shutdown_command(command: &str) -> Result<(), String> {
+    let command = command.trim();
+    if command.is_empty() {
+        return Err("shutdown command is empty".to_string());
+    }
+
+    let status = shutdown_process(command)
+        .status()
+        .map_err(|error| error.to_string())?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "shutdown command exited with {}",
+            status
+                .code()
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "signal".to_string())
+        ))
+    }
+}
+
+#[cfg(windows)]
+fn shutdown_process(command: &str) -> Command {
+    let mut process = Command::new("cmd");
+    process.args(["/C", command]);
+    process
+}
+
+#[cfg(not(windows))]
+fn shutdown_process(command: &str) -> Command {
+    let mut process = Command::new("sh");
+    process.args(["-c", command]);
+    process
+}
+
+fn current_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
 }

--- a/yoyopod_rs/runtime/src/state.rs
+++ b/yoyopod_rs/runtime/src/state.rs
@@ -330,6 +330,104 @@ impl Default for CloudRuntimeState {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct PowerSafetyConfig {
+    pub enabled: bool,
+    pub low_battery_warning_percent: f64,
+    pub low_battery_warning_cooldown_seconds: f64,
+    pub auto_shutdown_enabled: bool,
+    pub critical_shutdown_percent: f64,
+    pub shutdown_delay_seconds: f64,
+    pub shutdown_command: String,
+    pub shutdown_state_file: String,
+}
+
+impl Default for PowerSafetyConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            low_battery_warning_percent: 20.0,
+            low_battery_warning_cooldown_seconds: 300.0,
+            auto_shutdown_enabled: true,
+            critical_shutdown_percent: 10.0,
+            shutdown_delay_seconds: 15.0,
+            shutdown_command: "sudo -n shutdown -h now".to_string(),
+            shutdown_state_file: "data/last_shutdown_state.json".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PowerSafetyState {
+    pub config: PowerSafetyConfig,
+    pub low_battery_warning_active: bool,
+    pub next_warning_at_seconds: u64,
+    pub shutdown_pending: bool,
+    pub shutdown_reason: String,
+    pub shutdown_requested_at_seconds: u64,
+    pub shutdown_execute_at_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PowerSafetyAction {
+    LowBatteryWarning {
+        threshold_percent: f64,
+        battery_percent: f64,
+        next_warning_at_seconds: u64,
+    },
+    GracefulShutdownRequested {
+        reason: String,
+        delay_seconds: f64,
+        battery_percent: f64,
+        requested_at_seconds: u64,
+        execute_at_seconds: u64,
+    },
+    GracefulShutdownCancelled {
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PowerRuntimeState {
+    pub available: bool,
+    pub source: String,
+    pub battery_percent: i32,
+    pub battery_known: bool,
+    pub charging: bool,
+    pub charging_known: bool,
+    pub external_power: bool,
+    pub external_power_known: bool,
+    pub model: String,
+    pub firmware_version: String,
+    pub voltage_text: String,
+    pub rtc_time: String,
+    pub alarm_text: String,
+    pub error: String,
+    pub safety: PowerSafetyState,
+}
+
+impl Default for PowerRuntimeState {
+    fn default() -> Self {
+        Self {
+            available: true,
+            source: "pisugar".to_string(),
+            battery_percent: 100,
+            battery_known: true,
+            charging: false,
+            charging_known: true,
+            external_power: false,
+            external_power_known: true,
+            model: String::new(),
+            firmware_version: String::new(),
+            voltage_text: "Unknown".to_string(),
+            rtc_time: "Unknown".to_string(),
+            alarm_text: "Unknown".to_string(),
+            error: String::new(),
+            safety: PowerSafetyState::default(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetupRow {
     pub label: String,
@@ -349,12 +447,13 @@ impl SetupRow {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeState {
     pub current_screen: String,
     pub media: MediaState,
     pub call: CallRuntimeState,
     pub voice: VoiceRuntimeState,
+    pub power: PowerRuntimeState,
     pub network: NetworkRuntimeState,
     pub cloud: CloudRuntimeState,
     pub ui: WorkerHealth,
@@ -375,6 +474,7 @@ impl Default for RuntimeState {
             media: MediaState::default(),
             call: CallRuntimeState::default(),
             voice: VoiceRuntimeState::default(),
+            power: PowerRuntimeState::default(),
             network: NetworkRuntimeState::default(),
             cloud: CloudRuntimeState::default(),
             ui: WorkerHealth::default(),
@@ -421,6 +521,187 @@ impl RuntimeState {
         let voice_note_store_dir = voice_note_store_dir.into();
         if !voice_note_store_dir.trim().is_empty() {
             self.voice.voice_note_store_dir = voice_note_store_dir;
+        }
+    }
+
+    pub fn configure_power_safety(&mut self, config: PowerSafetyConfig) {
+        self.power.safety.config = config;
+    }
+
+    pub fn power_safety_actions(
+        &self,
+        snapshot: &Value,
+        now_seconds: u64,
+    ) -> Vec<PowerSafetyAction> {
+        let snapshot = snapshot.get("snapshot").unwrap_or(snapshot);
+        if !self.power.safety.config.enabled {
+            return Vec::new();
+        }
+        if !snapshot
+            .get("available")
+            .and_then(Value::as_bool)
+            .unwrap_or(self.power.available)
+        {
+            return Vec::new();
+        }
+
+        let Some(battery) = snapshot
+            .get("battery")
+            .filter(|battery| battery.is_object())
+        else {
+            return Vec::new();
+        };
+        let Some(battery_percent) =
+            f64_field(battery, "level_percent").filter(|level| level.is_finite())
+        else {
+            return Vec::new();
+        };
+
+        let has_external_power = battery
+            .get("power_plugged")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            || battery
+                .get("charging")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+        if has_external_power {
+            if self.power.safety.shutdown_pending {
+                return vec![PowerSafetyAction::GracefulShutdownCancelled {
+                    reason: "external_power_restored".to_string(),
+                }];
+            }
+            return Vec::new();
+        }
+
+        let config = &self.power.safety.config;
+        if config.auto_shutdown_enabled
+            && battery_percent <= config.critical_shutdown_percent
+            && !self.power.safety.shutdown_pending
+        {
+            return vec![PowerSafetyAction::GracefulShutdownRequested {
+                reason: "critical_battery".to_string(),
+                delay_seconds: config.shutdown_delay_seconds,
+                battery_percent,
+                requested_at_seconds: now_seconds,
+                execute_at_seconds: now_seconds
+                    + seconds_to_u64_ceiling(config.shutdown_delay_seconds),
+            }];
+        }
+
+        if battery_percent > config.low_battery_warning_percent {
+            return Vec::new();
+        }
+        if now_seconds < self.power.safety.next_warning_at_seconds {
+            return Vec::new();
+        }
+
+        vec![PowerSafetyAction::LowBatteryWarning {
+            threshold_percent: config.low_battery_warning_percent,
+            battery_percent,
+            next_warning_at_seconds: now_seconds
+                + seconds_to_u64_ceiling(config.low_battery_warning_cooldown_seconds),
+        }]
+    }
+
+    pub fn power_shutdown_due(&self, now_seconds: u64) -> bool {
+        self.power.safety.shutdown_pending
+            && self.power.safety.shutdown_execute_at_seconds <= now_seconds
+    }
+
+    pub fn power_shutdown_state_payload(&self, saved_at_seconds: u64) -> Value {
+        json!({
+            "saved_at_epoch_seconds": saved_at_seconds,
+            "shutdown": {
+                "reason": self.power.safety.shutdown_reason,
+                "requested_at_epoch_seconds": self.power.safety.shutdown_requested_at_seconds,
+                "execute_at_epoch_seconds": self.power.safety.shutdown_execute_at_seconds,
+                "command": self.power.safety.config.shutdown_command,
+            },
+            "screen": {
+                "current": self.current_screen,
+            },
+            "power": {
+                "available": self.power.available,
+                "battery_percent": self.power.battery_percent,
+                "battery_known": self.power.battery_known,
+                "charging": self.power.charging,
+                "charging_known": self.power.charging_known,
+                "external_power": self.power.external_power,
+                "external_power_known": self.power.external_power_known,
+                "source": self.power.source,
+                "model": self.power.model,
+                "error": self.power.error,
+            },
+            "media": {
+                "connected": self.media.connected,
+                "playback_state": self.media.playback_state,
+                "title": self.media.title,
+                "artist": self.media.artist,
+                "progress_permille": self.media.progress_permille,
+            },
+            "voip": {
+                "registered": self.call.registered,
+                "registration_state": self.call.registration_state,
+                "call_state": self.call.state.as_str(),
+                "peer_name": self.call.peer_name,
+                "peer_address": self.call.peer_address,
+                "muted": self.call.muted,
+            },
+            "network": {
+                "enabled": self.network.enabled,
+                "connected": self.network.connected,
+                "connection_type": self.network.connection_type,
+                "signal_strength": self.network.signal_strength,
+                "gps_has_fix": self.network.gps_has_fix,
+            },
+            "cloud": {
+                "device_id": self.cloud.device_id,
+                "provisioning_state": self.cloud.provisioning_state,
+                "cloud_state": self.cloud.cloud_state,
+                "mqtt_connected": self.cloud.mqtt_connected,
+            },
+            "loop": {
+                "iterations": self.loop_iterations,
+                "last_duration_ms": self.last_loop_duration_ms,
+            },
+        })
+    }
+
+    pub fn mark_power_shutdown_completed(&mut self) {
+        self.power.safety.shutdown_pending = false;
+    }
+
+    fn apply_power_safety_actions(&mut self, actions: &[PowerSafetyAction]) {
+        for action in actions {
+            match action {
+                PowerSafetyAction::LowBatteryWarning {
+                    next_warning_at_seconds,
+                    ..
+                } => {
+                    self.power.safety.low_battery_warning_active = true;
+                    self.power.safety.next_warning_at_seconds = *next_warning_at_seconds;
+                }
+                PowerSafetyAction::GracefulShutdownRequested {
+                    reason,
+                    requested_at_seconds,
+                    execute_at_seconds,
+                    ..
+                } => {
+                    self.power.safety.shutdown_pending = true;
+                    self.power.safety.shutdown_reason = reason.clone();
+                    self.power.safety.shutdown_requested_at_seconds = *requested_at_seconds;
+                    self.power.safety.shutdown_execute_at_seconds = *execute_at_seconds;
+                }
+                PowerSafetyAction::GracefulShutdownCancelled { .. } => {
+                    self.power.safety.shutdown_pending = false;
+                    self.power.safety.shutdown_reason.clear();
+                    self.power.safety.shutdown_requested_at_seconds = 0;
+                    self.power.safety.shutdown_execute_at_seconds = 0;
+                    self.power.safety.low_battery_warning_active = false;
+                    self.power.safety.next_warning_at_seconds = 0;
+                }
+            }
         }
     }
 
@@ -682,6 +963,99 @@ impl RuntimeState {
         }
     }
 
+    pub fn apply_power_snapshot(&mut self, snapshot: &Value) {
+        let snapshot = snapshot.get("snapshot").unwrap_or(snapshot);
+        let safety_actions = self.power_safety_actions(snapshot, current_epoch_seconds());
+        if let Some(available) = snapshot.get("available").and_then(Value::as_bool) {
+            self.power.available = available;
+        }
+        if let Some(source) = string_field(snapshot, "source") {
+            self.power.source = source;
+        }
+        if let Some(error) = string_field(snapshot, "error") {
+            self.power.error = error;
+        }
+        if let Some(device) = snapshot.get("device").filter(|device| device.is_object()) {
+            if let Some(model) = string_field(device, "model") {
+                self.power.model = model;
+            }
+            if let Some(firmware_version) = string_field(device, "firmware_version") {
+                self.power.firmware_version = firmware_version;
+            }
+        }
+        if let Some(battery) = snapshot
+            .get("battery")
+            .filter(|battery| battery.is_object())
+        {
+            if let Some(level_percent) = f64_field(battery, "level_percent") {
+                if level_percent.is_finite() {
+                    self.power.battery_percent = (level_percent.round() as i32).clamp(0, 100);
+                    self.power.battery_known = true;
+                }
+            }
+            if let Some(charging) = battery.get("charging").and_then(Value::as_bool) {
+                self.power.charging = charging;
+                self.power.charging_known = true;
+            }
+            if let Some(power_plugged) = battery.get("power_plugged").and_then(Value::as_bool) {
+                self.power.external_power = power_plugged;
+                self.power.external_power_known = true;
+            }
+            self.power.voltage_text = format_voltage_text(
+                f64_field(battery, "voltage_volts"),
+                f64_field(battery, "temperature_celsius"),
+            );
+        }
+        if let Some(rtc) = snapshot.get("rtc").filter(|rtc| rtc.is_object()) {
+            if let Some(time) = string_field(rtc, "time") {
+                self.power.rtc_time = compact_datetime_text(&time);
+            }
+            if let Some(alarm_enabled) = rtc.get("alarm_enabled").and_then(Value::as_bool) {
+                self.power.alarm_text = if alarm_enabled {
+                    string_field(rtc, "alarm_time")
+                        .map(|time| compact_time_text(&time))
+                        .unwrap_or_else(|| "On".to_string())
+                } else {
+                    "Off".to_string()
+                };
+            }
+        }
+        self.reconcile_power_safety(snapshot);
+        self.apply_power_safety_actions(&safety_actions);
+    }
+
+    fn reconcile_power_safety(&mut self, snapshot: &Value) {
+        if !self.power.available {
+            self.power.safety.shutdown_pending = false;
+            self.power.safety.shutdown_reason.clear();
+            self.power.safety.shutdown_requested_at_seconds = 0;
+            self.power.safety.shutdown_execute_at_seconds = 0;
+            return;
+        }
+        let Some(battery) = snapshot
+            .get("battery")
+            .filter(|battery| battery.is_object())
+        else {
+            return;
+        };
+        let has_external_power = battery
+            .get("power_plugged")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            || battery
+                .get("charging")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+        let battery_percent = f64_field(battery, "level_percent");
+        if has_external_power
+            || battery_percent
+                .is_some_and(|level| level > self.power.safety.config.low_battery_warning_percent)
+        {
+            self.power.safety.low_battery_warning_active = false;
+            self.power.safety.next_warning_at_seconds = 0;
+        }
+    }
+
     pub fn apply_cloud_snapshot(&mut self, snapshot: &Value) {
         let snapshot = snapshot.get("snapshot").unwrap_or(snapshot);
         if let Some(device_id) = string_field(snapshot, "device_id") {
@@ -735,9 +1109,9 @@ impl RuntimeState {
                 "ptt_active": self.voice.phase == "recording",
             },
             "power": {
-                "battery_percent": 100,
-                "charging": false,
-                "power_available": true,
+                "battery_percent": self.power.battery_percent,
+                "charging": self.power.charging,
+                "power_available": self.power.available,
                 "rows": self.power_rows(),
                 "pages": self.setup_pages(),
             },
@@ -803,8 +1177,8 @@ impl RuntimeState {
 
     fn power_rows(&self) -> Vec<String> {
         vec![
-            "Battery 100%".to_string(),
-            "On battery".to_string(),
+            format!("Battery {}", self.power_battery_value()),
+            self.power_external_value().to_string(),
             self.network_status_row(),
             if self.call.registered {
                 "VoIP ready".to_string()
@@ -825,15 +1199,7 @@ impl RuntimeState {
     }
 
     fn setup_pages(&self) -> Vec<Value> {
-        let mut pages = vec![setup_page(
-            "Power",
-            "battery",
-            vec![
-                SetupRow::new("Battery", "100%"),
-                SetupRow::new("Charging", "On battery"),
-                SetupRow::new("External", "Available"),
-            ],
-        )];
+        let mut pages = vec![setup_page("Power", "battery", self.power_setup_rows())];
 
         if self.network.enabled {
             pages.push(setup_page(
@@ -944,6 +1310,73 @@ impl RuntimeState {
         }
     }
 
+    fn power_setup_rows(&self) -> Vec<SetupRow> {
+        if !self.power.available {
+            return vec![
+                SetupRow::new("Source", self.power.source.clone()),
+                SetupRow::new("Model", self.power_model_value()),
+                SetupRow::new("Status", "Offline"),
+                SetupRow::new("Reason", truncate(&self.power_error_value(), 18)),
+                SetupRow::new("RTC", self.power.rtc_time.clone()),
+                SetupRow::new("Alarm", self.power.alarm_text.clone()),
+            ];
+        }
+
+        vec![
+            SetupRow::new("Model", self.power_model_value()),
+            SetupRow::new("Battery", self.power_battery_value()),
+            SetupRow::new("Charging", self.power_charging_value()),
+            SetupRow::new("External", self.power_external_value()),
+            SetupRow::new("Voltage", self.power.voltage_text.clone()),
+            SetupRow::new("RTC", self.power.rtc_time.clone()),
+            SetupRow::new("Alarm", self.power.alarm_text.clone()),
+        ]
+    }
+
+    fn power_battery_value(&self) -> String {
+        if !self.power.battery_known {
+            return "Unknown".to_string();
+        }
+        let suffix = if self.power.charging { " chg" } else { "" };
+        format!("{}%{suffix}", self.power.battery_percent)
+    }
+
+    fn power_charging_value(&self) -> &'static str {
+        if !self.power.charging_known {
+            "Unknown"
+        } else if self.power.charging {
+            "Charging"
+        } else {
+            "Idle"
+        }
+    }
+
+    fn power_external_value(&self) -> &'static str {
+        if !self.power.external_power_known {
+            "Unknown"
+        } else if self.power.external_power {
+            "Plugged"
+        } else {
+            "On battery"
+        }
+    }
+
+    fn power_model_value(&self) -> String {
+        if self.power.model.trim().is_empty() {
+            "Unknown".to_string()
+        } else {
+            self.power.model.clone()
+        }
+    }
+
+    fn power_error_value(&self) -> String {
+        if self.power.error.trim().is_empty() {
+            "Unavailable".to_string()
+        } else {
+            self.power.error.clone()
+        }
+    }
+
     pub fn status_payload(&self) -> Value {
         json!({
             "screen": {
@@ -970,6 +1403,22 @@ impl RuntimeState {
                 "mqtt_connected": self.cloud.mqtt_connected,
                 "last_error_summary": self.cloud.last_error_summary,
             },
+            "power": {
+                "available": self.power.available,
+                "battery_percent": self.power.battery_percent,
+                "charging": self.power.charging,
+                "external_power": self.power.external_power,
+                "source": self.power.source,
+                "model": self.power.model,
+                "error": self.power.error,
+                "low_battery_warning_active": self.power.safety.low_battery_warning_active,
+                "shutdown_pending": self.power.safety.shutdown_pending,
+                "shutdown_reason": self.power.safety.shutdown_reason,
+                "warning_threshold_percent": self.power.safety.config.low_battery_warning_percent,
+                "critical_shutdown_percent": self.power.safety.config.critical_shutdown_percent,
+                "shutdown_delay_seconds": self.power.safety.config.shutdown_delay_seconds,
+                "shutdown_state_file": self.power.safety.config.shutdown_state_file,
+            },
             "workers": {
                 WorkerDomain::Ui.as_str(): worker_payload(&self.ui),
                 WorkerDomain::Cloud.as_str(): worker_payload(&self.cloud_worker),
@@ -994,6 +1443,13 @@ fn string_field(value: &Value, key: &str) -> Option<String> {
 fn i32_field(value: &Value, key: &str) -> Option<i32> {
     let raw = value.get(key)?.as_i64()?;
     i32::try_from(raw).ok()
+}
+
+fn f64_field(value: &Value, key: &str) -> Option<f64> {
+    let value = value.get(key)?;
+    value
+        .as_f64()
+        .or_else(|| value.as_str()?.trim().parse::<f64>().ok())
 }
 
 fn i64_field(value: &Value, key: &str) -> Option<i64> {
@@ -1127,6 +1583,48 @@ fn setup_rows(value: Option<&Value>) -> Option<Vec<SetupRow>> {
     Some(parsed)
 }
 
+fn format_voltage_text(voltage: Option<f64>, temperature: Option<f64>) -> String {
+    match (voltage, temperature) {
+        (Some(voltage), Some(temperature)) if voltage.is_finite() && temperature.is_finite() => {
+            format!("{voltage:.2}V {temperature:.0}C")
+        }
+        (Some(voltage), _) if voltage.is_finite() => format!("{voltage:.2} V"),
+        (_, Some(temperature)) if temperature.is_finite() => format!("{temperature:.1} C"),
+        _ => "Unknown".to_string(),
+    }
+}
+
+fn compact_datetime_text(value: &str) -> String {
+    let value = value.trim();
+    if value.len() >= 16 && value.as_bytes().get(10) == Some(&b'T') {
+        format!("{} {}", &value[5..10], &value[11..16])
+    } else {
+        value.to_string()
+    }
+}
+
+fn compact_time_text(value: &str) -> String {
+    let value = value.trim();
+    if value.len() >= 16 && value.as_bytes().get(10) == Some(&b'T') {
+        value[11..16].to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn truncate(value: &str, max_length: usize) -> String {
+    if value.len() <= max_length {
+        value.to_string()
+    } else if max_length <= 3 {
+        value.chars().take(max_length).collect()
+    } else {
+        format!(
+            "{}...",
+            value.chars().take(max_length - 3).collect::<String>()
+        )
+    }
+}
+
 fn voice_note_summary_from_value(value: &Value) -> Option<VoiceNoteSummary> {
     if !value.is_object() {
         return None;
@@ -1181,6 +1679,21 @@ fn current_millis() -> u128 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis())
         .unwrap_or_default()
+}
+
+fn current_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
+}
+
+fn seconds_to_u64_ceiling(seconds: f64) -> u64 {
+    if !seconds.is_finite() || seconds <= 0.0 {
+        0
+    } else {
+        seconds.ceil() as u64
+    }
 }
 
 fn normalized(value: &str) -> String {

--- a/yoyopod_rs/runtime/tests/cli.rs
+++ b/yoyopod_rs/runtime/tests/cli.rs
@@ -297,9 +297,57 @@ logging:
     assert!(normalized_cloud_args.contains(&yaml_path(&config_dir)));
     assert!(captured_cloud_stdin.contains(r#""type":"cloud.health""#));
     assert!(captured_cloud_stdin.contains(r#""type":"cloud.publish_heartbeat""#));
-    assert!(captured_cloud_stdin.contains(r#""type":"cloud.publish_battery""#));
+    assert!(!captured_cloud_stdin.contains(r#""type":"cloud.publish_battery""#));
     assert!(captured_ui.contains(r#""cloud""#));
     assert!(captured_ui.contains(r#""state":"running""#));
+}
+
+#[test]
+fn boot_starts_power_worker_and_projects_initial_power_snapshot() {
+    let _guard = env_lock();
+    let dir = temp_dir("power-worker");
+    let config_dir = dir.join("config");
+    let ui_stdin = dir.join("ui-stdin.ndjson");
+    let power_args = dir.join("power-args.txt");
+    let power_stdin = dir.join("power-stdin.ndjson");
+    let ui_worker = write_ui_worker_script(&dir, &ui_stdin);
+    let power_worker = write_power_worker_script(&dir, &power_args, &power_stdin);
+    write(
+        &config_dir.join("app/core.yaml"),
+        &format!(
+            r#"
+logging:
+  pid_file: "{}"
+  file: "{}"
+"#,
+            yaml_path(&dir.join("run/yoyopod.pid")),
+            yaml_path(&dir.join("logs/yoyopod.log"))
+        ),
+    );
+    std::env::set_var("YOYOPOD_RUST_UI_HOST_WORKER", &ui_worker);
+    std::env::set_var("YOYOPOD_RUST_POWER_HOST_WORKER", &power_worker);
+
+    let result = run(Args {
+        config_dir: config_dir.clone(),
+        dry_run: false,
+        hardware: "whisplay".to_string(),
+    });
+    std::env::remove_var("YOYOPOD_RUST_UI_HOST_WORKER");
+    std::env::remove_var("YOYOPOD_RUST_POWER_HOST_WORKER");
+    result.expect("runtime exits after UI shutdown intent");
+
+    let captured_ui = wait_for_file(&ui_stdin);
+    let captured_power_args = wait_for_file(&power_args);
+    let captured_power_stdin = wait_for_file(&power_stdin);
+    let normalized_power_args = captured_power_args.replace('\\', "/");
+
+    assert!(captured_power_args.contains("--config-dir"));
+    assert!(normalized_power_args.contains(&yaml_path(&config_dir)));
+    assert!(captured_power_stdin.contains(r#""type":"power.health""#));
+    assert!(captured_ui.contains(r#""battery_percent":58"#));
+    assert!(captured_ui.contains(r#""charging":true"#));
+    assert!(captured_ui.contains(r#""power_available":true"#));
+    assert!(captured_ui.contains(r#"Model: PiSugar 3"#));
 }
 
 fn temp_dir(test_name: &str) -> PathBuf {
@@ -527,6 +575,70 @@ Set-Content -LiteralPath '{}' -Value $lines
         ),
     );
     let command_path = dir.join("cloud-worker.cmd");
+    write(
+        &command_path,
+        &format!(
+            "@echo off\r\npowershell -NoProfile -ExecutionPolicy Bypass -File \"{}\" %*\r\n",
+            script_path.to_string_lossy()
+        ),
+    );
+    command_path
+}
+
+fn write_power_worker_script(dir: &Path, args_path: &Path, stdin_path: &Path) -> PathBuf {
+    let ready = r#"{"schema_version":1,"kind":"event","type":"power.ready","payload":{"capabilities":["telemetry","battery"]}}"#;
+    let snapshot = r#"{"schema_version":1,"kind":"event","type":"power.snapshot","payload":{"available":true,"source":"pisugar","device":{"model":"PiSugar 3","firmware_version":"1.8.7"},"battery":{"level_percent":58.0,"voltage_volts":4.08,"charging":true,"power_plugged":true,"temperature_celsius":29.5},"rtc":{"time":"2026-05-04T12:30:00+00:00","alarm_enabled":false},"shutdown":{"safe_shutdown_level_percent":8.0,"safe_shutdown_delay_seconds":15},"error":""}}"#;
+
+    if !cfg!(windows) {
+        let script_path = dir.join("power-worker.sh");
+        write(
+            &script_path,
+            &format!(
+                r#"#!/bin/sh
+printf '%s\n' "$@" > {}
+printf '%s\n' '{}'
+printf '%s\n' '{}'
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> {}
+  case "$line" in
+    *'"type":"worker.stop"'*) break ;;
+  esac
+done
+"#,
+                shell_single_quote(args_path),
+                ready,
+                snapshot,
+                shell_single_quote(stdin_path)
+            ),
+        );
+        make_executable(&script_path);
+        return script_path;
+    }
+
+    let script_path = dir.join("power-worker.ps1");
+    write(
+        &script_path,
+        &format!(
+            r#"
+Set-Content -LiteralPath '{}' -Value ($args -join "`n")
+Write-Output '{}'
+Write-Output '{}'
+$lines = @()
+while (($line = [Console]::In.ReadLine()) -ne $null) {{
+  $lines += $line
+  if ($line -match '"type":"worker.stop"') {{
+    break
+  }}
+}}
+Set-Content -LiteralPath '{}' -Value $lines
+"#,
+            args_path.to_string_lossy().replace('\'', "''"),
+            ready.replace('\'', "''"),
+            snapshot.replace('\'', "''"),
+            stdin_path.to_string_lossy().replace('\'', "''")
+        ),
+    );
+    let command_path = dir.join("power-worker.cmd");
     write(
         &command_path,
         &format!(

--- a/yoyopod_rs/runtime/tests/config.rs
+++ b/yoyopod_rs/runtime/tests/config.rs
@@ -45,8 +45,17 @@ const CONFIG_ENV_KEYS: &[&str] = &[
     "YOYOPOD_RUST_UI_WORKER",
     "YOYOPOD_RUST_CLOUD_HOST_WORKER",
     "YOYOPOD_RUST_MEDIA_HOST_WORKER",
+    "YOYOPOD_RUST_POWER_HOST_WORKER",
     "YOYOPOD_RUST_VOIP_HOST_WORKER",
     "YOYOPOD_RUST_NETWORK_HOST_WORKER",
+    "YOYOPOD_POWER_ENABLED",
+    "YOYOPOD_LOW_BATTERY_WARNING_PERCENT",
+    "YOYOPOD_LOW_BATTERY_WARNING_COOLDOWN_SECONDS",
+    "YOYOPOD_AUTO_SHUTDOWN_ENABLED",
+    "YOYOPOD_CRITICAL_BATTERY_SHUTDOWN_PERCENT",
+    "YOYOPOD_POWER_SHUTDOWN_DELAY_SECONDS",
+    "YOYOPOD_POWER_SHUTDOWN_COMMAND",
+    "YOYOPOD_POWER_SHUTDOWN_STATE_FILE",
 ];
 
 struct EnvSnapshot {
@@ -635,4 +644,73 @@ fn cloud_worker_path_can_be_overridden_by_env() {
     let config = RuntimeConfig::load(&dir).expect("load runtime config");
 
     assert_eq!(config.worker_paths.cloud, "/host/yoyopod-cloud-host");
+}
+
+#[test]
+fn power_worker_path_can_be_overridden_by_env() {
+    let _lock = lock_env();
+    let _env = clean_config_env();
+    let dir = temp_config_dir("power-worker-env");
+    fs::create_dir_all(&dir).expect("config dir");
+
+    std::env::set_var("YOYOPOD_RUST_POWER_HOST_WORKER", "/host/yoyopod-power-host");
+
+    let config = RuntimeConfig::load(&dir).expect("load runtime config");
+
+    assert_eq!(config.worker_paths.power, "/host/yoyopod-power-host");
+}
+
+#[test]
+fn power_policy_config_loads_from_yaml_and_env() {
+    let _lock = lock_env();
+    let _env = clean_config_env();
+    let dir = temp_config_dir("power-policy");
+    write(
+        &dir.join("power/backend.yaml"),
+        r#"
+power:
+  enabled: true
+  low_battery_warning_percent: 18.0
+  low_battery_warning_cooldown_seconds: 120.0
+  auto_shutdown_enabled: true
+  critical_shutdown_percent: 7.5
+  shutdown_delay_seconds: 20.0
+  shutdown_command: "test-poweroff --now"
+  shutdown_state_file: "data/custom_shutdown_state.json"
+"#,
+    );
+
+    let yaml_config = RuntimeConfig::load(&dir).expect("load yaml power policy");
+
+    assert!(yaml_config.power.enabled);
+    assert_eq!(yaml_config.power.low_battery_warning_percent, 18.0);
+    assert_eq!(
+        yaml_config.power.low_battery_warning_cooldown_seconds,
+        120.0
+    );
+    assert!(yaml_config.power.auto_shutdown_enabled);
+    assert_eq!(yaml_config.power.critical_shutdown_percent, 7.5);
+    assert_eq!(yaml_config.power.shutdown_delay_seconds, 20.0);
+    assert_eq!(
+        serde_json::to_value(&yaml_config.power).expect("power json")["shutdown_command"],
+        "test-poweroff --now"
+    );
+    assert!(Path::new(&yaml_config.power.shutdown_state_file)
+        .ends_with(Path::new("data/custom_shutdown_state.json")));
+    assert!(Path::new(&yaml_config.power.shutdown_state_file).is_absolute());
+
+    std::env::set_var("YOYOPOD_LOW_BATTERY_WARNING_PERCENT", "16.5");
+    std::env::set_var("YOYOPOD_AUTO_SHUTDOWN_ENABLED", "false");
+    std::env::set_var("YOYOPOD_POWER_SHUTDOWN_DELAY_SECONDS", "9.5");
+    std::env::set_var("YOYOPOD_POWER_SHUTDOWN_COMMAND", "test-poweroff --env");
+
+    let env_config = RuntimeConfig::load(&dir).expect("load env power policy");
+
+    assert_eq!(env_config.power.low_battery_warning_percent, 16.5);
+    assert!(!env_config.power.auto_shutdown_enabled);
+    assert_eq!(env_config.power.shutdown_delay_seconds, 9.5);
+    assert_eq!(
+        serde_json::to_value(&env_config.power).expect("power json")["shutdown_command"],
+        "test-poweroff --env"
+    );
 }

--- a/yoyopod_rs/runtime/tests/event.rs
+++ b/yoyopod_rs/runtime/tests/event.rs
@@ -54,6 +54,33 @@ fn network_snapshot_event_updates_status_snapshot() {
 }
 
 #[test]
+fn power_snapshot_event_updates_status_snapshot() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Power,
+        event_envelope(
+            "power.snapshot",
+            json!({
+                "available": true,
+                "battery": {
+                    "level_percent": 88.0,
+                    "charging": true,
+                    "power_plugged": true
+                }
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+
+    event.apply(&mut state);
+
+    let power = &state.ui_snapshot_payload()["power"];
+    assert_eq!(power["battery_percent"], 88);
+    assert_eq!(power["charging"], true);
+    assert_eq!(power["power_available"], true);
+}
+
+#[test]
 fn network_snapshot_result_updates_status_snapshot() {
     let event = runtime_event_from_worker(
         WorkerDomain::Network,
@@ -82,6 +109,87 @@ fn network_snapshot_result_updates_status_snapshot() {
     assert_eq!(network["connection_type"], "4g");
     assert_eq!(network["signal_strength"], 2);
     assert_eq!(network["gps_has_fix"], false);
+}
+
+#[test]
+fn power_snapshot_result_updates_status_snapshot() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Power,
+        envelope(
+            EnvelopeKind::Result,
+            "power.health",
+            json!({
+                "available": true,
+                "battery": {
+                    "level_percent": 67.0,
+                    "charging": false,
+                    "power_plugged": false
+                }
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+
+    event.apply(&mut state);
+
+    let power = &state.ui_snapshot_payload()["power"];
+    assert_eq!(power["battery_percent"], 67);
+    assert_eq!(power["charging"], false);
+    assert_eq!(power["rows"][1], "On battery");
+}
+
+#[test]
+fn power_snapshot_routes_cloud_battery_publish() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Power,
+        event_envelope(
+            "power.snapshot",
+            json!({
+                "available": true,
+                "battery": {
+                    "level_percent": 42.0,
+                    "charging": true,
+                    "power_plugged": true
+                }
+            }),
+        ),
+    )
+    .expect("event");
+
+    let commands = commands_for_event(&RuntimeState::default(), &event);
+
+    assert!(commands.iter().any(|command| matches!(
+        command,
+        RuntimeCommand::WorkerCommand { domain: WorkerDomain::Cloud, envelope }
+            if envelope.message_type == "cloud.publish_battery"
+                && envelope.payload == json!({"level": 42, "charging": true})
+    )));
+}
+
+#[test]
+fn power_snapshot_without_battery_level_skips_cloud_battery_publish() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Power,
+        event_envelope(
+            "power.snapshot",
+            json!({
+                "available": true,
+                "battery": {
+                    "charging": true
+                }
+            }),
+        ),
+    )
+    .expect("event");
+
+    let commands = commands_for_event(&RuntimeState::default(), &event);
+
+    assert!(!commands.iter().any(|command| matches!(
+        command,
+        RuntimeCommand::WorkerCommand { domain: WorkerDomain::Cloud, envelope }
+            if envelope.message_type == "cloud.publish_battery"
+    )));
 }
 
 #[test]
@@ -592,6 +700,60 @@ fn ui_call_toggle_mute_routes_inverse_mute_state() {
             WorkerDomain::Voip,
             "voip.set_mute",
             json!({"muted": false})
+        )]
+    );
+}
+
+#[test]
+fn ui_power_control_intents_route_to_power_worker() {
+    let state = RuntimeState::default();
+    let cases = [
+        ("refresh", "power.refresh", json!({})),
+        ("sync_time_to_rtc", "power.sync_time_to_rtc", json!({})),
+        ("sync_time_from_rtc", "power.sync_time_from_rtc", json!({})),
+        ("disable_rtc_alarm", "power.disable_rtc_alarm", json!({})),
+    ];
+
+    for (action, message_type, payload) in cases {
+        let event = runtime_event_from_worker(
+            WorkerDomain::Ui,
+            ui_intent("power", action, payload.clone()),
+        )
+        .expect("event");
+
+        assert_eq!(
+            commands_for_event(&state, &event),
+            vec![worker_command(WorkerDomain::Power, message_type, payload)]
+        );
+    }
+}
+
+#[test]
+fn ui_power_set_alarm_intent_routes_alarm_payload_to_power_worker() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Ui,
+        ui_intent(
+            "power",
+            "set_rtc_alarm",
+            json!({
+                "when": "2026-05-05T07:30:00+00:00",
+                "repeat_mask": 31
+            }),
+        ),
+    )
+    .expect("event");
+
+    let commands = commands_for_event(&RuntimeState::default(), &event);
+
+    assert_eq!(
+        commands,
+        vec![worker_command(
+            WorkerDomain::Power,
+            "power.set_rtc_alarm",
+            json!({
+                "when": "2026-05-05T07:30:00+00:00",
+                "repeat_mask": 31
+            })
         )]
     );
 }

--- a/yoyopod_rs/runtime/tests/runtime_loop.rs
+++ b/yoyopod_rs/runtime/tests/runtime_loop.rs
@@ -1,9 +1,13 @@
 use std::collections::VecDeque;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Value};
+use yoyopod_runtime::config::RuntimeConfig;
 use yoyopod_runtime::protocol::{EnvelopeKind, WorkerEnvelope};
 use yoyopod_runtime::runtime_loop::{LoopIo, RuntimeLoop};
-use yoyopod_runtime::state::{RuntimeState, WorkerDomain};
+use yoyopod_runtime::state::{PowerSafetyConfig, RuntimeState, WorkerDomain};
 use yoyopod_runtime::worker::WorkerProtocolError;
 
 #[test]
@@ -265,12 +269,239 @@ fn cloud_remote_media_command_nacks_when_media_dispatch_fails() {
     );
 }
 
+#[test]
+fn low_battery_snapshot_publishes_warning_once_per_cooldown() {
+    let mut state = RuntimeState::default();
+    state.configure_power_safety(PowerSafetyConfig {
+        enabled: true,
+        low_battery_warning_percent: 20.0,
+        low_battery_warning_cooldown_seconds: 300.0,
+        auto_shutdown_enabled: true,
+        critical_shutdown_percent: 10.0,
+        shutdown_delay_seconds: 15.0,
+        shutdown_command: "sudo -n shutdown -h now".to_string(),
+        shutdown_state_file: "data/last_shutdown_state.json".to_string(),
+    });
+    let mut runtime_loop = RuntimeLoop::new(state);
+    let mut io = FakeLoopIo::with_messages([
+        (
+            WorkerDomain::Power,
+            event_envelope(
+                "power.snapshot",
+                json!({
+                    "available": true,
+                    "battery": {
+                        "level_percent": 15.0,
+                        "charging": false,
+                        "power_plugged": false
+                    }
+                }),
+            ),
+        ),
+        (
+            WorkerDomain::Power,
+            event_envelope(
+                "power.snapshot",
+                json!({
+                    "available": true,
+                    "battery": {
+                        "level_percent": 14.0,
+                        "charging": false,
+                        "power_plugged": false
+                    }
+                }),
+            ),
+        ),
+    ]);
+
+    let processed = runtime_loop.run_once(&mut io);
+
+    assert_eq!(processed, 2);
+    let warning_events = sent_messages(&io, WorkerDomain::Cloud, "cloud.publish_event")
+        .into_iter()
+        .filter(|envelope| envelope.payload["event_type"] == "power.low_battery_warning")
+        .collect::<Vec<_>>();
+    assert_eq!(warning_events.len(), 1);
+    assert_eq!(
+        warning_events[0].payload["payload"]["battery_percent"],
+        15.0
+    );
+    assert_eq!(
+        runtime_loop.state().status_payload()["power"]["low_battery_warning_active"],
+        true
+    );
+}
+
+#[test]
+fn critical_battery_snapshot_requests_shutdown_once_until_power_restored() {
+    let mut state = RuntimeState::default();
+    state.configure_power_safety(PowerSafetyConfig {
+        enabled: true,
+        low_battery_warning_percent: 20.0,
+        low_battery_warning_cooldown_seconds: 300.0,
+        auto_shutdown_enabled: true,
+        critical_shutdown_percent: 10.0,
+        shutdown_delay_seconds: 12.0,
+        shutdown_command: "sudo -n shutdown -h now".to_string(),
+        shutdown_state_file: "data/last_shutdown_state.json".to_string(),
+    });
+    let mut runtime_loop = RuntimeLoop::new(state);
+    let mut io = FakeLoopIo::with_messages([
+        (
+            WorkerDomain::Power,
+            event_envelope(
+                "power.snapshot",
+                json!({
+                    "available": true,
+                    "battery": {
+                        "level_percent": 8.0,
+                        "charging": false,
+                        "power_plugged": false
+                    }
+                }),
+            ),
+        ),
+        (
+            WorkerDomain::Power,
+            event_envelope(
+                "power.snapshot",
+                json!({
+                    "available": true,
+                    "battery": {
+                        "level_percent": 7.5,
+                        "charging": false,
+                        "power_plugged": false
+                    }
+                }),
+            ),
+        ),
+        (
+            WorkerDomain::Power,
+            event_envelope(
+                "power.snapshot",
+                json!({
+                    "available": true,
+                    "battery": {
+                        "level_percent": 7.5,
+                        "charging": true,
+                        "power_plugged": true
+                    }
+                }),
+            ),
+        ),
+    ]);
+
+    let processed = runtime_loop.run_once(&mut io);
+
+    assert_eq!(processed, 3);
+    let shutdown_events = sent_messages(&io, WorkerDomain::Cloud, "cloud.publish_event")
+        .into_iter()
+        .filter(|envelope| envelope.payload["event_type"] == "power.graceful_shutdown_requested")
+        .collect::<Vec<_>>();
+    assert_eq!(shutdown_events.len(), 1);
+    assert_eq!(
+        shutdown_events[0].payload["payload"]["reason"],
+        "critical_battery"
+    );
+    assert_eq!(shutdown_events[0].payload["payload"]["delay_seconds"], 12.0);
+
+    let cancel = sent_to_event(
+        &io,
+        WorkerDomain::Cloud,
+        "cloud.publish_event",
+        "power.graceful_shutdown_cancelled",
+    );
+    assert_eq!(
+        cancel.payload["payload"]["reason"],
+        "external_power_restored"
+    );
+    assert_eq!(
+        runtime_loop.state().status_payload()["power"]["shutdown_pending"],
+        false
+    );
+    assert!(!runtime_loop.shutdown_requested());
+}
+
+#[test]
+fn due_critical_battery_shutdown_persists_state_runs_configured_command_and_stops_loop() {
+    let root = temp_runtime_root("power-shutdown-exec");
+    let config_dir = root.join("config");
+    write_file(
+        &config_dir.join("power/backend.yaml"),
+        r#"
+power:
+  enabled: true
+  auto_shutdown_enabled: true
+  critical_shutdown_percent: 10.0
+  shutdown_delay_seconds: 0.0
+  shutdown_command: "test-poweroff --now"
+  shutdown_state_file: "data/poweroff-state.json"
+"#,
+    );
+    let config = RuntimeConfig::load(&config_dir).expect("load runtime config");
+
+    let mut state = RuntimeState {
+        current_screen: "setup".to_string(),
+        ..RuntimeState::default()
+    };
+    state.configure_power_safety(config.power.to_safety_config());
+    state.apply_media_snapshot(&json!({
+        "connected": true,
+        "playback_state": "playing",
+        "current_track": {
+            "name": "Last Track",
+            "artists": ["YoYo"]
+        }
+    }));
+    state.apply_voip_snapshot(&json!({
+        "registered": true,
+        "registration_state": "ok"
+    }));
+
+    let mut runtime_loop = RuntimeLoop::new(state);
+    let mut io = FakeLoopIo::with_messages([(
+        WorkerDomain::Power,
+        event_envelope(
+            "power.snapshot",
+            json!({
+                "available": true,
+                "battery": {
+                    "level_percent": 8.0,
+                    "charging": false,
+                    "power_plugged": false
+                }
+            }),
+        ),
+    )]);
+
+    let processed = runtime_loop.run_once(&mut io);
+
+    assert_eq!(processed, 1);
+    assert!(runtime_loop.shutdown_requested());
+    assert_eq!(io.shutdown_commands, vec!["test-poweroff --now"]);
+    let suppress = sent_to(&io, WorkerDomain::Power, "power.watchdog_suppress");
+    assert_eq!(suppress.payload["reason"], "pending_system_poweroff");
+    let saved_path = root.join("data/poweroff-state.json");
+    let saved: Value =
+        serde_json::from_str(&fs::read_to_string(&saved_path).expect("shutdown state file"))
+            .expect("shutdown state json");
+    assert_eq!(saved["shutdown"]["reason"], "critical_battery");
+    assert_eq!(saved["shutdown"]["command"], "test-poweroff --now");
+    assert_eq!(saved["screen"]["current"], "setup");
+    assert_eq!(saved["power"]["battery_percent"], 8);
+    assert_eq!(saved["power"]["external_power"], false);
+    assert_eq!(saved["media"]["playback_state"], "playing");
+    assert_eq!(saved["media"]["title"], "Last Track");
+    assert_eq!(saved["voip"]["registered"], true);
+}
+
 #[derive(Default)]
 struct FakeLoopIo {
     messages: VecDeque<(WorkerDomain, WorkerEnvelope)>,
     protocol_errors: VecDeque<(WorkerDomain, WorkerProtocolError)>,
     fail_sends: VecDeque<(WorkerDomain, String)>,
     failed_sends: Vec<(WorkerDomain, String)>,
+    shutdown_commands: Vec<String>,
     sent: Vec<(WorkerDomain, WorkerEnvelope)>,
 }
 
@@ -316,11 +547,36 @@ impl LoopIo for FakeLoopIo {
         self.sent.push((domain, envelope));
         true
     }
+
+    fn write_power_shutdown_state(&mut self, path: &str, payload: &Value) -> Result<(), String> {
+        let contents = serde_json::to_string_pretty(payload).map_err(|error| error.to_string())?;
+        write_file(Path::new(path), &contents);
+        Ok(())
+    }
+
+    fn request_system_shutdown(&mut self, command: &str) -> Result<(), String> {
+        self.shutdown_commands.push(command.to_string());
+        Ok(())
+    }
 }
 
 fn sent_to<'a>(io: &'a FakeLoopIo, domain: WorkerDomain, message_type: &str) -> &'a WorkerEnvelope {
     sent_optional(io, domain, message_type)
         .unwrap_or_else(|| panic!("missing sent envelope {message_type} to {domain:?}"))
+}
+
+fn sent_to_event<'a>(
+    io: &'a FakeLoopIo,
+    domain: WorkerDomain,
+    message_type: &str,
+    event_type: &str,
+) -> &'a WorkerEnvelope {
+    sent_messages(io, domain, message_type)
+        .into_iter()
+        .find(|envelope| envelope.payload["event_type"] == event_type)
+        .unwrap_or_else(|| {
+            panic!("missing sent envelope {message_type}/{event_type} to {domain:?}")
+        })
 }
 
 fn sent_optional<'a>(
@@ -334,6 +590,20 @@ fn sent_optional<'a>(
             *sent_domain == domain && envelope.message_type == message_type
         })
         .map(|(_, envelope)| envelope)
+}
+
+fn sent_messages<'a>(
+    io: &'a FakeLoopIo,
+    domain: WorkerDomain,
+    message_type: &str,
+) -> Vec<&'a WorkerEnvelope> {
+    io.sent
+        .iter()
+        .filter(|(sent_domain, envelope)| {
+            *sent_domain == domain && envelope.message_type == message_type
+        })
+        .map(|(_, envelope)| envelope)
+        .collect()
 }
 
 fn sent_index(io: &FakeLoopIo, domain: WorkerDomain, message_type: &str) -> usize {
@@ -366,4 +636,22 @@ fn ui_intent(domain: &str, action: &str, payload: Value) -> WorkerEnvelope {
             "payload": payload,
         }),
     )
+}
+
+fn temp_runtime_root(test_name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "yoyopod-runtime-loop-{test_name}-{}-{unique}",
+        std::process::id()
+    ))
+}
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("parent dir");
+    }
+    fs::write(path, contents).expect("write file");
 }

--- a/yoyopod_rs/runtime/tests/state.rs
+++ b/yoyopod_rs/runtime/tests/state.rs
@@ -295,6 +295,55 @@ fn network_snapshot_updates_status_bar_payload_and_power_row() {
 }
 
 #[test]
+fn power_snapshot_updates_status_bar_payload_and_setup_page() {
+    let mut state = RuntimeState::default();
+
+    state.apply_power_snapshot(&json!({
+        "available": true,
+        "source": "pisugar",
+        "device": {
+            "model": "PiSugar 3",
+            "firmware_version": "1.8.7"
+        },
+        "battery": {
+            "level_percent": 42.8,
+            "voltage_volts": 4.02,
+            "charging": false,
+            "power_plugged": true,
+            "temperature_celsius": 30.4
+        },
+        "rtc": {
+            "time": "2026-05-04T12:30:00+00:00",
+            "alarm_enabled": false
+        },
+        "shutdown": {
+            "safe_shutdown_level_percent": 8.0,
+            "safe_shutdown_delay_seconds": 15
+        }
+    }));
+
+    let ui = state.ui_snapshot_payload();
+
+    assert_eq!(ui["power"]["battery_percent"], 43);
+    assert_eq!(ui["power"]["charging"], false);
+    assert_eq!(ui["power"]["power_available"], true);
+    assert_eq!(ui["power"]["rows"][0], "Battery 43%");
+    assert_eq!(ui["power"]["rows"][1], "Plugged");
+
+    let pages = ui["power"]["pages"].as_array().expect("setup pages");
+    assert_eq!(pages[0]["title"], "Power");
+    assert_eq!(pages[0]["rows"][0], "Model: PiSugar 3");
+    assert_eq!(pages[0]["rows"][1], "Battery: 43%");
+    assert_eq!(pages[0]["rows"][2], "Charging: Idle");
+    assert_eq!(pages[0]["rows"][3], "External: Plugged");
+    assert_eq!(pages[0]["rows"][4], "Voltage: 4.02V 30C");
+
+    let status = state.status_payload();
+    assert_eq!(status["power"]["available"], true);
+    assert_eq!(status["power"]["battery_percent"], 43);
+}
+
+#[test]
 fn cloud_snapshot_updates_runtime_status_payload() {
     let mut state = RuntimeState::default();
 


### PR DESCRIPTION
## Summary

Ports the YoYoPod power domain into the Rust runtime path.

- Adds a new `yoyopod-power-host` crate for PiSugar telemetry, RTC control, shutdown telemetry, and watchdog control.
- Wires the Rust runtime to start the power worker, ingest `power.snapshot` / `power.health`, publish real battery telemetry, and project power state into UI/status payloads.
- Ports low-battery warning, critical-battery graceful shutdown policy, shutdown state persistence, configured shutdown execution, and watchdog suppression before system poweroff.
- Removes the synthetic startup battery publish so cloud battery state now comes from real power snapshots.

## Impact

Rust becomes the owner for the power domain in the runtime host. Python remains useful for legacy tooling/tests, but the runtime power worker path is now native Rust.

## Validation

- `cargo fmt --manifest-path yoyopod_rs/Cargo.toml --all --check`
- `cargo clippy --manifest-path yoyopod_rs/Cargo.toml -p yoyopod-power-host --all-targets --locked -- -D warnings`
- `cargo clippy --manifest-path yoyopod_rs/Cargo.toml -p yoyopod-runtime --all-targets --locked -- -D warnings`
- `cargo test --manifest-path yoyopod_rs/Cargo.toml --workspace --locked`

## Notes

Pi hardware validation has not been run yet. The remaining validation target is PiSugar telemetry, RTC commands, watchdog I2C behavior, and critical-battery shutdown behavior with a safe test command first.