### PR TITLE
[codex] Port ASK voice commands to Rust runtime

### DIFF
--- a/yoyopod_rs/runtime/src/cli.rs
+++ b/yoyopod_rs/runtime/src/cli.rs
@@ -95,7 +95,11 @@ fn start_workers(
 ) -> Result<RuntimeState> {
     let mut state = RuntimeState::default();
     state.seed_contacts(config.people.to_contact_items());
+    state.configure_media_volume(config.media.default_volume);
     state.configure_voice_note_store_dir(config.voip.voice_note_store_dir.clone());
+    state.configure_voice_commands(config.voice.to_command_settings());
+    state.configure_voice_capture(config.voice.to_capture_settings());
+    state.configure_voice_speech(config.voice.to_speech_settings());
     state.configure_power_safety(config.power.to_safety_config());
     state.mark_worker(WorkerDomain::Ui, WorkerState::Starting, "starting");
 
@@ -235,6 +239,33 @@ fn start_workers(
         );
     }
 
+    if config.voice.worker_enabled {
+        state.mark_worker(WorkerDomain::Voice, WorkerState::Starting, "starting");
+        if workers.start(WorkerSpec::new(
+            WorkerDomain::Voice,
+            config.worker_paths.voice.clone(),
+            Vec::<String>::new(),
+        )) {
+            if workers.wait_for_ready(WorkerDomain::Voice, "voice.ready", Duration::from_secs(3)) {
+                state.mark_worker(WorkerDomain::Voice, WorkerState::Running, "ready");
+            } else {
+                state.mark_worker(
+                    WorkerDomain::Voice,
+                    WorkerState::Degraded,
+                    "timed out waiting for voice.ready",
+                );
+            }
+        } else {
+            state.mark_worker(
+                WorkerDomain::Voice,
+                WorkerState::Degraded,
+                "failed to start",
+            );
+        }
+    } else {
+        state.mark_worker(WorkerDomain::Voice, WorkerState::Disabled, "disabled");
+    }
+
     Ok(state)
 }
 
@@ -271,6 +302,7 @@ fn send_startup_commands(workers: &mut WorkerSupervisor, config: &RuntimeConfig)
     workers.send_command(WorkerDomain::Network, "network.health", json!({}));
     workers.send_command(WorkerDomain::Network, "network.query_gps", json!({}));
     workers.send_command(WorkerDomain::Power, "power.health", json!({}));
+    workers.send_command(WorkerDomain::Voice, "voice.health", json!({}));
     workers.send_command(
         WorkerDomain::Media,
         "media.configure",

--- a/yoyopod_rs/runtime/src/config.rs
+++ b/yoyopod_rs/runtime/src/config.rs
@@ -7,6 +7,10 @@ use serde::{Deserialize, Serialize, Serializer};
 use serde_json::{json, Value};
 use thiserror::Error;
 
+use crate::voice::{
+    load_voice_command_dictionary, VoiceCaptureSettings, VoiceCommandSettings, VoiceSpeechSettings,
+};
+
 const LINPHONE_HOSTED_SIP_SERVER: &str = "sip.linphone.org";
 const LINPHONE_HOSTED_CONFERENCE_FACTORY_URI: &str = "sip:conference-factory@sip.linphone.org";
 const LINPHONE_HOSTED_FILE_TRANSFER_SERVER_URL: &str = "https://files.linphone.org/lft.php";
@@ -16,12 +20,14 @@ const RUST_UI_HOST_DEFAULT_WORKER: &str = "yoyopod_rs/ui-host/build/yoyopod-ui-h
 const RUST_CLOUD_HOST_DEFAULT_WORKER: &str = "yoyopod_rs/cloud-host/build/yoyopod-cloud-host";
 const RUST_NETWORK_HOST_DEFAULT_WORKER: &str = "yoyopod_rs/network-host/build/yoyopod-network-host";
 const RUST_POWER_HOST_DEFAULT_WORKER: &str = "yoyopod_rs/power-host/build/yoyopod-power-host";
+const VOICE_WORKER_DEFAULT: &str = "workers/voice/go/build/yoyopod-voice-worker";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeConfig {
     pub ui: UiConfig,
     pub media: MediaRuntimeConfig,
     pub power: PowerRuntimeConfig,
+    pub voice: VoiceRuntimeConfig,
     pub voip: VoipRuntimeConfig,
     pub people: PeopleRuntimeConfig,
     pub worker_paths: WorkerPaths,
@@ -62,6 +68,29 @@ pub struct PowerRuntimeConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VoiceRuntimeConfig {
+    pub worker_enabled: bool,
+    pub commands_enabled: bool,
+    pub ai_requests_enabled: bool,
+    pub activation_prefixes: Vec<String>,
+    pub command_dictionary_path: String,
+    pub ask_fallback_enabled: bool,
+    pub sample_rate_hz: u64,
+    pub request_timeout_ms: u64,
+    pub max_audio_ms: u64,
+    pub stt_model: String,
+    pub stt_language: String,
+    pub stt_prompt: String,
+    pub tts_model: String,
+    pub tts_voice: String,
+    pub tts_instructions: String,
+    pub ask_model: String,
+    pub ask_instructions: String,
+    pub ask_max_history_turns: usize,
+    pub ask_max_response_chars: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PeopleRuntimeConfig {
     pub contacts: Vec<ContactRuntimeConfig>,
 }
@@ -72,6 +101,7 @@ pub struct ContactRuntimeConfig {
     pub display_name: String,
     pub sip_address: String,
     pub favorite: bool,
+    pub aliases: Vec<String>,
 }
 
 #[derive(Clone, PartialEq, Deserialize)]
@@ -107,6 +137,7 @@ pub struct WorkerPaths {
     pub voip: String,
     pub network: String,
     pub power: String,
+    pub voice: String,
 }
 
 #[derive(Debug, Error)]
@@ -137,6 +168,7 @@ impl RuntimeConfig {
         let secrets = read_yaml(config_dir.join("communication/calling.secrets.yaml"))?;
         let people = read_yaml(config_dir.join("people/directory.yaml"))?;
         let power = read_yaml(config_dir.join("power/backend.yaml"))?;
+        let voice = read_yaml(config_dir.join("voice/assistant.yaml"))?;
 
         let default_volume = int_at_env(
             &music,
@@ -259,6 +291,84 @@ impl RuntimeConfig {
                         "data/last_shutdown_state.json",
                         "YOYOPOD_POWER_SHUTDOWN_STATE_FILE",
                     ),
+                ),
+            },
+            voice: VoiceRuntimeConfig {
+                worker_enabled: bool_at_env(
+                    &voice,
+                    &["worker", "enabled"],
+                    true,
+                    "YOYOPOD_VOICE_WORKER_ENABLED",
+                ),
+                commands_enabled: bool_at(&voice, &["assistant", "commands_enabled"], true),
+                ai_requests_enabled: bool_at(&voice, &["assistant", "ai_requests_enabled"], true),
+                activation_prefixes: string_array_at(
+                    &voice,
+                    &["assistant", "activation_prefixes"],
+                    &["yoyo", "hey yoyo"],
+                ),
+                command_dictionary_path: resolve_runtime_path(
+                    &runtime_root,
+                    string_at_env(
+                        &voice,
+                        &["assistant", "command_dictionary_path"],
+                        "data/voice/commands.yaml",
+                        "YOYOPOD_VOICE_COMMAND_DICTIONARY",
+                    ),
+                ),
+                ask_fallback_enabled: bool_at(
+                    &voice,
+                    &["assistant", "command_routing", "ask_fallback_enabled"],
+                    true,
+                ),
+                sample_rate_hz: uint_at(&voice, &["assistant", "sample_rate_hz"], 16_000),
+                request_timeout_ms: seconds_at_ms(
+                    &voice,
+                    &["worker", "request_timeout_seconds"],
+                    12.0,
+                ),
+                max_audio_ms: seconds_at_ms(&voice, &["worker", "max_audio_seconds"], 30.0),
+                stt_model: string_at(
+                    &voice,
+                    &["worker", "stt_model"],
+                    VoiceCaptureSettings::default().stt_model.as_str(),
+                ),
+                stt_language: string_at(
+                    &voice,
+                    &["worker", "stt_language"],
+                    VoiceCaptureSettings::default().stt_language.as_str(),
+                ),
+                stt_prompt: string_at(
+                    &voice,
+                    &["worker", "stt_prompt"],
+                    VoiceCaptureSettings::default().stt_prompt.as_str(),
+                ),
+                tts_model: string_at(
+                    &voice,
+                    &["worker", "tts_model"],
+                    VoiceSpeechSettings::default().tts_model.as_str(),
+                ),
+                tts_voice: string_at(
+                    &voice,
+                    &["worker", "tts_voice"],
+                    VoiceSpeechSettings::default().tts_voice.as_str(),
+                ),
+                tts_instructions: string_at(
+                    &voice,
+                    &["worker", "tts_instructions"],
+                    VoiceSpeechSettings::default().tts_instructions.as_str(),
+                ),
+                ask_model: string_at(&voice, &["worker", "ask_model"], "gpt-4.1-mini"),
+                ask_instructions: string_at(
+                    &voice,
+                    &["worker", "ask_instructions"],
+                    VoiceCommandSettings::default().ask_instructions.as_str(),
+                ),
+                ask_max_history_turns: usize_at(&voice, &["worker", "ask_max_history_turns"], 4),
+                ask_max_response_chars: usize_at(
+                    &voice,
+                    &["worker", "ask_max_response_chars"],
+                    480,
                 ),
             },
             voip: VoipRuntimeConfig {
@@ -404,6 +514,7 @@ impl RuntimeConfig {
                     "YOYOPOD_RUST_POWER_HOST_WORKER",
                     RUST_POWER_HOST_DEFAULT_WORKER,
                 ),
+                voice: voice_worker_path(&voice),
             },
             pid_file: resolve_runtime_path(
                 &runtime_root,
@@ -457,6 +568,46 @@ impl PowerRuntimeConfig {
     }
 }
 
+impl VoiceRuntimeConfig {
+    pub fn to_command_settings(&self) -> VoiceCommandSettings {
+        let dictionary = load_voice_command_dictionary(&self.command_dictionary_path);
+        VoiceCommandSettings {
+            commands_enabled: self.commands_enabled,
+            ai_requests_enabled: self.ai_requests_enabled,
+            activation_prefixes: self.activation_prefixes.clone(),
+            ask_fallback_enabled: self.ask_fallback_enabled,
+            disabled_intents: dictionary.disabled_intents,
+            command_aliases: dictionary.command_aliases,
+            route_actions: dictionary.route_actions,
+            ask_model: self.ask_model.clone(),
+            ask_instructions: self.ask_instructions.clone(),
+            ask_max_history_turns: self.ask_max_history_turns,
+            ask_max_response_chars: self.ask_max_response_chars,
+        }
+    }
+
+    pub fn to_capture_settings(&self) -> VoiceCaptureSettings {
+        VoiceCaptureSettings {
+            sample_rate_hz: self.sample_rate_hz,
+            request_timeout_ms: self.request_timeout_ms,
+            max_audio_ms: self.max_audio_ms,
+            stt_model: self.stt_model.clone(),
+            stt_language: self.stt_language.clone(),
+            stt_prompt: self.stt_prompt.clone(),
+        }
+    }
+
+    pub fn to_speech_settings(&self) -> VoiceSpeechSettings {
+        VoiceSpeechSettings {
+            sample_rate_hz: self.sample_rate_hz,
+            request_timeout_ms: self.request_timeout_ms,
+            tts_model: self.tts_model.clone(),
+            tts_voice: self.tts_voice.clone(),
+            tts_instructions: self.tts_instructions.clone(),
+        }
+    }
+}
+
 impl PeopleRuntimeConfig {
     pub fn to_contact_items(&self) -> Vec<crate::state::ListItem> {
         self.contacts
@@ -466,6 +617,7 @@ impl PeopleRuntimeConfig {
                 title: contact.display_name.clone(),
                 subtitle: String::new(),
                 icon_key: format!("mono:{}", talk_monogram(&contact.display_name)),
+                aliases: contact.aliases.clone(),
             })
             .collect()
     }
@@ -686,6 +838,7 @@ fn contact_config_from_value(value: &Value) -> Option<ContactRuntimeConfig> {
             .get("favorite")
             .and_then(Value::as_bool)
             .unwrap_or(false),
+        aliases: string_array_field(value, "aliases"),
     })
 }
 
@@ -720,6 +873,22 @@ fn uint_at_env(value: &Value, path: &[&str], default: u64, env: &str) -> u64 {
     env_string(env)
         .and_then(|text| text.parse::<u64>().ok())
         .unwrap_or_else(|| uint_at(value, path, default))
+}
+
+fn string_array_field(value: &Value, key: &str) -> Vec<String> {
+    value
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn f64_at_env(value: &Value, path: &[&str], default: f64, env: &str) -> f64 {
@@ -763,6 +932,12 @@ fn uint_at(value: &Value, path: &[&str], default: u64) -> u64 {
         .unwrap_or(default)
 }
 
+fn usize_at(value: &Value, path: &[&str], default: usize) -> usize {
+    uint_at(value, path, default as u64)
+        .try_into()
+        .unwrap_or(default)
+}
+
 fn f64_at(value: &Value, path: &[&str], default: f64) -> f64 {
     at_path(value, path)
         .and_then(|value| {
@@ -771,6 +946,30 @@ fn f64_at(value: &Value, path: &[&str], default: f64) -> f64 {
                 .or_else(|| value.as_str()?.trim().parse::<f64>().ok())
         })
         .unwrap_or(default)
+}
+
+fn seconds_at_ms(value: &Value, path: &[&str], default_seconds: f64) -> u64 {
+    let seconds = f64_at(value, path, default_seconds);
+    if !seconds.is_finite() || seconds <= 0.0 {
+        return (default_seconds * 1000.0).round() as u64;
+    }
+    (seconds * 1000.0).round() as u64
+}
+
+fn string_array_at(value: &Value, path: &[&str], default: &[&str]) -> Vec<String> {
+    at_path(value, path)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .filter(|items| !items.is_empty())
+        .unwrap_or_else(|| default.iter().map(|value| (*value).to_string()).collect())
 }
 
 fn bool_at(value: &Value, path: &[&str], default: bool) -> bool {
@@ -799,6 +998,16 @@ fn ui_worker_path() -> String {
         Some(value) if value != RUST_UI_HOST_DEFAULT_WORKER => value,
         _ => env_or_default("YOYOPOD_RUST_UI_WORKER", RUST_UI_HOST_DEFAULT_WORKER),
     }
+}
+
+fn voice_worker_path(voice: &Value) -> String {
+    if let Some(value) = env_string("YOYOPOD_RUST_VOICE_WORKER") {
+        return value;
+    }
+    string_array_at(voice, &["worker", "argv"], &[VOICE_WORKER_DEFAULT])
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| VOICE_WORKER_DEFAULT.to_string())
 }
 
 fn env_or_default(name: &str, default: &str) -> String {

--- a/yoyopod_rs/runtime/src/event.rs
+++ b/yoyopod_rs/runtime/src/event.rs
@@ -4,6 +4,9 @@ use serde_json::{json, Value};
 
 use crate::protocol::{EnvelopeKind, WorkerEnvelope};
 use crate::state::{CallState, PowerSafetyAction, RuntimeState, WorkerDomain, WorkerState};
+use crate::voice::{
+    route_voice_transcript, VoiceCommandIntent, VoiceConfirmationResponse, VoiceRouteKind,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum RuntimeEvent {
@@ -16,6 +19,9 @@ pub enum RuntimeEvent {
     VoipSnapshot(Value),
     NetworkSnapshot(Value),
     PowerSnapshot(Value),
+    VoiceTranscript(Value),
+    VoiceAskResult(Value),
+    VoiceSpeakResult(Value),
     UiInput(Value),
     UiIntent {
         domain: String,
@@ -65,6 +71,9 @@ impl RuntimeEvent {
             Self::VoipSnapshot(snapshot) => state.apply_voip_snapshot(snapshot),
             Self::NetworkSnapshot(snapshot) => state.apply_network_snapshot(snapshot),
             Self::PowerSnapshot(snapshot) => state.apply_power_snapshot(snapshot),
+            Self::VoiceTranscript(snapshot) => state.apply_voice_transcript(snapshot),
+            Self::VoiceAskResult(snapshot) => state.apply_voice_ask_result(snapshot),
+            Self::VoiceSpeakResult(_) => {}
             Self::UiScreenChanged { screen } => {
                 state.current_screen = screen.clone();
             }
@@ -113,6 +122,9 @@ pub fn runtime_event_from_worker(
         {
             Some(RuntimeEvent::PowerSnapshot(payload))
         }
+        EnvelopeKind::Result if domain == WorkerDomain::Voice => {
+            Some(voice_event_from_message(&message_type, payload))
+        }
         EnvelopeKind::Command | EnvelopeKind::Result | EnvelopeKind::Heartbeat => {
             Some(RuntimeEvent::Ignored)
         }
@@ -132,6 +144,9 @@ pub fn commands_for_event(state: &RuntimeState, event: &RuntimeEvent) -> Vec<Run
         RuntimeEvent::VoipSnapshot(snapshot) => commands_for_voip_snapshot(state, snapshot),
         RuntimeEvent::NetworkSnapshot(snapshot) => commands_for_network_snapshot(snapshot),
         RuntimeEvent::PowerSnapshot(snapshot) => commands_for_power_snapshot(state, snapshot),
+        RuntimeEvent::VoiceTranscript(snapshot) => commands_for_voice_transcript(state, snapshot),
+        RuntimeEvent::VoiceAskResult(snapshot) => commands_for_voice_ask_result(state, snapshot),
+        RuntimeEvent::VoiceSpeakResult(snapshot) => commands_for_voice_speak_result(snapshot),
         RuntimeEvent::Shutdown => vec![RuntimeCommand::Shutdown],
         RuntimeEvent::WorkerReady { .. }
         | RuntimeEvent::CloudSnapshot(_)
@@ -161,13 +176,7 @@ fn runtime_event_from_message(
         WorkerDomain::Voip => voip_event_from_message(message_type, payload),
         WorkerDomain::Network => network_event_from_message(message_type, payload),
         WorkerDomain::Power => power_event_from_message(message_type, payload),
-        WorkerDomain::Voice => health_only_event_from_message(
-            domain,
-            message_type,
-            &payload,
-            "voice.ready",
-            "voice.error",
-        ),
+        WorkerDomain::Voice => voice_event_from_message(message_type, payload),
     }
 }
 
@@ -264,24 +273,36 @@ fn power_event_from_message(message_type: &str, payload: Value) -> RuntimeEvent 
     }
 }
 
-fn health_only_event_from_message(
-    domain: WorkerDomain,
-    message_type: &str,
-    payload: &Value,
-    ready_type: &str,
-    error_type: &str,
-) -> RuntimeEvent {
-    if message_type == ready_type {
-        return RuntimeEvent::WorkerReady { domain };
+fn voice_event_from_message(message_type: &str, payload: Value) -> RuntimeEvent {
+    match message_type {
+        "voice.ready" => RuntimeEvent::WorkerReady {
+            domain: WorkerDomain::Voice,
+        },
+        "voice.health.result" | "voice.health" => {
+            if payload
+                .get("healthy")
+                .and_then(Value::as_bool)
+                .unwrap_or(true)
+            {
+                RuntimeEvent::WorkerReady {
+                    domain: WorkerDomain::Voice,
+                }
+            } else {
+                RuntimeEvent::WorkerError {
+                    domain: WorkerDomain::Voice,
+                    message: worker_error_message(message_type, &payload),
+                }
+            }
+        }
+        "voice.transcribe.result" | "voice.transcript" => RuntimeEvent::VoiceTranscript(payload),
+        "voice.ask.result" => RuntimeEvent::VoiceAskResult(payload),
+        "voice.speak.result" => RuntimeEvent::VoiceSpeakResult(payload),
+        "voice.error" => RuntimeEvent::WorkerError {
+            domain: WorkerDomain::Voice,
+            message: worker_error_message(message_type, &payload),
+        },
+        _ => RuntimeEvent::Ignored,
     }
-    if message_type == error_type {
-        return RuntimeEvent::WorkerError {
-            domain,
-            message: worker_error_message(message_type, payload),
-        };
-    }
-
-    RuntimeEvent::Ignored
 }
 
 fn runtime_intent_from_payload(payload: Value) -> RuntimeEvent {
@@ -428,6 +449,24 @@ fn commands_for_voice_intent(
     payload: &Value,
 ) -> Vec<RuntimeCommand> {
     match action {
+        "ask_start" | "begin_ask" => {
+            let file_path = state.voice.ask_recording_file_path();
+            vec![worker_command(
+                WorkerDomain::Voip,
+                "voip.start_voice_note_recording",
+                json!({ "file_path": file_path }),
+            )]
+        }
+        "ask_stop" | "finish_ask" => vec![worker_command(
+            WorkerDomain::Voip,
+            "voip.stop_voice_note_recording",
+            empty_payload(),
+        )],
+        "ask_cancel" => vec![worker_command(
+            WorkerDomain::Voip,
+            "voip.cancel_voice_note_recording",
+            empty_payload(),
+        )],
         "capture_start" | "start_recording" => {
             let file_path = state.voice.recording_file_path();
             vec![worker_command(
@@ -529,6 +568,141 @@ fn commands_for_voice_intent(
         "discard" | "again" | "reset" => Vec::new(),
         _ => Vec::new(),
     }
+}
+
+fn commands_for_voice_transcript(state: &RuntimeState, payload: &Value) -> Vec<RuntimeCommand> {
+    let transcript = string_field(payload, "text")
+        .or_else(|| string_field(payload, "transcript"))
+        .unwrap_or_default();
+    if transcript.trim().is_empty() {
+        return Vec::new();
+    }
+
+    if let Some(response) = state.pending_voice_call_confirmation_response(&transcript) {
+        return match response {
+            VoiceConfirmationResponse::Yes => state
+                .pending_voice_call_confirmation_contact()
+                .map(|contact| {
+                    vec![worker_command(
+                        WorkerDomain::Voip,
+                        "voip.dial",
+                        json!({ "uri": contact.id }),
+                    )]
+                })
+                .unwrap_or_default(),
+            VoiceConfirmationResponse::No => Vec::new(),
+        };
+    }
+
+    let decision = route_voice_transcript(&transcript, &state.voice.command_settings);
+    if decision.kind != VoiceRouteKind::Command
+        && state.infer_voice_call_confirmation(&transcript).is_some()
+    {
+        return Vec::new();
+    }
+    match decision.kind {
+        VoiceRouteKind::Command => decision
+            .command
+            .as_ref()
+            .map(|command| commands_for_voice_command(state, command.intent, &command.contact_name))
+            .unwrap_or_default(),
+        VoiceRouteKind::AskFallback => vec![worker_command(
+            WorkerDomain::Voice,
+            "voice.ask",
+            json!({
+                "question": decision.normalized_text,
+                "history": state.voice.ask_history_payload(),
+                "model": state.voice.command_settings.ask_model,
+                "instructions": state.voice.command_settings.ask_instructions,
+                "max_output_chars": state.voice.command_settings.ask_max_response_chars,
+            }),
+        )],
+        VoiceRouteKind::AskExit => vec![worker_command(
+            WorkerDomain::Ui,
+            "ui.input_action",
+            json!({"action": "back"}),
+        )],
+        VoiceRouteKind::Action => commands_for_voice_route_action(&decision.route_name),
+        VoiceRouteKind::LocalHelp => Vec::new(),
+    }
+}
+
+fn commands_for_voice_route_action(route_name: &str) -> Vec<RuntimeCommand> {
+    match route_name {
+        "back" => vec![worker_command(
+            WorkerDomain::Ui,
+            "ui.input_action",
+            json!({"action": "back"}),
+        )],
+        _ => Vec::new(),
+    }
+}
+
+fn commands_for_voice_ask_result(state: &RuntimeState, payload: &Value) -> Vec<RuntimeCommand> {
+    let Some(answer) = string_field(payload, "answer") else {
+        return Vec::new();
+    };
+    let mut envelope =
+        WorkerEnvelope::command("voice.speak", None, state.voice.speak_payload(&answer));
+    envelope.deadline_ms = state.voice.speech_settings.request_timeout_ms;
+    vec![RuntimeCommand::WorkerCommand {
+        domain: WorkerDomain::Voice,
+        envelope,
+    }]
+}
+
+fn commands_for_voice_speak_result(payload: &Value) -> Vec<RuntimeCommand> {
+    string_field(payload, "audio_path")
+        .map(|file_path| {
+            vec![worker_command(
+                WorkerDomain::Voip,
+                "voip.play_voice_note",
+                json!({ "file_path": file_path }),
+            )]
+        })
+        .unwrap_or_default()
+}
+
+fn commands_for_voice_command(
+    state: &RuntimeState,
+    intent: VoiceCommandIntent,
+    contact_name: &str,
+) -> Vec<RuntimeCommand> {
+    match intent {
+        VoiceCommandIntent::PlayMusic => vec![worker_command(
+            WorkerDomain::Media,
+            "media.shuffle_all",
+            empty_payload(),
+        )],
+        VoiceCommandIntent::CallContact => state
+            .contact_for_voice_label(contact_name)
+            .map(|contact| {
+                vec![worker_command(
+                    WorkerDomain::Voip,
+                    "voip.dial",
+                    json!({ "uri": contact.id }),
+                )]
+            })
+            .unwrap_or_default(),
+        VoiceCommandIntent::VolumeUp => vec![worker_command(
+            WorkerDomain::Media,
+            "media.set_volume",
+            json!({"volume": adjusted_volume(state, 10)}),
+        )],
+        VoiceCommandIntent::VolumeDown => vec![worker_command(
+            WorkerDomain::Media,
+            "media.set_volume",
+            json!({"volume": adjusted_volume(state, -10)}),
+        )],
+        VoiceCommandIntent::ReadScreen
+        | VoiceCommandIntent::MuteMic
+        | VoiceCommandIntent::UnmuteMic
+        | VoiceCommandIntent::Unknown => Vec::new(),
+    }
+}
+
+fn adjusted_volume(state: &RuntimeState, delta: i32) -> i32 {
+    (state.media.volume + delta).clamp(0, 100)
 }
 
 fn commands_for_power_intent(action: &str, payload: &Value) -> Vec<RuntimeCommand> {
@@ -714,6 +888,9 @@ fn commands_for_voip_snapshot(state: &RuntimeState, snapshot: &Value) -> Vec<Run
         }),
     ));
     if !is_music_playing(state) {
+        if let Some(command) = ask_capture_transcribe_command(state, snapshot) {
+            commands.push(command);
+        }
         return commands;
     }
 
@@ -729,8 +906,36 @@ fn commands_for_voip_snapshot(state: &RuntimeState, snapshot: &Value) -> Vec<Run
             empty_payload(),
         ));
     }
+    if let Some(command) = ask_capture_transcribe_command(state, snapshot) {
+        commands.push(command);
+    }
 
     commands
+}
+
+fn ask_capture_transcribe_command(
+    state: &RuntimeState,
+    snapshot: &Value,
+) -> Option<RuntimeCommand> {
+    if !state.voice.ask_capture_active || state.voice.ask_transcribe_requested {
+        return None;
+    }
+    let voice_note = snapshot.get("voice_note")?;
+    let raw_state = string_field(voice_note, "state").unwrap_or_default();
+    if !matches!(normalized(&raw_state).as_str(), "recorded" | "review") {
+        return None;
+    }
+    let file_path = string_field(voice_note, "file_path")?;
+    let mut envelope = WorkerEnvelope::command(
+        "voice.transcribe",
+        None,
+        state.voice.transcribe_payload(&file_path),
+    );
+    envelope.deadline_ms = state.voice.capture_settings.request_timeout_ms;
+    Some(RuntimeCommand::WorkerCommand {
+        domain: WorkerDomain::Voice,
+        envelope,
+    })
 }
 
 fn commands_for_network_snapshot(snapshot: &Value) -> Vec<RuntimeCommand> {

--- a/yoyopod_rs/runtime/src/lib.rs
+++ b/yoyopod_rs/runtime/src/lib.rs
@@ -6,6 +6,7 @@ pub mod protocol;
 pub mod runtime_loop;
 pub mod state;
 pub mod status;
+pub mod voice;
 pub mod worker;
 
 pub fn runtime_name() -> &'static str {

--- a/yoyopod_rs/runtime/src/state.rs
+++ b/yoyopod_rs/runtime/src/state.rs
@@ -4,6 +4,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::{json, Value};
 
+use crate::voice::{
+    match_voice_confirmation_response, normalize_voice_activation, route_voice_transcript,
+    VoiceCaptureSettings, VoiceCommandIntent, VoiceCommandSettings, VoiceConfirmationResponse,
+    VoiceRouteKind, VoiceSpeechSettings,
+};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum WorkerDomain {
     Ui,
@@ -112,6 +118,7 @@ pub struct ListItem {
     pub title: String,
     pub subtitle: String,
     pub icon_key: String,
+    pub aliases: Vec<String>,
 }
 
 impl ListItem {
@@ -137,6 +144,7 @@ impl ListItem {
             title,
             subtitle,
             icon_key,
+            aliases: string_array_field(value, "aliases"),
         })
     }
 
@@ -146,6 +154,7 @@ impl ListItem {
             "title": self.title,
             "subtitle": self.subtitle,
             "icon_key": self.icon_key,
+            "aliases": self.aliases,
         })
     }
 }
@@ -157,6 +166,7 @@ pub struct MediaState {
     pub title: String,
     pub artist: String,
     pub progress_permille: i32,
+    pub volume: i32,
     pub playlists: Vec<ListItem>,
     pub recent_tracks: Vec<ListItem>,
 }
@@ -169,6 +179,7 @@ impl Default for MediaState {
             title: "Nothing Playing".to_string(),
             artist: String::new(),
             progress_permille: 0,
+            volume: 50,
             playlists: Vec::new(),
             recent_tracks: Vec::new(),
         }
@@ -219,6 +230,24 @@ pub struct VoiceNoteSummary {
     pub display_name: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VoiceCommandOutcome {
+    headline: String,
+    body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceAskTurn {
+    pub question: String,
+    pub answer: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceCallConfirmation {
+    pub spoken_name: String,
+    pub display_name: String,
+}
+
 impl VoiceNoteSummary {
     fn to_payload(&self) -> Value {
         json!({
@@ -236,6 +265,8 @@ impl VoiceNoteSummary {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VoiceRuntimeState {
     pub phase: String,
+    pub headline: String,
+    pub body: String,
     pub status_text: String,
     pub file_path: String,
     pub duration_ms: i32,
@@ -244,12 +275,23 @@ pub struct VoiceRuntimeState {
     pub playback_active: bool,
     pub playback_file_path: String,
     pub voice_note_store_dir: String,
+    pub last_transcript: String,
+    pub command_settings: VoiceCommandSettings,
+    pub capture_settings: VoiceCaptureSettings,
+    pub speech_settings: VoiceSpeechSettings,
+    pub ask_capture_active: bool,
+    pub ask_transcribe_requested: bool,
+    pub pending_ask_question: String,
+    pub ask_history: Vec<VoiceAskTurn>,
+    pub pending_call_confirmation: Option<VoiceCallConfirmation>,
 }
 
 impl Default for VoiceRuntimeState {
     fn default() -> Self {
         Self {
             phase: "idle".to_string(),
+            headline: "Ask".to_string(),
+            body: "Ask me anything...".to_string(),
             status_text: String::new(),
             file_path: String::new(),
             duration_ms: 0,
@@ -258,6 +300,15 @@ impl Default for VoiceRuntimeState {
             playback_active: false,
             playback_file_path: String::new(),
             voice_note_store_dir: "data/communication/voice_notes".to_string(),
+            last_transcript: String::new(),
+            command_settings: VoiceCommandSettings::default(),
+            capture_settings: VoiceCaptureSettings::default(),
+            speech_settings: VoiceSpeechSettings::default(),
+            ask_capture_active: false,
+            ask_transcribe_requested: false,
+            pending_ask_question: String::new(),
+            ask_history: Vec::new(),
+            pending_call_confirmation: None,
         }
     }
 }
@@ -275,12 +326,101 @@ impl VoiceRuntimeState {
             .to_string()
     }
 
+    pub fn ask_recording_file_path(&self) -> String {
+        let filename = format!(
+            "yoyopod-ask-{}-{}.wav",
+            std::process::id(),
+            current_millis()
+        );
+        Path::new(&self.voice_note_store_dir)
+            .join(filename)
+            .to_string_lossy()
+            .to_string()
+    }
+
+    pub fn transcribe_payload(&self, audio_path: &str) -> Value {
+        json!({
+            "audio_path": audio_path,
+            "format": "wav",
+            "sample_rate_hz": self.capture_settings.sample_rate_hz,
+            "channels": 1,
+            "language": self.capture_settings.stt_language,
+            "model": self.capture_settings.stt_model,
+            "prompt": self.capture_settings.stt_prompt,
+            "max_audio_seconds": self.capture_settings.max_audio_ms as f64 / 1000.0,
+            "delete_input_on_success": true,
+        })
+    }
+
+    pub fn speak_payload(&self, text: &str) -> Value {
+        json!({
+            "text": text.trim(),
+            "voice": self.speech_settings.tts_voice,
+            "model": self.speech_settings.tts_model,
+            "instructions": self.speech_settings.tts_instructions,
+            "format": "wav",
+            "sample_rate_hz": self.speech_settings.sample_rate_hz,
+        })
+    }
+
+    pub fn ask_history_payload(&self) -> Value {
+        let history = self
+            .ask_history
+            .iter()
+            .flat_map(|turn| {
+                [
+                    json!({"role": "user", "text": turn.question}),
+                    json!({"role": "assistant", "text": turn.answer}),
+                ]
+            })
+            .collect::<Vec<_>>();
+        json!(history)
+    }
+
+    fn remember_ask_turn(&mut self, question: &str, answer: &str) {
+        let limit = self.command_settings.ask_max_response_chars.max(1);
+        let question = trim_ask_history_text(question, limit);
+        let answer = trim_ask_history_text(answer, limit);
+        if question.is_empty() || answer.is_empty() {
+            return;
+        }
+
+        self.ask_history.push(VoiceAskTurn { question, answer });
+        let max_turns = self.command_settings.ask_max_history_turns.max(1);
+        if self.ask_history.len() > max_turns {
+            let keep_from = self.ask_history.len() - max_turns;
+            self.ask_history.drain(..keep_from);
+        }
+    }
+
     fn reset_draft(&mut self) {
         let store_dir = self.voice_note_store_dir.clone();
+        let command_settings = self.command_settings.clone();
+        let capture_settings = self.capture_settings.clone();
+        let speech_settings = self.speech_settings.clone();
+        let pending_ask_question = self.pending_ask_question.clone();
+        let ask_history = self.ask_history.clone();
         *self = Self {
             voice_note_store_dir: store_dir,
+            command_settings,
+            capture_settings,
+            speech_settings,
+            pending_ask_question,
+            ask_history,
             ..Self::default()
         };
+    }
+
+    fn set_interaction(
+        &mut self,
+        phase: impl Into<String>,
+        headline: impl Into<String>,
+        body: impl Into<String>,
+    ) {
+        self.phase = phase.into();
+        self.headline = headline.into();
+        self.body = body.into();
+        self.status_text.clear();
     }
 }
 
@@ -524,6 +664,43 @@ impl RuntimeState {
         }
     }
 
+    pub fn configure_voice_commands(&mut self, command_settings: VoiceCommandSettings) {
+        self.voice.command_settings = command_settings;
+    }
+
+    pub fn configure_voice_capture(&mut self, capture_settings: VoiceCaptureSettings) {
+        self.voice.capture_settings = capture_settings;
+    }
+
+    pub fn configure_voice_speech(&mut self, speech_settings: VoiceSpeechSettings) {
+        self.voice.speech_settings = speech_settings;
+    }
+
+    pub fn configure_media_volume(&mut self, volume: i32) {
+        self.media.volume = volume.clamp(0, 100);
+    }
+
+    pub fn contact_for_voice_label(&self, label: &str) -> Option<&ListItem> {
+        find_contact(self, label)
+    }
+
+    pub fn pending_voice_call_confirmation_response(
+        &self,
+        transcript: &str,
+    ) -> Option<VoiceConfirmationResponse> {
+        self.voice.pending_call_confirmation.as_ref()?;
+        match_voice_confirmation_response(transcript)
+    }
+
+    pub fn pending_voice_call_confirmation_contact(&self) -> Option<&ListItem> {
+        let pending = self.voice.pending_call_confirmation.as_ref()?;
+        find_contact(self, &pending.spoken_name)
+    }
+
+    pub fn infer_voice_call_confirmation(&self, transcript: &str) -> Option<VoiceCallConfirmation> {
+        infer_voice_call_confirmation(self, transcript)
+    }
+
     pub fn configure_power_safety(&mut self, config: PowerSafetyConfig) {
         self.power.safety.config = config;
     }
@@ -724,6 +901,11 @@ impl RuntimeState {
         if let Some(playback_state) = string_field(snapshot, "playback_state") {
             self.media.playback_state = playback_state;
         }
+        if let Some(volume) =
+            i32_field(snapshot, "volume").or_else(|| i32_field(snapshot, "default_volume"))
+        {
+            self.media.volume = volume.clamp(0, 100);
+        }
         let explicit_progress_permille = i32_field(snapshot, "progress_permille")
             .filter(|progress_permille| (0..=1000).contains(progress_permille));
         if let Some(progress_permille) = explicit_progress_permille {
@@ -813,7 +995,11 @@ impl RuntimeState {
                 .collect();
         }
         if let Some(voice_note) = snapshot.get("voice_note") {
-            self.apply_voice_note_snapshot(voice_note);
+            if self.voice.ask_capture_active {
+                self.apply_ask_capture_snapshot(voice_note);
+            } else {
+                self.apply_voice_note_snapshot(voice_note);
+            }
         }
         if let Some(playback) = snapshot.get("voice_note_playback") {
             self.apply_voice_note_playback_snapshot(playback);
@@ -828,6 +1014,27 @@ impl RuntimeState {
 
     fn apply_voice_intent(&mut self, action: &str, payload: &Value) {
         match normalized(action).as_str() {
+            "ask_start" | "begin_ask" => {
+                self.voice.ask_capture_active = true;
+                self.voice.ask_transcribe_requested = false;
+                self.voice.set_interaction(
+                    "listening",
+                    "Listening",
+                    "Say YoYo, then ask or command...",
+                );
+            }
+            "ask_stop" | "finish_ask" => {
+                self.voice.ask_capture_active = true;
+                self.voice
+                    .set_interaction("thinking", "Thinking", "Just a moment...");
+            }
+            "ask_cancel" => {
+                self.voice.ask_capture_active = false;
+                self.voice.ask_transcribe_requested = false;
+                self.voice.pending_ask_question.clear();
+                self.voice
+                    .set_interaction("idle", "Ask", "Ask me anything...");
+            }
             "capture_start" | "start_recording" => {
                 self.voice.phase = "recording".to_string();
                 self.voice.status_text = "Recording...".to_string();
@@ -857,6 +1064,197 @@ impl RuntimeState {
                 self.voice.playback_file_path.clear();
             }
             "discard" | "again" | "reset" => self.voice.reset_draft(),
+            _ => {}
+        }
+    }
+
+    pub fn apply_voice_transcript(&mut self, payload: &Value) {
+        self.voice.ask_capture_active = false;
+        self.voice.ask_transcribe_requested = false;
+        let transcript = string_field(payload, "text")
+            .or_else(|| string_field(payload, "transcript"))
+            .unwrap_or_default();
+        self.voice.last_transcript = transcript.trim().to_string();
+        if self.voice.last_transcript.is_empty() {
+            self.voice.pending_ask_question.clear();
+            self.voice.pending_call_confirmation = None;
+            self.voice
+                .set_interaction("reply", "No Speech", "I did not catch a command.");
+            return;
+        }
+
+        if self.apply_pending_voice_call_confirmation_response() {
+            return;
+        }
+
+        let decision =
+            route_voice_transcript(&self.voice.last_transcript, &self.voice.command_settings);
+        match decision.kind {
+            VoiceRouteKind::Command => {
+                self.voice.pending_ask_question.clear();
+                let command = decision.command.as_ref();
+                self.apply_voice_command_outcome(command.and_then(|command| {
+                    voice_command_outcome(self, command.intent, &command.contact_name)
+                }));
+            }
+            VoiceRouteKind::AskFallback => {
+                if let Some(confirmation) =
+                    infer_voice_call_confirmation(self, &self.voice.last_transcript)
+                {
+                    self.voice.pending_ask_question.clear();
+                    self.voice.pending_call_confirmation = Some(confirmation.clone());
+                    self.voice.set_interaction(
+                        "reply",
+                        "Confirm Call",
+                        format!(
+                            "Did you want to call {}? Say yes or no.",
+                            confirmation.display_name
+                        ),
+                    );
+                    return;
+                }
+                self.voice.pending_ask_question = decision.normalized_text;
+                self.voice
+                    .set_interaction("thinking", "Thinking", "Finding an answer...");
+            }
+            VoiceRouteKind::AskExit => {
+                self.voice.pending_ask_question.clear();
+                self.voice.set_interaction("reply", "Ask", "Going back.");
+            }
+            VoiceRouteKind::Action => {
+                self.voice.pending_ask_question.clear();
+                self.voice.set_interaction("reply", "Command", "");
+                if let Some(screen) = screen_for_voice_route(&decision.route_name) {
+                    self.current_screen = screen.to_string();
+                }
+            }
+            VoiceRouteKind::LocalHelp => {
+                if let Some(confirmation) =
+                    infer_voice_call_confirmation(self, &self.voice.last_transcript)
+                {
+                    self.voice.pending_ask_question.clear();
+                    self.voice.pending_call_confirmation = Some(confirmation.clone());
+                    self.voice.set_interaction(
+                        "reply",
+                        "Confirm Call",
+                        format!(
+                            "Did you want to call {}? Say yes or no.",
+                            confirmation.display_name
+                        ),
+                    );
+                    return;
+                }
+                self.voice.pending_ask_question.clear();
+                self.voice.set_interaction(
+                    "reply",
+                    "Try Again",
+                    "Try saying call mom, play music, or volume up.",
+                );
+            }
+        }
+    }
+
+    pub fn apply_voice_ask_result(&mut self, payload: &Value) {
+        self.voice.ask_capture_active = false;
+        self.voice.ask_transcribe_requested = false;
+        let answer_from_payload = string_field(payload, "answer");
+        let answer = answer_from_payload.clone().unwrap_or_else(|| {
+            "I cannot reach Ask right now. I can still help with music, calls, and volume."
+                .to_string()
+        });
+        if let Some(answer_from_payload) = answer_from_payload {
+            let question = std::mem::take(&mut self.voice.pending_ask_question);
+            self.voice
+                .remember_ask_turn(&question, &answer_from_payload);
+        } else {
+            self.voice.pending_ask_question.clear();
+        }
+        self.voice.set_interaction("reply", "Answer", answer);
+    }
+
+    fn apply_voice_command_outcome(&mut self, outcome: Option<VoiceCommandOutcome>) {
+        let outcome = outcome.unwrap_or(VoiceCommandOutcome {
+            headline: "Not Ready".to_string(),
+            body: "That command is recognized but not wired yet.".to_string(),
+        });
+        self.voice
+            .set_interaction("reply", outcome.headline, outcome.body);
+    }
+
+    fn apply_pending_voice_call_confirmation_response(&mut self) -> bool {
+        let Some(response) =
+            self.pending_voice_call_confirmation_response(&self.voice.last_transcript)
+        else {
+            if self.voice.pending_call_confirmation.is_some() {
+                self.voice.pending_call_confirmation = None;
+            }
+            return false;
+        };
+        let Some(pending) = self.voice.pending_call_confirmation.take() else {
+            return false;
+        };
+        self.voice.pending_ask_question.clear();
+        match response {
+            VoiceConfirmationResponse::Yes => {
+                let outcome = find_contact(self, &pending.spoken_name)
+                    .map(|contact| VoiceCommandOutcome {
+                        headline: "Calling".to_string(),
+                        body: format!("Calling {}.", contact.title),
+                    })
+                    .unwrap_or_else(|| VoiceCommandOutcome {
+                        headline: "No Match".to_string(),
+                        body: format!("I could not find {}.", pending.spoken_name),
+                    });
+                self.voice
+                    .set_interaction("reply", outcome.headline, outcome.body);
+            }
+            VoiceConfirmationResponse::No => {
+                self.voice.set_interaction(
+                    "reply",
+                    "Cancelled",
+                    format!("Okay, I will not call {}.", pending.display_name),
+                );
+            }
+        }
+        true
+    }
+
+    fn apply_ask_capture_snapshot(&mut self, voice_note: &Value) {
+        let raw_state = string_field(voice_note, "state").unwrap_or_else(|| "idle".to_string());
+        if let Some(file_path) = string_field(voice_note, "file_path") {
+            self.voice.file_path = file_path;
+        }
+        if let Some(duration_ms) = i32_field(voice_note, "duration_ms") {
+            self.voice.duration_ms = duration_ms.max(0);
+        }
+        match normalized(&raw_state).as_str() {
+            "recording" => {
+                if self.voice.phase != "thinking" {
+                    self.voice.set_interaction(
+                        "listening",
+                        "Listening",
+                        "Say YoYo, then ask or command...",
+                    );
+                }
+            }
+            "recorded" | "review" => {
+                self.voice.ask_transcribe_requested = true;
+                self.voice
+                    .set_interaction("thinking", "Thinking", "Just a moment...");
+            }
+            "failed" | "error" => {
+                self.voice.ask_capture_active = false;
+                self.voice.ask_transcribe_requested = false;
+                self.voice.set_interaction(
+                    "reply",
+                    "Mic Unavailable",
+                    "Voice capture is not ready on this device.",
+                );
+            }
+            "cancelled" | "canceled" | "idle" => {
+                self.voice.ask_capture_active = false;
+                self.voice.ask_transcribe_requested = false;
+            }
             _ => {}
         }
     }
@@ -1087,6 +1485,7 @@ impl RuntimeState {
                 "title": self.media.title,
                 "artist": self.media.artist,
                 "progress_permille": self.media.progress_permille,
+                "volume": self.media.volume,
                 "playlists": list_payload(&self.media.playlists),
                 "recent_tracks": list_payload(&self.media.recent_tracks),
             },
@@ -1103,9 +1502,9 @@ impl RuntimeState {
             },
             "voice": {
                 "phase": self.voice.phase,
-                "headline": "Ask",
+                "headline": self.voice.headline,
                 "body": voice_body_text(&self.voice),
-                "capture_in_flight": self.voice.phase == "recording",
+                "capture_in_flight": self.voice.ask_capture_active || self.voice.phase == "recording",
                 "ptt_active": self.voice.phase == "recording",
             },
             "power": {
@@ -1388,6 +1787,7 @@ impl RuntimeState {
                 "title": self.media.title,
                 "artist": self.media.artist,
                 "progress_permille": self.media.progress_permille,
+                "volume": self.media.volume,
             },
             "voip": {
                 "registered": self.call.registered,
@@ -1438,6 +1838,22 @@ impl RuntimeState {
 
 fn string_field(value: &Value, key: &str) -> Option<String> {
     value.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+fn string_array_field(value: &Value, key: &str) -> Vec<String> {
+    value
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn i32_field(value: &Value, key: &str) -> Option<i32> {
@@ -1538,6 +1954,7 @@ fn recent_call_history_item(value: &Value, contacts: &[ListItem]) -> Option<List
         title,
         subtitle,
         icon_key: icon_key.to_string(),
+        aliases: Vec::new(),
     })
 }
 
@@ -1665,13 +2082,204 @@ fn voice_status_text(phase: &str) -> String {
 }
 
 fn voice_body_text(voice: &VoiceRuntimeState) -> String {
-    if voice.phase == "idle" {
-        "Ask me anything...".to_string()
+    if matches!(
+        voice.phase.as_str(),
+        "idle" | "listening" | "thinking" | "reply"
+    ) {
+        voice.body.clone()
     } else if voice.status_text.trim().is_empty() {
         voice_status_text(&voice.phase)
     } else {
         voice.status_text.clone()
     }
+}
+
+fn trim_ask_history_text(text: &str, limit: usize) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .take(limit.max(1))
+        .collect()
+}
+
+fn screen_for_voice_route(route_name: &str) -> Option<&'static str> {
+    match normalized(route_name).as_str() {
+        "open_talk" => Some("talk"),
+        "open_listen" => Some("listen"),
+        "open_setup" => Some("power"),
+        "go_home" => Some("hub"),
+        _ => None,
+    }
+}
+
+const VOICE_CALL_HINT_TOKENS: &[&str] = &["call", "dial", "phone", "ring"];
+const VOICE_NEGATION_TOKENS: &[&str] = &[
+    "no", "not", "never", "dont", "don't", "cant", "can't", "cannot", "wont", "won't",
+];
+
+fn infer_voice_call_confirmation(
+    state: &RuntimeState,
+    transcript: &str,
+) -> Option<VoiceCallConfirmation> {
+    let activation = normalize_voice_activation(
+        transcript,
+        &state.voice.command_settings.activation_prefixes,
+    );
+    let tokens = voice_command_tokens(&activation.normalized_text);
+    if tokens.is_empty()
+        || !tokens
+            .iter()
+            .any(|token| VOICE_CALL_HINT_TOKENS.contains(&token.as_str()))
+        || tokens
+            .iter()
+            .any(|token| VOICE_NEGATION_TOKENS.contains(&token.as_str()))
+    {
+        return None;
+    }
+
+    for contact in &state.call.contacts {
+        let mut labels = contact_labels(contact);
+        labels.sort_by_key(|label| std::cmp::Reverse(label.len()));
+        for label in labels {
+            let label_tokens = voice_command_tokens(&label);
+            if !label_tokens.is_empty()
+                && label_tokens
+                    .iter()
+                    .all(|label_token| tokens.contains(label_token))
+            {
+                return Some(VoiceCallConfirmation {
+                    spoken_name: label,
+                    display_name: contact.title.clone(),
+                });
+            }
+        }
+    }
+    None
+}
+
+fn voice_command_tokens(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    for character in text.chars() {
+        if character.is_ascii_alphanumeric() || character == '\'' {
+            current.push(character.to_ascii_lowercase());
+        } else if !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+fn voice_command_outcome(
+    state: &RuntimeState,
+    intent: VoiceCommandIntent,
+    contact_name: &str,
+) -> Option<VoiceCommandOutcome> {
+    match intent {
+        VoiceCommandIntent::PlayMusic => Some(VoiceCommandOutcome {
+            headline: "Playing".to_string(),
+            body: "Starting local music.".to_string(),
+        }),
+        VoiceCommandIntent::CallContact => match find_contact(state, contact_name) {
+            Some(contact) => Some(VoiceCommandOutcome {
+                headline: "Calling".to_string(),
+                body: format!("Calling {}.", contact.title),
+            }),
+            None => Some(VoiceCommandOutcome {
+                headline: "No Match".to_string(),
+                body: format!("I could not find {contact_name}."),
+            }),
+        },
+        VoiceCommandIntent::VolumeUp => Some(volume_outcome(state.media.volume + 10)),
+        VoiceCommandIntent::VolumeDown => Some(volume_outcome(state.media.volume - 10)),
+        VoiceCommandIntent::ReadScreen => Some(VoiceCommandOutcome {
+            headline: "Screen Read".to_string(),
+            body: "You are on Ask. Say a direct command now.".to_string(),
+        }),
+        VoiceCommandIntent::MuteMic => Some(VoiceCommandOutcome {
+            headline: "Mic Muted".to_string(),
+            body: "Voice commands mic is muted.".to_string(),
+        }),
+        VoiceCommandIntent::UnmuteMic => Some(VoiceCommandOutcome {
+            headline: "Mic Live".to_string(),
+            body: "Voice commands mic is live.".to_string(),
+        }),
+        VoiceCommandIntent::Unknown => None,
+    }
+}
+
+fn volume_outcome(volume: i32) -> VoiceCommandOutcome {
+    let volume = volume.clamp(0, 100);
+    let level = ((volume as f64) / 10.0).round() as i32;
+    VoiceCommandOutcome {
+        headline: "Volume".to_string(),
+        body: format!("Volume is {level} out of 10."),
+    }
+}
+
+fn find_contact<'a>(state: &'a RuntimeState, spoken_name: &str) -> Option<&'a ListItem> {
+    let spoken_name = normalize_contact_label(spoken_name);
+    if spoken_name.is_empty() {
+        return None;
+    }
+
+    state.call.contacts.iter().find(|contact| {
+        contact_labels(contact)
+            .iter()
+            .any(|label| label == &spoken_name)
+    })
+}
+
+fn contact_labels(contact: &ListItem) -> Vec<String> {
+    let mut labels = vec![
+        normalize_contact_label(&contact.title),
+        normalize_contact_label(&contact.subtitle),
+        normalize_contact_label(&contact.id),
+    ];
+    labels.extend(
+        contact
+            .aliases
+            .iter()
+            .map(|alias| normalize_contact_label(alias)),
+    );
+    labels.retain(|label| !label.is_empty());
+
+    if labels
+        .iter()
+        .any(|label| ["mom", "mama", "mum", "mommy", "mother"].contains(&label.as_str()))
+    {
+        labels.extend(
+            ["mom", "mama", "mum", "mommy", "mother"]
+                .iter()
+                .map(|label| (*label).to_string()),
+        );
+    }
+    if labels
+        .iter()
+        .any(|label| ["dad", "dada", "daddy", "papa", "father"].contains(&label.as_str()))
+    {
+        labels.extend(
+            ["dad", "dada", "daddy", "papa", "father"]
+                .iter()
+                .map(|label| (*label).to_string()),
+        );
+    }
+
+    labels.sort();
+    labels.dedup();
+    labels
+}
+
+fn normalize_contact_label(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
 }
 
 fn current_millis() -> u128 {

--- a/yoyopod_rs/runtime/src/voice.rs
+++ b/yoyopod_rs/runtime/src/voice.rs
@@ -1,0 +1,1105 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceCommandSettings {
+    pub commands_enabled: bool,
+    pub ai_requests_enabled: bool,
+    pub activation_prefixes: Vec<String>,
+    pub ask_fallback_enabled: bool,
+    pub disabled_intents: Vec<VoiceCommandIntent>,
+    pub command_aliases: Vec<VoiceCommandAlias>,
+    pub route_actions: Vec<VoiceRouteAction>,
+    pub ask_model: String,
+    pub ask_instructions: String,
+    pub ask_max_history_turns: usize,
+    pub ask_max_response_chars: usize,
+}
+
+impl Default for VoiceCommandSettings {
+    fn default() -> Self {
+        Self {
+            commands_enabled: true,
+            ai_requests_enabled: true,
+            activation_prefixes: vec!["yoyo".to_string(), "hey yoyo".to_string()],
+            ask_fallback_enabled: true,
+            disabled_intents: Vec::new(),
+            command_aliases: Vec::new(),
+            route_actions: Vec::new(),
+            ask_model: "gpt-4.1-mini".to_string(),
+            ask_instructions: DEFAULT_ASK_INSTRUCTIONS.to_string(),
+            ask_max_history_turns: 4,
+            ask_max_response_chars: 480,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceCaptureSettings {
+    pub sample_rate_hz: u64,
+    pub request_timeout_ms: u64,
+    pub max_audio_ms: u64,
+    pub stt_model: String,
+    pub stt_language: String,
+    pub stt_prompt: String,
+}
+
+impl Default for VoiceCaptureSettings {
+    fn default() -> Self {
+        Self {
+            sample_rate_hz: 16_000,
+            request_timeout_ms: 12_000,
+            max_audio_ms: 30_000,
+            stt_model: "gpt-4o-mini-transcribe".to_string(),
+            stt_language: "en".to_string(),
+            stt_prompt: DEFAULT_STT_PROMPT.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceSpeechSettings {
+    pub sample_rate_hz: u64,
+    pub request_timeout_ms: u64,
+    pub tts_model: String,
+    pub tts_voice: String,
+    pub tts_instructions: String,
+}
+
+impl Default for VoiceSpeechSettings {
+    fn default() -> Self {
+        Self {
+            sample_rate_hz: 16_000,
+            request_timeout_ms: 12_000,
+            tts_model: "gpt-4o-mini-tts".to_string(),
+            tts_voice: "coral".to_string(),
+            tts_instructions: DEFAULT_TTS_INSTRUCTIONS.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceCommandAlias {
+    pub intent: VoiceCommandIntent,
+    pub aliases: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceRouteAction {
+    pub route_name: String,
+    pub aliases: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VoiceConfirmationResponse {
+    Yes,
+    No,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VoiceCommandDictionary {
+    pub disabled_intents: Vec<VoiceCommandIntent>,
+    pub command_aliases: Vec<VoiceCommandAlias>,
+    pub route_actions: Vec<VoiceRouteAction>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VoiceCommandIntent {
+    CallContact,
+    PlayMusic,
+    ReadScreen,
+    VolumeUp,
+    VolumeDown,
+    MuteMic,
+    UnmuteMic,
+    Unknown,
+}
+
+impl VoiceCommandIntent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CallContact => "call_contact",
+            Self::PlayMusic => "play_music",
+            Self::ReadScreen => "read_screen",
+            Self::VolumeUp => "volume_up",
+            Self::VolumeDown => "volume_down",
+            Self::MuteMic => "mute_mic",
+            Self::UnmuteMic => "unmute_mic",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceCommandMatch {
+    pub intent: VoiceCommandIntent,
+    pub transcript: String,
+    pub contact_name: String,
+}
+
+impl VoiceCommandMatch {
+    pub fn unknown(transcript: impl Into<String>) -> Self {
+        Self {
+            intent: VoiceCommandIntent::Unknown,
+            transcript: transcript.into(),
+            contact_name: String::new(),
+        }
+    }
+
+    pub fn is_command(&self) -> bool {
+        self.intent != VoiceCommandIntent::Unknown
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VoiceRouteKind {
+    Command,
+    Action,
+    AskFallback,
+    AskExit,
+    LocalHelp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceRouteDecision {
+    pub kind: VoiceRouteKind,
+    pub original_text: String,
+    pub normalized_text: String,
+    pub stripped_prefix: String,
+    pub command: Option<VoiceCommandMatch>,
+    pub route_name: String,
+    pub reason: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceActivationResult {
+    pub original_text: String,
+    pub normalized_text: String,
+    pub stripped_prefix: String,
+}
+
+const DEFAULT_ASK_INSTRUCTIONS: &str = "You are YoYoPod's friendly Ask helper for a child using a small handheld audio device. Answer in simple language a child can understand. Keep answers to 1-3 short sentences unless the child asks for a story. Be warm, calm, and encouraging. Do not use scary detail. Do not ask for private information. For medical, legal, safety, emergency, or adult topics, give a brief safe answer and say to ask a grown-up. If you are unsure, say so simply. Do not claim to browse the internet or know live facts.";
+const DEFAULT_STT_PROMPT: &str = "Transcribe this YoYoPod voice command in English Latin letters. Do not output Arabic, Persian, Korean, or other non-Latin scripts. Preserve family names such as mama, baba, mom, dad, mommy, daddy, and papa.";
+const DEFAULT_TTS_INSTRUCTIONS: &str = "Speak warmly and calmly for a child. Use simple words, friendly pacing, and brief answers. Avoid scary emphasis.";
+
+const POLITE_PREFIX_TOKENS: &[&str] = &[
+    "please", "hey", "hi", "hello", "yo", "can", "could", "would", "will", "you",
+];
+const SLOT_FILLER_TOKENS: &[&str] = &["a", "an", "the", "to", "for", "my", "please", "now"];
+const NEGATION_TOKENS: &[&str] = &[
+    "no", "not", "never", "dont", "don't", "cant", "can't", "cannot", "wont", "won't", "n't",
+];
+const EXACT_TRIGGER_SUFFIX_TOKENS: &[&str] = &["please", "now"];
+const CALL_TRIGGERS: &[&str] = &["call", "phone", "ring"];
+const VOLUME_UP_TRIGGERS: &[&str] = &[
+    "volume up",
+    "turn volume up",
+    "turn it up",
+    "raise volume",
+    "increase volume",
+    "louder",
+    "make it louder",
+    "too quiet",
+];
+const VOLUME_DOWN_TRIGGERS: &[&str] = &[
+    "volume down",
+    "turn volume down",
+    "turn it down",
+    "lower volume",
+    "decrease volume",
+    "quieter",
+    "make it quieter",
+    "too loud",
+];
+const PLAY_MUSIC_TRIGGERS: &[&str] = &[
+    "play music",
+    "play",
+    "play some music",
+    "start music",
+    "start some music",
+    "start playing music",
+    "shuffle music",
+    "play a song",
+    "play songs",
+    "put on music",
+    "start songs",
+    "play kids music",
+];
+const READ_SCREEN_TRIGGERS: &[&str] = &[
+    "read screen",
+    "read the screen",
+    "read this screen",
+    "read this",
+    "what is on the screen",
+    "tell me what is on the screen",
+];
+const MUTE_MIC_TRIGGERS: &[&str] = &[
+    "mute mic",
+    "mute microphone",
+    "mute the mic",
+    "mute the microphone",
+    "turn off the mic",
+    "turn off microphone",
+    "turn off the microphone",
+];
+const UNMUTE_MIC_TRIGGERS: &[&str] = &[
+    "unmute mic",
+    "unmute microphone",
+    "unmute the mic",
+    "unmute the microphone",
+    "turn on the mic",
+    "turn on microphone",
+    "turn on the microphone",
+];
+const ASK_EXIT_PHRASES: &[&str] = &[
+    "exit ask",
+    "go back",
+    "stop asking",
+    "stop ask",
+    "leave ask",
+    "close ask",
+];
+const CALL_TRIGGER_FUZZY_THRESHOLD: f64 = 0.86;
+const VOLUME_FUZZY_THRESHOLD: f64 = 0.78;
+const PLAY_MUSIC_FUZZY_THRESHOLD: f64 = 0.78;
+const SAFE_ROUTE_ACTIONS: &[&str] = &["open_talk", "open_listen", "open_setup", "go_home", "back"];
+const CONFIRM_YES_TOKENS: &[&str] = &["yes", "yeah", "yep", "yup", "sure", "ok", "okay"];
+const CONFIRM_NO_TOKENS: &[&str] = &[
+    "no", "nope", "nah", "cancel", "stop", "dont", "don't", "not", "never",
+];
+const EXACT_TRIGGERS: &[&str] = &[
+    "louder",
+    "quieter",
+    "play",
+    "play a song",
+    "play songs",
+    "put on music",
+    "start songs",
+    "play kids music",
+    "read screen",
+    "read the screen",
+    "read this screen",
+    "read this",
+    "what is on the screen",
+    "tell me what is on the screen",
+    "mute mic",
+    "mute microphone",
+    "mute the mic",
+    "mute the microphone",
+    "turn off the mic",
+    "turn off microphone",
+    "turn off the microphone",
+    "unmute mic",
+    "unmute microphone",
+    "unmute the mic",
+    "unmute the microphone",
+    "turn on the mic",
+    "turn on microphone",
+    "turn on the microphone",
+];
+
+pub fn route_voice_transcript(
+    transcript: &str,
+    settings: &VoiceCommandSettings,
+) -> VoiceRouteDecision {
+    let activation = normalize_voice_activation(transcript, &settings.activation_prefixes);
+    if ASK_EXIT_PHRASES.contains(&activation.normalized_text.as_str()) {
+        return VoiceRouteDecision {
+            kind: VoiceRouteKind::AskExit,
+            original_text: transcript.to_string(),
+            normalized_text: activation.normalized_text,
+            stripped_prefix: activation.stripped_prefix,
+            command: None,
+            route_name: String::new(),
+            reason: "ask_exit",
+        };
+    }
+
+    let command = match_voice_command_with_settings(&activation.normalized_text, settings);
+    if settings.commands_enabled && command.is_command() {
+        return VoiceRouteDecision {
+            kind: VoiceRouteKind::Command,
+            original_text: transcript.to_string(),
+            normalized_text: activation.normalized_text,
+            stripped_prefix: activation.stripped_prefix,
+            command: Some(command),
+            route_name: String::new(),
+            reason: "command_match",
+        };
+    }
+    if settings.commands_enabled {
+        if let Some(action) =
+            match_voice_route_action(&activation.normalized_text, &settings.route_actions)
+        {
+            return VoiceRouteDecision {
+                kind: VoiceRouteKind::Action,
+                original_text: transcript.to_string(),
+                normalized_text: activation.normalized_text,
+                stripped_prefix: activation.stripped_prefix,
+                command: None,
+                route_name: action.route_name.clone(),
+                reason: "action_match",
+            };
+        }
+    }
+    if settings.ask_fallback_enabled
+        && settings.ai_requests_enabled
+        && !activation.normalized_text.trim().is_empty()
+    {
+        return VoiceRouteDecision {
+            kind: VoiceRouteKind::AskFallback,
+            original_text: transcript.to_string(),
+            normalized_text: activation.normalized_text,
+            stripped_prefix: activation.stripped_prefix,
+            command: None,
+            route_name: String::new(),
+            reason: "ask_fallback",
+        };
+    }
+    VoiceRouteDecision {
+        kind: VoiceRouteKind::LocalHelp,
+        original_text: transcript.to_string(),
+        normalized_text: activation.normalized_text,
+        stripped_prefix: activation.stripped_prefix,
+        command: None,
+        route_name: String::new(),
+        reason: "no_command_no_fallback",
+    }
+}
+
+pub fn normalize_voice_activation(transcript: &str, prefixes: &[String]) -> VoiceActivationResult {
+    let mut tokens = tokenize(transcript);
+    let prefix_tokens = prefixes
+        .iter()
+        .filter_map(|prefix| {
+            let normalized = tokenize(prefix);
+            if normalized.is_empty() {
+                None
+            } else {
+                Some((normalized.join(" "), normalized))
+            }
+        })
+        .collect::<Vec<_>>();
+    let mut stripped_prefix = String::new();
+    while !tokens.is_empty() {
+        let mut matched = false;
+        for (prefix, prefix_tokens) in &prefix_tokens {
+            if starts_with_tokens(&tokens, prefix_tokens) {
+                if stripped_prefix.is_empty() {
+                    stripped_prefix = prefix.clone();
+                }
+                tokens = tokens[prefix_tokens.len()..].to_vec();
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            break;
+        }
+    }
+
+    let normalized_text = if stripped_prefix.is_empty() {
+        transcript.trim().to_string()
+    } else {
+        tokens.join(" ")
+    };
+
+    VoiceActivationResult {
+        original_text: transcript.to_string(),
+        normalized_text,
+        stripped_prefix,
+    }
+}
+
+pub fn load_voice_command_dictionary(path: impl AsRef<Path>) -> VoiceCommandDictionary {
+    let path = path.as_ref();
+    if path.as_os_str().is_empty() || !path.exists() {
+        return VoiceCommandDictionary::default();
+    }
+
+    let Ok(contents) = fs::read_to_string(path) else {
+        return VoiceCommandDictionary::default();
+    };
+    let Ok(payload) = serde_yaml::from_str::<Value>(&contents) else {
+        return VoiceCommandDictionary::default();
+    };
+
+    VoiceCommandDictionary {
+        disabled_intents: dictionary_disabled_intents(payload.get("intents")),
+        command_aliases: dictionary_command_aliases(payload.get("intents")),
+        route_actions: dictionary_route_actions(payload.get("actions")),
+    }
+}
+
+pub fn match_voice_confirmation_response(transcript: &str) -> Option<VoiceConfirmationResponse> {
+    let tokens = tokenize(transcript);
+    if tokens
+        .iter()
+        .any(|token| CONFIRM_YES_TOKENS.contains(&token.as_str()))
+    {
+        return Some(VoiceConfirmationResponse::Yes);
+    }
+    if tokens
+        .iter()
+        .any(|token| CONFIRM_NO_TOKENS.contains(&token.as_str()))
+    {
+        return Some(VoiceConfirmationResponse::No);
+    }
+    None
+}
+
+fn match_voice_command_with_settings(
+    transcript: &str,
+    settings: &VoiceCommandSettings,
+) -> VoiceCommandMatch {
+    if !settings.commands_enabled {
+        return VoiceCommandMatch::unknown(transcript);
+    }
+
+    if let Some(alias_match) = match_command_alias(
+        transcript,
+        &settings.command_aliases,
+        &settings.disabled_intents,
+    ) {
+        return alias_match;
+    }
+
+    let command = match_voice_command(transcript);
+    if settings.disabled_intents.contains(&command.intent) {
+        VoiceCommandMatch::unknown(transcript)
+    } else {
+        command
+    }
+}
+
+fn match_command_alias(
+    transcript: &str,
+    aliases: &[VoiceCommandAlias],
+    disabled_intents: &[VoiceCommandIntent],
+) -> Option<VoiceCommandMatch> {
+    let expanded = expand_common_stt_aliases(transcript);
+    let transcript_tokens = tokenize(&expanded);
+    if has_negation(&transcript_tokens) {
+        return None;
+    }
+    let tokens = strip_polite_prefix(&transcript_tokens);
+    let normalized = tokens.join(" ");
+    if normalized.is_empty() {
+        return None;
+    }
+
+    for alias in aliases {
+        if disabled_intents.contains(&alias.intent) {
+            continue;
+        }
+        if alias.intent == VoiceCommandIntent::CallContact {
+            if let Some(contact_name) = match_call_alias(&tokens, &alias.aliases) {
+                return Some(VoiceCommandMatch {
+                    intent: alias.intent,
+                    transcript: transcript.to_string(),
+                    contact_name,
+                });
+            }
+            continue;
+        }
+        if alias.aliases.iter().any(|phrase| {
+            phrase == &normalized
+                || fixed_phrase_score(&tokens, phrase, fuzzy_threshold_for_intent(alias.intent))
+                    .is_some()
+        }) {
+            return Some(VoiceCommandMatch {
+                intent: alias.intent,
+                transcript: transcript.to_string(),
+                contact_name: String::new(),
+            });
+        }
+    }
+    None
+}
+
+fn fuzzy_threshold_for_intent(intent: VoiceCommandIntent) -> f64 {
+    match intent {
+        VoiceCommandIntent::CallContact => CALL_TRIGGER_FUZZY_THRESHOLD,
+        VoiceCommandIntent::VolumeUp | VoiceCommandIntent::VolumeDown => VOLUME_FUZZY_THRESHOLD,
+        VoiceCommandIntent::PlayMusic => PLAY_MUSIC_FUZZY_THRESHOLD,
+        VoiceCommandIntent::ReadScreen => 0.8,
+        VoiceCommandIntent::MuteMic | VoiceCommandIntent::UnmuteMic => 0.84,
+        VoiceCommandIntent::Unknown => 1.0,
+    }
+}
+
+fn match_call_alias(tokens: &[String], aliases: &[String]) -> Option<String> {
+    for alias in aliases {
+        let alias_tokens = tokenize(alias);
+        if alias_tokens.is_empty() || !starts_with_tokens(tokens, &alias_tokens) {
+            continue;
+        }
+        let slot_tokens = trim_slot_tokens(&tokens[alias_tokens.len()..]);
+        if !slot_tokens.is_empty() && !has_negation(&slot_tokens) {
+            return Some(slot_tokens.join(" "));
+        }
+    }
+    None
+}
+
+fn match_voice_route_action<'a>(
+    transcript: &str,
+    actions: &'a [VoiceRouteAction],
+) -> Option<&'a VoiceRouteAction> {
+    let normalized = normalize_dictionary_phrase(transcript);
+    if normalized.is_empty() {
+        return None;
+    }
+    actions
+        .iter()
+        .find(|action| action.aliases.iter().any(|alias| alias == &normalized))
+}
+
+pub fn match_voice_command(transcript: &str) -> VoiceCommandMatch {
+    let expanded = expand_common_stt_aliases(transcript);
+    let transcript_tokens = tokenize(&expanded);
+    if has_negation(&transcript_tokens) {
+        return VoiceCommandMatch::unknown(transcript);
+    }
+    let tokens = strip_polite_prefix(&transcript_tokens);
+    if tokens.is_empty() {
+        return VoiceCommandMatch::unknown(transcript);
+    }
+
+    if let Some(contact_name) = match_call_contact(&tokens) {
+        return VoiceCommandMatch {
+            intent: VoiceCommandIntent::CallContact,
+            transcript: transcript.to_string(),
+            contact_name,
+        };
+    }
+
+    if let Some(intent) = match_fixed_command_intent(&tokens) {
+        return VoiceCommandMatch {
+            intent,
+            transcript: transcript.to_string(),
+            contact_name: String::new(),
+        };
+    }
+
+    VoiceCommandMatch::unknown(transcript)
+}
+
+fn match_fixed_command_intent(tokens: &[String]) -> Option<VoiceCommandIntent> {
+    let mut best_score = 0.0;
+    let mut best_intent = None;
+
+    for (intent, phrases, fuzzy_threshold) in [
+        (
+            VoiceCommandIntent::VolumeUp,
+            VOLUME_UP_TRIGGERS,
+            VOLUME_FUZZY_THRESHOLD,
+        ),
+        (
+            VoiceCommandIntent::VolumeDown,
+            VOLUME_DOWN_TRIGGERS,
+            VOLUME_FUZZY_THRESHOLD,
+        ),
+        (
+            VoiceCommandIntent::PlayMusic,
+            PLAY_MUSIC_TRIGGERS,
+            PLAY_MUSIC_FUZZY_THRESHOLD,
+        ),
+        (VoiceCommandIntent::ReadScreen, READ_SCREEN_TRIGGERS, 1.0),
+        (VoiceCommandIntent::UnmuteMic, UNMUTE_MIC_TRIGGERS, 1.0),
+        (VoiceCommandIntent::MuteMic, MUTE_MIC_TRIGGERS, 1.0),
+    ] {
+        for phrase in phrases {
+            let Some(score) = fixed_phrase_score(tokens, phrase, fuzzy_threshold) else {
+                continue;
+            };
+            if score > best_score {
+                best_score = score;
+                best_intent = Some(intent);
+            }
+        }
+    }
+
+    best_intent
+}
+
+fn match_call_contact(tokens: &[String]) -> Option<String> {
+    for (index, token) in tokens.iter().enumerate() {
+        if !call_trigger_matches(token) {
+            continue;
+        }
+        if has_negation(&tokens[..index]) {
+            continue;
+        }
+        let slot_tokens = trim_slot_tokens(&tokens[index + 1..]);
+        if slot_tokens.is_empty() || has_negation(&slot_tokens) {
+            continue;
+        }
+        return Some(slot_tokens.join(" "));
+    }
+    None
+}
+
+fn call_trigger_matches(token: &str) -> bool {
+    CALL_TRIGGERS.contains(&token)
+        || CALL_TRIGGERS
+            .iter()
+            .any(|trigger| text_similarity(token, trigger) >= CALL_TRIGGER_FUZZY_THRESHOLD)
+}
+
+fn fixed_phrase_score(tokens: &[String], phrase: &str, fuzzy_threshold: f64) -> Option<f64> {
+    let phrase_tokens = tokenize(phrase);
+    if phrase_tokens.is_empty() {
+        return None;
+    }
+    if EXACT_TRIGGERS.contains(&phrase) {
+        return matches_exact_trigger(tokens, &phrase_tokens).then_some(1.0);
+    }
+    if tokens.len() < phrase_tokens.len() {
+        return None;
+    }
+    if tokens
+        .windows(phrase_tokens.len())
+        .enumerate()
+        .any(|(index, window)| {
+            window == phrase_tokens.as_slice()
+                && !has_negation(&tokens[..index])
+                && !has_negation(window)
+        })
+    {
+        return Some(1.0);
+    }
+    if fuzzy_threshold >= 1.0 {
+        return None;
+    }
+
+    best_window_match(tokens, &phrase_tokens).and_then(|(score, start, end)| {
+        if score >= fuzzy_threshold
+            && !has_negation(&tokens[..start])
+            && !has_negation(&tokens[start..end])
+        {
+            Some(score)
+        } else {
+            None
+        }
+    })
+}
+
+fn matches_exact_trigger(tokens: &[String], phrase_tokens: &[String]) -> bool {
+    let mut end = tokens.len();
+    while end > 0 && EXACT_TRIGGER_SUFFIX_TOKENS.contains(&tokens[end - 1].as_str()) {
+        end -= 1;
+    }
+    tokens[..end] == *phrase_tokens
+}
+
+fn best_window_match(tokens: &[String], phrase_tokens: &[String]) -> Option<(f64, usize, usize)> {
+    if tokens.is_empty() || phrase_tokens.is_empty() {
+        return None;
+    }
+
+    let min_window = phrase_tokens.len().saturating_sub(1).max(1);
+    if tokens.len() < min_window {
+        return None;
+    }
+    let max_window = if tokens.len() <= phrase_tokens.len() + 2 {
+        tokens.len()
+    } else {
+        (phrase_tokens.len() + 2).min(tokens.len())
+    };
+
+    let mut best_score = 0.0;
+    let mut best_start = 0;
+    let mut best_end = 0;
+    for window_size in min_window..=max_window {
+        for start in 0..=tokens.len() - window_size {
+            let end = start + window_size;
+            let window = &tokens[start..end];
+            let score = if window == phrase_tokens {
+                1.0
+            } else {
+                phrase_similarity(window, phrase_tokens)
+            };
+            if score > best_score {
+                best_score = score;
+                best_start = start;
+                best_end = end;
+            }
+        }
+    }
+    Some((best_score, best_start, best_end))
+}
+
+fn phrase_similarity(candidate_tokens: &[String], phrase_tokens: &[String]) -> f64 {
+    let candidate = candidate_tokens
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(" ");
+    let phrase = phrase_tokens
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(" ");
+    text_similarity(&candidate, &phrase)
+        .max(token_overlap_similarity(candidate_tokens, phrase_tokens))
+}
+
+fn text_similarity(candidate: &str, phrase: &str) -> f64 {
+    let candidate_chars = candidate.chars().collect::<Vec<_>>();
+    let phrase_chars = phrase.chars().collect::<Vec<_>>();
+    if candidate_chars.is_empty() || phrase_chars.is_empty() {
+        return 0.0;
+    }
+
+    let matching_len = sequence_matching_len(&candidate_chars, &phrase_chars);
+    (2.0 * matching_len as f64) / (candidate_chars.len() + phrase_chars.len()) as f64
+}
+
+fn sequence_matching_len(left: &[char], right: &[char]) -> usize {
+    let (left_start, right_start, size) = longest_common_substring(left, right);
+    if size == 0 {
+        return 0;
+    }
+
+    size + sequence_matching_len(&left[..left_start], &right[..right_start])
+        + sequence_matching_len(&left[left_start + size..], &right[right_start + size..])
+}
+
+fn longest_common_substring(left: &[char], right: &[char]) -> (usize, usize, usize) {
+    let mut best_left = 0;
+    let mut best_right = 0;
+    let mut best_size = 0;
+
+    for left_start in 0..left.len() {
+        for right_start in 0..right.len() {
+            let mut size = 0;
+            while left_start + size < left.len()
+                && right_start + size < right.len()
+                && left[left_start + size] == right[right_start + size]
+            {
+                size += 1;
+            }
+            if size > best_size {
+                best_left = left_start;
+                best_right = right_start;
+                best_size = size;
+            }
+        }
+    }
+
+    (best_left, best_right, best_size)
+}
+
+fn token_overlap_similarity(candidate_tokens: &[String], phrase_tokens: &[String]) -> f64 {
+    if candidate_tokens.is_empty() || phrase_tokens.is_empty() {
+        return 0.0;
+    }
+    let candidate = candidate_tokens
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    let phrase = phrase_tokens
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    (2.0 * candidate.intersection(&phrase).count() as f64) / (candidate.len() + phrase.len()) as f64
+}
+
+fn expand_common_stt_aliases(transcript: &str) -> String {
+    let mut expanded = String::new();
+    let mut token = String::new();
+    let mut token_kind = None;
+
+    for character in transcript.chars() {
+        let Some(kind) = stt_token_kind(character) else {
+            flush_stt_token(&mut expanded, &mut token, token_kind);
+            token_kind = None;
+            expanded.push(character);
+            continue;
+        };
+
+        if token_kind.is_some_and(|current| current != kind) {
+            flush_stt_token(&mut expanded, &mut token, token_kind);
+        }
+        token_kind = Some(kind);
+        token.push(normalize_stt_token_character(kind, character));
+    }
+    flush_stt_token(&mut expanded, &mut token, token_kind);
+
+    expanded
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SttTokenKind {
+    Latin,
+    ArabicScript,
+    Hangul,
+    Cjk,
+}
+
+fn stt_token_kind(character: char) -> Option<SttTokenKind> {
+    if character.is_ascii_alphanumeric() || character == '\'' {
+        Some(SttTokenKind::Latin)
+    } else if ('\u{0600}'..='\u{06ff}').contains(&character) {
+        Some(SttTokenKind::ArabicScript)
+    } else if ('\u{ac00}'..='\u{d7af}').contains(&character) {
+        Some(SttTokenKind::Hangul)
+    } else if ('\u{4e00}'..='\u{9fff}').contains(&character) {
+        Some(SttTokenKind::Cjk)
+    } else {
+        None
+    }
+}
+
+fn normalize_stt_token_character(kind: SttTokenKind, character: char) -> char {
+    match kind {
+        SttTokenKind::Latin => character.to_ascii_lowercase(),
+        SttTokenKind::ArabicScript => match character {
+            '\u{064a}' => '\u{06cc}',
+            '\u{0643}' => '\u{06a9}',
+            '\u{0622}' => '\u{0627}',
+            _ => character,
+        },
+        SttTokenKind::Hangul | SttTokenKind::Cjk => character,
+    }
+}
+
+fn flush_stt_token(expanded: &mut String, token: &mut String, token_kind: Option<SttTokenKind>) {
+    let Some(kind) = token_kind else {
+        token.clear();
+        return;
+    };
+    if token.is_empty() {
+        return;
+    }
+
+    if let Some(alias) = stt_token_alias(kind, token) {
+        push_stt_alias(expanded, alias);
+    } else {
+        expanded.push_str(token);
+    }
+    token.clear();
+}
+
+fn push_stt_alias(expanded: &mut String, alias: &str) {
+    if expanded
+        .chars()
+        .last()
+        .is_some_and(|last| !last.is_whitespace())
+    {
+        expanded.push(' ');
+    }
+    expanded.push_str(alias);
+    expanded.push(' ');
+}
+
+fn stt_token_alias(kind: SttTokenKind, token: &str) -> Option<&'static str> {
+    match kind {
+        SttTokenKind::Latin => match token {
+            "kual" => Some("call"),
+            _ => None,
+        },
+        SttTokenKind::ArabicScript => match token {
+            "\u{06a9}\u{0648}" | "\u{06a9}\u{0648}\u{0644}" => Some("call"),
+            "\u{0645}\u{0627}\u{0645}\u{0627}" => Some("mama"),
+            "\u{0648}\u{0648}\u{0644}\u{06cc}\u{0648}\u{0645}"
+            | "\u{0648}\u{0644}\u{06cc}\u{0648}\u{0645}"
+            | "\u{0648}\u{0627}\u{0644}\u{06cc}\u{0648}\u{0645}" => Some("volume"),
+            "\u{0627}\u{067e}" => Some("up"),
+            "\u{062f}\u{0627}\u{0648}\u{0646}" | "\u{062f}\u{0627}\u{0646}" => Some("down"),
+            "\u{067e}\u{0644}\u{06cc}" => Some("play"),
+            "\u{0645}\u{0648}\u{0632}\u{06cc}\u{06a9}"
+            | "\u{0645}\u{06cc}\u{0648}\u{0632}\u{06cc}\u{06a9}" => Some("music"),
+            _ => None,
+        },
+        SttTokenKind::Hangul => match token {
+            "\u{ace0}" | "\u{cf5c}" => Some("call"),
+            "\u{b9c8}\u{b9c8}" => Some("mama"),
+            _ => None,
+        },
+        SttTokenKind::Cjk => match token {
+            "\u{63a8}" => Some("play"),
+            "\u{97f3}\u{4e50}" => Some("music"),
+            _ => None,
+        },
+    }
+}
+
+fn tokenize(text: &str) -> Vec<String> {
+    let mut raw = Vec::new();
+    let mut current = String::new();
+    for character in text.chars() {
+        if character.is_ascii_alphanumeric() || character == '\'' {
+            current.push(character.to_ascii_lowercase());
+        } else if !current.is_empty() {
+            raw.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        raw.push(current);
+    }
+
+    let mut normalized = Vec::new();
+    let mut index = 0;
+    while index < raw.len() {
+        if index + 1 < raw.len() && raw[index] == "yo" && raw[index + 1] == "yo" {
+            normalized.push("yoyo".to_string());
+            index += 2;
+        } else {
+            normalized.push(raw[index].clone());
+            index += 1;
+        }
+    }
+    normalized
+}
+
+fn dictionary_disabled_intents(value: Option<&Value>) -> Vec<VoiceCommandIntent> {
+    let Some(Value::Object(intents)) = value else {
+        return Vec::new();
+    };
+    intents
+        .iter()
+        .filter_map(|(intent_name, payload)| {
+            if payload
+                .get("enabled")
+                .and_then(Value::as_bool)
+                .is_some_and(|enabled| !enabled)
+            {
+                voice_command_intent_from_name(intent_name)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn dictionary_command_aliases(value: Option<&Value>) -> Vec<VoiceCommandAlias> {
+    let Some(Value::Object(intents)) = value else {
+        return Vec::new();
+    };
+    intents
+        .iter()
+        .filter_map(|(intent_name, payload)| {
+            if payload
+                .get("enabled")
+                .and_then(Value::as_bool)
+                .is_some_and(|enabled| !enabled)
+            {
+                return None;
+            }
+            let intent = voice_command_intent_from_name(intent_name)?;
+            let aliases = normalized_phrase_list(payload.get("aliases"));
+            if aliases.is_empty() {
+                None
+            } else {
+                Some(VoiceCommandAlias { intent, aliases })
+            }
+        })
+        .collect()
+}
+
+fn dictionary_route_actions(value: Option<&Value>) -> Vec<VoiceRouteAction> {
+    let Some(Value::Object(actions)) = value else {
+        return Vec::new();
+    };
+    actions
+        .values()
+        .filter_map(|payload| {
+            let route_name = payload.get("route").and_then(Value::as_str)?.trim();
+            if !SAFE_ROUTE_ACTIONS.contains(&route_name) {
+                return None;
+            }
+            let aliases = normalized_phrase_list(payload.get("aliases"));
+            if aliases.is_empty() {
+                None
+            } else {
+                Some(VoiceRouteAction {
+                    route_name: route_name.to_string(),
+                    aliases,
+                })
+            }
+        })
+        .collect()
+}
+
+fn normalized_phrase_list(value: Option<&Value>) -> Vec<String> {
+    let raw = match value {
+        Some(Value::String(phrase)) => vec![phrase.as_str()],
+        Some(Value::Array(phrases)) => phrases.iter().filter_map(Value::as_str).collect(),
+        _ => Vec::new(),
+    };
+    let mut normalized = Vec::new();
+    for phrase in raw {
+        let phrase = normalize_dictionary_phrase(phrase);
+        if !phrase.is_empty() && !normalized.contains(&phrase) {
+            normalized.push(phrase);
+        }
+    }
+    normalized
+}
+
+fn normalize_dictionary_phrase(value: &str) -> String {
+    tokenize(value).join(" ")
+}
+
+fn voice_command_intent_from_name(value: &str) -> Option<VoiceCommandIntent> {
+    match value.trim() {
+        "call_contact" => Some(VoiceCommandIntent::CallContact),
+        "play_music" => Some(VoiceCommandIntent::PlayMusic),
+        "read_screen" => Some(VoiceCommandIntent::ReadScreen),
+        "volume_up" => Some(VoiceCommandIntent::VolumeUp),
+        "volume_down" => Some(VoiceCommandIntent::VolumeDown),
+        "mute_mic" => Some(VoiceCommandIntent::MuteMic),
+        "unmute_mic" => Some(VoiceCommandIntent::UnmuteMic),
+        _ => None,
+    }
+}
+
+fn strip_polite_prefix(tokens: &[String]) -> Vec<String> {
+    let mut start = 0;
+    while start < tokens.len() && POLITE_PREFIX_TOKENS.contains(&tokens[start].as_str()) {
+        start += 1;
+    }
+    tokens[start..].to_vec()
+}
+
+fn trim_slot_tokens(tokens: &[String]) -> Vec<String> {
+    let mut start = 0;
+    let mut end = tokens.len();
+    while start < end && SLOT_FILLER_TOKENS.contains(&tokens[start].as_str()) {
+        start += 1;
+    }
+    while end > start && SLOT_FILLER_TOKENS.contains(&tokens[end - 1].as_str()) {
+        end -= 1;
+    }
+    tokens[start..end].to_vec()
+}
+
+fn has_negation(tokens: &[String]) -> bool {
+    tokens
+        .iter()
+        .any(|token| NEGATION_TOKENS.contains(&token.as_str()))
+        || contains_token_sequence(tokens, &["can", "t"])
+        || contains_token_sequence(tokens, &["do", "nt"])
+        || contains_token_sequence(tokens, &["do", "n", "t"])
+        || contains_token_sequence(tokens, &["don", "t"])
+        || contains_token_sequence(tokens, &["won", "t"])
+}
+
+fn contains_token_sequence(tokens: &[String], sequence: &[&str]) -> bool {
+    tokens.len() >= sequence.len()
+        && tokens.windows(sequence.len()).any(|window| {
+            window
+                .iter()
+                .map(String::as_str)
+                .eq(sequence.iter().copied())
+        })
+}
+
+fn starts_with_tokens(tokens: &[String], prefix: &[String]) -> bool {
+    tokens.len() >= prefix.len() && tokens[..prefix.len()] == *prefix
+}

--- a/yoyopod_rs/runtime/tests/cli.rs
+++ b/yoyopod_rs/runtime/tests/cli.rs
@@ -303,6 +303,56 @@ logging:
 }
 
 #[test]
+fn boot_starts_voice_worker_and_sends_health_probe() {
+    let _guard = env_lock();
+    let dir = temp_dir("voice-worker");
+    let config_dir = dir.join("config");
+    let ui_stdin = dir.join("ui-stdin.ndjson");
+    let voice_args = dir.join("voice-args.txt");
+    let voice_stdin = dir.join("voice-stdin.ndjson");
+    let ui_worker = write_ui_worker_script(&dir, &ui_stdin);
+    let voice_worker = write_voice_worker_script(&dir, &voice_args, &voice_stdin);
+    write(
+        &config_dir.join("app/core.yaml"),
+        &format!(
+            r#"
+logging:
+  pid_file: "{}"
+  file: "{}"
+"#,
+            yaml_path(&dir.join("run/yoyopod.pid")),
+            yaml_path(&dir.join("logs/yoyopod.log"))
+        ),
+    );
+    write(
+        &config_dir.join("voice/assistant.yaml"),
+        r#"
+worker:
+  enabled: true
+"#,
+    );
+    std::env::set_var("YOYOPOD_RUST_UI_HOST_WORKER", &ui_worker);
+    std::env::set_var("YOYOPOD_RUST_VOICE_WORKER", &voice_worker);
+
+    let result = run(Args {
+        config_dir: config_dir.clone(),
+        dry_run: false,
+        hardware: "whisplay".to_string(),
+    });
+    std::env::remove_var("YOYOPOD_RUST_UI_HOST_WORKER");
+    std::env::remove_var("YOYOPOD_RUST_VOICE_WORKER");
+    result.expect("runtime exits after UI shutdown intent");
+
+    let captured_ui = wait_for_file(&ui_stdin);
+    let captured_voice_stdin = wait_for_file(&voice_stdin);
+
+    assert!(voice_args.exists());
+    assert!(captured_voice_stdin.contains(r#""type":"voice.health""#));
+    assert!(captured_ui.contains(r#""voice""#));
+    assert!(captured_ui.contains(r#""state":"running""#));
+}
+
+#[test]
 fn boot_starts_power_worker_and_projects_initial_power_snapshot() {
     let _guard = env_lock();
     let dir = temp_dir("power-worker");
@@ -639,6 +689,79 @@ Set-Content -LiteralPath '{}' -Value $lines
         ),
     );
     let command_path = dir.join("power-worker.cmd");
+    write(
+        &command_path,
+        &format!(
+            "@echo off\r\npowershell -NoProfile -ExecutionPolicy Bypass -File \"{}\" %*\r\n",
+            script_path.to_string_lossy()
+        ),
+    );
+    command_path
+}
+
+fn write_voice_worker_script(dir: &Path, args_path: &Path, stdin_path: &Path) -> PathBuf {
+    let ready = r#"{"schema_version":1,"kind":"event","type":"voice.ready","payload":{"capabilities":["health","ask","transcribe"]}}"#;
+    let health = r#"{"schema_version":1,"kind":"result","type":"voice.health.result","payload":{"healthy":true,"provider":"mock"}}"#;
+
+    if !cfg!(windows) {
+        let script_path = dir.join("voice-worker.sh");
+        write(
+            &script_path,
+            &format!(
+                r#"#!/bin/sh
+: > {}
+printf '%s\n' "$@" >> {}
+printf '%s\n' '{}'
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> {}
+  case "$line" in
+    *'"type":"voice.health"'*) printf '%s\n' '{}' ;;
+    *'"type":"worker.stop"'*) break ;;
+  esac
+done
+"#,
+                shell_single_quote(args_path),
+                shell_single_quote(args_path),
+                ready,
+                shell_single_quote(stdin_path),
+                health
+            ),
+        );
+        make_executable(&script_path);
+        return script_path;
+    }
+
+    let script_path = dir.join("voice-worker.ps1");
+    write(
+        &script_path,
+        &format!(
+            r#"
+Set-Content -LiteralPath '{}' -Value ($args -join "`n")
+if (-not (Test-Path -LiteralPath '{}')) {{
+  New-Item -ItemType File -LiteralPath '{}' -Force | Out-Null
+}}
+Write-Output '{}'
+$lines = @()
+while (($line = [Console]::In.ReadLine()) -ne $null) {{
+  $lines += $line
+  if ($line -match '"type":"voice.health"') {{
+    Write-Output '{}'
+  }}
+  if ($line -match '"type":"worker.stop"') {{
+    break
+  }}
+}}
+Set-Content -LiteralPath '{}' -Value $lines
+"#,
+            args_path.to_string_lossy().replace('\'', "''"),
+            args_path.to_string_lossy().replace('\'', "''"),
+            args_path.to_string_lossy().replace('\'', "''"),
+            ready.replace('\'', "''"),
+            health.replace('\'', "''"),
+            stdin_path.to_string_lossy().replace('\'', "''")
+        ),
+    );
+    let command_path = dir.join("voice-worker.cmd");
     write(
         &command_path,
         &format!(

--- a/yoyopod_rs/runtime/tests/config.rs
+++ b/yoyopod_rs/runtime/tests/config.rs
@@ -6,6 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::json;
 use yoyopod_runtime::config::RuntimeConfig;
+use yoyopod_runtime::voice::{route_voice_transcript, VoiceCommandIntent, VoiceRouteKind};
 
 const CONFIG_ENV_KEYS: &[&str] = &[
     "YOYOPOD_DISPLAY",
@@ -48,6 +49,9 @@ const CONFIG_ENV_KEYS: &[&str] = &[
     "YOYOPOD_RUST_POWER_HOST_WORKER",
     "YOYOPOD_RUST_VOIP_HOST_WORKER",
     "YOYOPOD_RUST_NETWORK_HOST_WORKER",
+    "YOYOPOD_RUST_VOICE_WORKER",
+    "YOYOPOD_VOICE_WORKER_ENABLED",
+    "YOYOPOD_VOICE_COMMAND_DICTIONARY",
     "YOYOPOD_POWER_ENABLED",
     "YOYOPOD_LOW_BATTERY_WARNING_PERCENT",
     "YOYOPOD_LOW_BATTERY_WARNING_COOLDOWN_SECONDS",
@@ -442,6 +446,9 @@ contacts:
     sip_address: "sip:hagar@example.test"
     favorite: true
     notes: "Mama"
+    aliases:
+      - "mom"
+      - "mommy"
   - name: "Ignored"
     sip_address: ""
   - name: "Baba"
@@ -455,6 +462,10 @@ contacts:
     assert_eq!(seed_config.people.contacts.len(), 2);
     assert_eq!(seed_config.people.contacts[0].name, "Hagar");
     assert_eq!(seed_config.people.contacts[0].display_name, "Mama");
+    assert_eq!(
+        seed_config.people.contacts[0].aliases,
+        vec!["mom".to_string(), "mommy".to_string()]
+    );
     assert_eq!(seed_config.people.to_contact_items()[0].icon_key, "mono:MA");
 
     write(
@@ -474,6 +485,128 @@ contacts:
         mutable_config.people.contacts[0].sip_address,
         "sip:local@example.test"
     );
+}
+
+#[test]
+fn voice_assistant_config_loads_command_routing_and_worker_defaults() {
+    let _lock = lock_env();
+    let _env = clean_config_env();
+    let dir = temp_config_dir("voice-assistant");
+    write(
+        &dir.join("voice/assistant.yaml"),
+        r#"
+assistant:
+  commands_enabled: true
+  ai_requests_enabled: false
+  activation_prefixes:
+    - "yoyo"
+    - "hey yoyo"
+  command_routing:
+    ask_fallback_enabled: false
+  worker:
+    ignored: true
+worker:
+  enabled: true
+  provider: "mock"
+  argv:
+    - "workers/voice/go/build/yoyopod-voice-worker"
+  request_timeout_seconds: 12.0
+  max_audio_seconds: 30.0
+  stt_model: "gpt-4o-mini-transcribe"
+  stt_language: "en"
+  stt_prompt: "Transcribe this YoYoPod voice command."
+  tts_model: "gpt-4o-mini-tts"
+  tts_voice: "coral"
+  tts_instructions: "Speak warmly for a child."
+  ask_model: "gpt-4.1-mini"
+  ask_max_history_turns: 3
+  ask_max_response_chars: 321
+  ask_instructions: "Kid-safe answers."
+"#,
+    );
+
+    let config = RuntimeConfig::load(&dir).expect("load runtime config");
+
+    assert!(config.voice.worker_enabled);
+    assert!(config.voice.commands_enabled);
+    assert!(!config.voice.ai_requests_enabled);
+    assert!(!config.voice.ask_fallback_enabled);
+    assert_eq!(
+        config.voice.activation_prefixes,
+        vec!["yoyo".to_string(), "hey yoyo".to_string()]
+    );
+    assert_eq!(config.voice.ask_model, "gpt-4.1-mini");
+    assert_eq!(config.voice.request_timeout_ms, 12_000);
+    assert_eq!(config.voice.max_audio_ms, 30_000);
+    assert_eq!(config.voice.sample_rate_hz, 16_000);
+    assert_eq!(config.voice.stt_model, "gpt-4o-mini-transcribe");
+    assert_eq!(config.voice.stt_language, "en");
+    assert_eq!(
+        config.voice.stt_prompt,
+        "Transcribe this YoYoPod voice command."
+    );
+    assert_eq!(config.voice.tts_model, "gpt-4o-mini-tts");
+    assert_eq!(config.voice.tts_voice, "coral");
+    assert_eq!(config.voice.tts_instructions, "Speak warmly for a child.");
+    assert_eq!(config.voice.ask_max_history_turns, 3);
+    assert_eq!(config.voice.ask_max_response_chars, 321);
+    assert_eq!(config.voice.ask_instructions, "Kid-safe answers.");
+    assert_eq!(
+        config.worker_paths.voice,
+        "workers/voice/go/build/yoyopod-voice-worker"
+    );
+}
+
+#[test]
+fn voice_command_dictionary_extends_rust_command_router() {
+    let _lock = lock_env();
+    let _env = clean_config_env();
+    let root = temp_config_dir("voice-command-dictionary");
+    let config_dir = root.join("config");
+    write(
+        &config_dir.join("voice/assistant.yaml"),
+        r#"
+assistant:
+  commands_enabled: true
+  ai_requests_enabled: true
+  activation_prefixes:
+    - "yoyo"
+    - "hey yoyo"
+  command_dictionary_path: "data/voice/commands.yaml"
+  command_routing:
+    ask_fallback_enabled: true
+worker:
+  enabled: true
+"#,
+    );
+    write(
+        &root.join("data/voice/commands.yaml"),
+        r#"
+version: 1
+intents:
+  volume_up:
+    aliases:
+      - "boost sound"
+actions:
+  open_talk:
+    aliases:
+      - "open talk"
+    route: "open_talk"
+"#,
+    );
+
+    let config = RuntimeConfig::load(&config_dir).expect("load runtime config");
+    let settings = config.voice.to_command_settings();
+
+    let command = route_voice_transcript("hey yoyo boost sound", &settings);
+    assert_eq!(command.kind, VoiceRouteKind::Command);
+    assert_eq!(
+        command.command.expect("command").intent,
+        VoiceCommandIntent::VolumeUp
+    );
+
+    let action = route_voice_transcript("hey yoyo open talk", &settings);
+    assert_eq!(action.reason, "action_match");
 }
 
 #[test]

--- a/yoyopod_rs/runtime/tests/event.rs
+++ b/yoyopod_rs/runtime/tests/event.rs
@@ -4,6 +4,7 @@ use yoyopod_runtime::event::{
 };
 use yoyopod_runtime::protocol::{EnvelopeKind, WorkerEnvelope};
 use yoyopod_runtime::state::{CallState, RuntimeState, WorkerDomain, WorkerState};
+use yoyopod_runtime::voice::{VoiceCommandSettings, VoiceRouteAction};
 
 #[test]
 fn media_snapshot_event_updates_state() {
@@ -781,6 +782,65 @@ fn ui_voice_capture_start_routes_to_voip_recording() {
 }
 
 #[test]
+fn ui_voice_ask_start_routes_to_voip_recording_with_ask_path() {
+    let event =
+        runtime_event_from_worker(WorkerDomain::Ui, ui_intent("voice", "ask_start", json!({})))
+            .expect("event");
+    let mut state = RuntimeState::default();
+    state.configure_voice_note_store_dir("/tmp/yoyopod-notes");
+
+    let commands = commands_for_event(&state, &event);
+    let [RuntimeCommand::WorkerCommand { domain, envelope }] = commands.as_slice() else {
+        panic!("expected one worker command");
+    };
+
+    assert_eq!(*domain, WorkerDomain::Voip);
+    assert_eq!(envelope.message_type, "voip.start_voice_note_recording");
+    let file_path = envelope.payload["file_path"].as_str().expect("file path");
+    assert!(file_path.contains("yoyopod-notes"));
+    assert!(file_path.contains("ask"));
+    assert!(file_path.ends_with(".wav"));
+}
+
+#[test]
+fn ui_voice_ask_stop_routes_to_voip_recording_stop() {
+    let event =
+        runtime_event_from_worker(WorkerDomain::Ui, ui_intent("voice", "ask_stop", json!({})))
+            .expect("event");
+
+    let commands = commands_for_event(&RuntimeState::default(), &event);
+
+    assert_eq!(
+        commands,
+        vec![worker_command(
+            WorkerDomain::Voip,
+            "voip.stop_voice_note_recording",
+            json!({})
+        )]
+    );
+}
+
+#[test]
+fn ui_voice_ask_cancel_routes_to_voip_recording_cancel() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Ui,
+        ui_intent("voice", "ask_cancel", json!({})),
+    )
+    .expect("event");
+
+    let commands = commands_for_event(&RuntimeState::default(), &event);
+
+    assert_eq!(
+        commands,
+        vec![worker_command(
+            WorkerDomain::Voip,
+            "voip.cancel_voice_note_recording",
+            json!({})
+        )]
+    );
+}
+
+#[test]
 fn ui_voice_send_routes_recorded_note_to_voip() {
     let event = runtime_event_from_worker(
         WorkerDomain::Ui,
@@ -865,6 +925,775 @@ fn ui_voice_discard_resets_local_voice_note_state() {
 
     assert_eq!(state.ui_snapshot_payload()["voice"]["phase"], "idle");
     assert_eq!(state.voice.file_path, "");
+}
+
+#[test]
+fn voice_transcript_routes_play_music_before_ask_fallback() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo play music",
+                "confidence": 0.91,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+
+    let commands = commands_for_event(&state, &event);
+    event.apply(&mut state);
+
+    assert_eq!(
+        commands,
+        vec![worker_command(
+            WorkerDomain::Media,
+            "media.shuffle_all",
+            json!({})
+        )]
+    );
+    assert_eq!(state.ui_snapshot_payload()["voice"]["headline"], "Playing");
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["body"],
+        "Starting local music."
+    );
+}
+
+#[test]
+fn voice_transcript_routes_family_call_to_matching_contact() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo call mom",
+                "confidence": 0.88,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+    state.seed_contacts(vec![yoyopod_runtime::state::ListItem {
+        id: "sip:mama@example.test".to_string(),
+        title: "Mama".to_string(),
+        subtitle: String::new(),
+        icon_key: "mono:MA".to_string(),
+        aliases: vec!["mom".to_string(), "mommy".to_string()],
+    }]);
+
+    let commands = commands_for_event(&state, &event);
+    event.apply(&mut state);
+
+    assert_eq!(
+        commands,
+        vec![worker_command(
+            WorkerDomain::Voip,
+            "voip.dial",
+            json!({"uri": "sip:mama@example.test"})
+        )]
+    );
+    assert_eq!(state.ui_snapshot_payload()["voice"]["headline"], "Calling");
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["body"],
+        "Calling Mama."
+    );
+}
+
+#[test]
+fn voice_transcript_prompts_for_likely_reordered_call_before_ask() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo mama please call",
+                "confidence": 0.88,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+    state.seed_contacts(vec![yoyopod_runtime::state::ListItem {
+        id: "sip:mama@example.test".to_string(),
+        title: "Mama".to_string(),
+        subtitle: String::new(),
+        icon_key: "mono:MA".to_string(),
+        aliases: vec!["mom".to_string(), "mommy".to_string()],
+    }]);
+
+    let commands = commands_for_event(&state, &event);
+    event.apply(&mut state);
+
+    assert!(commands.is_empty());
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["headline"],
+        "Confirm Call"
+    );
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["body"],
+        "Did you want to call Mama? Say yes or no."
+    );
+}
+
+#[test]
+fn voice_transcript_yes_confirms_pending_call() {
+    let prompt = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo mama please call",
+                "confidence": 0.88,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let confirm = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "yes",
+                "confidence": 0.9,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+    state.seed_contacts(vec![yoyopod_runtime::state::ListItem {
+        id: "sip:mama@example.test".to_string(),
+        title: "Mama".to_string(),
+        subtitle: String::new(),
+        icon_key: "mono:MA".to_string(),
+        aliases: vec!["mom".to_string(), "mommy".to_string()],
+    }]);
+    prompt.apply(&mut state);
+
+    let commands = commands_for_event(&state, &confirm);
+    confirm.apply(&mut state);
+
+    assert_eq!(
+        commands,
+        vec![worker_command(
+            WorkerDomain::Voip,
+            "voip.dial",
+            json!({"uri": "sip:mama@example.test"})
+        )]
+    );
+    assert_eq!(state.ui_snapshot_payload()["voice"]["headline"], "Calling");
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["body"],
+        "Calling Mama."
+    );
+}
+
+#[test]
+fn voice_transcript_no_cancels_pending_call() {
+    let prompt = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo mama call",
+                "confidence": 0.88,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let cancel = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "no",
+                "confidence": 0.9,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+    state.seed_contacts(vec![yoyopod_runtime::state::ListItem {
+        id: "sip:mama@example.test".to_string(),
+        title: "Mama".to_string(),
+        subtitle: String::new(),
+        icon_key: "mono:MA".to_string(),
+        aliases: vec!["mom".to_string(), "mommy".to_string()],
+    }]);
+    prompt.apply(&mut state);
+
+    let commands = commands_for_event(&state, &cancel);
+    cancel.apply(&mut state);
+
+    assert!(commands.is_empty());
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["headline"],
+        "Cancelled"
+    );
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["body"],
+        "Okay, I will not call Mama."
+    );
+}
+
+#[test]
+fn voice_transcript_routes_volume_to_media_set_volume() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo volume up",
+                "confidence": 0.9,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+    state.apply_media_snapshot(&json!({"volume": 40}));
+
+    let commands = commands_for_event(&state, &event);
+    event.apply(&mut state);
+
+    assert_eq!(
+        commands,
+        vec![worker_command(
+            WorkerDomain::Media,
+            "media.set_volume",
+            json!({"volume": 50})
+        )]
+    );
+    assert_eq!(state.ui_snapshot_payload()["voice"]["headline"], "Volume");
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["body"],
+        "Volume is 5 out of 10."
+    );
+}
+
+#[test]
+fn voice_transcript_routes_non_command_to_ask_worker_when_fallback_enabled() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo why is the sky blue",
+                "confidence": 0.95,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+
+    let commands = commands_for_event(&state, &event);
+    event.apply(&mut state);
+
+    let [RuntimeCommand::WorkerCommand { domain, envelope }] = commands.as_slice() else {
+        panic!("expected one ask worker command");
+    };
+    assert_eq!(*domain, WorkerDomain::Voice);
+    assert_eq!(envelope.message_type, "voice.ask");
+    assert_eq!(envelope.payload["question"], "why is the sky blue");
+    assert_eq!(envelope.payload["history"], json!([]));
+    assert_eq!(envelope.payload["model"], "gpt-4.1-mini");
+    assert_eq!(envelope.payload["max_output_chars"], 480);
+    assert!(envelope.payload["instructions"]
+        .as_str()
+        .is_some_and(|value| value.contains("friendly Ask helper")));
+    assert_eq!(state.ui_snapshot_payload()["voice"]["headline"], "Thinking");
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["body"],
+        "Finding an answer..."
+    );
+}
+
+#[test]
+fn voice_transcript_ask_exit_routes_ui_back_without_ask_worker() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo stop asking",
+                "confidence": 0.95,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+    state.voice.pending_ask_question = "why is the sky blue".to_string();
+    state
+        .voice
+        .ask_history
+        .push(yoyopod_runtime::state::VoiceAskTurn {
+            question: "earlier question".to_string(),
+            answer: "earlier answer".to_string(),
+        });
+    state.voice.command_settings.ask_fallback_enabled = false;
+
+    let commands = commands_for_event(&state, &event);
+    event.apply(&mut state);
+
+    assert_eq!(
+        commands,
+        vec![worker_command(
+            WorkerDomain::Ui,
+            "ui.input_action",
+            json!({"action": "back"})
+        )]
+    );
+    assert_eq!(state.ui_snapshot_payload()["voice"]["headline"], "Ask");
+    assert_eq!(state.ui_snapshot_payload()["voice"]["body"], "Going back.");
+    assert!(state.voice.pending_ask_question.is_empty());
+    assert_eq!(state.voice.ask_history.len(), 1);
+}
+
+#[test]
+fn voice_transcript_dictionary_action_routes_screen_without_ask_worker() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo open talk",
+                "confidence": 0.95,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+    let mut settings = VoiceCommandSettings::default();
+    settings.route_actions.push(VoiceRouteAction {
+        route_name: "open_talk".to_string(),
+        aliases: vec!["open talk".to_string()],
+    });
+    state.configure_voice_commands(settings);
+
+    let commands = commands_for_event(&state, &event);
+    event.apply(&mut state);
+
+    assert!(commands.is_empty());
+    assert_eq!(state.current_screen, "talk");
+    assert_eq!(state.ui_snapshot_payload()["voice"]["headline"], "Command");
+    assert_eq!(state.ui_snapshot_payload()["voice"]["body"], "");
+}
+
+#[test]
+fn ask_fallback_includes_previous_turn_history_after_answer() {
+    let mut state = RuntimeState::default();
+    let first_question = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo why is sky blue",
+                "confidence": 0.95,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let first_answer = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.ask.result",
+            json!({
+                "answer": "Because sunlight scatters.",
+                "model": "gpt-4.1-mini"
+            }),
+        ),
+    )
+    .expect("event");
+    let second_question = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo what about sunsets",
+                "confidence": 0.95,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+
+    first_question.apply(&mut state);
+    first_answer.apply(&mut state);
+    let commands = commands_for_event(&state, &second_question);
+
+    let [RuntimeCommand::WorkerCommand { domain, envelope }] = commands.as_slice() else {
+        panic!("expected one ask worker command");
+    };
+    assert_eq!(*domain, WorkerDomain::Voice);
+    assert_eq!(envelope.message_type, "voice.ask");
+    assert_eq!(envelope.payload["question"], "what about sunsets");
+    assert_eq!(
+        envelope.payload["history"],
+        json!([
+            {"role": "user", "text": "why is sky blue"},
+            {"role": "assistant", "text": "Because sunlight scatters."}
+        ])
+    );
+}
+
+#[test]
+fn ask_history_is_bounded_and_trimmed_for_worker_payload() {
+    let mut state = RuntimeState::default();
+    state.voice.command_settings.ask_max_history_turns = 1;
+    state.voice.command_settings.ask_max_response_chars = 6;
+
+    for (question, answer) in [
+        (
+            "hey yoyo first question has extra words",
+            "first answer has extra words",
+        ),
+        (
+            "hey yoyo second question has extra words",
+            "second answer has extra words",
+        ),
+    ] {
+        let transcript_event = runtime_event_from_worker(
+            WorkerDomain::Voice,
+            envelope(
+                EnvelopeKind::Result,
+                "voice.transcribe.result",
+                json!({
+                    "text": question,
+                    "confidence": 0.95,
+                    "is_final": true
+                }),
+            ),
+        )
+        .expect("event");
+        let answer_event = runtime_event_from_worker(
+            WorkerDomain::Voice,
+            envelope(
+                EnvelopeKind::Result,
+                "voice.ask.result",
+                json!({
+                    "answer": answer,
+                    "model": "gpt-4.1-mini"
+                }),
+            ),
+        )
+        .expect("event");
+
+        transcript_event.apply(&mut state);
+        answer_event.apply(&mut state);
+    }
+
+    let next_question = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo third question",
+                "confidence": 0.95,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+
+    let commands = commands_for_event(&state, &next_question);
+
+    let [RuntimeCommand::WorkerCommand { domain, envelope }] = commands.as_slice() else {
+        panic!("expected one ask worker command");
+    };
+    assert_eq!(*domain, WorkerDomain::Voice);
+    assert_eq!(envelope.message_type, "voice.ask");
+    assert_eq!(
+        envelope.payload["history"],
+        json!([
+            {"role": "user", "text": "second"},
+            {"role": "assistant", "text": "second"}
+        ])
+    );
+}
+
+#[test]
+fn stopped_ask_recording_routes_recorded_wav_to_voice_transcribe() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voip,
+        event_envelope(
+            "voip.snapshot",
+            json!({
+                "voice_note": {
+                    "state": "recorded",
+                    "file_path": "/tmp/yoyopod-ask.wav",
+                    "duration_ms": 1800,
+                    "mime_type": "audio/wav"
+                }
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+    state.apply_ui_intent("voice", "ask_start", &json!({}));
+    state.apply_ui_intent("voice", "ask_stop", &json!({}));
+
+    let commands = commands_for_event(&state, &event);
+
+    let Some(RuntimeCommand::WorkerCommand { domain, envelope }) =
+        commands.iter().find(|command| {
+            matches!(
+                command,
+                RuntimeCommand::WorkerCommand { domain: WorkerDomain::Voice, envelope }
+                    if envelope.message_type == "voice.transcribe"
+            )
+        })
+    else {
+        panic!("expected voice transcribe worker command, got {commands:#?}");
+    };
+    assert_eq!(*domain, WorkerDomain::Voice);
+    assert_eq!(envelope.message_type, "voice.transcribe");
+    assert_eq!(envelope.payload["audio_path"], "/tmp/yoyopod-ask.wav");
+    assert_eq!(envelope.payload["format"], "wav");
+    assert_eq!(envelope.payload["sample_rate_hz"], 16000);
+    assert_eq!(envelope.payload["channels"], 1);
+    assert_eq!(envelope.payload["language"], "en");
+    assert_eq!(envelope.payload["max_audio_seconds"], 30.0);
+    assert_eq!(envelope.payload["delete_input_on_success"], true);
+    assert!(envelope.payload["model"]
+        .as_str()
+        .is_some_and(|value| value.contains("transcribe")));
+    assert!(envelope.payload["prompt"]
+        .as_str()
+        .is_some_and(|value| value.contains("YoYoPod voice command")));
+}
+
+#[test]
+fn voice_note_recording_snapshot_does_not_transcribe_without_active_ask() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voip,
+        event_envelope(
+            "voip.snapshot",
+            json!({
+                "voice_note": {
+                    "state": "recorded",
+                    "file_path": "/tmp/yoyopod-note.wav"
+                }
+            }),
+        ),
+    )
+    .expect("event");
+
+    let commands = commands_for_event(&RuntimeState::default(), &event);
+
+    assert!(!commands.iter().any(|command| matches!(
+        command,
+        RuntimeCommand::WorkerCommand { domain: WorkerDomain::Voice, envelope }
+            if envelope.message_type == "voice.transcribe"
+    )));
+}
+
+#[test]
+fn ask_recording_snapshot_keeps_ask_thinking_state_until_transcript() {
+    let mut state = RuntimeState::default();
+    state.apply_ui_intent("voice", "ask_start", &json!({}));
+    state.apply_ui_intent("voice", "ask_stop", &json!({}));
+
+    state.apply_voip_snapshot(&json!({
+        "voice_note": {
+            "state": "recorded",
+            "file_path": "/tmp/yoyopod-ask.wav",
+            "duration_ms": 1800
+        }
+    }));
+
+    assert_eq!(state.ui_snapshot_payload()["voice"]["phase"], "thinking");
+    assert_eq!(state.ui_snapshot_payload()["voice"]["headline"], "Thinking");
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["body"],
+        "Just a moment..."
+    );
+}
+
+#[test]
+fn recorded_ask_snapshot_transcribes_only_once() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voip,
+        event_envelope(
+            "voip.snapshot",
+            json!({
+                "voice_note": {
+                    "state": "recorded",
+                    "file_path": "/tmp/yoyopod-ask.wav",
+                    "duration_ms": 1800
+                }
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+    state.apply_ui_intent("voice", "ask_start", &json!({}));
+    state.apply_ui_intent("voice", "ask_stop", &json!({}));
+
+    assert!(commands_for_event(&state, &event)
+        .iter()
+        .any(|command| matches!(
+            command,
+            RuntimeCommand::WorkerCommand { domain: WorkerDomain::Voice, envelope }
+                if envelope.message_type == "voice.transcribe"
+        )));
+
+    event.apply(&mut state);
+
+    assert!(!commands_for_event(&state, &event)
+        .iter()
+        .any(|command| matches!(
+            command,
+            RuntimeCommand::WorkerCommand { domain: WorkerDomain::Voice, envelope }
+                if envelope.message_type == "voice.transcribe"
+        )));
+}
+
+#[test]
+fn voice_transcript_returns_local_help_when_ask_fallback_disabled() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.transcribe.result",
+            json!({
+                "text": "hey yoyo tell me a story",
+                "confidence": 0.95,
+                "is_final": true
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+    state.voice.command_settings.ask_fallback_enabled = false;
+
+    let commands = commands_for_event(&state, &event);
+    event.apply(&mut state);
+
+    assert!(commands.is_empty());
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["headline"],
+        "Try Again"
+    );
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["body"],
+        "Try saying call mom, play music, or volume up."
+    );
+}
+
+#[test]
+fn voice_ask_result_updates_ask_reply_state() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.ask.result",
+            json!({
+                "answer": "Because sunlight scatters in the air.",
+                "model": "gpt-4.1-mini"
+            }),
+        ),
+    )
+    .expect("event");
+    let mut state = RuntimeState::default();
+
+    event.apply(&mut state);
+
+    assert_eq!(state.ui_snapshot_payload()["voice"]["phase"], "reply");
+    assert_eq!(state.ui_snapshot_payload()["voice"]["headline"], "Answer");
+    assert_eq!(
+        state.ui_snapshot_payload()["voice"]["body"],
+        "Because sunlight scatters in the air."
+    );
+}
+
+#[test]
+fn voice_ask_result_routes_answer_to_voice_speak_worker() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.ask.result",
+            json!({
+                "answer": "Because sunlight scatters in the air.",
+                "model": "gpt-4.1-mini"
+            }),
+        ),
+    )
+    .expect("event");
+
+    let commands = commands_for_event(&RuntimeState::default(), &event);
+
+    let [RuntimeCommand::WorkerCommand { domain, envelope }] = commands.as_slice() else {
+        panic!("expected one voice speak command");
+    };
+    assert_eq!(*domain, WorkerDomain::Voice);
+    assert_eq!(envelope.message_type, "voice.speak");
+    assert_eq!(envelope.deadline_ms, 12_000);
+    assert_eq!(
+        envelope.payload["text"],
+        "Because sunlight scatters in the air."
+    );
+    assert_eq!(envelope.payload["voice"], "coral");
+    assert_eq!(envelope.payload["model"], "gpt-4o-mini-tts");
+    assert_eq!(envelope.payload["format"], "wav");
+    assert_eq!(envelope.payload["sample_rate_hz"], 16000);
+    assert!(envelope.payload["instructions"]
+        .as_str()
+        .is_some_and(|value| value.contains("child")));
+}
+
+#[test]
+fn voice_speak_result_routes_audio_to_voip_playback() {
+    let event = runtime_event_from_worker(
+        WorkerDomain::Voice,
+        envelope(
+            EnvelopeKind::Result,
+            "voice.speak.result",
+            json!({
+                "audio_path": "/tmp/yoyopod-answer.wav",
+                "format": "wav",
+                "sample_rate_hz": 16000
+            }),
+        ),
+    )
+    .expect("event");
+
+    let commands = commands_for_event(&RuntimeState::default(), &event);
+
+    assert_eq!(
+        commands,
+        vec![worker_command(
+            WorkerDomain::Voip,
+            "voip.play_voice_note",
+            json!({"file_path": "/tmp/yoyopod-answer.wav"})
+        )]
+    );
 }
 
 #[test]

--- a/yoyopod_rs/runtime/tests/state.rs
+++ b/yoyopod_rs/runtime/tests/state.rs
@@ -199,6 +199,7 @@ fn seeded_people_contacts_are_available_before_voip_snapshots() {
         title: "Mama".to_string(),
         subtitle: String::new(),
         icon_key: "mono:MA".to_string(),
+        aliases: Vec::new(),
     }]);
 
     let ui = state.ui_snapshot_payload();

--- a/yoyopod_rs/runtime/tests/voice.rs
+++ b/yoyopod_rs/runtime/tests/voice.rs
@@ -1,0 +1,207 @@
+use yoyopod_runtime::voice::{
+    match_voice_command, normalize_voice_activation, route_voice_transcript, VoiceCommandAlias,
+    VoiceCommandIntent, VoiceCommandSettings, VoiceRouteKind,
+};
+
+#[test]
+fn match_voice_command_extracts_family_call_variants() {
+    for (phrase, expected_contact) in [
+        ("call mama", "mama"),
+        ("call mommy", "mommy"),
+        ("call my mama", "mama"),
+        ("please call my mom", "mom"),
+        ("ring mama", "mama"),
+        ("phone mom", "mom"),
+        ("call daddy", "daddy"),
+        ("call papa", "papa"),
+    ] {
+        let command = match_voice_command(phrase);
+
+        assert_eq!(command.intent, VoiceCommandIntent::CallContact, "{phrase}");
+        assert_eq!(command.contact_name, expected_contact, "{phrase}");
+    }
+}
+
+#[test]
+fn match_voice_command_handles_observed_stt_script_noise_for_call_mama() {
+    for phrase in [
+        "Kual mama?",
+        "\u{ace0} \u{b9c8}\u{b9c8}",
+        "\u{06a9}\u{0648}\u{0644} \u{0645}\u{0627}\u{0645}\u{0627}",
+        "\u{06a9}\u{0648} \u{0645}\u{0627}\u{0645}\u{0627}",
+    ] {
+        let command = match_voice_command(phrase);
+
+        assert_eq!(command.intent, VoiceCommandIntent::CallContact, "{phrase}");
+        assert_eq!(command.contact_name, "mama", "{phrase}");
+    }
+}
+
+#[test]
+fn match_voice_command_tolerates_python_fuzzy_trigger_typos() {
+    for (phrase, expected_contact) in [("caall mama", "mama"), ("phonee mama", "mama")] {
+        let command = match_voice_command(phrase);
+
+        assert_eq!(command.intent, VoiceCommandIntent::CallContact, "{phrase}");
+        assert_eq!(command.contact_name, expected_contact, "{phrase}");
+    }
+
+    for (phrase, expected_intent) in [
+        ("volum up", VoiceCommandIntent::VolumeUp),
+        ("shufle music", VoiceCommandIntent::PlayMusic),
+    ] {
+        assert_eq!(
+            match_voice_command(phrase).intent,
+            expected_intent,
+            "{phrase}"
+        );
+    }
+}
+
+#[test]
+fn match_voice_command_handles_music_volume_screen_and_mic_phrases() {
+    for (phrase, expected_intent) in [
+        ("play a song", VoiceCommandIntent::PlayMusic),
+        ("play songs", VoiceCommandIntent::PlayMusic),
+        ("put on music", VoiceCommandIntent::PlayMusic),
+        ("start songs", VoiceCommandIntent::PlayMusic),
+        ("play kids music", VoiceCommandIntent::PlayMusic),
+        ("play", VoiceCommandIntent::PlayMusic),
+        ("\u{63a8},\u{97f3}\u{4e50}", VoiceCommandIntent::PlayMusic),
+        (
+            "\u{067e}\u{0644}\u{06cc} \u{0645}\u{0648}\u{0632}\u{06cc}\u{06a9}",
+            VoiceCommandIntent::PlayMusic,
+        ),
+        ("louder", VoiceCommandIntent::VolumeUp),
+        ("make it louder", VoiceCommandIntent::VolumeUp),
+        ("too quiet", VoiceCommandIntent::VolumeUp),
+        (
+            "\u{0648}\u{0648}\u{0644}\u{06cc}\u{0648}\u{0645} \u{0627}\u{067e}",
+            VoiceCommandIntent::VolumeUp,
+        ),
+        ("quieter", VoiceCommandIntent::VolumeDown),
+        ("make it quieter", VoiceCommandIntent::VolumeDown),
+        ("too loud", VoiceCommandIntent::VolumeDown),
+        ("read this", VoiceCommandIntent::ReadScreen),
+        ("what is on the screen", VoiceCommandIntent::ReadScreen),
+        ("turn off the mic", VoiceCommandIntent::MuteMic),
+        ("mute the microphone", VoiceCommandIntent::MuteMic),
+        ("turn on the microphone", VoiceCommandIntent::UnmuteMic),
+        ("unmute the mic", VoiceCommandIntent::UnmuteMic),
+    ] {
+        assert_eq!(
+            match_voice_command(phrase).intent,
+            expected_intent,
+            "{phrase}"
+        );
+    }
+}
+
+#[test]
+fn match_voice_command_rejects_negated_and_nearby_non_commands() {
+    for phrase in [
+        "loud",
+        "quiet",
+        "not louder",
+        "do not make it louder",
+        "turn volume not up",
+        "read this book",
+        "turn on the music",
+        "turn off the light",
+        "mute music",
+        "play a game",
+        "do not call mom",
+        "don't call mom",
+        "never call dad",
+        "can t call mom",
+        "do nt call mom",
+        "call not mom",
+    ] {
+        assert_eq!(
+            match_voice_command(phrase).intent,
+            VoiceCommandIntent::Unknown,
+            "{phrase}"
+        );
+    }
+}
+
+#[test]
+fn route_voice_transcript_strips_activation_before_ask_fallback() {
+    let settings = VoiceCommandSettings::default();
+
+    let decision = route_voice_transcript("hey yoyo why is mars red", &settings);
+
+    assert_eq!(decision.kind, VoiceRouteKind::AskFallback);
+    assert_eq!(decision.stripped_prefix, "hey yoyo");
+    assert_eq!(decision.normalized_text, "why is mars red");
+}
+
+#[test]
+fn route_voice_transcript_recognizes_ask_exit_before_fallback() {
+    let settings = VoiceCommandSettings {
+        ask_fallback_enabled: false,
+        ..VoiceCommandSettings::default()
+    };
+
+    for phrase in [
+        "exit ask",
+        "hey yoyo go back",
+        "yoyo stop asking",
+        "stop ask",
+        "leave ask",
+        "close ask",
+    ] {
+        let decision = route_voice_transcript(phrase, &settings);
+
+        assert_eq!(decision.kind, VoiceRouteKind::AskExit, "{phrase}");
+        assert_eq!(decision.reason, "ask_exit", "{phrase}");
+        assert_eq!(decision.command, None, "{phrase}");
+    }
+}
+
+#[test]
+fn command_dictionary_call_alias_requires_contact_slot() {
+    let settings = VoiceCommandSettings {
+        command_aliases: vec![VoiceCommandAlias {
+            intent: VoiceCommandIntent::CallContact,
+            aliases: vec!["dial".to_string()],
+        }],
+        ..VoiceCommandSettings::default()
+    };
+
+    let incomplete = route_voice_transcript("hey yoyo dial", &settings);
+    assert_eq!(incomplete.kind, VoiceRouteKind::AskFallback);
+
+    let command = route_voice_transcript("hey yoyo dial mama", &settings);
+    assert_eq!(command.kind, VoiceRouteKind::Command);
+    let command = command.command.expect("command");
+    assert_eq!(command.intent, VoiceCommandIntent::CallContact);
+    assert_eq!(command.contact_name, "mama");
+}
+
+#[test]
+fn command_dictionary_aliases_use_intent_fuzzy_matching() {
+    let settings = VoiceCommandSettings {
+        command_aliases: vec![VoiceCommandAlias {
+            intent: VoiceCommandIntent::VolumeUp,
+            aliases: vec!["boost sound".to_string()],
+        }],
+        ..VoiceCommandSettings::default()
+    };
+
+    let decision = route_voice_transcript("hey yoyo boast sound", &settings);
+
+    assert_eq!(decision.kind, VoiceRouteKind::Command);
+    let command = decision.command.expect("command");
+    assert_eq!(command.intent, VoiceCommandIntent::VolumeUp);
+}
+
+#[test]
+fn normalize_voice_activation_handles_repeated_yoyo_prefixes() {
+    let prefixes = vec!["yoyo".to_string(), "hey yoyo".to_string()];
+
+    let result = normalize_voice_activation("yo yo yoyo play music", &prefixes);
+
+    assert_eq!(result.stripped_prefix, "yoyo");
+    assert_eq!(result.normalized_text, "play music");
+}

--- a/yoyopod_rs/ui-host/src/runtime/state_machine.rs
+++ b/yoyopod_rs/ui-host/src/runtime/state_machine.rs
@@ -370,7 +370,7 @@ impl UiRuntime {
                 }
             }
             UiScreen::NowPlaying => self.intents.push(UiIntent::new("music", "play_pause")),
-            UiScreen::Ask => self.intents.push(UiIntent::new("voice", "capture_toggle")),
+            UiScreen::Ask => self.intents.push(UiIntent::new("voice", "ask_start")),
             UiScreen::VoiceNote => self.select_voice_note(),
             UiScreen::Contacts => {
                 if let Some(item) = self.snapshot.call.contacts.get(self.focus_index).cloned() {
@@ -488,7 +488,7 @@ impl UiRuntime {
             return;
         }
         if self.active_screen == UiScreen::Ask {
-            self.intents.push(UiIntent::new("voice", "capture_start"));
+            self.intents.push(UiIntent::new("voice", "ask_start"));
         }
     }
 
@@ -498,7 +498,7 @@ impl UiRuntime {
             return;
         }
         if self.active_screen == UiScreen::Ask {
-            self.intents.push(UiIntent::new("voice", "capture_stop"));
+            self.intents.push(UiIntent::new("voice", "ask_stop"));
         }
     }
 

--- a/yoyopod_rs/ui-host/tests/runtime_state_machine.rs
+++ b/yoyopod_rs/ui-host/tests/runtime_state_machine.rs
@@ -538,6 +538,40 @@ fn voice_note_ready_uses_hold_passthrough_for_recording() {
 }
 
 #[test]
+fn ask_select_emits_ask_start_intent_not_voice_note_capture() {
+    let mut runtime = UiRuntime::default();
+    let mut snapshot = RuntimeSnapshot::default();
+    snapshot.app_state = "ask".to_string();
+    runtime.apply_snapshot(snapshot);
+
+    runtime.handle_input(InputAction::Select);
+
+    assert_eq!(
+        runtime.take_intents(),
+        vec![UiIntent::new("voice", "ask_start")]
+    );
+}
+
+#[test]
+fn ask_ptt_press_release_uses_ask_intents() {
+    let mut runtime = UiRuntime::default();
+    let mut snapshot = RuntimeSnapshot::default();
+    snapshot.app_state = "ask".to_string();
+    runtime.apply_snapshot(snapshot);
+
+    runtime.handle_input(InputAction::PttPress);
+    runtime.handle_input(InputAction::PttRelease);
+
+    assert_eq!(
+        runtime.take_intents(),
+        vec![
+            UiIntent::new("voice", "ask_start"),
+            UiIntent::new("voice", "ask_stop")
+        ]
+    );
+}
+
+#[test]
 fn required_screens_have_view_models() {
     let snapshot = RuntimeSnapshot::default();
     let screens = [


### PR DESCRIPTION
## What changed

- Adds a Rust voice-command router/settings surface for ASK and deterministic local voice commands.
- Routes ASK capture through Rust runtime UI intents, VoIP recording, voice transcription, ASK fallback, TTS, and voice playback.
- Ports Python voice-command parity for activation stripping, command dictionary aliases/actions, fuzzy matching, STT script/noise aliases, ASK exit, multi-turn ASK history, and pending call confirmation.
- Updates the Rust UI host ASK input flow so select/PTT emit ASK intents instead of voice-note capture intents.

## Why

This moves the ASK voice-command path behind the Rust runtime owner, reducing dependence on the legacy Python voice coordinator while keeping Python-compatible command behavior.

## Validation

- `cargo fmt --manifest-path yoyopod_rs/Cargo.toml --all --check`
- `cargo clippy --manifest-path yoyopod_rs/Cargo.toml -p yoyopod-runtime --all-targets --locked -- -D warnings`
- `cargo test --manifest-path yoyopod_rs/Cargo.toml -p yoyopod-runtime --locked`
- `cargo run --manifest-path yoyopod_rs/Cargo.toml -p yoyopod-runtime -- --config-dir config --dry-run`
- `cargo test --manifest-path yoyopod_rs/Cargo.toml --workspace --locked`

## Notes

The cloud STT/TTS/ASK worker remains the existing Go voice worker; this PR ports the Rust runtime ASK/voice-command ownership around it.