### PR TITLE
Docs/rules/skills cleanup after Rust CLI rebuild

### DIFF
--- a/deploy/pi-deploy.yaml
+++ b/deploy/pi-deploy.yaml
@@ -1,15 +1,15 @@
 # Raspberry Pi deploy contract for YoYoPod.
-# This is the shared source of truth for `yoyopod remote` and the Pi skills.
+# This is the shared source of truth for `yoyopod target` (Rust CLI) and the Pi skills.
 # Dev lane checkouts live under /opt/yoyopod-dev; prod slots live under /opt/yoyopod-prod.
 # Machine-specific connection overrides belong in deploy/pi-deploy.local.yaml.
 # Leave host/user blank in the tracked file; do not commit personal Pi values here.
 # Create or edit that file with:
-#   yoyopod remote config edit
-# Default board validation flow:
+#   yoyopod target config edit
+# Default board deploy flow:
 #   git branch --show-current
 #   git rev-parse HEAD
-#   yoyopod remote validate --branch <branch>
-# Dirty-tree `yoyopod remote sync` is a rare debugging escape hatch only.
+#   yoyopod target deploy --branch <branch>
+# Dirty-tree deploys are not supported; `target deploy` always uses a CI artifact.
 
 host: ""
 user: ""

--- a/deploy/scripts/bootstrap_pi.sh
+++ b/deploy/scripts/bootstrap_pi.sh
@@ -172,18 +172,24 @@ Prod lane root: ${ROOT}
 Dev lane root:  ${DEV_ROOT}
 
 Next steps on the dev machine:
-  uv run yoyopod remote release build-pi --output ./build/releases --channel dev
-  yoyopod remote release push ./build/releases/<version>.tar.gz --first-deploy
 
-Or install a published CI/release artifact directly:
-  yoyopod remote release install-url <artifact-url> --first-deploy
+  # For the dev lane (PR testing):
+  yoyopod target config edit
+  yoyopod target mode activate dev
+  yoyopod target deploy --branch <branch>
+
+  # For prod slot installs:
+  # The prod release CLI (yoyopod target release ...) returns in Round 3
+  # of the CLI rebuild; see docs/operations/CLI_REBUILD_ROUNDS.md.
+  # Reinstalling a previously-shipped slot still works manually via
+  # SSH + /opt/yoyopod-prod/bin/install-release.sh.
 
 Then on the Pi:
   sudo systemctl enable --now yoyopod-prod.service
 
-After bootstrap, 'yoyopod remote release ...' talks directly to the prod
-lane at ${ROOT}. The dev lane uses ${DEV_ROOT}/checkout for 'remote sync',
-'remote validate', and 'remote setup'.
+After bootstrap, the dev lane uses ${DEV_ROOT}/checkout for
+'yoyopod target deploy' and the prod lane at ${ROOT} runs whichever
+slot is symlinked at current/.
 
 NOTE: the running app does not yet honour YOYOPOD_STATE_DIR/config/ -
 the config loader still reads from the slot's relative ./config dir.

--- a/deploy/scripts/install_release.sh
+++ b/deploy/scripts/install_release.sh
@@ -2,8 +2,9 @@
 # deploy/scripts/install_release.sh
 #
 # Install one self-contained slot artifact into /opt/yoyopod-prod and flip it live.
-# The artifact is expected to be the tar.gz emitted by scripts/build_release.py
-# in a Linux/aarch64 build environment or by the CI slot build pipeline.
+# The artifact is the tar.gz that Round 3 of the CLI rebuild will produce
+# (see docs/operations/CLI_REBUILD_ROUNDS.md). Until then, only
+# previously-shipped slot tarballs can be reinstalled with this script.
 
 set -euo pipefail
 

--- a/deploy/systemd/yoyopod-dev.service
+++ b/deploy/systemd/yoyopod-dev.service
@@ -7,10 +7,9 @@ Conflicts=yoyopod-prod.service
 [Service]
 Type=simple
 EnvironmentFile=-/etc/default/yoyopod-dev
-Environment=PYTHONUNBUFFERED=1
 Environment=HOME=/root
 WorkingDirectory=/
-ExecStartPre=/usr/bin/env bash -lc 'HOME="$${HOME:-/root}"; DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; install -d -m 700 "$$HOME/.local/share/linphone" "$$HOME/.config/linphone"; install -d -m 755 "$$STATE_DIR"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; test -f "$$CHECKOUT/pyproject.toml"; test -x "$$CHECKOUT/device/runtime/build/yoyopod-runtime"; test -x "$$CHECKOUT/device/ui/build/yoyopod-ui-host"'
+ExecStartPre=/usr/bin/env bash -lc 'HOME="$${HOME:-/root}"; DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; install -d -m 700 "$$HOME/.local/share/linphone" "$$HOME/.config/linphone"; install -d -m 755 "$$STATE_DIR"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; test -d "$$CHECKOUT/config"; test -x "$$CHECKOUT/device/runtime/build/yoyopod-runtime"; test -x "$$CHECKOUT/device/ui/build/yoyopod-ui-host"'
 ExecStart=/usr/bin/env bash -lc 'DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; export YOYOPOD_PID_FILE="$${YOYOPOD_PID_FILE:-$$STATE_DIR/yoyopod.pid}"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; cd "$$CHECKOUT"; exec "$$CHECKOUT/device/runtime/build/yoyopod-runtime" --config-dir "$$CHECKOUT/config" --hardware whisplay'
 Restart=on-failure
 RestartSec=5

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,15 +15,19 @@ If you are new here, read these first:
 When docs disagree, trust sources in this order:
 
 1. Current Rust runtime and host code in `device/`
-2. Current deploy/runtime tooling in `deploy/` and `yoyopod_cli/`
-3. Current runtime, operations, hardware, feature, and design docs under the folders below
-4. Rules and agent guidance in `rules/`, `AGENTS.md`, and `skills/`
-5. Current rules and agent guidance in `rules/`, `AGENTS.md`, and `skills/`
+2. Current Rust operator CLI in `cli/` and deploy tooling under `deploy/`
+3. [`operations/CLI_REBUILD_ROUNDS.md`](operations/CLI_REBUILD_ROUNDS.md)
+   for what's currently broken or paused during the CLI rebuild
+4. Current runtime, operations, hardware, feature, and design docs
+   under the folders below
+5. Rules and agent guidance in `../rules/`, `../AGENTS.md`, and
+   `../skills/`
 
-The retired Python app runtime has been deleted. Python remains only for
-operations CLI, deploy, release, and validation orchestration.
+The retired Python app runtime and the Python operator CLI have both
+been deleted. The repo is Rust-only.
 
-Plan docs are useful context, but they are not automatically the current implementation contract.
+Plan docs are useful context, but they are not automatically the
+current implementation contract.
 
 ## Folder Map
 
@@ -60,11 +64,12 @@ Plan docs are useful context, but they are not automatically the current impleme
 ### Working On Raspberry Pi Deployment
 
 1. [`operations/CONTRIBUTOR_WORKFLOW.md`](operations/CONTRIBUTOR_WORKFLOW.md)
-2. [`operations/SETUP_CONTRACT.md`](operations/SETUP_CONTRACT.md)
-3. [`operations/DEV_PROD_LANES.md`](operations/DEV_PROD_LANES.md)
-4. [`operations/SLOT_DEPLOY.md`](operations/SLOT_DEPLOY.md)
+2. [`operations/CLI_REBUILD_ROUNDS.md`](operations/CLI_REBUILD_ROUNDS.md) — current rebuild state
+3. [`operations/SETUP_CONTRACT.md`](operations/SETUP_CONTRACT.md)
+4. [`operations/DEV_PROD_LANES.md`](operations/DEV_PROD_LANES.md)
 5. [`operations/PI_DEV_WORKFLOW.md`](operations/PI_DEV_WORKFLOW.md)
 6. [`operations/RPI_SMOKE_VALIDATION.md`](operations/RPI_SMOKE_VALIDATION.md)
+7. [`operations/SLOT_DEPLOY.md`](operations/SLOT_DEPLOY.md) — paused; Round 3
 
 ### Working On UI Or Design
 
@@ -86,6 +91,7 @@ Plan docs are useful context, but they are not automatically the current impleme
 
 These docs describe current implementation contracts:
 
+- [`operations/CLI_REBUILD_ROUNDS.md`](operations/CLI_REBUILD_ROUNDS.md)
 - [`architecture/SYSTEM_ARCHITECTURE.md`](architecture/SYSTEM_ARCHITECTURE.md)
 - [`architecture/WORK_AREAS.md`](architecture/WORK_AREAS.md)
 - [`architecture/CANONICAL_STRUCTURE.md`](architecture/CANONICAL_STRUCTURE.md)
@@ -95,7 +101,8 @@ These docs describe current implementation contracts:
 - [`operations/SETUP_CONTRACT.md`](operations/SETUP_CONTRACT.md)
 - [`operations/QUALITY_GATES.md`](operations/QUALITY_GATES.md)
 - [`operations/DEV_PROD_LANES.md`](operations/DEV_PROD_LANES.md)
-- [`operations/SLOT_DEPLOY.md`](operations/SLOT_DEPLOY.md)
+- [`operations/PI_DEV_WORKFLOW.md`](operations/PI_DEV_WORKFLOW.md)
+- [`operations/SLOT_DEPLOY.md`](operations/SLOT_DEPLOY.md) (paused; Round 3)
 - [`hardware/POWER_MODULE.md`](hardware/POWER_MODULE.md)
 - [`hardware/AUDIO_STACK.md`](hardware/AUDIO_STACK.md)
 - [`features/CLOUD_PROVISIONING_AND_BACKEND.md`](features/CLOUD_PROVISIONING_AND_BACKEND.md)

--- a/docs/architecture/CANONICAL_STRUCTURE.md
+++ b/docs/architecture/CANONICAL_STRUCTURE.md
@@ -170,13 +170,14 @@ Core package exports should follow the same rule:
 
 ## Validation Layout
 
-The repo no longer carries unit-test trees. Validation ownership should mirror
-the runtime ownership split:
+The repo no longer carries unit-test trees. Validation ownership mirrors
+the runtime/CLI ownership split:
 
-- Rust build checks stay with `device/Cargo.toml`
-- target hardware validation stays behind `yoyopod pi validate ...`
-- remote committed-code validation stays behind `yoyopod remote validate ...`
-- Python CLI/deploy verification stays in `scripts/quality.py`
+- Rust workspace checks stay with `device/Cargo.toml` and `cli/Cargo.toml`
+- target hardware deploy + manual exercise stays behind `yoyopod target deploy`
+- automated on-Pi validation (`yoyopod target validate`) is a Round 2
+  deliverable of the CLI rebuild; see
+  [`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md)
 
 ## Exemplar: Call + Contacts
 

--- a/docs/architecture/RUNTIME_EVENT_FLOW.md
+++ b/docs/architecture/RUNTIME_EVENT_FLOW.md
@@ -110,5 +110,5 @@ domain-specific hardware/backend details.
 - Shared envelope behavior lives in `device/protocol/`.
 - Host-specific protocol payloads and snapshots stay in their domain crate.
 
-Python under `yoyopod_cli/` is operations and validation tooling. It is not in
-the runtime event path.
+The Rust operator CLI under `cli/` is dev-machine orchestration only.
+It is not in the runtime event path.

--- a/docs/architecture/SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM_ARCHITECTURE.md
@@ -20,8 +20,9 @@ Unsupported runtime launch surfaces:
 - imports from the retired Python app package
 - any `yoyopod.*` Python app-runtime package
 
-The installed `yoyopod` console entrypoint in `pyproject.toml` belongs to
-`yoyopod_cli`. It is the operations CLI, not the app runtime.
+The installed `yoyopod` console entrypoint comes from the Rust CLI at
+`cli/`. It is the operator CLI for dev-machine to Pi orchestration, not
+the app runtime.
 
 ## Rust Workspace
 
@@ -64,29 +65,28 @@ yoyopod-runtime
 Each host is a sidecar process with a narrow domain owner. The runtime owns
 orchestration and policy; hosts own hardware/backend integration details.
 
-## Python Surface
+## Operator CLI Surface
 
-Python remains in the repo for:
+The operator CLI lives in `cli/` as a separate Cargo workspace. It
+produces a single binary, `yoyopod`, used from the dev machine for
+target orchestration (deploy, restart, logs, screenshot, mode).
 
-- `yoyopod_cli/` operations commands
-- deploy, release, slot, and Pi validation helpers
-- compatibility support modules that the CLI still uses
-
-The retired Python app runtime has been deleted. Active code must not import a
-`yoyopod.*` Python app-runtime package.
+The Python CLI was retired in Round 0 of the CLI rebuild; see
+[`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md).
+Active code must not depend on a `yoyopod_cli` Python package.
 
 ## Packaging
 
-The Python package wheel contains `yoyopod_cli` only. Release slots copy the
-active application sources under `app/device` and `app/yoyopod_cli`; they do not
-package a Python app-runtime package.
+Slot tarballs (Round 3 work) package the runtime workers under
+`app/device/.../build/`. No Python is included.
 
 ## Source Of Truth
 
 When docs disagree, trust sources in this order:
 
 1. Current Rust runtime and hosts under `device/`
-2. Current deploy/runtime tooling in `deploy/` and `yoyopod_cli/`
-3. Current operations and architecture docs
+2. Current operator CLI under `cli/` and deploy tooling under `deploy/`
+3. Current operations and architecture docs (especially
+   [`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md))
 4. `rules/`, `AGENTS.md`, and `skills/`
 5. Historical plans and archived material

--- a/docs/architecture/WORK_AREAS.md
+++ b/docs/architecture/WORK_AREAS.md
@@ -24,12 +24,13 @@ where a change belongs.
 - Device runtime code must not depend on `apps/`.
 - Shared contracts should flow through `packages/contracts/` when that package exists.
 
-## Python Still-Owned Areas
+## Operator CLI And Deploy Areas
 
-- `yoyopod_cli/` owns local and Pi operations tooling.
-- `deploy/` owns systemd, installer, slot, and release packaging scripts.
-- Python code is CLI/deploy/compatibility tooling only; it is not the device
-  runtime owner.
+- `cli/` owns the Rust operator CLI (`yoyopod target …`). See
+  [`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md)
+  for the current rebuild status.
+- `deploy/` owns systemd unit files, installer scripts, and slot/release
+  packaging primitives.
 
 ## Local Build Output
 
@@ -37,8 +38,7 @@ Do not work from generated output directories. These are disposable:
 
 - `device/target/`
 - `device/*/build/`
-- `.venv/`
-- `__pycache__/`
+- `cli/target/`
 - `logs/`
 - local `data/`
 

--- a/docs/features/CLOUD_VOICE_WORKER.md
+++ b/docs/features/CLOUD_VOICE_WORKER.md
@@ -86,29 +86,30 @@ keeps local controls usable.
 
 ## Live Worker Smoke Test
 
-From the Pi checkout, source the lane environment and run the worker with the
-OpenAI provider:
+The voice worker binary (`yoyopod-speech-host`) is built and shipped
+alongside the other Rust workers via the
+`yoyopod-rust-device-arm64-<sha>` CI artifact. From the Pi checkout,
+source the lane environment and run the worker directly:
 
 ```bash
 cd /opt/yoyopod-dev/checkout
-/opt/yoyopod-dev/venv/bin/python -m yoyopod_cli.main build voice-worker
 set -a
 . /etc/default/yoyopod-dev
 set +a
 YOYOPOD_VOICE_WORKER_PROVIDER=openai \
-  workers/voice/go/build/yoyopod-voice-worker
+  device/speech/build/yoyopod-speech-host
 ```
 
-The worker reads newline-delimited JSON command envelopes on stdin and writes
-JSON envelopes on stdout. For normal hardware validation, prefer the app-level
-smoke route:
+The worker reads newline-delimited JSON command envelopes on stdin and
+writes JSON envelopes on stdout.
+
+For normal hardware validation, prefer the dev-machine deploy:
 
 ```bash
-yoyopod pi validate stability
+yoyopod target deploy --branch <branch>           # or --sha <commit>
+yoyopod target logs --follow --filter speech
 ```
 
-or from the dev machine:
-
-```bash
-uv run yoyopod remote --host rpi-zero --branch <branch> validate --sha <commit>
-```
+Automated on-Pi voice validation (`yoyopod target validate
+--with-cloud-voice`) returns in Round 2 of the CLI rebuild. See
+[`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md).

--- a/docs/features/MPV_DEPENDENCIES.md
+++ b/docs/features/MPV_DEPENDENCIES.md
@@ -70,9 +70,9 @@ Notes:
 ## Validation
 
 ```bash
-pgrep -af mpv
-yoyopod remote validate --branch <branch> --sha <commit>
-yoyopod remote logs --filter music --lines 100
+yoyopod target deploy --branch <branch>           # or --sha <commit>
+yoyopod target logs --filter music --lines 100
+ssh <user>@<host> 'pgrep -af mpv'
 ```
 
 Expected checks:

--- a/docs/hardware/CUBIE_A7Z_BRINGUP.md
+++ b/docs/hardware/CUBIE_A7Z_BRINGUP.md
@@ -47,24 +47,25 @@ sudo apt install -y mpv espeak-ng unzip
 
 Install `uv` and Python `3.12`:
 
+Cubie-side Python installation is no longer required. The runtime and
+operator CLI are Rust-only; install a stable Rust toolchain instead if
+you need to build locally:
+
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-source ~/.bashrc
-uv python install 3.12
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ```
-
-Important note:
-
-- Debian system `python3` remains `3.9.2`
-- YoYoPod should use `uv` / `.venv`, not replace `/usr/bin/python3`
 
 Project setup on the board:
 
 ```bash
-cd ~/yoyopod-core
-~/.local/bin/uv venv --python 3.12 .venv
-~/.local/bin/uv sync --extra dev
+sudo mkdir -p /opt/yoyopod-dev
+sudo chown -R $USER:$USER /opt/yoyopod-dev
+git clone <repo-url> /opt/yoyopod-dev/checkout
 ```
+
+The Rust workers are delivered as CI-built artifacts via
+`yoyopod target deploy` from a dev machine; you do not need to build
+them on the Cubie.
 
 ## 3. Hostname and timezone
 
@@ -183,7 +184,8 @@ And a simple playlist was created:
 
 The Cubie A7Z is currently able to run YoYoPod with:
 
-- Python `3.12` in the project `.venv`
+- the Rust runtime (`yoyopod-runtime`) and worker hosts deployed from
+  CI artifacts
 - working SPI display path
 - working Whisplay display
 - working WM8960 playback/capture path
@@ -252,21 +254,7 @@ If one-button input is needed later, preferred next options are:
 - use the PiSugar custom function button as a semantic input source
 - or add an external button wired to a known-safe `3.3V` GPIO path
 
-### 5. System Python should not be replaced
-
-The Cubie image still uses Debian Bullseye system Python:
-
-- `python3 = 3.9.2`
-
-YoYoPod uses:
-
-- `uv`
-- Python `3.12`
-- project `.venv`
-
-Do not change `/usr/bin/python3` on this image.
-
-### 6. ALSA card index ordering is not stable
+### 5. ALSA card index ordering is not stable
 
 ALSA card numbering can vary after reboot.
 
@@ -275,7 +263,7 @@ Recommendation:
 - target playback/capture devices by device name
 - avoid assuming a fixed card index for `wm8960-soundcard`
 
-### 7. Avoid casual kernel upgrades
+### 6. Avoid casual kernel upgrades
 
 The current working state depends on the Radxa vendor BSP kernel and overlays.
 
@@ -331,7 +319,8 @@ For immediate development:
 1. use Cubie A7Z powered directly by USB
 2. keep PiSugar detached unless specifically testing PiSugar features
 3. do not press the Whisplay physical button on Cubie A7Z
-4. use SSH plus service restarts for app validation
-5. use the Cubie board config override and the project `.venv`
+4. deploy via `yoyopod target deploy` from a dev machine
+5. use the Cubie board config override (`YOYOPOD_CONFIG_BOARD=radxa-cubie-a7z`)
+   and SSH plus `yoyopod target {restart, logs, status}` for app validation
 
 This is the safest current path while keeping the board productive for display, audio, VoIP, music, and local voice-command development.

--- a/docs/hardware/CUBIE_A7Z_PIMORONI_SETUP.md
+++ b/docs/hardware/CUBIE_A7Z_PIMORONI_SETUP.md
@@ -12,7 +12,8 @@ The Pimoroni HAT was designed for the Raspberry Pi. On the Cubie, the Pi-specifi
 
 - Radxa Cubie A7Z with Debian Bullseye and vendor BSP kernel `5.15.147-18-a733`
 - SPI1 enabled via `sun60iw2p1-spi1-spidev.dtbo` overlay (see `docs/hardware/CUBIE_A7Z_BRINGUP.md`)
-- YoYoPod project deployed at `~/yoyopod-core` with Python 3.12 venv
+- YoYoPod dev lane deployed at `/opt/yoyopod-dev/checkout` with worker
+  binaries installed via `yoyopod target deploy`
 - `dtc` (device tree compiler) installed: `sudo apt install device-tree-compiler`
 
 ## Pin Mapping
@@ -205,8 +206,9 @@ config changes are needed.
 ### Launch with Pimoroni display
 
 ```bash
-cd ~/yoyopod-core
-YOYOPOD_DISPLAY=pimoroni YOYOPOD_CONFIG_BOARD=radxa-cubie-a7z .venv/bin/device/runtime/build/yoyopod-runtime --config-dir config
+cd /opt/yoyopod-dev/checkout
+YOYOPOD_DISPLAY=pimoroni YOYOPOD_CONFIG_BOARD=radxa-cubie-a7z \
+  device/runtime/build/yoyopod-runtime --config-dir config
 ```
 
 ### Set as the default systemd service display
@@ -214,7 +216,7 @@ YOYOPOD_DISPLAY=pimoroni YOYOPOD_CONFIG_BOARD=radxa-cubie-a7z .venv/bin/device/r
 To make the systemd service use Pimoroni, create or update the local deploy override:
 
 ```bash
-yoyopod remote config edit --host cubie-a7z
+yoyopod target --host cubie-a7z config edit
 ```
 
 Or manually add to `deploy/pi-deploy.local.yaml`:
@@ -243,7 +245,7 @@ The following has been validated on-device:
 - **Button X requires I2S0 disabled.** Re-enabling I2S0 (for WM8960 audio) will block Button X.
 - **SPI `no_cs` not supported** by the Allwinner SPI driver. The driver uses hardware CS on PIN_24 (CS0) which does not reach the Pimoroni HAT's CE1 trace (PIN_26). Software CS via GPIO on PIN_26 is used as a fallback.
 - **Whisplay adapter import side effects.** The Whisplay vendor driver claims GPIO pins at import time. Display adapter imports are lazy to prevent this, but importing the Whisplay adapter module (e.g., for testing) while Pimoroni is active will cause GPIO conflicts.
-- **gpiod 1.x API.** The Cubie runs gpiod 1.6.2 (lowercase `gpiod.chip()`). Current Pi-facing compatibility helpers live under `yoyopod_cli/pi/support/`.
+- **gpiod 1.x API.** The Cubie runs gpiod 1.6.2 (lowercase `gpiod.chip()`). Any Cubie-specific gpiod compatibility belongs in the relevant Rust worker crate under `device/`.
 
 ## Switching Back to Whisplay
 

--- a/docs/hardware/POWER_MODULE.md
+++ b/docs/hardware/POWER_MODULE.md
@@ -28,7 +28,12 @@ Main files:
 - `device/power/`
 - `device/runtime/`
 - `device/ui/`
-- `yoyopod_cli/pi/power.py` (`yoyopod pi power battery`, `yoyopod pi power rtc`)
+
+CLI diagnostics for the power module (`yoyopod pi power battery`,
+`yoyopod pi power rtc …`) were deleted in Round 0 of the CLI rebuild
+and return in Round 4. Until then, query PiSugar state via the
+PiSugar server directly. See
+[`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md).
 
 Runtime flow:
 
@@ -202,21 +207,11 @@ Supported RTC operations:
 - set a wake alarm
 - disable the wake alarm
 
-Primary helper:
-
-```bash
-yoyopod pi power rtc status
-yoyopod pi power rtc sync-to
-yoyopod pi power rtc sync-from
-yoyopod pi power rtc set-alarm --time 2026-04-06T07:30:00+02:00
-yoyopod pi power rtc disable-alarm
-```
-
-Remote helper:
-
-```bash
-yoyopod remote rtc status --host rpi-zero
-```
+CLI helpers for RTC operations (`yoyopod pi power rtc …`,
+`yoyopod target rtc …`) were deleted in Round 0 and return in Round 4
+of the CLI rebuild. Until then, drive the PiSugar RTC directly via the
+`pisugar-server` daemon or the device file under `/dev/`. See
+[`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md).
 
 ## Watchdog Support
 
@@ -270,41 +265,27 @@ Note:
 
 ## Diagnostics And Validation
 
-Focused power helper:
+Power-module CLI diagnostics (`yoyopod pi power battery`,
+`yoyopod target power`, `yoyopod pi power rtc status`) were deleted in
+Round 0 of the CLI rebuild. Until they return in Round 4, use the
+PiSugar server directly:
 
 ```bash
-yoyopod pi power battery
+ssh <user>@<host> 'pisugar-shell ls'         # list available fields
+ssh <user>@<host> 'pisugar-shell get battery'
+ssh <user>@<host> 'pisugar-shell get model'
 ```
 
-This prints:
-- availability
-- model
-- battery percent
-- voltage
-- temperature
-- charging state
-- external power state
-- RTC state
-- safe-shutdown values
-- watchdog configuration
+Or query the socket / TCP transport that `pisugar-server` exposes (see
+the Dependencies section).
 
-Remote power helper:
+Smoke validation (`yoyopod pi validate smoke`) returns in Round 2. Until
+then, after `yoyopod target deploy`:
 
-```bash
-yoyopod remote power --host rpi-zero
-```
-
-Smoke validation:
-
-```bash
-yoyopod pi validate smoke
-```
-
-Recommended hardware sequence:
-1. `uv run pytest -q`
-2. `yoyopod pi validate smoke`
-3. `yoyopod pi power battery`
-4. `yoyopod pi power rtc status`
+1. `yoyopod target status`
+2. `yoyopod target logs --follow --filter power`
+3. exercise the device and confirm battery / charging telemetry
+   reaches the UI Power Status screen
 
 ## Dependencies On The Pi
 
@@ -321,7 +302,8 @@ The PiSugar server should expose at least one of:
 If power telemetry fails:
 - check `pisugar-server` is running
 - check `/tmp/pisugar-server.sock` exists or TCP `8423` is listening
-- run `yoyopod pi power battery`
+- run `ssh <user>@<host> 'pisugar-shell get battery'` to query the
+  PiSugar server directly
 - run `i2cdetect -y 1` on Raspberry Pi Zero 2W hardware
 - run `i2cdetect -y 7` on Radxa Cubie A7Z hardware
 
@@ -330,7 +312,7 @@ If PiSugar is not visible on the expected I2C bus:
 - if `0x57` disappears but other bus devices still respond, suspect physical contact between the PiSugar pogo pins and the underside of the Raspberry Pi GPIO header
 - clean the underside GPIO pads, reseat the PiSugar carefully, and re-run `i2cdetect`
 - if needed, add a small amount of solder to the underside GPIO pads to improve pogo-pin contact, then power-cycle and retest
-- once the PiSugar device reappears on I2C, restart `pisugar-server` and confirm `yoyopod pi power battery` returns real battery values again
+- once the PiSugar device reappears on I2C, restart `pisugar-server` and confirm `pisugar-shell get battery` returns real battery values again
 
 Expected PiSugar 3 visibility usually includes:
 - `0x57`
@@ -342,7 +324,7 @@ If watchdog commands fail:
 - confirm passwordless `sudo` is not required for your chosen flow, because the watchdog uses direct I2C tools
 
 If RTC sync behaves strangely:
-- validate with `yoyopod pi power rtc status`
+- query the PiSugar server directly: `pisugar-shell get rtc_time`
 - check whether the distro image has a working `hwclock` path
 
 If the app shuts down too aggressively:

--- a/docs/operations/CONTRIBUTOR_WORKFLOW.md
+++ b/docs/operations/CONTRIBUTOR_WORKFLOW.md
@@ -20,50 +20,34 @@ If you are new here, read in this order:
 
 ## Baseline local setup
 
-Use the repo-owned setup contract first:
+Automated host setup tooling (`yoyopod setup host` / `verify-host`) was
+deleted in Round 0 of the CLI rebuild and has not yet been ported back.
+See [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md). Until then, install
+dependencies manually:
+
+- a Rust stable toolchain via `rustup`
+- `gh` (GitHub CLI) authenticated for `yoyopod target deploy`
+- standard Pi-side prereqs (`ssh`, `scp`, `git`)
+
+Then build the Rust CLI and (optionally) install it into PATH:
 
 ```bash
-uv run yoyopod setup host
-uv run yoyopod setup verify-host
+cargo build --manifest-path cli/Cargo.toml --release
+cargo install --path cli/yoyopod
 ```
-
-This is the baseline executable setup contract.
-
-It is not the same thing as complete setup ownership. Feature-specific assets and unusual hardware edges can still need extra follow-through.
-
-Before you start a workflow that depends on more than local simulation and CI-safe checks, verify the extra host prerequisites explicitly:
-
-```bash
-uv run yoyopod setup verify-host --with-remote-tools
-uv run yoyopod setup verify-host --with-github
-```
-
-Use `--with-remote-tools --with-github` together when you plan to both validate on a Raspberry Pi over SSH and use GitHub CLI helpers for branch or PR work.
 
 ## Fast local loop
 
-Legacy Python simulation run:
-
-```bash
-yoyopod build simulation
-device/runtime/build/yoyopod-runtime --config-dir config
-```
-
-Core Rust validation loop:
+Rust workspace check (preferred):
 
 ```bash
 cargo check --manifest-path device/Cargo.toml --workspace --locked
+cargo test  --manifest-path cli/Cargo.toml
 ```
 
-Legacy Python quality debt audit:
-
-```bash
-uv run --extra dev python scripts/quality.py audit
-```
-
-Use `scripts/quality.py` when changing Python CLI/deploy surfaces or fixing
-Python CI. Do not treat Python checks as the default gate for Rust runtime
-iteration.
+Run targeted crate checks during iteration on a specific worker
+(`-p yoyopod-runtime`, `-p yoyopod-ui`, etc.). See
+[`QUALITY_GATES.md`](QUALITY_GATES.md).
 
 ## Choose the right doc path for the work
 
@@ -79,9 +63,9 @@ Read:
 
 Current reality:
 
-- `yoyopod-runtime` is the target top-level owner for runtime state and worker supervision
-- Python code is operations CLI, deploy, release, validation, or compatibility tooling unless current code proves otherwise
-- runtime/state/model cleanup should prefer Rust ownership over broad Python rewrites
+- `yoyopod-runtime` owns top-level runtime state and worker supervision.
+- The operator CLI is Rust (`cli/`), currently rebuilding in rounds.
+- No Python code remains in tree.
 
 ### Raspberry Pi and setup work
 
@@ -96,16 +80,19 @@ Read:
 Baseline commands:
 
 ```bash
-uv run yoyopod setup verify-host --with-remote-tools
-yoyopod remote config edit
-uv run yoyopod remote setup --with-pisugar
-uv run yoyopod remote verify-setup --with-pisugar
-yoyopod remote validate --branch <branch> --sha <commit> --with-voip
+yoyopod target config edit
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>           # or --sha <commit>
+yoyopod target logs --follow
 ```
 
-These are the canonical contributor-path commands.
-Add `--with-voice` and/or `--with-network` when the target needs the TTS or modem paths.
-For direct on-Pi validation commands such as `yoyopod pi validate smoke`, use [`RPI_SMOKE_VALIDATION.md`](RPI_SMOKE_VALIDATION.md).
+`yoyopod target deploy` is the everyday command — it pushes, fetches
+the CI artifact, syncs the Pi, installs binaries, restarts, and
+verifies startup in one step.
+
+Automated on-Pi validation (`yoyopod target validate`) is a Round 1
+stub during the CLI rebuild; validate manually after deploy. See
+[`RPI_SMOKE_VALIDATION.md`](RPI_SMOKE_VALIDATION.md).
 
 ### Docs and contributor guidance work
 
@@ -125,20 +112,23 @@ When updating docs:
 
 ## Before opening a PR
 
-At minimum for Rust runtime work, run the relevant Rust build check:
+At minimum, run the relevant Rust build check:
 
 ```bash
 cargo check --manifest-path device/Cargo.toml --workspace --locked
+cargo test  --manifest-path cli/Cargo.toml      # if you touched cli/
 ```
 
-Then add any focused commands relevant to your area, for example:
+For hardware-touching work, run a deploy and a manual eyes-on check:
 
 ```bash
-python -m compileall yoyopod_cli scripts
-yoyopod remote validate --branch <branch> --sha <commit>
+yoyopod target deploy --branch <branch>
+yoyopod target status
+yoyopod target logs --follow
 ```
 
-If your change is outside the currently gated surface, say so plainly in the PR instead of pretending CI covered more than it did.
+If your change is outside the currently gated surface, say so plainly
+in the PR instead of pretending CI covered more than it did.
 
 ## What a good PR looks like here
 
@@ -164,13 +154,12 @@ Watch for these recurring mistakes:
 
 These are good places to be extra careful:
 
-- `yoyopod/core/bootstrap/`
-- `yoyopod/core/application.py`
-- `yoyopod/core/bus.py`
-- `yoyopod/core/scheduler.py`
-- `yoyopod/core/app_context.py`
-- duplicated domain/state models that drift across layers
-- setup/docs wording that can overstate what the new commands guarantee
+- `device/runtime/` — top-level runtime supervision
+- `device/ui/` + LVGL scene controllers — visual fidelity on real hardware
+- `cli/yoyopod/` — operator surface (under active rebuild; see
+  CLI_REBUILD_ROUNDS.md)
+- duplicated domain/state models that drift across `device/` crates
+- setup/docs wording that overstates what the rebuilt CLI guarantees today
 
 ## If you only remember one thing
 

--- a/docs/operations/DEVELOPMENT_GUIDE.md
+++ b/docs/operations/DEVELOPMENT_GUIDE.md
@@ -1,6 +1,7 @@
 # Development Guide
 
-This guide holds the operational detail that does not belong on the repo landing page.
+This guide holds the operational detail that does not belong on the
+repo landing page.
 
 If you are new here, read these first:
 
@@ -8,52 +9,46 @@ If you are new here, read these first:
 2. [`README.md`](../README.md)
 3. [`CONTRIBUTOR_WORKFLOW.md`](CONTRIBUTOR_WORKFLOW.md)
 4. [`SYSTEM_ARCHITECTURE.md`](../architecture/SYSTEM_ARCHITECTURE.md)
+5. [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md)
 
 ## Source of truth
 
-For current behavior, trust:
-- current Rust runtime and host code in `device/`
-- current operations tooling in `yoyopod_cli/`
+For current behaviour, trust:
+
+- current Rust runtime and worker code in `device/`
+- current operator CLI source in `cli/`
 - this guide for setup and workflow
-- [`SYSTEM_ARCHITECTURE.md`](../architecture/SYSTEM_ARCHITECTURE.md) for runtime topology
+- [`SYSTEM_ARCHITECTURE.md`](../architecture/SYSTEM_ARCHITECTURE.md) for
+  runtime topology
+- [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md) for what's broken
+  during the CLI rebuild
 - [`../AGENTS.md`](../../AGENTS.md) and `rules/` for repo guidance
 
-Treat plan docs and checklists as supporting context unless they explicitly state they are current.
+Treat plan docs and checklists as supporting context unless they
+explicitly state they are current.
 
-## Python Environment
-
-```bash
-uv run yoyopod setup host
-uv run yoyopod setup verify-host
-```
-
-These commands define the baseline executable setup contract. They do not yet
-cover external service credentials or every board/modem-specific setup edge.
-If `yoyopod` reports that the contributor CLI dependencies are missing, run
-`uv sync --extra dev` and retry.
-
-If you plan to use the remote Pi workflow from your dev machine, verify the
-extra host tools explicitly:
+## Toolchain
 
 ```bash
-uv run yoyopod setup verify-host --with-remote-tools
+# Stable Rust via rustup
+rustup default stable
+rustup component add rustfmt clippy
+
+# Build the operator CLI:
+cargo build --manifest-path cli/Cargo.toml --release
+cargo install --path cli/yoyopod          # optional, into ~/.cargo/bin
+
+# Build the runtime locally (optional; CI artifacts are normally used):
+cargo build --manifest-path device/Cargo.toml --release -p yoyopod-runtime
 ```
 
-If you plan to use GitHub CLI helpers for branch or PR work, verify that too:
-
-```bash
-uv run yoyopod setup verify-host --with-github
-```
-
-Combine both flags when you need both surfaces.
+`gh` (GitHub CLI) must be authenticated for `yoyopod target deploy`.
 
 ## System Dependencies
 
-The current repo-owned setup contract lives in [`SETUP_CONTRACT.md`](SETUP_CONTRACT.md).
+The full setup contract lives in [`SETUP_CONTRACT.md`](SETUP_CONTRACT.md).
 
-Short version:
-
-Core Raspberry Pi packages and services expected by the active stack:
+Core Raspberry Pi packages and services:
 
 - `mpv`
 - `ffmpeg`
@@ -63,22 +58,11 @@ Core Raspberry Pi packages and services expected by the active stack:
 - `alsa-utils`
 - `i2c-tools`
 - `pisugar-server` on PiSugar-based targets
+- `ppp` for the cellular modem path
 
-Feature-gated extras are documented there too, including:
-
-- `ppp` for the modem PPP path
-
-Example:
-
-```bash
-uv run yoyopod setup pi --with-pisugar
-uv run yoyopod setup verify-pi --with-pisugar
-```
-
-Treat those commands as the baseline package/build verifier, not proof that all
-feature assets and hardware-specific setup are complete.
-
-Add `--with-voice` and/or `--with-network` when the target uses the TTS or modem paths. For PiSugar-based hardware, `--with-pisugar` is what makes `pisugar-server` part of the verified contract.
+Automated host/Pi setup commands (`yoyopod setup …`) were deleted in
+Round 0 of the CLI rebuild; install manually until they return. See
+[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
 
 ## Configuration
 
@@ -102,15 +86,20 @@ Key settings:
 - `config/app/core.yaml`
   - `app.*`, `ui.*`, `logging.*`, `diagnostics.*`
 - `config/audio/music.yaml`
-  - `audio.music_dir`, `audio.recent_tracks_file`, `audio.mpv_*`, `audio.default_volume`
+  - `audio.music_dir`, `audio.recent_tracks_file`, `audio.mpv_*`,
+    `audio.default_volume`
 - `config/device/hardware.yaml`
-  - `input.*`, `display.*`, `communication_audio.*`, `media_audio.*`, `voice_audio.*`
+  - `input.*`, `display.*`, `communication_audio.*`, `media_audio.*`,
+    `voice_audio.*`
 - `config/power/backend.yaml`
-  - `power.*` PiSugar backend transport, watchdog, polling, warning, and shutdown policy
+  - `power.*` PiSugar backend transport, watchdog, polling, warning,
+    and shutdown policy
 - `config/network/cellular.yaml`
-  - `network.*` cellular modem enablement, ports, APN, GPS, and PPP timeout
+  - `network.*` cellular modem enablement, ports, APN, GPS, and PPP
+    timeout
 - `config/voice/assistant.yaml`
-  - `assistant.*` voice commands, cloud-worker STT/TTS, prompt policy, and command routing
+  - `assistant.*` voice commands, cloud-worker STT/TTS, prompt policy,
+    and command routing
 - `config/communication/calling.yaml`
   - SIP identity, transport, STUN, call policy, call-history path
 - `config/communication/messaging.yaml`
@@ -118,19 +107,20 @@ Key settings:
 - `config/people/directory.yaml`
   - paths for mutable people data under `data/people/`
 
-Local SIP credentials belong in `config/communication/calling.secrets.yaml` or
-env vars. Mutable contacts live in `data/people/contacts.yaml`, optionally
-bootstrapped from `config/people/contacts.seed.yaml`. Mutable media history
-lives in `data/media/recent_tracks.json`.
+Local SIP credentials belong in
+`config/communication/calling.secrets.yaml` or env vars. Mutable
+contacts live in `data/people/contacts.yaml`, optionally bootstrapped
+from `config/people/contacts.seed.yaml`. Mutable media history lives in
+`data/media/recent_tracks.json`.
 
-Current approved-contacts behavior:
+Current approved-contacts behaviour:
 
 - contacts may include both `sip_address` and `phone_number`
 - the runtime prefers SIP for calling while GSM remains disabled
-- backend config sync can replace the cloud-managed subset while preserving
-  local-only contacts
-- a claimed device may upload prestored local contacts once when backend
-  authority is still empty for that household
+- backend config sync can replace the cloud-managed subset while
+  preserving local-only contacts
+- a claimed device may upload prestored local contacts once when
+  backend authority is still empty for that household
 
 ## Running
 
@@ -140,23 +130,22 @@ Rust runtime dry run:
 cargo run --manifest-path device/Cargo.toml -p yoyopod-runtime -- --config-dir config --dry-run
 ```
 
-Rust runtime:
+Rust runtime (after a local build):
 
 ```bash
-device/runtime/build/yoyopod-runtime --config-dir config
+device/target/release/yoyopod-runtime --config-dir config
 ```
 
 Installed console entrypoint:
 
 ```bash
-yoyopod
+yoyopod                # Rust operator CLI; does NOT launch the runtime
 ```
 
-The installed `yoyopod` command is the operations CLI. It does not launch the
-app runtime.
-
-Legacy Python runtime demos have been deleted. The Rust runtime is the only
-supported app runtime workflow.
+The installed `yoyopod` command is the operator CLI for dev-machine to
+Pi orchestration. It does not launch the app runtime — that runs on the
+Pi via `yoyopod-dev.service` (dev lane) or `yoyopod-prod.service`
+(prod lane).
 
 ## Validation
 
@@ -164,83 +153,46 @@ Local validation:
 
 ```bash
 cargo check --manifest-path device/Cargo.toml --workspace --locked
+cargo test  --manifest-path cli/Cargo.toml
+cargo clippy --manifest-path cli/Cargo.toml --all-targets
 ```
 
-Run Python lint/type checks only when Python CLI/deploy/compatibility files
-change:
+See [`QUALITY_GATES.md`](QUALITY_GATES.md).
 
-```bash
-uv run --extra dev python scripts/quality.py gate
-```
+Profiling tooling (`yoyopod dev profile …`) was retired with the rest
+of the Python CLI in Round 0. For ad-hoc profiling, use the standard
+Rust tools (`cargo flamegraph`, `samply`, `perf` on the Pi) directly
+against `yoyopod-runtime` and worker binaries.
 
-Optional extra syntax/import smoke for broad Python tree changes:
-
-```bash
-python -m compileall yoyopod_cli scripts
-```
-
-Full quality audit of the current repo debt:
-
-```bash
-uv run --extra dev python scripts/quality.py audit
-```
-
-The staged gate contract and exact target set live in [`QUALITY_GATES.md`](QUALITY_GATES.md).
-
-Profiling and bounded branch-to-branch benchmarks:
-
-```bash
-uv run yoyopod dev profile tools
-uv run yoyopod dev profile targets
-uv run yoyopod dev profile cprofile --target simulate-bootstrap
-uv run yoyopod dev profile pyinstrument --target simulate-loop --iterations 300 --html
-uv run yoyopod dev profile pyperf --target scaffold-loop --fast
-```
-
-For the full Pi-focused profiling path, including `py-spy`, `perf`, and the
-repo's coordinator-loop diagnostics, see [`PI_PROFILING_WORKFLOW.md`](PI_PROFILING_WORKFLOW.md).
-
-Target-side validation suite:
-
-```bash
-yoyopod pi validate deploy
-yoyopod pi validate smoke
-yoyopod pi validate voip
-yoyopod pi validate navigation
-yoyopod pi validate stability
-```
+Automated on-Pi validation (`yoyopod target validate …` /
+`yoyopod pi validate …`) is on the CLI rebuild roadmap and is not yet
+available. Until then, validate manually after `yoyopod target deploy`
+via `systemd` and `journalctl`.
 
 ## Raspberry Pi Workflow
 
-Preferred remote helper:
-
 ```bash
-uv run yoyopod setup verify-host --with-remote-tools
-yoyopod remote config edit
-uv run yoyopod remote setup --with-pisugar
-uv run yoyopod remote verify-setup --with-pisugar
-yoyopod remote config show
-yoyopod remote status
-git branch --show-current
-git rev-parse HEAD
-yoyopod remote validate --branch <branch> --sha <commit> --with-voip --with-lvgl-soak
-yoyopod remote validate --branch <branch> --sha <commit> --with-navigation
-yoyopod remote preflight --branch <branch>
-yoyopod remote logs --lines 200
+yoyopod target config edit                       # one-time per machine
+yoyopod target mode status
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>          # or --sha <commit>
+yoyopod target status
+yoyopod target logs --lines 200
+yoyopod target logs --follow --filter ERROR
 ```
 
-That remote flow mirrors the same baseline contract. You still need feature-specific
-follow-through for external credentials and unusual board/modem bringup.
-Add `--with-voice` and/or `--with-network` to the setup commands when the target depends on those paths.
+`yoyopod target deploy` pushes, finds the CI artifact for the exact
+commit, syncs the Pi, installs the worker binaries, restarts the
+service, and verifies startup in one step.
 
-If a GitHub fetch or push fails with a short-lived connectivity error, retry it
-several times before treating it as a real failure. This environment has seen
-brief `github.com` reachability blips.
+If a GitHub fetch or push fails with a short-lived connectivity error,
+retry it several times before treating it as a real failure. This
+environment has seen brief `github.com` reachability blips.
 
 The detailed deploy and validation flows live in:
 
-- `docs/operations/PI_DEV_WORKFLOW.md`
-- `docs/operations/RPI_SMOKE_VALIDATION.md`
+- [`PI_DEV_WORKFLOW.md`](PI_DEV_WORKFLOW.md)
+- [`RPI_SMOKE_VALIDATION.md`](RPI_SMOKE_VALIDATION.md)
 - `rules/deploy.md`
 
 ## Logging
@@ -253,15 +205,15 @@ The app writes:
 Pi deploy defaults live in:
 
 - `deploy/pi-deploy.yaml`
-- `deploy/pi-deploy.local.yaml` for gitignored machine-local overrides
+- `deploy/pi-deploy.local.yaml` (gitignored, machine-local)
 
 Useful remote log commands:
 
 ```bash
-yoyopod remote logs --lines 200
-yoyopod remote logs --errors
-yoyopod remote logs --filter comm
-yoyopod remote logs --follow --filter ERROR
+yoyopod target logs --lines 200
+yoyopod target logs --errors
+yoyopod target logs --filter comm
+yoyopod target logs --follow --filter ERROR
 ```
 
 ## Package Layout
@@ -279,15 +231,15 @@ device/
   speech/
   ui/
   voip/
-yoyopod_cli/
-  main.py
-  pi/
-  config/
-  contracts/
-scripts/
-  quality.py
-legacy/
-  python-runtime/
+cli/
+  yoyopod/
+    src/
+      commands/
+        target/
+deploy/
+  pi-deploy.yaml
+  scripts/
+  systemd/
 ```
 
 ## Current Active Docs
@@ -295,15 +247,17 @@ legacy/
 Start with [`README.md`](../README.md) for the full docs map.
 
 Current contributor, runtime, and setup docs:
+
 - `docs/operations/CONTRIBUTOR_WORKFLOW.md`
 - `docs/operations/QUALITY_GATES.md`
 - `docs/operations/SETUP_CONTRACT.md`
+- `docs/operations/CLI_REBUILD_ROUNDS.md`
+- `docs/operations/PI_DEV_WORKFLOW.md`
+- `docs/operations/RPI_SMOKE_VALIDATION.md`
 - `docs/architecture/SYSTEM_ARCHITECTURE.md`
 - `docs/hardware/POWER_MODULE.md`
 - `docs/features/LOCAL_FIRST_MUSIC_PLAN.md`
 - `docs/features/MPV_DEPENDENCIES.md`
-- `docs/operations/PI_DEV_WORKFLOW.md`
-- `docs/operations/RPI_SMOKE_VALIDATION.md`
 
-Old plan and migration archives were removed from the tracked repo. Current code
-and current operation docs are the source of truth.
+Old plan and migration archives were removed from the tracked repo.
+Current code and current operation docs are the source of truth.

--- a/docs/operations/DEV_PROD_LANES.md
+++ b/docs/operations/DEV_PROD_LANES.md
@@ -12,8 +12,7 @@ the opposite lane before starting the requested one.
 
 ```text
 /opt/yoyopod-dev/
-|-- checkout/        # git checkout used by remote sync, validate, setup
-|-- venv/            # checkout virtualenv; no uv dependency on the Pi
+|-- checkout/        # git checkout used by yoyopod target deploy
 |-- state/           # dev-only runtime state
 |-- logs/
 |-- tmp/
@@ -33,12 +32,10 @@ The tracked default config lives in `deploy/pi-deploy.yaml`:
 
 ```yaml
 project_dir: /opt/yoyopod-dev/checkout
-venv: /opt/yoyopod-dev/venv
 
 lane:
   dev_root: /opt/yoyopod-dev
   dev_checkout: /opt/yoyopod-dev/checkout
-  dev_venv: /opt/yoyopod-dev/venv
   prod_root: /opt/yoyopod-prod
 
 slot:
@@ -54,56 +51,47 @@ Per-board overrides still belong in `deploy/pi-deploy.local.yaml`.
 - `yoyopod-prod-rollback.service` is triggered by prod service failure.
 - `yoyopod-prod-ota.timer` and `yoyopod-prod-ota.service` are reserved for the OTA poller.
 
-The dev and prod runtime units conflict with each other. Lane activation also
-disables and removes unsupported old `yoyopod-slot.service` and
-`yoyopod@<user>.service` unit files, removes `/etc/default/yoyopod`, and stops
-unmanaged `yoyopod-runtime` or old Python app-runtime processes before
-starting the requested lane.
+The dev and prod runtime units conflict with each other. Lane
+activation stops the other lane and any unmanaged `yoyopod-runtime`
+processes before starting the requested one.
 
-Before changing lanes, run `yoyopod remote mode status`. It reports:
-
-- `active_lane`: `dev`, `prod`, `legacy`, `manual-process`, `conflict`, or `none`.
-- `legacy_units`: unsupported old `yoyopod@*.service` or `yoyopod-slot.service`
-  units that can still own hardware.
-- `manual_processes`: ad hoc `yoyopod-runtime` or old Python app-runtime processes.
-- `prod_ota_conflict`: whether prod OTA is active while dev owns the board.
-- `conflict_reasons`: the active conflict sources.
+Before changing lanes, run `yoyopod target mode status`. It reports the
+active service for each lane and a summary of unrelated `yoyopod-*`
+processes that may still own hardware.
 
 ## Lane Commands
 
 Check state:
 
 ```bash
-uv run yoyopod remote mode status
+yoyopod target mode status
 ```
 
 Activate dev for PR hardware testing:
 
 ```bash
-uv run yoyopod remote mode activate dev
-uv run yoyopod remote sync --branch <branch>
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>           # or --sha <commit>
 ```
 
-If branch switching leaves stale native CMake caches, force a clean native
-rebuild during sync:
-
-```bash
-uv run yoyopod remote sync --branch <branch> --clean-native
-```
+`target deploy` always uses a CI-built artifact for the exact commit;
+there is no dirty-tree fallback. Add `--clean-native` if branch
+switching leaves stale native LVGL CMake caches.
 
 Activate prod again:
 
 ```bash
-uv run yoyopod remote mode activate prod
-uv run yoyopod remote release status
+yoyopod target mode activate prod
 ```
 
-Deactivate a lane without enabling the other:
+`yoyopod target release status` (prod slot status) returns in Round 3
+of the CLI rebuild; see
+[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md). Until then, check prod
+state directly via `systemctl status yoyopod-prod.service` over SSH.
 
-```bash
-uv run yoyopod remote mode deactivate dev
-uv run yoyopod remote mode deactivate prod
-```
+`yoyopod target mode deactivate` is not yet ported; stop a lane
+directly with `sudo systemctl stop yoyopod-dev.service` (or
+`yoyopod-prod.service`) over SSH.
 
 ## Fresh Board Bootstrap
 
@@ -127,16 +115,16 @@ For PR/testing a non-main installer, pin the source ref explicitly:
 curl -fsSL https://raw.githubusercontent.com/moustafattia/yoyopod-core/<ref>/deploy/scripts/install_pi.sh | sudo env YOYOPOD_INSTALL_REF=<ref> bash -s --
 ```
 
-After bootstrap, prod release commands do not need a repo checkout. Dev commands
-do need `/opt/yoyopod-dev/checkout`; for a fresh board, seed it before using
-`remote sync`:
+After bootstrap, dev commands need `/opt/yoyopod-dev/checkout`. For a
+fresh board, seed it before using `target deploy`:
 
 ```bash
 sudo chown -R <user>:<user> /opt/yoyopod-dev
 sudo -u <user> git clone <repo-url> /opt/yoyopod-dev/checkout
 ```
 
-Then run `yoyopod remote setup` once to create `/opt/yoyopod-dev/venv`.
+(`yoyopod target setup` for one-command Pi setup returns in a later
+round of the CLI rebuild.)
 
 ## Migrating an Existing Board
 
@@ -152,24 +140,23 @@ it does not copy the legacy checkout into the dev lane. After migration, treat
 the old `~/yoyopod-core` checkout as an archive only; the live dev truth is
 `/opt/yoyopod-dev/checkout`.
 
-Populate the dev lane explicitly before using `remote sync`:
+Populate the dev lane explicitly before using `target deploy`:
 
 ```bash
 sudo chown -R <user>:<user> /opt/yoyopod-dev
 sudo -u <user> git clone <repo-url> /opt/yoyopod-dev/checkout
-uv run yoyopod remote setup
 ```
 
 Then activate the desired lane:
 
 ```bash
-uv run yoyopod remote mode activate dev
+yoyopod target mode activate dev
 ```
 
 or:
 
 ```bash
-uv run yoyopod remote mode activate prod
+yoyopod target mode activate prod
 ```
 
 Migration copies old `config/` and `logs/` into `/opt/yoyopod-prod/state/` for
@@ -179,21 +166,18 @@ publishing a prod slot.
 
 ## Pitfalls
 
-- Do not run dev and prod runtime services together; they share hardware, audio, and
-  the PID file contract.
-- Do not ignore `active_lane=conflict`; `remote mode activate dev|prod` is the
-  supported cleanup path for legacy/manual owners.
-- Do not mutate prod release directories in place; publish a new version and
-  flip `current`.
-- Do not depend on `uv` on the Pi; dev uses `/opt/yoyopod-dev/venv`, prod slots
-  carry their own runtime.
-- Do not trust dev native build dirs after large branch switches; use
-  `yoyopod remote sync --clean-native` or run `yoyopod build clean-native` inside
-  the dev checkout before rebuilding.
-- Do not delete `/opt/yoyopod-prod/previous` before a normal prod update; it is
-  the rollback target.
-- Do not assume old `~/yoyopod-core` is the dev lane. The dev lane checkout is
-  `/opt/yoyopod-dev/checkout`.
+- Do not run dev and prod runtime services together; they share
+  hardware, audio, and the PID file contract.
+- `target mode activate dev|prod` is the supported way to clean up
+  unrelated `yoyopod-*` processes that may still own hardware.
+- Do not mutate prod release directories in place; publish a new version
+  and flip `current` (blocked until Round 3 of the CLI rebuild).
+- Do not trust dev native build dirs after large branch switches; pass
+  `--clean-native` to `yoyopod target deploy` to wipe LVGL CMake caches.
+- Do not delete `/opt/yoyopod-prod/previous` before a normal prod
+  update; it is the rollback target.
+- Do not assume old `~/yoyopod-core` is the dev lane. The dev lane
+  checkout is `/opt/yoyopod-dev/checkout`.
 
 ## Prod OTA Guard
 

--- a/docs/operations/OTA_ROADMAP.md
+++ b/docs/operations/OTA_ROADMAP.md
@@ -1,49 +1,38 @@
 # OTA Roadmap
 
-The slot-deploy foundation (`docs/operations/SLOT_DEPLOY.md`) is designed so a future
-OTA daemon can be added without changing any of the core deploy pieces.
-This doc lists the exact extension points.
+The slot-deploy foundation was originally designed so a future OTA
+daemon could be added without changing the core deploy pieces. As of
+2026-05-13, slot-deploy itself is paused while the CLI is rebuilt in
+Rust; see
+[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md). Round 3 restores the
+slot pipeline. The OTA work below sits on top of Round 3.
 
-## What is already OTA-shaped
+## Recommended build order for OTA (once Round 3 lands)
 
-- **Manifest schema** (`yoyopod_cli/release_manifest.py`): already has
-  `signature`, `channel`, `requires`, and diff-artifact fields. When OTA
-  signing goes live, only the signing and verification paths change —
-  the schema is stable.
-- **Atomic slot flip**: `yoyopod_cli/atomic_symlink.py` + `rollback.sh`
-  are the only state-mutating primitives. An OTA daemon calls the same
-  primitives after downloading an artifact.
-- **Rollback on failure**: `yoyopod-prod.service` has `OnFailure=`
-  pointing at `yoyopod-prod-rollback.service`. An OTA-applied update that
-  crash-loops triggers rollback without daemon involvement.
-- **Health probes**: `yoyopod health preflight` + `yoyopod health live`
-  are the same entry points the deploy CLI uses.
-
-## What is NOT yet built
-
-- **Update checker**: a systemd timer that polls an HTTPS manifest URL,
-  diffs against the current version, and downloads when a match is found.
-- **Signature verification**: manifest signing + on-device public-key
-  verification before applying.
-- **Diff patch application**: the manifest's `diff` artifact type is
-  defined but the `zstd --patch-from` apply path isn't wired.
-- **Per-device channel rollout**: server-side gating (canary 10% → 50%
-  → 100%) based on device ID hashes.
-
-## Recommended build order for OTA
-
-1. **Manifest signing** — minisign/ed25519, CI-only signing key. Add
-   `verify_manifest(path, pubkey)` to `release_manifest.py`.
-2. **Static OTA bucket** — Cloudflare R2 / S3. Upload `manifest.json`
+1. **Manifest schema** — re-introduce a release-manifest type in Rust
+   (the Python equivalent shipped under `yoyopod_cli/release_manifest.py`
+   and was deleted in Round 0). The schema should keep `signature`,
+   `channel`, `requires`, and diff-artifact fields ready.
+2. **Atomic slot flip + rollback** — re-port the atomic symlink primitive
+   into the new Rust slot tooling. `yoyopod-prod.service`'s
+   `OnFailure=yoyopod-prod-rollback.service` wiring is preserved and
+   already triggers rollback when a flipped slot crash-loops.
+3. **Health probes** — `yoyopod target health preflight` and
+   `... health live` (also in Round 3) are the entry points the OTA
+   daemon will share with the CLI.
+4. **Manifest signing** — minisign/ed25519, CI-only signing key. Verify
+   on device before applying.
+5. **Static OTA bucket** — Cloudflare R2 / S3. Upload `manifest.json`
    + release tarballs + diff patches on every CI release tag.
-3. **`yoyopod ota check` command** — fetches the manifest, compares
+6. **`yoyopod ota check` command** — fetches the manifest, compares
    versions, prints the update. No side effects yet.
-4. **`yoyopod ota apply`** — downloads, verifies signature, runs
-   preflight, flips symlinks. Reuses `atomic_symlink`.
-5. **systemd timer** — runs `yoyopod ota check && yoyopod ota apply`
+7. **`yoyopod ota apply`** — downloads, verifies signature, runs
+   preflight, flips symlinks.
+8. **systemd timer** — runs `yoyopod ota check && yoyopod ota apply`
    every 6 h on the stable channel.
-6. **Diff patches** — cut tarball size by 10–50× for small changes.
-7. **Channel rollout** — server-side manifest variants + a device-ID
-   hash check on the client.
+9. **Diff patches** — cut tarball size by 10–50× for small changes.
+10. **Channel rollout** — server-side manifest variants + a device-ID
+    hash check on the client.
 
-See `docs/operations/SLOT_DEPLOY.md` for the current ops flow.
+See [`SLOT_DEPLOY.md`](SLOT_DEPLOY.md) for the ops flow as it stood
+before the rebuild; that doc is being updated alongside Round 3.

--- a/docs/operations/PI_DEV_WORKFLOW.md
+++ b/docs/operations/PI_DEV_WORKFLOW.md
@@ -2,64 +2,64 @@
 
 This guide covers the normal dev-machine-to-board loop for YoYoPod.
 
-If the board is already on the slot-deploy path, read
-[`docs/operations/DEV_PROD_LANES.md`](DEV_PROD_LANES.md) and
-[`docs/operations/SLOT_DEPLOY.md`](SLOT_DEPLOY.md) alongside this file. Those documents
-cover fresh-board bootstrap, migration from `~/yoyopod-core`, rollback, and the
-operator-facing release flow under `/opt/yoyopod-prod`.
+For fresh-board bootstrap, lane structure, and rollback, read:
+
+- [`DEV_PROD_LANES.md`](DEV_PROD_LANES.md)
+- [`SLOT_DEPLOY.md`](SLOT_DEPLOY.md) (paused; pointer to Round 3 work)
+- [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md) for what's broken
+  during the CLI rebuild
 
 The default contract is:
 
 1. finish the implementation locally
 2. commit the intended changes
-3. push the branch
-4. validate that committed branch and exact SHA on the Pi
-5. leave the app running for manual hardware testing
+3. push the branch (CI must complete the `rust-device-arm64` build for
+   the exact commit)
+4. deploy that committed branch / commit SHA to the Pi via the Rust CLI
+5. verify the runtime started cleanly and exercise the change
 
-Dirty-tree sync still exists, but only as a rare debugging override.
+Dirty-tree deploys are not supported by `yoyopod target deploy`. The
+CI-artifact contract requires a pushed commit so the matching
+`yoyopod-rust-device-arm64-<sha>` bundle can be downloaded.
 
-Terminology in this guide is intentional:
+Terminology:
 
-- `remote sync` updates the **dev lane** checkout and restarts `yoyopod-dev.service`.
-- `remote release ...` updates the **prod lane** slot tree under `/opt/yoyopod-prod`.
-- `remote mode status` should be checked before lane flips or hardware debugging.
+- `yoyopod target deploy` updates the **dev lane** checkout and
+  installs the CI-built worker binaries.
+- `yoyopod target restart` restarts `yoyopod-dev.service` and verifies
+  startup.
+- `yoyopod target mode status` should be checked before lane flips or
+  hardware debugging.
 
 ## Stable Board Checkout
 
-The Raspberry Pi should reuse one stable dev checkout path, configured by
+The Raspberry Pi reuses one stable dev checkout path, configured by
 `project_dir` in `deploy/pi-deploy.yaml`. The tracked default is
 `/opt/yoyopod-dev/checkout`.
 
-Exception: `yoyopod remote release ...` no longer needs that checkout after the
-board has been bootstrapped for slot deploy. The checkout is still required for
-the dev-lane `remote sync`, `remote validate`, and `remote setup` flows
-described in this guide, but those flows use the checkout-local `.venv`
-directly and do not require `uv` to be installed on the Pi.
+Why one stable path:
 
-Why this is the default:
-
-- Python environment refreshes are expensive on Pi Zero hardware
-- native LVGL and Liblinphone rebuilds can be expensive
+- the systemd unit, logs, PID file, and CLI shell builders all expect
+  it
+- native LVGL rebuilds are expensive
 - repeated fresh copies waste time
-- the service unit, logs, PID file, and restart flow all assume one stable path
 
-Do not normalize ad hoc per-branch checkout directories on the board.
+Do not normalise ad-hoc per-branch checkout directories on the board.
 
 ## Setup
 
-Make sure your dev machine can SSH into the Raspberry Pi with an alias or reachable host name.
+Make sure your dev machine can SSH into the Raspberry Pi with an alias
+or reachable hostname.
 
-Before the first `yoyopod remote validate`, verify the host prerequisites that the remote workflow depends on:
-
-```bash
-uv run yoyopod setup verify-host --with-remote-tools
-```
-
-If you also use GitHub CLI helpers for branch or PR work, verify that separately:
+Install the Rust CLI on the dev machine:
 
 ```bash
-uv run yoyopod setup verify-host --with-github
+cargo build --manifest-path cli/Cargo.toml --release
+cargo install --path cli/yoyopod
 ```
+
+`gh` (GitHub CLI) must be authenticated (`gh auth status`) for
+`yoyopod target deploy` to pull CI artifacts.
 
 The repo-tracked deploy contract lives in `deploy/pi-deploy.yaml`.
 
@@ -69,19 +69,13 @@ The repo-tracked deploy contract lives in `deploy/pi-deploy.yaml`.
 - create or update that file with:
 
 ```bash
-yoyopod remote config edit
+yoyopod target config edit
 ```
 
-Bootstrap and verify the target with flags that match the hardware and feature paths you actually expect:
-
-```bash
-uv run yoyopod remote setup --with-pisugar
-uv run yoyopod remote verify-setup --with-pisugar
-```
-
-Add `--with-voice` and/or `--with-network` when the target needs the TTS or modem paths. `--with-pisugar` is the normal Whisplay and PiSugar path because it pulls in the `pisugar-server` package and service check.
-`remote setup` now bootstraps the board checkout with `python3 -m venv` and
-`pip install -e '.[dev]'`, so the Pi no longer needs a separate `uv` install.
+Pi-side setup (system packages, lane directories, systemd units) is
+manual until the CLI rebuild restores `yoyopod target setup`; see
+[`SETUP_CONTRACT.md`](SETUP_CONTRACT.md) and
+[`DEV_PROD_LANES.md`](DEV_PROD_LANES.md).
 
 Examples:
 
@@ -94,331 +88,95 @@ Optional environment defaults:
 
 ```bash
 export YOYOPOD_PI_HOST=rpi-zero
+export YOYOPOD_PI_USER=tifo
 export YOYOPOD_PI_PROJECT_DIR=/opt/yoyopod-dev/checkout
 ```
 
-On Windows PowerShell:
+The CLI reads these as fallbacks for the `--host`, `--user`, and
+`--project-dir` flags.
 
-```powershell
-$env:YOYOPOD_PI_HOST="rpi-zero"
-$env:YOYOPOD_PI_PROJECT_DIR="/opt/yoyopod-dev/checkout"
-```
-
-If your actual deployed board uses a different stable checkout path, set that in
-your local override instead of assuming the repo default.
-
-## Default Validate-On-Board Flow
-
-Use this when validating a feature branch or PR on target hardware.
-
-1. Confirm the local tree is committed:
-   ```bash
-   git status --short
-   ```
-2. Resolve the branch and exact commit:
-   ```bash
-   git branch --show-current
-   git rev-parse HEAD
-   ```
-3. Push the branch:
-   ```bash
-   git push
-   ```
-   If the branch has no upstream yet:
-   ```bash
-   git push -u origin <branch>
-   ```
-   If `github.com` is briefly unreachable, do not treat one short network error
-   as a definitive failure. Retry the push a few times before escalating.
-4. Run the repo-owned hardware validation flow:
-   ```bash
-   yoyopod remote validate --branch <branch> --sha <commit>
-   ```
-
-If you are switching across branches that touch native LVGL
-sources, clean mutable native CMake caches before the dev restart:
+## Daily loop
 
 ```bash
-yoyopod remote sync --branch <branch> --clean-native
+# 1. Confirm lane state.
+yoyopod target mode status
+yoyopod target mode activate dev          # if needed
+
+# 2. Commit + push the change you want on hardware.
+git add -p && git commit -m '…'
+git push
+
+# 3. Deploy. The CLI pushes if needed, finds the CI artifact, syncs the
+#    Pi, installs the worker binaries, restarts and verifies startup.
+yoyopod target deploy --branch <branch>   # or --sha <commit>
+
+# 4. Manual eyes-on verification.
+yoyopod target status
+yoyopod target logs --follow
 ```
 
-If `yoyopod remote mode status` reports `active_lane=conflict`, resolve the
-listed legacy/manual owner before trusting audio, display, or VoIP behavior.
+Add `--wait-for-ci` when CI is still queued or in-progress (timeout 30
+minutes).
 
-Useful variations:
+Add `--clean-native` after native LVGL / CMake input changes so the
+Pi-side build dir gets wiped.
+
+## Inspection commands
 
 ```bash
-yoyopod remote validate --branch <branch> --sha <commit> --with-voip
-yoyopod remote validate --branch <branch> --sha <commit> --with-navigation
-yoyopod remote validate --branch <branch> --sha <commit> --with-lvgl-soak
+yoyopod target status                     # git SHA + processes + log tail
+yoyopod target logs --lines 200
+yoyopod target logs --errors
+yoyopod target logs --filter ERROR
+yoyopod target logs --follow --filter comm
+yoyopod target screenshot                 # captures Pi display to logs/screenshots/
+yoyopod target screenshot --readback      # LVGL readback path
+yoyopod target restart                    # systemd restart + startup verify
 ```
 
-`yoyopod remote validate` does all of this:
+## Validation gap
 
-1. stops if the local worktree is dirty
-2. verifies the requested branch is pushed
-3. syncs the stable Pi checkout to the branch and exact SHA
-4. uses the checkout-local `.venv/bin/python` to run the Pi-side validation commands
-5. runs `yoyopod pi validate deploy`
-6. runs the requested target-side validation checks
-7. restarts the app
-8. verifies startup with the PID file and startup marker
-9. prints the latest startup marker and recent logs
-10. leaves the app running for manual testing
-
-## Lower-Level Commands
-
-### Check remote status
+Automated on-Pi validation (`yoyopod target validate`) is a Round 1
+stub that returns exit 2. Until Round 2 of the CLI rebuild lands,
+validate manually after deploy:
 
 ```bash
-yoyopod remote status
+yoyopod target status
+yoyopod target logs --follow
+ssh <user>@<host> 'journalctl -u yoyopod-dev.service -f'
 ```
 
-Shows:
+Exercise the changed surface on the device with human eyes and report
+the result.
 
-- remote branch or `DETACHED`
-- remote commit
-- dirty working tree state on the Pi checkout
-- music backend process state
-- tracked PID file state
-- latest startup marker from the file log
-- top memory processes
+## Troubleshooting
 
-### Sync committed code without launching the app
+If `target deploy` fails:
 
 ```bash
-yoyopod remote sync --branch <branch>
-yoyopod remote sync --branch <branch> --sha <commit>
+yoyopod target logs --lines 200 --errors
+yoyopod target status
+ssh <user>@<host> 'systemctl status yoyopod-dev.service --no-pager -l'
 ```
 
-Use this when you want the stable checkout updated but do not want the full validate flow yet.
+Common causes:
 
-### Rust Runtime Dev-Lane Entry Point
+- `gh` not authenticated → run `gh auth login`
+- CI run for that commit still in-progress → use `--wait-for-ci`, or
+  wait and rerun
+- CI run failed → fix the underlying problem; don't try to deploy a
+  broken commit
+- prod lane active → `yoyopod target mode activate dev` first
+- Pi checkout owned by wrong user → check ownership of
+  `/opt/yoyopod-dev/checkout`
 
-The Rust runtime is the target long-running dev service. The systemd unit still
-has a Python fallback for compatibility, so make the active owner explicit when
-testing the Rust path:
+## Related Docs
 
-```ini
-Environment=```
-
-With that override, `yoyopod-dev.service` executes:
-
-```bash
-/opt/yoyopod-dev/checkout/device/runtime/build/yoyopod-runtime \
-  --config-dir /opt/yoyopod-dev/checkout/config \
-  --hardware whisplay
-```
-
-Use committed GitHub Actions artifacts for the exact commit under test. Install
-`yoyopod-rust-device-arm64-<sha>` into the dev checkout before restarting the
-service. Do not build Rust binaries on the Pi Zero 2W unless the user
-explicitly overrides that rule.
-
-### Run validation
-
-```bash
-yoyopod remote validate --branch <branch> --sha <commit>
-yoyopod remote validate --branch <branch> --sha <commit> --with-voip
-yoyopod remote validate --branch <branch> --sha <commit> --with-navigation
-yoyopod remote validate --branch <branch> --sha <commit> --with-lvgl-soak
-```
-
-This composes the target-side suite:
-
-- `yoyopod pi validate smoke`
-- `yoyopod pi validate voip`
-- `yoyopod pi validate navigation`
-- `yoyopod pi validate stability`
-
-### Restart the already-synced app
-
-```bash
-yoyopod remote restart
-```
-
-This waits for the startup marker and matching PID before returning success.
-
-### Structured file logs
-
-```bash
-yoyopod remote logs --lines 200
-yoyopod remote logs --errors
-yoyopod remote logs --filter comm
-yoyopod remote logs --filter coord
-yoyopod remote logs --follow --filter ERROR
-```
-
-This tails the file sinks declared in `deploy/pi-deploy.yaml`, which is the stable Pi contract for:
-
-- `<project-dir>/logs/yoyopod.log`
-- `<project-dir>/logs/yoyopod_errors.log`
-- `/opt/yoyopod-dev/state/yoyopod.pid`
-
-For keep-alive freeze triage, watch the `comm` and `coord` lines together:
-
-- `VoIP timing window`: rolling summary of keep-alive schedule delay, iterate duration, and the worst loop gap in that window
-- `VoIP iterate timing drift`: one-off warning when a keep-alive step ran late or took unusually long
-- `Runtime loop blocked`: one-off warning when some other coordinator work starved the loop enough to threaten VoIP cadence
-
-### Freeze investigation
-
-When the app looks stuck during idle navigation, use the screenshot signal path as the first
-evidence trigger:
-
-```bash
-yoyopod remote logs --follow --filter ERROR
-yoyopod remote screenshot --readback
-```
-
-What to expect:
-
-- `yoyopod remote screenshot --readback` sends `SIGUSR1` to the app.
-- `SIGUSR1` now does two things:
-  - appends an all-thread traceback dump to `logs/yoyopod_errors.log`
-  - logs a structured runtime snapshot before trying the queued screenshot capture
-- recent runtime logs also expose VoIP keep-alive timing in three layers:
-  - `VoIP keep-alive native iterate slow` means the Liblinphone keep-alive call itself blocked
-  - `VoIP iterate timing drift` means the coordinator reached keep-alive late or the full iterate pass ran long
-  - `Coordinator blocking span` points at nearby coordinator work that may have delayed keep-alives
-- the periodic `VoIP timing window` summary rolls those samples up for hardware runs without logging every 20 ms iterate
-- if the main loop is still healthy enough, you also get the PNG
-- if the main loop is wedged and the PNG never appears, the error log is still the first place to inspect
-
-For shadow-buffer comparison, use:
-
-```bash
-yoyopod remote screenshot
-```
-
-That uses `SIGUSR2`, which captures the same traceback + runtime evidence but prefers the legacy
-shadow-first screenshot path.
-
-### Automatic responsiveness watchdog
-
-For validation runs where you want the app to capture evidence on its own, enable the
-opt-in responsiveness watchdog in `config/app/core.yaml` or via env vars:
-
-```yaml
-diagnostics:
-  responsiveness_watchdog_enabled: true
-  responsiveness_stall_threshold_seconds: 5.0
-```
-
-What it does:
-
-- watches `loop_heartbeat_age_seconds` in the running app status
-- captures one evidence bundle when the coordinator loop stops advancing past the threshold
-- writes:
-  - `logs/responsiveness/<timestamp>-<reason>.json`
-  - `logs/responsiveness/<timestamp>-<reason>.traceback.txt`
-- logs one summary line to `logs/yoyopod_errors.log` pointing at those artifacts
-
-How to interpret the extra status markers in the JSON bundle:
-
-- `input_activity_age_seconds`: raw or semantic input activity seen by the input side
-- `handled_input_activity_age_seconds`: last input activity the coordinator actually drained
-- `last_input_action` / `last_handled_input_action`: the latest action names on each side
-
-If `input_activity_age_seconds` is fresh but `handled_input_activity_age_seconds` is stale, the
-input side is still alive and the stall is likely between input delivery and the coordinator/UI
-thread. If both are stale and `loop_heartbeat_age_seconds` is also stale, treat it as a broader
-runtime stall.
-
-### Lane systemd services
-
-```bash
-yoyopod remote mode status
-yoyopod remote mode activate dev
-yoyopod remote mode activate prod
-```
-
-Use `yoyopod-dev.service` for mutable hardware testing and
-`yoyopod-prod.service` for packaged slot releases. Manage lane ownership through
-`yoyopod remote mode ...`.
-
-### PiSugar helpers
-
-```bash
-yoyopod remote rtc status
-yoyopod remote power
-```
-
-## Preflight
-
-`yoyopod remote preflight` is still useful, but it is a preparation step, not the full hardware-validation finish line.
-
-```bash
-yoyopod remote preflight --branch <branch>
-```
-
-What it does:
-
-1. runs local `compileall`
-2. runs local Python quality checks when requested by the workflow
-3. syncs the chosen branch to the Raspberry Pi
-4. runs the Raspberry Pi smoke pass
-
-Use it before `yoyopod remote validate` when you want a broader sanity pass. It
-is not the Rust artifact contract and does not replace exact-SHA CI artifacts
-for `yoyopod-runtime` or Rust workers.
-
-## Dirty-Tree Escape Hatch
-
-`yoyopod remote sync` is a debugging escape hatch and is not the normal validation path.
-
-Use it only when:
-
-- the user explicitly wants to validate uncommitted local changes
-- you are doing a one-off debugging session and have called out that the Pi is not running committed code
-
-Commands:
-
-```bash
-yoyopod remote sync
-yoyopod remote sync --skip-restart
-```
-
-If you use it, say clearly that the board is running a dirty-tree override instead of the committed branch/SHA flow.
-
-## Suggested Daily Loop
-
-1. Run focused local Rust checks as needed:
-   ```bash
-   cargo check --manifest-path device/Cargo.toml -p yoyopod-runtime --locked
-   cargo check --manifest-path device/Cargo.toml -p yoyopod-ui --locked
-   ```
-2. Commit the intended change.
-3. Push the branch.
-4. Resolve the exact commit:
-   ```bash
-   git rev-parse HEAD
-   ```
-5. Validate on the Pi:
-   ```bash
-   yoyopod remote validate --branch <branch> --sha <commit> --with-rust-ui-host --with-lvgl-soak
-   ```
-6. Manually test on the target hardware while the app remains running.
-
-When you are chasing idle freezes or routed-screen hangs, add the deterministic soak:
-
-```bash
-yoyopod remote validate --branch <branch> --sha <commit> --with-navigation
-```
-
-## Release / Pre-Merge Checklist
-
-- local Rust checks relevant to the changed crates pass
-- branch is pushed and reviewed
-- exact-SHA Rust artifacts are installed when testing the Rust runtime owner
-- `yoyopod remote validate --branch <branch> --sha <commit> --with-voip --with-lvgl-soak` passes
-- if you touched idle navigation, `yoyopod remote validate --branch <branch> --sha <commit> --with-navigation` passes
-- the selected runtime owner starts cleanly and stays running for manual hardware testing
-- manual sanity still passes for display, input, music, SIP registration, and call flow
-
-## Notes
-
-- `yoyopod remote validate` is the default board-validation contract for branches and PRs.
-- `yoyopod remote preflight` is intentionally non-launching.
-- `yoyopod remote sync` used as a dirty-tree override is a debugging escape hatch, not the normal deploy story.
-- For deeper hardware debugging, use `docs/operations/RPI_SMOKE_VALIDATION.md`.
+- [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md) for the rebuild
+  roadmap
+- [`DEV_PROD_LANES.md`](DEV_PROD_LANES.md) for lane structure
+- [`SLOT_DEPLOY.md`](SLOT_DEPLOY.md) for the (paused) prod slot flow
+- [`SETUP_CONTRACT.md`](SETUP_CONTRACT.md) for system dependencies
+- [`QUALITY_GATES.md`](QUALITY_GATES.md) for what passes for
+  verification today
+- `rules/deploy.md` for the policy that backs all of the above

--- a/docs/operations/PI_PROFILING_WORKFLOW.md
+++ b/docs/operations/PI_PROFILING_WORKFLOW.md
@@ -1,57 +1,84 @@
 # Raspberry Pi Profiling Workflow
 
-This guide is the repo-owned profiling path for YoYoPod performance and
-runtime investigations.
+**Status: in transition.**
 
-Use it when you want to answer questions like:
+The Python profiling helpers (`yoyopod dev profile …`,
+`yoyopod build voice-worker`, `yoyopod remote validate`,
+`yoyopod remote sync`) were deleted in Round 0 of the CLI rebuild.
+Hardware profiling now uses native Rust tools directly. See
+[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
+
+## When to profile
+
+Use this workflow when you want to answer:
 
 - did the branch make startup slower?
-- is the coordinator loop spending more time in one phase?
+- is the runtime spending more time in one worker?
 - is the Pi staying responsive during music, VoIP, and navigation soaks?
-- is memory growth coming from Python code or a native dependency?
+- is memory growth coming from a specific worker or a native dependency?
 
-For the Raspberry Pi Zero 2 W, treat target-hardware results as the source of
-truth. Desktop simulation is still useful, but it is a fast triage step, not
-proof that the Pi will behave the same way.
+The Pi Zero 2 W is the source of truth. Desktop simulation is useful as
+a fast triage, not as proof that the Pi will behave the same way.
 
-## Runtime Hybrid Phase 0 Baseline
-
-Use this workflow before moving voice and network work into sidecar workers.
-The goal is to capture responsiveness and PSS/RSS with the current
-single-supervisor runtime so Phase 2/3 changes can be compared against a real
-target-hardware baseline.
-
-Enable responsiveness captures for the dev-lane run in the Pi service/runtime
-environment. These exports are examples of the values the service must see;
-running them only in the local shell before `yoyopod remote sync` does not
-guarantee they will be present in the systemd service environment. Apply the
-same values through the Pi runtime environment or config used by the dev-lane
-service:
+## Deploy + capture loop
 
 ```bash
-export YOYOPOD_RESPONSIVENESS_WATCHDOG_ENABLED=true
-export YOYOPOD_RESPONSIVENESS_STALL_THRESHOLD_SECONDS=5
-export YOYOPOD_RESPONSIVENESS_RECENT_INPUT_WINDOW_SECONDS=3
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>           # or --sha <commit>
+yoyopod target status
+yoyopod target logs --follow                      # leave running during soak
 ```
 
-Deploy and confirm the dev lane:
+After the run, snapshot logs:
 
 ```bash
-yoyopod remote mode activate dev
-yoyopod remote sync --branch <branch>
-yoyopod remote status
+yoyopod target logs --lines 500
+yoyopod target status
 ```
 
-Capture recent logs and a status snapshot after the exercise:
+## Responsiveness watchdog env vars
 
-```bash
-yoyopod remote logs --lines 200
-yoyopod remote status
+The runtime exports responsiveness diagnostics when these env vars are
+set in the dev service environment (e.g. via `/etc/default/yoyopod-dev`):
+
+```
+YOYOPOD_RESPONSIVENESS_WATCHDOG_ENABLED=true
+YOYOPOD_RESPONSIVENESS_STALL_THRESHOLD_SECONDS=5
+YOYOPOD_RESPONSIVENESS_RECENT_INPUT_WINDOW_SECONDS=3
 ```
 
-Record these fields from logs, status output, and any generated responsiveness
-captures. Keep null or missing values in the baseline notes too, because some
-fields may be absent until enough samples or captures exist:
+Setting them in the local shell before `yoyopod target deploy` does NOT
+propagate to the systemd-managed runtime. Either edit the service's
+`EnvironmentFile=` target on the Pi, or fold them into
+`config/app/core.yaml`:
+
+```yaml
+diagnostics:
+  responsiveness_watchdog_enabled: true
+  responsiveness_stall_threshold_seconds: 5.0
+```
+
+That captures evidence bundles under `logs/responsiveness/` when the
+loop stops advancing.
+
+## Pre-worker baseline
+
+Use this workflow before any architectural change that moves work
+between workers. The goal is to capture responsiveness and PSS/RSS with
+the current single-supervisor runtime so changes can be compared
+against a real target-hardware baseline.
+
+After deploy, run a one-hour mixed soak covering:
+
+- idle screen wake/sleep
+- music navigation and playback
+- incoming or simulated VoIP state changes
+- voice command path with current local settings
+- cellular/network reconnect or status polling
+- low-risk power/status screen navigation
+
+Record these fields from log output and any responsiveness evidence
+bundles. Keep null or missing values too:
 
 - `responsiveness_input_to_action_p95_ms`
 - `responsiveness_action_to_visible_p95_ms`
@@ -63,234 +90,89 @@ fields may be absent until enough samples or captures exist:
 - `process_memory_pss_kb`
 - `workers`
 
-Run a one-hour mixed soak that covers:
+The baseline is not pass/fail. Use it to identify the top stalls and
+memory pressure, then keep the raw notes with the branch or release
+artifacts they describe.
 
-- idle screen wake/sleep
-- music navigation and playback
-- incoming or simulated VoIP state changes
-- voice command path with current local settings
-- cellular/network reconnect or status polling
-- low-risk power/status screen navigation
+## Cloud voice measurement
 
-The pre-worker baseline is not pass/fail. Use it to identify the top stalls
-and memory pressure before Phase 2/3, then keep the raw notes with the branch
-or release artifacts they describe.
+When measuring cloud voice changes:
 
-## Runtime Hybrid Phase 2 Cloud Voice Measurement
+1. Deploy the change as usual via `yoyopod target deploy`.
+2. Capture status and process memory for each scenario:
+   - voice disabled
+   - cloud voice configured and one transcription attempted
+   - voice worker idle with mock provider
+   - voice worker cloud STT request
+   - voice worker cloud TTS request
+   - provider unavailable or missing credentials
+   - worker crash and supervisor restart
+3. Fields to record:
+   - supervisor PSS/RSS
+   - voice worker PSS/RSS
+   - total process tree PSS/RSS
+   - `responsiveness_input_to_action_p95_ms`
+   - `responsiveness_action_to_visible_p95_ms`
+   - `runtime_main_thread_drain_seconds`
+   - voice worker pending requests
+   - voice worker restart count
+   - protocol errors and dropped messages
 
-Use this after the Go cloud voice worker is wired behind the feature flag.
+Cloud voice mode is acceptable only if STT/TTS requests avoid UI-loop
+stalls and total PSS stays within the Pi Zero 2W service budget.
 
-### Build and deploy
+## Native profiling tools
 
-```bash
-uv run yoyopod build voice-worker
-yoyopod remote mode activate dev
-yoyopod remote sync --branch <branch>
-```
+For Rust runtime / worker profiling on the Pi:
 
-### Required scenarios
+- `perf` (system profile) — `perf record -g -p $(pgrep yoyopod-runtime)`
+- `cargo flamegraph` — install via `cargo install flamegraph` on the
+  dev machine; produce flamegraphs from `perf` data captured on the Pi
+- `samply` — modern flamegraph-friendly profiler
+- `heaptrack` / `valgrind --tool=massif` — for memory growth questions
+- `journalctl -u yoyopod-dev.service -o json` — structured runtime
+  events
+- `top -p $(pgrep yoyopod-runtime)` / `pidstat` — quick CPU and memory
+  baseline
 
-Capture status and process memory for each scenario:
+Capture data on the Pi, copy it to the dev machine, and post-process
+locally.
 
-- voice disabled
-- cloud voice configured and one transcription attempted
-- Go voice worker idle with mock provider
-- Go voice worker cloud STT request
-- Go voice worker cloud TTS request
-- provider unavailable or missing credentials
-- worker crash and supervisor restart
+### perf examples
 
-### Fields to record
-
-- supervisor PSS/RSS
-- voice worker PSS/RSS
-- total process tree PSS/RSS
-- `responsiveness_input_to_action_p95_ms`
-- `responsiveness_action_to_visible_p95_ms`
-- `runtime_main_thread_drain_seconds`
-- voice worker pending requests
-- voice worker restart count
-- protocol errors and dropped messages
-
-### Acceptance target
-
-Cloud voice mode is acceptable only if STT/TTS requests avoid UI-loop stalls
-and total PSS stays within the Pi Zero 2W service budget.
-
-## 1. Install the profiling tools
-
-The repo now tracks the common Python-side tools in the `dev` extra:
+For a live runtime process:
 
 ```bash
-uv sync --extra dev
-uv run yoyopod dev profile tools
+ssh <user>@<host>
+perf stat -p "$(pgrep yoyopod-runtime)" -I 1000
 ```
 
-That gives you:
-
-- `pyinstrument` for quick sampled call-stack reports
-- `pyperf` for repeatable benchmark runs and branch-to-branch comparisons
-- `py-spy` for low-overhead sampling, especially on the Pi
-
-The Linux `perf` tool is still a system package, not a Python dependency.
-
-## 2. Start with the repo's own target diagnostics
-
-Before reaching for external profilers, run the normal target validation flow.
-YoYoPod already emits the most important coordinator-loop timing signals:
-
-- `Runtime loop blocked`
-- `Coordinator blocking span`
-- `Runtime iteration slow`
-- `VoIP iterate timing drift`
-- `VoIP timing window`
-
-Recommended flow:
-
-```bash
-git branch --show-current
-git rev-parse HEAD
-yoyopod remote validate --branch <branch> --sha <commit> --with-voip --with-navigation
-yoyopod remote logs --follow --filter coord
-yoyopod remote logs --follow --filter comm
-```
-
-For longer Pi soaks, consider enabling the responsiveness watchdog in
-`config/app/core.yaml`:
-
-```yaml
-diagnostics:
-  responsiveness_watchdog_enabled: true
-  responsiveness_stall_threshold_seconds: 5.0
-```
-
-That captures evidence bundles under `logs/responsiveness/` when the loop
-stops advancing.
-
-## 3. Use bounded local targets for branch-to-branch comparisons
-
-The repo ships a bounded helper script plus `yoyopod dev profile` wrappers so
-you can benchmark startup and loop behavior without manually stopping the app.
-
-List the targets:
-
-```bash
-uv run yoyopod dev profile targets
-```
-
-Current targets:
-
-- `scaffold-loop`: lightweight event-bus and scheduler loop without full boot
-- `simulate-bootstrap`: full simulated app setup + teardown once
-- `simulate-loop`: simulated boot plus bounded coordinator-loop iterations
-
-### Quick startup triage with `cProfile`
-
-```bash
-uv run yoyopod dev profile cprofile --target simulate-bootstrap
-uv run yoyopod dev profile cprofile --target simulate-loop --iterations 300
-```
-
-Artifacts land under `logs/profiles/` by default, and the command also prints a
-top-functions summary.
-
-### Fast call-stack report with `pyinstrument`
-
-```bash
-uv run yoyopod dev profile pyinstrument --target simulate-bootstrap
-uv run yoyopod dev profile pyinstrument --target simulate-loop --iterations 300 --html
-```
-
-Use `--html` when you want the navigable report.
-
-### Repeatable benchmark runs with `pyperf`
-
-```bash
-uv run yoyopod dev profile pyperf --target scaffold-loop --fast
-uv run yoyopod dev profile pyperf --target simulate-bootstrap --output logs/profiles/bootstrap.json
-uv run yoyopod dev profile pyperf --target simulate-loop --iterations 300 --track-memory
-```
-
-Compare saved runs with:
-
-```bash
-uv run python -m pyperf compare_to logs/profiles/baseline.json logs/profiles/changed.json --table
-```
-
-If results look noisy on Linux, use:
-
-```bash
-uv run python -m pyperf system tune
-```
-
-Only do that on machines where changing benchmark-related system settings is
-acceptable.
-
-## 4. Profile the running Pi with `py-spy` when logs point at CPU hotspots
-
-After `yoyopod remote validate` leaves the app running on the board:
-
-```bash
-ssh <pi-host>
-cd ~/yoyopod-core
-source .venv/bin/activate
-mkdir -p logs/profiles
-py-spy record -o logs/profiles/pyspy.svg --pid "$(cat /opt/yoyopod-dev/state/yoyopod.pid)"
-```
-
-Useful variants:
-
-```bash
-py-spy top --pid "$(cat /opt/yoyopod-dev/state/yoyopod.pid)"
-py-spy dump --pid "$(cat /opt/yoyopod-dev/state/yoyopod.pid)"
-py-spy record -o logs/profiles/pyspy-speedscope.json --format speedscope --pid "$(cat /opt/yoyopod-dev/state/yoyopod.pid)"
-```
-
-Notes:
-
-- attaching to a live process may require `sudo` or relaxed ptrace settings
-- use this after the repo's own coordinator and VoIP timing logs already point
-  at "something CPU-bound is wrong"
-- `py-spy` is especially useful when you want a flame graph without modifying
-  the running code
-
-## 5. Use Linux `perf` when native code or scheduler behavior looks suspicious
-
-`perf` matters here because YoYoPod crosses Python, mpv, Liblinphone, display
-drivers, and kernel scheduling.
-
-For a live process:
-
-```bash
-perf stat -p "$(cat /opt/yoyopod-dev/state/yoyopod.pid)" -I 1000
-```
-
-For a bounded Rust runtime run:
+For a bounded run (locally on the dev machine for triage):
 
 ```bash
 mkdir -p logs/profiles
 perf record -F 99 -g -o logs/profiles/perf-runtime.data \
-  device/runtime/build/yoyopod-runtime --config-dir config
+  device/target/release/yoyopod-runtime --config-dir config
 perf report -g -i logs/profiles/perf-runtime.data
 ```
 
-## 6. Use test timeouts for hangs, not performance regressions
+## Practical sequence
 
-Use it to get thread dumps when the suite stalls. Do not use it as a benchmark
-tool.
+When checking whether a change regressed the Pi:
 
-## 7. Practical sequence for this repo
+1. Run focused Rust build checks for the crates you changed
+   (`cargo check -p <crate>`).
+2. `yoyopod target deploy --branch <branch>` (always uses the CI
+   artifact).
+3. Watch `yoyopod target logs --follow --filter coord` and
+   `--filter comm` warnings first.
+4. If the Pi looks CPU-bound, attach `perf` or `samply` to the live
+   runtime PID.
+5. If memory looks suspect, use `pidstat -r` and capture PSS/RSS at
+   intervals.
+6. Report branch, exact commit SHA, CI artifact name, target hardware,
+   duration, tool used, and the raw data location.
 
-When you are checking whether an architecture change regressed the Pi, use this
-order:
-
-1. Run focused Rust build checks for the runtime/worker crates you changed.
-2. Install exact-SHA Rust artifacts when profiling the Rust owner.
-3. Run `yoyopod remote validate --branch <branch> --sha <commit> --with-voip --with-navigation`.
-4. Inspect `coord` and `comm` log warnings first.
-5. Compare `simulate-bootstrap` or `simulate-loop` with `yoyopod dev profile`.
-6. If the Pi still looks CPU-bound, attach `py-spy`.
-7. If the time is disappearing into native code or scheduling, use `perf`.
-
-That order keeps the cheapest and most repo-specific signals first, and only
-drops to heavier system profilers when the app's own diagnostics are not enough.
+That order keeps the cheapest and most repo-specific signals first, and
+only drops to heavier system profilers when the runtime's own
+diagnostics are not enough.

--- a/docs/operations/QUALITY_GATES.md
+++ b/docs/operations/QUALITY_GATES.md
@@ -1,12 +1,11 @@
 # Verification Policy
 
-The project is Rust-first for runtime work and no longer carries repo-local
-automated suites. Verification is split between build/lint/type checks and Raspberry Pi
-runtime validation.
+The project is Rust-only for runtime and CLI. Verification splits
+between Rust build/lint checks and Raspberry Pi runtime validation.
 
 ## Rust Build Checks
 
-Use focused Rust checks for the crate you changed:
+Use focused checks for the crate you changed:
 
 ```bash
 cargo check --manifest-path device/Cargo.toml -p yoyopod-runtime --locked
@@ -16,48 +15,59 @@ cargo check --manifest-path device/Cargo.toml -p yoyopod-voip --locked
 cargo check --manifest-path device/Cargo.toml -p yoyopod-network --locked
 ```
 
-For broad Rust workspace changes:
+For broad workspace changes:
 
 ```bash
 cargo check --manifest-path device/Cargo.toml --workspace --locked
 ```
 
-If native LVGL or Whisplay hardware features are involved, use the CI-built ARM
-artifact for the exact commit before claiming hardware parity.
+For CLI changes:
+
+```bash
+cargo check --manifest-path cli/Cargo.toml
+cargo test  --manifest-path cli/Cargo.toml
+cargo clippy --manifest-path cli/Cargo.toml --all-targets
+```
+
+If native LVGL or Whisplay hardware features are involved, use the
+CI-built ARM artifact for the exact commit before claiming hardware
+parity.
 
 ## Hardware Checks
 
-The Raspberry Pi is the real validation target for runtime ownership, display,
-button input, audio, SIP, modem, power, and LVGL behavior.
+The Raspberry Pi is the real validation target for the runtime,
+display, button input, audio, SIP, modem, power, and LVGL behaviour.
 
 Normal committed-code flow:
 
 ```bash
 git rev-parse HEAD
-yoyopod remote mode activate dev
-yoyopod remote validate --branch <branch> --sha <commit> --with-rust-ui-host --with-lvgl-soak
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>           # or --sha <commit>
 ```
 
-When testing `yoyopod-runtime`, install the exact-SHA Rust artifacts first. See
-`skills/yoyopod-rust-artifact/SKILL.md`.
-
-## Python Checks
-
-Python remains for CLI, deployment, and compatibility tooling. Use the repo
-quality gate for that surface:
+Automated on-Pi validation (`yoyopod target validate`) is a Round 1
+stub during the CLI rebuild. Until Round 2 restores it, validate
+manually after deploy:
 
 ```bash
-uv run --extra dev python scripts/quality.py gate
-python -m compileall yoyopod_cli scripts
+yoyopod target status
+yoyopod target logs --follow
+journalctl -u yoyopod-dev.service -f
 ```
+
+Exercise the changed surface on the device with human eyes.
+
+See [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
 
 ## Reporting
 
-Always report the checks that actually ran. For hardware validation, include:
+Always report the checks that actually ran. For hardware validation,
+include:
 
 - branch
 - exact commit SHA
 - artifact names and CI run ID
-- active runtime owner (`yoyopod-runtime`)
 - Pi command result
 - whether the dev service was left running
+- manual validation steps performed and their outcomes

--- a/docs/operations/RELEASE_PROCESS.md
+++ b/docs/operations/RELEASE_PROCESS.md
@@ -1,125 +1,54 @@
 # Release Process
 
-YoYoPod now uses one explicit release contract:
+**Status: paused as of 2026-05-13.**
 
-- package version source: `yoyopod/_version.py`
-- release tag format: `vMAJOR.MINOR.PATCH`
-- release artifacts: Python package distributions, full repo bundles, and an ARM64 slot tarball
-- release automation: `.github/workflows/release.yml`
+The Python release pipeline was deleted in Round 0 of the CLI rebuild
+([`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md)). New prod slot builds
+are blocked until Round 3 reintroduces the Rust slot builder, manifest
+schema, and preflight tooling. CI's `slot-arm64` and `release` jobs are
+disabled (`if: ${{ false }}`) until then.
 
-## Versioning
+## What still works
 
-YoYoPod uses semantic versioning:
+- Previously-shipped slots continue to run on the Pi.
+- Reinstalling a previously-shipped slot via SSH +
+  `deploy/scripts/install_release.sh` still works (preflight is a no-op
+  during the gap; see the `_preflight_slot()` comment in that file).
+- The dev lane (`yoyopod target deploy`) is unaffected and remains the
+  daily workflow for hardware testing.
 
-- `major` for breaking or externally visible contract changes
-- `minor` for backward-compatible feature releases
-- `patch` for backward-compatible fixes and polish
+## What does NOT work yet
 
-Check the current version:
+- `yoyopod release {current,bump,set-version,build}` — deleted; not yet
+  ported to Rust.
+- `scripts/build_release.py` — deleted.
+- `deploy/docker/slot-builder.Dockerfile` — deprecated stub.
+- `yoyopod target release {push, install-url, status, rollback,
+  build-pi}` — not in the Round 1 MVP; returns in Round 3.
 
-```bash
-uv run yoyopod release current
-```
+## Round 3 sketch
 
-Bump the version source:
+Round 3 reintroduces:
 
-```bash
-uv run yoyopod release bump patch
-uv run yoyopod release bump minor
-uv run yoyopod release bump major
-```
+1. A Rust manifest type that mirrors the previous `release_manifest`
+   schema (version, channel, artifacts, signatures, requires).
+2. A Rust slot-contract module replacing the previous `slot_contract`
+   (required dirs, runtime files, config files).
+3. A Rust slot builder (replacing `scripts/build_release.py`) that
+   produces the same `app/`, `bin/`, `config/`, `venv/`,
+   `manifest.json`, and embedded native shims layout.
+4. A `yoyopod health {preflight, live}` command bundled inside slots so
+   `install_release.sh` can call `<slot>/bin/yoyopod health preflight`.
+5. Re-enabled `slot-arm64` and `release` CI jobs.
+6. Re-enabled `release.yml` workflow for tag-driven publishing.
 
-Or set it explicitly:
+## Versioning notes (for when the work resumes)
 
-```bash
-uv run yoyopod release set-version 0.2.0
-```
+Semantic versioning: `major` for externally visible contract changes,
+`minor` for backward-compatible features, `patch` for fixes. Tag format
+`vMAJOR.MINOR.PATCH`.
 
-## Local Release Build
-
-Build the release artifacts locally:
-
-```bash
-uv run yoyopod release build
-```
-
-That command builds:
-
-- Python wheel
-- Python source distribution
-- full repo bundle as `.tar.gz`
-- full repo bundle as `.zip`
-- `release-metadata.json`
-- `SHA256SUMS.txt`
-
-By default it refuses to build from a dirty tracked worktree. For local-only experiments, you can override that:
-
-```bash
-uv run yoyopod release build --allow-dirty
-```
-
-## GitHub Release Pipeline
-
-The release workflow runs on:
-
-- push of a tag like `v0.2.0`
-- manual dispatch with an existing release tag
-
-The workflow currently:
-
-1. checks out the tagged revision
-2. installs the dev environment with `uv`
-3. runs the configured CI jobs, including legacy Python CLI/deploy checks while they still exist
-5. runs `uv run yoyopod release build --check-tag <tag>`
-6. builds a Linux ARM64 self-contained slot artifact via `deploy/docker/slot-builder.Dockerfile`
-7. uploads the built artifacts
-8. creates or updates the matching GitHub Release
-
-On pull requests, the expensive ARM64 slot build is label-gated. Add the
-`build-arm-slot` label when you need a PR commit to produce a slot artifact.
-Normal PR commits still run the `quality` and `test` jobs, but they skip the
-roughly 20-minute ARM builder unless that label is present. Tagged releases and
-`main` pushes continue to build the ARM64 slot automatically.
-
-The published ARM64 slot artifact is intended to be installed directly under
-`/opt/yoyopod-prod/releases/<version>/` and consumed by:
-
-- `deploy/scripts/install_release.sh`
-- `yoyopod remote release install-url <artifact-url>`
-
-## Recommended Release Flow
-
-1. Bump the version:
-
-   ```bash
-   uv run yoyopod release bump patch
-   ```
-
-2. Run the relevant Rust checks:
-
-   ```bash
-   cargo check --manifest-path device/Cargo.toml --workspace --locked
-   ```
-
-   Add targeted Python CLI/deploy quality checks only if that surface changed.
-
-3. Commit and merge the version bump.
-4. Tag the release from the merged commit:
-
-   ```bash
-   git tag v0.1.1
-   git push origin v0.1.1
-   ```
-
-5. Let the release workflow build and publish the artifacts.
-
-## Notes
-
-- The Python package artifacts are useful for packaging and inspection.
-- The repo bundles are the more complete release asset for hardware-oriented YoYoPod workflows because they include the broader repo surface the device and deploy tooling rely on.
-- The ARM64 slot tarball is the OTA-style deploy asset. It already contains the
-  bundled config tree, native `.so` shims, launcher, manifest, and slot-local
-  runtime venv expected by the slot installer.
-- The slot tarball is published with a `.sha256` sidecar for the archive bytes.
-  The embedded `manifest.json` records the unpacked slot payload digest instead
-  of the digest of the tarball that contains the manifest.
+The version source is no longer in tree (the Python `_version.py` was
+deleted with the rest of `yoyopod_cli/`). Round 3 should decide whether
+to put the version into `cli/yoyopod/Cargo.toml` only, a plain `VERSION`
+file at repo root readable by both CLI and slot builder, or both.

--- a/docs/operations/RPI_SMOKE_VALIDATION.md
+++ b/docs/operations/RPI_SMOKE_VALIDATION.md
@@ -1,297 +1,94 @@
 # Raspberry Pi Smoke Validation
 
-This guide separates local Rust checks from the target-hardware checks that
-still require a Raspberry Pi, CI-built Rust device artifacts, and a reachable
-SIP account when VoIP validation is requested.
+**Status: in transition.**
 
-The default board-validation path from the dev machine is now committed-code validation through `yoyopod remote validate`.
+Automated hardware validation commands (`yoyopod target validate` and
+the `yoyopod pi validate …` suite) were deleted in Round 0 of the CLI
+rebuild and have not yet been ported back. See
+[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
 
-## Validation Layers
+Until Round 2 restores `yoyopod target validate`, validation is split
+between local Rust checks and a manual hardware exercise loop.
 
-### 1. Local Rust checks
+## 1. Local Rust checks
 
 Run these anywhere:
 
 ```bash
 cargo check --manifest-path device/Cargo.toml --workspace --locked
+cargo test  --manifest-path cli/Cargo.toml
+cargo clippy --manifest-path cli/Cargo.toml --all-targets
 ```
 
-Use Python CLI/deploy quality checks only when that surface changed.
-
-### 2. Default dev-machine-to-board validation
-
-Use this for feature branches and PR validation on target hardware:
+For targeted iteration on a single worker:
 
 ```bash
-git status --short
+cargo check --manifest-path device/Cargo.toml -p yoyopod-runtime --locked
+cargo check --manifest-path device/Cargo.toml -p yoyopod-ui --locked
+# … etc
+```
+
+If native LVGL or Whisplay hardware features are involved, use the
+CI-built ARM artifact (`yoyopod-rust-device-arm64-<sha>`) for the exact
+commit under test before claiming hardware parity.
+
+## 2. Deploy and manually exercise on the Pi
+
+```bash
+git status --short             # must be clean
 git branch --show-current
 git rev-parse HEAD
 git push
-yoyopod remote validate --branch <branch> --sha <commit>
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>         # or --sha <commit>
+yoyopod target status
+yoyopod target logs --follow                    # leave running while you exercise
 ```
 
-Useful variations:
-
-```bash
-yoyopod remote validate --branch <branch> --sha <commit> --with-voip
-yoyopod remote validate --branch <branch> --sha <commit> --with-navigation
-yoyopod remote validate --branch <branch> --sha <commit> --with-voip --with-lvgl-soak
-```
-
-What it checks:
-
-- the branch is committed locally
-- the branch and exact SHA are pushed
-- the stable Pi checkout is synced to committed code only
-- the target-side deploy validation passes
-- the requested Rust runtime, UI, cloud voice, VoIP, and stability checks pass
-- the app restarts cleanly
-- the PID file and startup marker agree
-- recent logs look sane before handoff
-
-Expected result:
-
-- the app stays running on the Pi after validation
-- the Pi reflects the requested committed branch/SHA, not dirty local state
-- the startup marker matches the active PID
-
-### 3. On-Pi target validation suite
-
-Run these directly on the target Raspberry Pi when you want focused, repeated-safe validation without the remote orchestration layer:
-
-```bash
-yoyopod pi validate deploy
-yoyopod pi validate smoke
-yoyopod pi validate voip
-yoyopod pi validate navigation
-yoyopod pi validate stability
-```
-
-What each command checks:
-
-- `deploy`: deploy contract files, tracked runtime config, runtime path parents, and app entrypoints without launching the app
-- `smoke`: target environment plus Rust runtime dry-run and Rust UI worker health through the runtime protocol
-- `voip`: quick Liblinphone startup and SIP registration smoke using `config/communication/calling.yaml` plus local secrets/env
-- `navigation`: repeatable one-button routed navigation through the Rust UI worker protocol
-- `stability`: repeated Rust UI navigation and idle health checks
-
-Useful flags:
-
-- `yoyopod pi validate voip --timeout 15`
-- `yoyopod pi validate navigation --cycles 3 --idle-seconds 5 --tail-idle-seconds 20`
-- `yoyopod remote validate --branch <branch> --sha <commit> --with-navigation`
-- `yoyopod pi validate stability --cycles 3 --hold-seconds 0.3`
-- `--verbose` on any suite command
-
-## Manual Follow-Up Checks
-
-### Full application startup on the Pi
-
-```bash
-/opt/yoyopod-dev/checkout/device/runtime/build/yoyopod-runtime \
-  --config-dir /opt/yoyopod-dev/checkout/config \
-  --hardware whisplay
-```
-
-Verify:
-
-- the home and menu UI render on the target display
-- button input navigates screens correctly
-- the app returns cleanly on `Ctrl+C`
-
-### VoIP registration drill
-
-```bash
-yoyopod pi voip check
-```
-
-Use this when you want a registration-only pass with detailed logs.
-
-### VoIP reliability drills
-
-These are the deeper real-hardware VoIP checks. They intentionally stay as a few focused commands instead of one giant wrapper, and each run writes a timestamped artifact bundle under `logs/voip-validation/` by default:
-
-- `summary.json` — pass/fail, timings, final status, and the exact thresholds used
-- `timeline.jsonl` — state changes, periodic status samples, and any network drop/restore hook results
-
-Use them after `yoyopod pi validate voip` passes, not instead of it.
-
-#### Registration stability
-
-```bash
-yoyopod pi validate voip --soak registration
-yoyopod pi validate voip --soak registration --hold-seconds 120
-```
-
-What it proves:
-
-- SIP registration reached `ok`
-- SIP registration stayed `ok` for the requested hold window instead of flapping immediately after startup
-
-Fail the run if registration never reaches `ok` or if it leaves `ok` during the hold.
-
-#### Reconnect drill
-
-```bash
-yoyopod pi validate voip --soak reconnect
-yoyopod pi validate voip --soak reconnect --disconnect-seconds 12
-```
-
-If you can automate the outage on the Pi, keep it explicit. The drill executes `--drop-command` and `--restore-command` with a shell, so treat them as trusted operator input for your own device only:
-
-```bash
-yoyopod pi validate voip --soak reconnect \
-  --drop-command "nmcli networking off" \
-  --restore-command "nmcli networking on"
-```
-
-What it proves:
-
-- the manager reached `ok` before the outage
-- registration actually left `ok` during the wobble or temporary loss
-- registration returned to `ok` within the recovery timeout
-
-Fail the run if the drill never sees registration leave `ok` or if recovery does not happen. That usually means the outage was too mild to prove reconnect behavior, or the backend failed to recover honestly.
-
-#### Call soak
-
-```bash
-yoyopod pi validate voip --soak call --target sip:echo@example.com
-yoyopod pi validate voip --soak call --target sip:echo@example.com --soak-seconds 900
-```
-
-Use a target that will actually answer, such as an echo bot or a second endpoint you control.
-
-What it proves:
-
-- registration reached `ok`
-- the outbound call connected
-- the call stayed in a connected media state for the requested soak duration
-
-Fail the run if the call never connects, if registration drops during the soak, or if the call leaves the connected media states before the soak finishes.
-
-#### Reading the artifacts
-
-- A passing reconnect drill should show an initial `registration=ok`, a later non-`ok` registration event during the outage, and then a final return to `registration=ok`.
-- A passing call soak should show the expected connect transition followed by periodic connected samples for the full soak duration.
-- If a run fails, compare `summary.json` across runs first. It makes timing drift, last seen state, and the exact failure point obvious without reading the whole timeline.
-
-When the full app is running, the coordinator-thread timing signals land in
-`logs/yoyopod.log` and through `yoyopod remote logs --follow`.
-
-- `VoIP iterate timing drift` is the per-keep-alive warning. `schedule_delay_ms` shows how late the iterate ran, `iterate_ms` shows how long the Liblinphone keep-alive took on the coordinator thread, and `native_events` shows how many backend events were drained during that pass.
-- `VoIP timing window` is the low-frequency summary for target-hardware runs. Use it to spot repeated delay or duration spikes without reading every keep-alive warning. `max_blocking_span` and `max_blocking_span_ms` point at the worst nearby coordinator step seen in that summary window.
-- `Runtime loop blocked` means the whole coordinator loop stalled between iterations.
-- `Coordinator blocking span` names the specific runtime step that blocked long enough to threaten keep-alive cadence or UI responsiveness.
-- `Runtime iteration slow` means the total loop iteration stayed on the coordinator thread too long even if the exact hot span was not obvious from a single callback.
-- `runtime_cadence_mode`, `runtime_target_sleep_seconds`, `runtime_requested_sleep_seconds`, and `voip_effective_iterate_interval_seconds` in `app.get_status()` snapshots tell you whether the loop is in a fast interactive path, awake idle, or screen-off idle and what sleep / VoIP cadence it actually requested.
-- Freeze snapshots also include `runtime_blocking_span_name`, `runtime_blocking_span_seconds`, and `runtime_blocking_span_age_seconds` so a `SIGUSR1` dump can tell you whether the last blocking span is still fresh or already stale.
-- When `diagnostics.responsiveness_watchdog_enabled=true`, the app also writes automatic evidence bundles under `logs/responsiveness/` once the loop heartbeat stops advancing past the configured threshold.
-- Those bundles include `input_activity_age_seconds` and `handled_input_activity_age_seconds` so you can tell whether input was still arriving while the coordinator/UI side stopped responding.
-
-### Incoming call debug drill
-
-```bash
-yoyopod pi voip debug
-```
-
-Use this when SIP registration works but incoming-call parsing or callback delivery looks wrong.
-
-### Whisplay display-only debug
-
-```bash
-yoyopod build lvgl
-yoyopod pi validate lvgl
-```
-
-Use this only on a Pi with the Whisplay hardware attached. It validates the display/LVGL path without starting the full app and is not part of CI.
-
-### Whisplay gesture tuning
-
-This tooling (`pi tune`) was removed in the 2026-04 CLI polish. Use hardware-manual testing with the running app for gesture feel adjustment, or edit `config/device/hardware.yaml` timing overrides directly.
-
-```bash
-### LVGL Whisplay soak
-
-```bash
-yoyopod pi validate lvgl
-yoyopod pi validate lvgl --cycles 3 --hold-seconds 0.3
-```
-
-Use this when Whisplay rendering feels fast but you still want a hardware pass for:
-
-- repeated routed screen transitions
-- sleep/wake recovery
-- LVGL-only corruption or stuck redraw issues
-
-### Navigation and idle stability soak
-
-```bash
-yoyopod pi validate navigation
-yoyopod pi validate navigation --cycles 3 --idle-seconds 5 --tail-idle-seconds 20
-yoyopod remote validate --branch <branch> --sha <commit> --with-navigation
-```
-
-Use this when you want a reproducible freeze-repro path that keeps the app mostly idle but still exercises:
-
-- routed one-button navigation from the real input dispatcher
-- click-driven transitions into `Listen`, `Talk`, `Ask`, and `Setup`
-- playlist and shuffle playback navigation while mpv is active
-- explicit idle dwell windows between actions
-- a final tail-idle and sleep/wake pass on the hub
-
-### PiSugar RTC drill
-
-```bash
-yoyopod pi power rtc status
-yoyopod pi power rtc sync-to
-```
-
-Use this when you want a focused RTC read or sync pass without running the full app.
-
-### PiSugar power drill
-
-```bash
-yoyopod pi power battery
-```
-
-Use this when you want a focused battery, charging, RTC, shutdown-threshold, and watchdog readout without the full smoke flow.
-
-## Suggested Order On Hardware
-
-1. Run focused Rust build checks for the changed crates.
-2. Commit the intended change.
-3. `git push`
-4. `git rev-parse HEAD`
-5. Install exact-SHA Rust artifacts when testing the Rust runtime owner.
-6. `yoyopod remote validate --branch <branch> --sha <commit> --with-voip`
-7. manual follow-up on the still-running app
-
-## Dirty-Tree Escape Hatch
-
-`yoyopod remote sync` is a debugging escape hatch and is not the default validation contract.
-
-Only use it when:
-
-- you explicitly need to validate uncommitted local state
-- you have called out that the board is not running committed branch/SHA code
-
-## Failure Triage
-
-- `deploy` fails: verify the checkout still has `deploy/pi-deploy.yaml`, `deploy/systemd/yoyopod-dev.service`, `deploy/systemd/yoyopod-prod.service`, the configured virtualenv, and writable runtime path parents
-- `display` fails: check attached HAT, driver and library install, and `display.hardware` config
-- `input` fails: check the matching display adapter initialized correctly first
-- `voip` fails: verify the CI-built Rust VoIP host artifact, `config/communication/integrations/liblinphone_factory.conf`, SIP credentials, network reachability, and audio device configuration
-- `voip --soak registration` fails: compare `logs/voip-validation/*/summary.json` across runs and look for whether startup never reached `ok` or whether `ok` flapped during the hold window
-- `voip --soak reconnect` fails: check whether the run ever recorded a non-`ok` registration state, whether the outage lasted long enough to force a drop, and whether recovery returned before the timeout
-- `voip --soak call` fails: check whether the target endpoint actually answered, whether registration stayed `ok`, and which non-connected call state ended the soak
-- `navigation` fails: rerun `yoyopod pi validate navigation --verbose` or `yoyopod remote validate --with-navigation --verbose` and inspect which expected screen or playback transition stalled
-- `stability` fails: rerun `yoyopod pi validate stability --verbose` or `yoyopod pi validate lvgl` for a deeper LVGL-only pass
-- `validate` fails before launch: check whether the branch was actually pushed and whether the Pi checkout is reachable over SSH
-
-## Notes
-
-- each `yoyopod pi validate <command>` exits non-zero if its requested check fails
-- CI intentionally does not run hardware-in-the-loop checks
-- `yoyopod remote validate` is the normal branch and PR validation path
-- the target validation suite is meant to stay small and composable; use the manual drills above when you need deeper debugging
+Use the device:
+
+- power on / off
+- navigate the main scene set with the button
+- play / pause local music
+- attempt an outbound SIP call
+- attempt an inbound SIP call (when relevant)
+- exercise the cellular path if testing modem changes
+- watch for UI freezes, audio dropouts, restart loops, or runtime
+  crashes
+
+Take screenshots with `yoyopod target screenshot` (or `--readback` for
+the LVGL native path) and compare against design intent.
+
+## 3. What you must report
+
+For every hardware validation, report:
+
+- branch + exact commit SHA
+- CI artifact name and run ID
+- Pi host
+- deploy result (success / failure + stderr)
+- manual exercise steps performed
+- visible issues found, with timestamps so logs can be cross-referenced
+- whether the dev service was left running for further testing
+
+If the change touches a specific worker (UI / media / VoIP / network /
+cloud / power / speech), call out that worker's behaviour explicitly
+in the report.
+
+## What returns when
+
+| Round | Restores |
+|---|---|
+| Round 2 | `yoyopod target validate --branch <b> --sha <s>` orchestration |
+| Round 2 | Per-stage on-Pi validation entrypoints (deploy / smoke / navigation / stability / voip / cloud-voice / lvgl) |
+| Round 3 | Slot install preflight (`yoyopod health preflight`) |
+| Round 4+ | Diagnostics (`yoyopod pi voip check`, `pi power battery`, etc.) |
+
+See [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
+
+## Related Docs
+
+- [`PI_DEV_WORKFLOW.md`](PI_DEV_WORKFLOW.md) for the daily deploy loop
+- [`DEV_PROD_LANES.md`](DEV_PROD_LANES.md) for lane structure
+- [`QUALITY_GATES.md`](QUALITY_GATES.md) for verification policy
+- `rules/deploy.md` for the policy that backs hardware validation

--- a/docs/operations/SETUP_CONTRACT.md
+++ b/docs/operations/SETUP_CONTRACT.md
@@ -1,38 +1,33 @@
 # Setup and System Dependency Contract
 
-This document defines the baseline repo-owned setup and verification contract for YoYoPod Core.
-
-Issue [`#87`](https://github.com/moustafattia/yoyopod-core/issues/87) is the work that turned this from wishful docs into executable commands. This file documents the contract those commands implement.
+This document defines the baseline setup contract for YoYoPod Core. As
+of 2026-05-13, automated setup commands (`yoyopod setup …`,
+`yoyopod target setup …`) were deleted in Round 0 of the CLI rebuild;
+see [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md). Until the
+relevant rounds restore them, follow the manual steps below.
 
 ## Why this exists
 
-The repo already owns a lot of runtime behavior, but setup still has too much implicit machine knowledge.
+The repo should let any contributor answer these questions from the
+repo itself:
 
-That is a foundation risk.
-
-For this repo to be the real base of the system, a contributor should be able to answer these questions from the repo itself:
-
-- what Python and system dependencies are required
+- which system dependencies are required
 - which dependencies are core vs feature-gated
 - which files are repo-owned vs machine-local
 - how to bring up a dev machine
 - how to bring up a target Pi
-- how to verify the setup before debugging product code
 
 ## Setup ownership rules
 
-The repo should own:
+The repo owns:
 
-- the Python dependency graph in `pyproject.toml`
+- the Rust dependency graph (in each workspace's `Cargo.toml` /
+  `Cargo.lock`)
 - the shared Pi deploy contract in `deploy/pi-deploy.yaml`
 - the tracked app config in `config/`
 - the documented system dependency list in this file
-- the validation commands in `docs/operations/DEVELOPMENT_GUIDE.md` and `docs/operations/RPI_SMOKE_VALIDATION.md`
-- the remote workflow exposed through `yoyopod remote`
 
-Machine-local values should stay out of tracked files.
-
-Examples of machine-local state:
+Machine-local values stay out of tracked files:
 
 - Pi hostname or SSH alias
 - Pi username
@@ -40,57 +35,40 @@ Examples of machine-local state:
 - secrets and account credentials
 - local audio paths or removable-media contents
 
-## Supported setup surfaces
+## Dev machine
 
-### 1. CI-safe developer machine
+Manual prereqs:
 
-Minimum expectation:
+- a Rust stable toolchain via `rustup`
+- `gh` (GitHub CLI) authenticated, used by `yoyopod target deploy`
+- standard Pi-side prereqs (`ssh`, `scp`, `git`)
+- `cmake` if you need to build LVGL locally (rare; CI artifacts
+  normally cover this)
 
-- Python `3.12+`
-- `uv`
-- Git
-
-Current repo-owned bootstrap baseline:
-
-```bash
-uv run yoyopod setup host
-```
-
-This is the executable baseline, not full setup ownership. It does not provision
-external service credentials or cover every board-specific edge.
-If `yoyopod` is invoked before the contributor CLI stack is present, it should
-now exit with a short bootstrap hint instead of crashing during import.
-
-Current repo-owned validation baseline:
+Build and install the CLI:
 
 ```bash
-uv run yoyopod setup verify-host
+cargo build --manifest-path cli/Cargo.toml --release
+cargo install --path cli/yoyopod   # puts `yoyopod` in ~/.cargo/bin/
 ```
 
-Optional but expected for Pi workflows:
-
-- `ssh`
-- `rsync`
-
-Optional but useful for repo operations:
-
-- `gh`
-
-Workflow-specific host verification:
+Local workspace check:
 
 ```bash
-uv run yoyopod setup verify-host --with-remote-tools
-uv run yoyopod setup verify-host --with-github
-uv run yoyopod setup verify-host --with-remote-tools --with-github
+cargo check --manifest-path device/Cargo.toml --workspace --locked
+cargo test  --manifest-path cli/Cargo.toml
 ```
 
-Use the baseline command for local-only work. Add `--with-remote-tools` before using `yoyopod remote`, `--with-github` before relying on `gh`, and combine them when you need both.
+Configure the Pi target:
 
-### 2. Target Raspberry Pi runtime
+```bash
+yoyopod target config edit
+```
 
-Current core system packages and services expected by the active stack:
+## Target Raspberry Pi (manual until CLI setup returns)
 
-- `python3-venv`
+Required system packages on the Pi:
+
 - `mpv`
 - `ffmpeg`
 - `liblinphone-dev`
@@ -99,66 +77,40 @@ Current core system packages and services expected by the active stack:
 - `alsa-utils`
 - `i2c-tools`
 - `pisugar-server` running on PiSugar-based targets
+- `ppp` for the modem PPP data path (cellular)
 
-Current repo-owned bootstrap baseline:
-
-```bash
-uv run yoyopod setup pi
-```
-
-This bootstraps the baseline package/build contract only. It does not yet solve
-cloud voice credential provisioning, board/modem permissions, or non-Debian portability.
-On the Pi, this flow now creates or refreshes the repo checkout `.venv` with
-`python3 -m venv` and `pip install -e '.[dev]'`, so the board does not need
-`uv` installed locally.
-
-Feature extras are opt-in:
-
-- `yoyopod setup pi --with-voice`
-- `yoyopod setup pi --with-network`
-- `yoyopod setup pi --with-pisugar`
-
-Current repo-owned verification baseline:
+Install on Raspberry Pi OS / Debian-based:
 
 ```bash
-uv run yoyopod setup verify-pi
+sudo apt-get update
+sudo apt-get install -y mpv ffmpeg liblinphone-dev pkg-config cmake \
+    alsa-utils i2c-tools
+# optional, depending on hardware:
+sudo apt-get install -y pisugar-server ppp
 ```
 
-This verifies presence and basic build state. It does not perform deeper
-artifact health checks for every native/runtime dependency. The current baseline
-checks the tracked config files, `python3`, the checkout venv Python, required
-apt packages, and the built native runtime artifacts.
-
-Use flags that match the actual target you are bringing up:
+Bootstrap lane directories and systemd units (one-shot per board):
 
 ```bash
-uv run yoyopod setup pi --with-pisugar
-uv run yoyopod setup verify-pi --with-pisugar
+ssh <user>@<pi>
+curl -fsSL https://raw.githubusercontent.com/moustafattia/yoyopod-core/main/deploy/scripts/install_pi.sh | sudo -E bash -s --
 ```
 
-Add `--with-voice` and/or `--with-network` when the target depends on the TTS or modem paths. `--with-pisugar` is the normal Whisplay/PiSugar hardware path because it adds the `pisugar-server` package and service check.
+Seed the dev lane checkout:
 
-### 3. Feature-gated or hardware-specific extras
+```bash
+sudo chown -R <user>:<user> /opt/yoyopod-dev
+sudo -u <user> git clone <repo-url> /opt/yoyopod-dev/checkout
+```
 
-These are not universal for every contributor machine, but the repo should still name them explicitly when a feature depends on them.
+Activate the dev lane and deploy:
 
-#### Voice path
+```bash
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>
+```
 
-- cloud voice worker binary built from `workers/voice/go/`
-- provider credentials supplied outside tracked config
-
-#### Cellular / GPS path
-
-- `ppp` for the modem PPP data path
-- board- and modem-specific serial/device access
-
-#### Board bringup variants
-
-See:
-
-- `docs/hardware/CUBIE_A7Z_BRINGUP.md`
-
-## Repo-owned configuration contract
+## Repo-owned configuration
 
 Tracked config lives in:
 
@@ -188,75 +140,35 @@ The tracked deploy contract must stay generic:
 - no secrets
 - no machine-specific absolute paths unless they are intended defaults
 
-## Current bringup contract
+## What will come back
 
-### Local developer bringup baseline
+| When | Restores |
+|---|---|
+| Round 2 | Automated on-Pi validation (`yoyopod target validate …`) |
+| Round 3 | Prod slot install + release tooling |
+| Round 4+ | `yoyopod target setup` / `verify-setup` style one-shot bootstrap |
 
-```bash
-uv run yoyopod setup host
-uv run yoyopod setup verify-host
-cargo run --manifest-path device/Cargo.toml -p yoyopod-runtime -- --config-dir config --dry-run
-cargo check --manifest-path device/Cargo.toml --workspace --locked
-```
-
-This is the minimum executable contract for contributors. Feature assets and
-hardware-specific extras still need follow-through when the feature requires them.
-
-### Target Pi bringup baseline
-
-```bash
-uv run yoyopod setup pi --with-pisugar
-uv run yoyopod setup verify-pi --with-pisugar
-yoyopod pi validate deploy
-yoyopod pi validate smoke
-yoyopod pi validate smoke
-/opt/yoyopod-dev/checkout/device/runtime/build/yoyopod-runtime --config-dir /opt/yoyopod-dev/checkout/config --hardware whisplay
-```
-
-This does not yet provision external credentials or encode every
-board/modem-specific permission step. Add `--with-voice` and/or `--with-network`
-when the target needs those feature paths.
-
-### Remote Pi workflow baseline
-
-```bash
-uv run yoyopod setup verify-host --with-remote-tools
-yoyopod remote config edit
-uv run yoyopod remote setup --with-pisugar
-uv run yoyopod remote verify-setup --with-pisugar
-yoyopod remote status
-yoyopod remote validate --branch <branch> --sha <commit> --with-voip
-```
-
-These remote helpers mirror the same baseline contract. They still rely on
-feature-specific follow-up for assets and unusual hardware bringup. Add
-`--with-voice` and/or `--with-network` to the setup commands when the target
-needs those feature paths. They now invoke the checkout-local `.venv/bin/python`
-instead of requiring `uv` on the board.
+See [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
 
 ## Verification before blaming product code
 
-Before treating a failure as an app bug, verify the setup layer first.
+Before treating a failure as an app bug, verify the setup layer first:
 
-Checklist:
-
-- local bootstrap completes with `uv run yoyopod setup host`
-- local verification passes with `uv run yoyopod setup verify-host`
-- remote Pi workflows use `uv run yoyopod setup verify-host --with-remote-tools`
-- GitHub CLI workflows use `uv run yoyopod setup verify-host --with-github`
-- tracked config files are present under `config/`
-- required system packages are verified with `uv run yoyopod setup verify-pi`
-- target feature extras are verified with the matching `--with-pisugar`, `--with-voice`, and `--with-network` flags
-- native artifacts have been built when the feature requires them
-- `yoyopod pi validate smoke` passes for the requested hardware path
-- remote config values come from `deploy/pi-deploy.yaml` plus local overrides, not tribal knowledge
+- local `cargo build` of the CLI succeeds
+- `yoyopod target config edit` shows host/user populated
+- `yoyopod target mode status` reports the expected lane
+- required system packages are installed on the Pi
+- the dev lane checkout exists at `/opt/yoyopod-dev/checkout`
+- `yoyopod target deploy` returns successfully
+- `journalctl -u yoyopod-dev.service -f` shows the runtime alive
+- remote config values come from `deploy/pi-deploy.yaml` plus the local
+  override, not tribal knowledge
 
 ## Current gaps
 
-This repo is still missing some setup hardening that a foundation-grade repo should have:
-
 - provisioning of external voice provider credentials
-- board- and modem-specific device-permission setup for every bringup variant
+- board- and modem-specific device-permission setup for every bringup
+  variant
 - portability beyond the current Debian-based Raspberry Pi package flow
-
-The contract is now executable, but those remaining edges are still real.
+- automated host/Pi setup CLI (deleted in Round 0; returns in later
+  rebuild rounds)

--- a/docs/operations/SLOT_DEPLOY.md
+++ b/docs/operations/SLOT_DEPLOY.md
@@ -1,22 +1,29 @@
 # Slot Deploy (Prod Lane)
 
-This is the operator guide for the prod slot/OTA lane. For the complete
-dev/prod split, read [DEV_PROD_LANES.md](DEV_PROD_LANES.md) first.
+**Status: paused as of 2026-05-13.**
 
-Terminology: `remote release ...` means prod slot work. `remote sync` means dev
-checkout work. Use `remote mode status` when you are unsure which lane owns the
-hardware.
+The prod slot/OTA CLI commands (`yoyopod target release …`) were
+deleted as part of Round 0 of the CLI rebuild and have not been ported
+back. New prod slot builds and installs through the CLI are blocked
+until Round 3; see
+[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
 
-## Contract
+This doc documents the slot layout, services, and rollback wiring that
+remain in place on previously-bootstrapped Pis. The contract is stable
+even while the CLI is being rebuilt.
+
+## Contract (unchanged)
 
 - Prod slots live under `/opt/yoyopod-prod/releases/<version>/`.
 - `/opt/yoyopod-prod/current` points at the active release.
 - `/opt/yoyopod-prod/previous` points at the rollback release.
 - `yoyopod-prod.service` runs `/opt/yoyopod-prod/current/bin/launch`.
-- `yoyopod-prod-rollback.service` swaps `current` and `previous` after repeated prod failures.
-- `deploy/scripts/install_release.sh` installs published artifacts directly into `/opt/yoyopod-prod`.
-- `yoyopod remote release push`, `rollback`, `status`, and `install-url` do not require `uv` or a repo checkout on the Pi after bootstrap.
-- `yoyopod remote release build-pi` still needs the dev checkout because it uses the Pi as an ARM build factory.
+- `yoyopod-prod-rollback.service` swaps `current` and `previous` after
+  repeated prod failures.
+- `deploy/scripts/install_release.sh` installs published artifacts
+  directly into `/opt/yoyopod-prod`. The slot preflight step is
+  currently a no-op (see comment in that file) until Round 3 restores
+  the Rust-based `yoyopod health preflight` command.
 
 ## Layout
 
@@ -29,8 +36,7 @@ hardware.
 |   |   |-- bin/launch
 |   |   |-- config/
 |   |   |-- manifest.json
-|   |   |-- runtime-requirements.txt
-|   |   `-- venv/
+|   |   `-- venv/                 (slots predating Round 3 only)
 |-- current -> releases/<version>
 |-- previous -> releases/<version>
 |-- bin/
@@ -40,146 +46,53 @@ hardware.
     `-- tmp/
 ```
 
-## Fresh Board Install
+## What works today
 
-On the Pi, run the installer directly. Do not clone a bootstrap checkout:
+- Previously-shipped prod slots continue to run on their boards.
+- A previously-shipped artifact can be reinstalled manually via SSH +
+  `install_release.sh`:
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/moustafattia/yoyopod-core/main/deploy/scripts/install_pi.sh | sudo -E bash -s --
-```
+  ```bash
+  ssh <user>@<pi>
+  sudo /opt/yoyopod-prod/bin/install-release.sh <path-to-tarball-or-url>
+  ```
 
-The installer downloads the matching source payload, runs the board bootstrap,
-and removes its installer workspace afterward.
+- Manual rollback:
 
-If you already have a published artifact URL:
+  ```bash
+  ssh <user>@<pi> 'sudo /opt/yoyopod-prod/bin/rollback.sh'
+  ```
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/moustafattia/yoyopod-core/main/deploy/scripts/install_pi.sh | sudo -E bash -s -- --release-url=<artifact-url>
-```
+- Automatic rollback wiring (`OnFailure=yoyopod-prod-rollback.service`)
+  is still in `deploy/systemd/yoyopod-prod.service` and unchanged.
 
-The installer forwards first-deploy semantics to the bootstrap/release installer.
+## What does NOT work yet
 
-## First Release
+- New slot builds (`yoyopod release build`, `scripts/build_release.py`,
+  `deploy/docker/slot-builder.Dockerfile`) — all deleted or deprecated.
+  CI `slot-arm64` job disabled.
+- All `yoyopod target release …` CLI subcommands (`push`, `rollback`,
+  `status`, `install-url`, `build-pi`).
+- Structural preflight before slot flip (`yoyopod health preflight`).
+- The CI `release` workflow.
 
-Build on the Pi and download the artifact:
+## Round 3 sketch
 
-```bash
-uv run yoyopod remote release build-pi --output build/releases --channel dev
-```
+Round 3 reintroduces:
 
-Push the first release:
-
-```bash
-uv run yoyopod remote release push build/releases/<version>.tar.gz --first-deploy
-```
-
-Or install a CI/GitHub-published artifact directly:
-
-```bash
-uv run yoyopod remote release install-url <artifact-url> --first-deploy
-```
-
-Verify:
-
-```bash
-uv run yoyopod remote release status
-ssh <user>@<pi> 'systemctl status yoyopod-prod.service --no-pager -l'
-```
-
-Expected result:
-
-- `current=<version>`
-- `health=ok`
-- `yoyopod-prod.service` is active
-
-## Normal Prod Update
-
-```bash
-uv run yoyopod remote release build-pi --output build/releases --channel dev
-uv run yoyopod remote release push build/releases/<version>.tar.gz
-uv run yoyopod remote release status
-```
-
-Published artifact path:
-
-```bash
-uv run yoyopod remote release install-url <artifact-url>
-uv run yoyopod remote release status
-```
-
-`release push` uploads the slot, repairs `bin/launch` permissions, runs
-preflight, flips `current`/`previous`, restarts `yoyopod-prod.service`, and
-performs a shell-only live probe against the active systemd PID and slot path.
-
-## Rollback
-
-Manual rollback:
-
-```bash
-uv run yoyopod remote release rollback
-```
-
-Check rollback state:
-
-```bash
-uv run yoyopod remote release status
-ssh <user>@<pi> 'readlink -f /opt/yoyopod-prod/current && readlink -f /opt/yoyopod-prod/previous'
-```
-
-Automatic rollback uses:
-
-- `OnFailure=yoyopod-prod-rollback.service`
-- `/opt/yoyopod-prod/bin/rollback.sh`
-- `systemctl reset-failed yoyopod-prod.service` before restart
-
-Prod OTA services must not run while the dev lane is active. Future OTA units
-should use `/opt/yoyopod-prod/bin/prod-ota-guard.sh` as an `ExecCondition` so
-systemd skips OTA work unless the prod lane owns the board.
-
-## Migration Notes
-
-For an old board with `~/yoyopod-core`, run:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/moustafattia/yoyopod-core/main/deploy/scripts/install_pi.sh | sudo -E bash -s -- --migrate
-```
-
-Then either activate dev:
-
-```bash
-uv run yoyopod remote mode activate dev
-```
-
-or publish/activate prod:
-
-```bash
-uv run yoyopod remote release install-url <artifact-url> --first-deploy
-uv run yoyopod remote mode activate prod
-```
-
-The migration preserves old `config/` and `logs/` under
-`/opt/yoyopod-prod/state/` for reference. The live prod app reads the bundled
-slot `config/`, not the preserved state copy. Migration does not seed
-`/opt/yoyopod-dev/checkout` from the old checkout; clone the repo there
-explicitly if you want to return to the dev lane.
-
-## Pitfalls Found During Bring-Up
-
-- The live probe must verify the systemd service PID and active slot path, not
-  just read `manifest.json`.
-- Reusing a version must not mutate the active release in place; bump the
-  version for every prod artifact.
-- Source-only slots are legacy; the default prod path expects self-contained
-  runtime artifacts.
-- The Pi Zero is memory-constrained, so prod deploy probes avoid launching a
-  second Python process after restart.
-- Windows `scp` fallback may lose executable bits, so deploy repairs
-  `bin/launch` after upload.
-- Native build directories are path-sensitive; copy only built shims or rebuild.
+1. A Rust slot-contract module (required dirs, runtime files, config
+   files) replacing the old `yoyopod_cli.slot_contract`.
+2. A Rust manifest type replacing the old `release_manifest`.
+3. A Rust slot builder producing the same on-disk layout as above.
+4. `yoyopod health {preflight, live}` as a bundled binary in each slot.
+5. `yoyopod target release {push, rollback, status, install-url}` in
+   the CLI.
+6. Re-enabled CI `slot-arm64` and `release` jobs.
 
 ## Related Docs
 
-- [DEV_PROD_LANES.md](DEV_PROD_LANES.md)
-- [PI_DEV_WORKFLOW.md](PI_DEV_WORKFLOW.md)
-- [RELEASE_PROCESS.md](RELEASE_PROCESS.md)
-- [DEPLOYED_PI_DEPENDENCIES.md](../hardware/DEPLOYED_PI_DEPENDENCIES.md)
+- [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md)
+- [`DEV_PROD_LANES.md`](DEV_PROD_LANES.md)
+- [`PI_DEV_WORKFLOW.md`](PI_DEV_WORKFLOW.md)
+- [`RELEASE_PROCESS.md`](RELEASE_PROCESS.md)
+- [`DEPLOYED_PI_DEPENDENCIES.md`](../hardware/DEPLOYED_PI_DEPENDENCIES.md)

--- a/rules/architecture.md
+++ b/rules/architecture.md
@@ -1,7 +1,9 @@
 # Architecture
 
-YoYoPod is Rust-first. Treat the Rust runtime workspace as the app owner and the
-Python package as CLI/deploy tooling unless current code proves otherwise.
+YoYoPod is Rust-only. The runtime, the workers, and the operator CLI
+are all Rust. The Python operator CLI was retired in Round 0 of the
+CLI rebuild (`docs/operations/CLI_REBUILD_ROUNDS.md`); active code must
+not depend on it.
 
 ```text
 yoyopod_rs/runtime        (yoyopod-runtime: orchestrator, config, state, routing)
@@ -16,13 +18,14 @@ yoyopod_rs/runtime        (yoyopod-runtime: orchestrator, config, state, routing
 
 ## Runtime Ownership
 
-- `yoyopod-runtime` is the process owner for app behavior.
-- Runtime domains should run as supervised Rust hosts/workers, not Python app
-  integrations.
-- The Python CLI may build, deploy, configure, and validate the Rust stack, but
-  it should not become an app runtime or domain owner again.
-- Target validation should prove the Rust runtime stack works. Do not add new
-  validation gates that only exercise Python domain shims.
+- `yoyopod-runtime` is the process owner for app behaviour.
+- Runtime domains run as supervised Rust hosts/workers; there are no
+  Python integrations.
+- The operator CLI in `cli/` builds, deploys, configures, and validates
+  the Rust stack from the dev machine. It is orchestration only — it
+  must not own runtime state or domain behaviour.
+- Target validation should prove the Rust runtime stack works on
+  hardware. Do not add new validation gates that bypass the runtime.
 
 ## Worker Protocol
 
@@ -52,6 +55,6 @@ Prefer this direction:
 Avoid the reverse:
 
 - hosts importing runtime orchestration
-- CLI validation becoming a substitute Python runtime
+- CLI validation becoming a substitute runtime
 - domain behavior living in docs, compatibility helpers, or CLI-only checks
 - historical Python plans being treated as current architecture

--- a/rules/code-style.md
+++ b/rules/code-style.md
@@ -1,9 +1,35 @@
 # Code Style
 
-- Python 3.12+, type hints required on all function definitions
-- Black formatting, 100 char line length
-- Logging via `loguru` (not stdlib logging) -- see `rules/logging.md`
-- Build system: hatchling
-- Local CI mirror: `uv run --extra dev python scripts/quality.py ci`
-- Repo-owned staged quality gate: `uv run --extra dev python scripts/quality.py gate`
-- Full quality debt audit: `uv run --extra dev python scripts/quality.py audit`
+The codebase is Rust-only across the runtime (`device/`) and the
+operator CLI (`cli/`). No Python remains as of the Round 0 rebuild
+(`docs/operations/CLI_REBUILD_ROUNDS.md`).
+
+## Rust (device/ and cli/)
+
+- Stable toolchain, pinned via `rust-toolchain.toml` in each workspace.
+- 2021 edition.
+- Format with `cargo fmt`; CI uses `--check`.
+- Lint with `cargo clippy --all-targets`. Workspace-level lint
+  allowlists live in the workspace `Cargo.toml`. Don't suppress lints
+  in individual files unless there's a specific reason worth a comment.
+- Logging via `tracing` + `tracing-subscriber`. The CLI binary
+  initialises the subscriber once at startup; library code uses
+  `tracing::{info, warn, error, debug}` directly.
+- Errors: `anyhow::Result<T>` in binaries and orchestration code;
+  `thiserror`-derived enums when defining a stable error API for a
+  library crate.
+- No `unsafe` in `cli/` (workspace lint forbids it). `device/` permits
+  it only where the LVGL native binding requires it.
+
+## Build commands
+
+```bash
+# device runtime + workers
+cargo check --manifest-path device/Cargo.toml --workspace --locked
+cargo build --manifest-path device/Cargo.toml --release -p yoyopod-runtime
+
+# operator CLI
+cargo build --manifest-path cli/Cargo.toml --release
+cargo test  --manifest-path cli/Cargo.toml
+cargo clippy --manifest-path cli/Cargo.toml --all-targets
+```

--- a/rules/deploy.md
+++ b/rules/deploy.md
@@ -1,104 +1,118 @@
 # Deploy Workflow
 
-Applies to: `deploy/pi-deploy.yaml`, `yoyopod remote`, Raspberry Pi validation, and Pi-facing agent skills
+Applies to: `deploy/pi-deploy.yaml`, `yoyopod target`, Raspberry Pi
+deploy and validation, and Pi-facing agent skills.
 
 ## Default Contract
 
-The normal target-hardware workflow validates committed code only.
+The normal target-hardware workflow deploys committed code only.
 
 Use this order:
 
 1. finish implementation locally
-2. run local checks as needed
+2. run local Rust checks as needed (`cargo check` / `cargo test`)
 3. commit the intended changes
-4. push the branch
-5. deploy the committed branch and preferably the exact commit SHA to the Raspberry Pi
-6. run smoke validation
-7. launch or restart the app
-8. verify startup with the PID file, startup marker, and recent logs
-9. leave the app running for manual testing
+4. push the branch (CI must finish the `rust-device-arm64` build for the
+   exact commit)
+5. deploy the committed branch / commit SHA to the Raspberry Pi via the
+   Rust CLI
+6. verify the runtime started cleanly and exercise the change manually
 
 The repo-owned command for that flow is:
 
 ```bash
 git branch --show-current
 git rev-parse HEAD
-yoyopod remote validate --branch <branch> --sha <commit> --with-music --with-voip --with-navigation
+yoyopod target deploy --branch <branch>           # or --sha <commit>
 ```
 
-`yoyopod remote validate` is the default because it:
+`yoyopod target deploy` is the default because it:
 
 - stops on uncommitted local changes
-- requires a pushed branch/SHA
-- syncs one stable checkout path on the board
-- runs the target-side deploy, smoke, and requested service/stability checks before launch
-- waits for the startup marker after restart
-- prints recent logs and leaves the app running
+- requires a pushed branch / SHA
+- finds the successful `CI` workflow run for the exact commit and
+  downloads `yoyopod-rust-device-arm64-<sha>` via `gh run download`
+- syncs the dev-lane checkout to the same commit on the Pi
+- `scp`s and extracts the worker binaries into `device/*/build/`
+- restarts `yoyopod-dev.service` and waits for the startup marker
+
+Add `--wait-for-ci` when CI is still queued or in-progress.
+
+## Validation gap
+
+Automated on-Pi validation (`yoyopod target validate`) is a Round 1 stub
+that returns exit 2. Until Round 2 of the CLI rebuild lands, validate
+manually after `target deploy`:
+
+```bash
+yoyopod target status
+yoyopod target logs --follow
+journalctl -u yoyopod-dev.service -f
+```
+
+Exercise the changed surface on the device. Don't claim a hardware pass
+without a real human-eyes check of the running app.
+
+See `docs/operations/CLI_REBUILD_ROUNDS.md`.
 
 ## Stable Pi Checkout Path
 
-The board must reuse one stable checkout path, configured by `project_dir` in `deploy/pi-deploy.yaml`.
+The board reuses one stable checkout path per lane:
 
-Why this is the normal contract:
+- Dev lane: `/opt/yoyopod-dev/checkout` (mutable, used by `target deploy`)
+- Prod lane: `/opt/yoyopod-prod/current/...` (immutable slots; release
+  tooling is on Round 3 and currently disabled)
 
-- dependency installs are expensive on Pi Zero hardware
-- native LVGL and Liblinphone rebuilds can be expensive
+Why one stable path:
+
+- dependency installs and native LVGL rebuilds are expensive on Pi Zero
+- the systemd unit, log paths, PID file, and CLI shell builders all
+  expect this fixed layout
 - repeated fresh copies waste time and introduce drift
-- the fixed path is what the service unit, logs, PID file, and agent skills expect
 
-Do not normalize ad hoc per-branch directories on the board.
+Do not normalise ad-hoc per-branch directories on the board.
 
 ## Command Map
 
-The `rpi-deploy` Claude Code plugin is still the high-level integration surface, but in this repo `yoyopod remote` is the executable implementation and the skills should stay thin wrappers around it.
+The Rust CLI binary is `yoyopod`. Skills are thin wrappers around it.
 
 | Command | Purpose |
 |---|---|
-| `/yoyopod-deploy` | Commit-safe branch/SHA validation on the Pi |
-| `/yoyopod-sync` | Rare-case dirty-tree rsync escape hatch for debugging only |
+| `/yoyopod-deploy` | Push, fetch CI artifact, sync Pi, install, restart, verify |
 | `/yoyopod-logs [N] [--errors] [--filter <sub>]` | Tail app logs from the Pi |
-| `/yoyopod-restart` | Restart the already-synced app |
-| `/yoyopod-status` | Health check dashboard |
+| `/yoyopod-restart` | Restart the dev runtime and verify startup |
+| `/yoyopod-status` | Lane / process / log dashboard |
 | `/yoyopod-screenshot [--readback]` | Capture display output as PNG |
-Lower-level `yoyopod remote` commands:
+| `/yoyopod-sync` | Same `target deploy` flow; kept for muscle memory |
+| `/yoyopod-rust-artifact` | Manual CI-artifact deploy reference (rarely needed now) |
 
-- `yoyopod remote validate` is the default branch/SHA validation flow (use `--with-navigation` for the navigation soak, `--with-lvgl-soak` for the LVGL soak)
-- `yoyopod remote sync` is the committed-code sync primitive
-- `yoyopod remote restart` restarts the synced app and verifies startup
+Direct CLI commands:
 
-Target-side `yoyopod pi validate` commands:
+- `yoyopod target deploy` — push + CI artifact + Pi sync + restart + verify (the everyday command)
+- `yoyopod target mode {status, activate}` — confirm or switch lane (dev/prod)
+- `yoyopod target {status, restart, logs, screenshot}` — runtime introspection
+- `yoyopod target config edit` — open `deploy/pi-deploy.local.yaml` in `$EDITOR`
+- `yoyopod target validate` — stub; returns in Round 2
 
-- `yoyopod pi validate deploy` checks the deploy contract, config files, runtime paths, and entrypoints without launching the app
-- `yoyopod pi validate smoke` checks environment, display, input, and optional PiSugar telemetry
-- `yoyopod pi validate music` checks the mpv backend in isolation
-- `yoyopod pi validate voip` checks Liblinphone startup and SIP registration in isolation
-- `yoyopod pi validate navigation` runs the one-button navigation, idle, and playback stress path used for freeze repro
-- `yoyopod pi validate stability` runs the repeated LVGL transition and sleep/wake stability pass
+## Config
 
-Config lives in `deploy/pi-deploy.yaml` plus optional `deploy/pi-deploy.local.yaml` for machine-specific host and user overrides. Preferred edit flow:
+`deploy/pi-deploy.yaml` is the tracked baseline. `deploy/pi-deploy.local.yaml`
+is the gitignored per-machine override (host, user, custom paths). Edit
+with `yoyopod target config edit`.
 
-```bash
-yoyopod remote config show
-yoyopod remote config edit
-uv run yoyopod remote setup
-uv run yoyopod remote verify-setup
-```
+## No dirty-tree escape hatch
 
-## Escape Hatch Only
-
-Dirty-tree deploys are still allowed as a rare debugging override, but they are not the default validation story.
-
-Use `yoyopod remote sync` with caution for dirty-tree debugging only when:
-
-- the user explicitly asks to validate uncommitted local state
-- you are doing one-off hardware debugging and have called out that the Pi is not running committed code
-
-Do not present dirty-tree sync as the normal way to validate a branch or PR.
+The Python-era `yoyopod remote sync` allowed a dirty-tree rsync escape
+hatch. The Rust `target deploy` does **not**. If you need to test
+uncommitted local state, commit to a throwaway branch, push, and
+deploy that. The CI-artifact contract requires it.
 
 ## Target Hardware
 
 - Raspberry Pi Zero 2W (416 MB RAM)
-- SSH host, user, and stable project-dir defaults come from `deploy/pi-deploy.yaml` plus gitignored `deploy/pi-deploy.local.yaml`
-- Machine-local hostnames, usernames, and path overrides must stay out of tracked files
-- Default project dir on Pi: `/home/pi/yoyopod-core`
-- Default venv on Pi: `/home/pi/yoyopod-core/.venv`
+- SSH host, user, and stable project-dir defaults come from
+  `deploy/pi-deploy.yaml` plus gitignored `deploy/pi-deploy.local.yaml`
+- Machine-local hostnames, usernames, and path overrides must stay out
+  of tracked files
+- Default dev project dir on Pi: `/opt/yoyopod-dev/checkout`
+- Default dev state dir on Pi: `/opt/yoyopod-dev/state`

--- a/rules/design-fidelity.md
+++ b/rules/design-fidelity.md
@@ -40,11 +40,11 @@ When implementing or refining Whisplay UI from Figma, preserve the product's exi
    - preserve safe margins
    - shorten helper text if it clips on real hardware
 3. Update shared theme primitives first.
-4. Update the Python screen behavior.
+4. Update the Rust screen controller in `device/ui/`.
 5. Update the LVGL view layer.
 6. Update the native LVGL scene when hardware parity requires it.
-7. Validate locally.
-8. Sync to the Pi and validate on the device.
+7. Validate locally with cargo checks and the LVGL simulation preview.
+8. Deploy to the Pi with `yoyopod target deploy` and validate on device.
 
 ## Extraction Heuristics
 
@@ -65,23 +65,32 @@ For Whisplay UI work, the standard loop is:
 
 1. Validate locally:
    ```bash
-   uv run --extra dev python scripts/quality.py ci
+   cargo check --manifest-path device/Cargo.toml --workspace --locked
+   cargo test  --manifest-path device/Cargo.toml -p yoyopod-ui
    ```
-   For iterative UI work, run the most relevant Rust build check and target validation command for the changed surface.
 2. Commit and push the branch you want to validate:
    ```bash
    git branch --show-current
    git rev-parse HEAD
    ```
-3. Validate the committed branch or exact SHA on the Pi:
+3. Deploy the committed branch or exact SHA to the Pi:
    ```bash
-   yoyopod remote validate --branch <branch> --sha <commit>
+   yoyopod target deploy --branch <branch>          # or --sha <commit>
    ```
 4. Capture output from the Pi:
-   - single capture with `yoyopod remote screenshot`
+   ```bash
+   yoyopod target screenshot
+   yoyopod target logs --follow
+   ```
 5. Compare the captured result against Figma and adjust.
 
-Use `yoyopod remote sync` only if the user explicitly wants a dirty-tree hardware check as a one-off debugging override.
+Automated on-Pi validation (`yoyopod target validate`) is a Round 1 stub
+during the CLI rebuild. Validate manually until Round 2 restores it; see
+`docs/operations/CLI_REBUILD_ROUNDS.md`.
+
+Dirty-tree deploys are not supported by `yoyopod target deploy` — the
+CI-artifact contract requires a pushed commit. If you need to test
+uncommitted state, commit to a throwaway branch first.
 
 ## Screenshot Interpretation
 
@@ -98,7 +107,7 @@ Use all three appropriately:
 ## Native Rebuild Rule
 
 - If `device/ui/native/lvgl/lv_conf.h` or Rust LVGL binding code changes, validate with a fresh CI Rust artifact before judging the hardware result.
-- `yoyopod remote validate` and `yoyopod remote restart` must not rebuild LVGL on the Pi. Do not assume a locally compiled Pi artifact reflects the committed code under test.
+- `yoyopod target deploy` and `yoyopod target restart` must not rebuild LVGL on the Pi. Do not assume a locally compiled Pi artifact reflects the committed code under test.
 
 ## Whisplay-Specific Acceptance Criteria
 

--- a/rules/logging.md
+++ b/rules/logging.md
@@ -36,7 +36,7 @@ Written under the active lane state directory on startup:
 - prod: `/opt/yoyopod-prod/state/yoyopod.pid`
 
 `YOYOPOD_PID_FILE` is the systemd/launcher override that keeps the Rust runtime
-and `yoyopod remote ...` CLI on the same path. Do not use `/tmp/yoyopod.pid`;
+and `yoyopod target ...` CLI on the same path. Do not use `/tmp/yoyopod.pid`;
 `/tmp` sticky-bit ownership breaks cleanup when the service and SSH user differ.
 
 ## Startup/Shutdown Markers

--- a/rules/lvgl.md
+++ b/rules/lvgl.md
@@ -43,22 +43,34 @@ Minimal config enabling only what YoYoPod uses:
 
 ## Building
 
+LVGL native build commands moved out of the CLI in the Round 0 rebuild
+and have not yet been ported back. For now, build LVGL via cmake directly
+or rely on the CI-built Rust artifacts that already bundle a working
+`liblvgl.a`:
+
 ```bash
-yoyopod build simulation   # prepares native LVGL used by the Rust runtime preview
-yoyopod build lvgl         # clones LVGL 9.5.0, compiles native LVGL
-yoyopod build ensure-native
+# CI route (preferred): yoyopod target deploy fetches the
+# yoyopod-rust-device-arm64-<sha> bundle which already contains the
+# linked LVGL.
+
+# Local route (rare; required only for simulation preview):
+cmake -S device/ui/native/lvgl -B device/ui/native/lvgl/build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLVGL_SOURCE_DIR=.cache/lvgl/lvgl-9.5.0 \
+    -DCONFIG_LV_BUILD_EXAMPLES=OFF -DCONFIG_LV_BUILD_DEMOS=OFF
+cmake --build device/ui/native/lvgl/build --parallel 2
 ```
 
-Do not rebuild LVGL on the Pi for normal dev/prod validation. Use CI-built Rust
-artifacts for the exact commit under test.
+Do not rebuild LVGL on the Pi for normal dev/prod validation. Use
+CI-built Rust artifacts for the exact commit under test.
 
 ## Screenshot Support
 
-- `yoyopod remote screenshot` defaults to the shadow-first path via `SIGUSR2`.
-- `yoyopod remote screenshot --readback` requests LVGL readback via `SIGUSR1`.
-- The remote helper now clears the previous remote PNG before capture and waits for a fresh file.
+- `yoyopod target screenshot` defaults to the shadow-first path via `SIGUSR2`.
+- `yoyopod target screenshot --readback` requests LVGL readback via `SIGUSR1`.
+- The CLI clears the previous remote PNG before capture and waits for a fresh file.
 - Both screenshot signals also append freeze diagnostics to `logs/yoyopod_errors.log`:
-  - an all-thread traceback dump from `faulthandler`
+  - an all-thread backtrace dump
   - a structured runtime snapshot logged before the screenshot is queued
 - To confirm which path actually succeeded, check the app log:
   - `Saved screenshot via LVGL readback` means native LVGL snapshotting succeeded.

--- a/rules/project.md
+++ b/rules/project.md
@@ -7,39 +7,32 @@ Three display/input surfaces are supported today: PiSugar Whisplay hardware, Pim
 ## Common Commands
 
 ```bash
-# Install dev dependencies
-uv run yoyopod setup host
-uv run yoyopod setup verify-host
+# Build the Rust operator CLI (single binary `yoyopod`):
+cargo build --manifest-path cli/Cargo.toml --release
+# Optional: install into ~/.cargo/bin/
+cargo install --path cli/yoyopod
 
-# Build and run the Rust runtime
-uv run yoyopod build rust-runtime
-device/runtime/build/yoyopod-runtime --config-dir config
-yoyopod build simulation
+# Build and run the Rust runtime locally:
+cargo build --manifest-path device/Cargo.toml --release -p yoyopod-runtime
+device/target/release/yoyopod-runtime --config-dir config
 
-# Local CI mirror
-uv run --extra dev python scripts/quality.py ci
+# Rust workspace checks:
+cargo check --manifest-path device/Cargo.toml --workspace --locked
+cargo test  --manifest-path cli/Cargo.toml
 
-# Repo-owned code quality gate
-uv run --extra dev python scripts/quality.py gate
-
-# Full quality debt audit
-uv run --extra dev python scripts/quality.py audit
-
-# Baseline Pi setup contract
-uv run yoyopod setup pi
-uv run yoyopod setup verify-pi
-
-# Focused target-side validation
-yoyopod pi validate deploy
-yoyopod pi validate smoke
-yoyopod pi validate voip
-yoyopod pi validate navigation
-yoyopod pi validate stability
+# Daily Pi loop:
+yoyopod target mode status
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>           # or --sha <commit>
+yoyopod target logs --follow
 ```
 
-`yoyopod setup *` is the baseline executable contract, not the finished setup story.
-It does not yet provision external service credentials, validate every native
-artifact deeply, or cover every board/modem-specific edge.
+Host setup, Pi bootstrap, code quality gates, and per-stage on-Pi
+validation (`pi validate deploy/smoke/voip/navigation/stability`) are
+all part of the CLI rebuild roadmap; see
+`docs/operations/CLI_REBUILD_ROUNDS.md`. Until they return, set up host
+dependencies manually and validate Rust changes after `target deploy`
+via `journalctl -u yoyopod-dev.service -f`.
 
 ## Configuration
 

--- a/rules/voip.md
+++ b/rules/voip.md
@@ -1,23 +1,26 @@
 # Communication (Liblinphone)
 
-Applies to: `yoyopod/integrations/call/**`, `yoyopod/integrations/contacts/**`, `yoyopod/backends/voip/**`
+Applies to: `device/voip/**`, `device/liblinphone-shim/**`, and any
+runtime code that consumes VoIP state snapshots.
 
 ## Overview
 
-The production VoIP path is Rust-owned Liblinphone:
+The VoIP path is fully Rust-owned:
 
 - Rust VoIP host under `device/voip/`
 - Rust Liblinphone shim under `device/liblinphone-shim/`
-- Python `RustHostBackend` only supervises the worker process and forwards commands
-- `VoIPManager` only exposes command helpers and Rust runtime snapshots to the app
+- The runtime supervises the host process and forwards commands over
+  the standard NDJSON worker protocol
+- Runtime VoIP state is sourced from the host's published snapshots
 
-Do not reintroduce `linphonec` subprocess control or `.linphonerc`-driven runtime behavior.
+Do not reintroduce `linphonec` subprocess control or `.linphonerc`-driven runtime behaviour.
 
 ## Integration Rules
 
-- Liblinphone iteration is owned by the Rust VoIP host, not the Python app loop.
-- Python must not expose live call-state or incoming-call callback ownership.
-- Rust runtime snapshots are the contract into the Python app layer for:
+- Liblinphone iteration is owned by the Rust VoIP host.
+- Live call-state and incoming-call callback ownership stays inside the
+  host.
+- Rust runtime snapshots are the contract into the app state for:
   - registration state
   - call/session state
   - message summaries

--- a/skills/yoyopod-deploy/SKILL.md
+++ b/skills/yoyopod-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoyopod-deploy
-description: Commit-safe Rust-first dev-lane branch/SHA validation or prod slot install on Raspberry Pi
+description: Commit-safe Rust-first dev-lane branch/SHA deploy to Raspberry Pi
 disable-model-invocation: true
 allowed-tools:
   - Read
@@ -8,77 +8,86 @@ allowed-tools:
   - Bash(git branch --show-current:*)
   - Bash(git rev-parse:*)
   - Bash(git push:*)
-  - Bash(yoyopod remote:*)
+  - Bash(yoyopod target:*)
 ---
 
 ## Config
 
-Use `deploy/pi-deploy.yaml` as the shared deploy contract and `deploy/pi-deploy.local.yaml` for machine-specific overrides such as host, SSH user, and the dev lane checkout. The tracked dev default is `project_dir: /opt/yoyopod-dev/checkout`; prod slots live under `/opt/yoyopod-prod`. `yoyopod remote` merges the files directly, and `yoyopod remote config edit` is the preferred way to create or update the local override.
+Use `deploy/pi-deploy.yaml` as the shared deploy contract and
+`deploy/pi-deploy.local.yaml` for machine-specific overrides such as
+host, SSH user, and the dev lane checkout. The tracked dev default is
+`project_dir: /opt/yoyopod-dev/checkout`; prod slots live under
+`/opt/yoyopod-prod`. `yoyopod target` merges the files directly, and
+`yoyopod target config edit` is the preferred way to create or update
+the local override.
 
-If the file does not exist yet, run `yoyopod remote config edit` first. That command creates `deploy/pi-deploy.local.yaml` automatically before opening it.
+If the file does not exist yet, run `yoyopod target config edit` first.
+That command creates `deploy/pi-deploy.local.yaml` automatically before
+opening it.
 
 ## Steps
 
-1. **Check local git status.** Run `git status --short`. If there are uncommitted or unstaged changes, stop and tell the user: "You have uncommitted changes. Commit and push first. `/yoyopod-sync` is a rare dirty-tree debugging override only."
+1. **Check local git status.** Run `git status --short`. If there are
+   uncommitted or unstaged changes, stop and tell the user: "You have
+   uncommitted changes. Commit and push first. The Rust CLI does not
+   support dirty-tree deploys (CI-artifact contract)."
 
 2. **Resolve the branch and exact commit.** Run:
    ```bash
    git branch --show-current
    git rev-parse HEAD
    ```
-   If the branch is empty, stop and ask the user which branch should be validated.
+   If the branch is empty, stop and ask the user which branch should be
+   deployed.
 
-3. **Push the branch.** Run `git push`. If the branch has no upstream yet, run `git push -u origin <branch>`.
+3. **Push the branch.** Run `git push`. If the branch has no upstream
+   yet, run `git push -u origin <branch>`.
 
 4. **Switch the board into the dev lane.** Run:
    ```bash
-   yoyopod remote mode status
-   yoyopod remote mode activate dev
+   yoyopod target mode status
+   yoyopod target mode activate dev
    ```
-   If `mode status` reports `active_lane=conflict`, include the conflict lines in the response and let `mode activate dev` clean the lane before validation.
+   If `mode status` reports a conflict, include the conflict lines in
+   the response and let `mode activate dev` clean the lane before
+   deploy.
 
-5. **Install Rust artifacts when validating the Rust owner.** If the task is
-   testing `yoyopod-runtime`, `yoyopod-ui-host`, media, or VoIP Rust workers,
-   use `skills/yoyopod-rust-artifact/SKILL.md` first. Do not build Rust
-   binaries on the Pi Zero 2W unless the user explicitly overrides that rule.
-
-6. **Validate the committed branch and exact SHA on the Pi.** Run:
+5. **Deploy the committed branch / SHA.** Run:
    ```bash
-   yoyopod remote validate --branch <branch> --sha <commit>
+   yoyopod target deploy --branch <branch>            # or --sha <commit>
    ```
-   Add smoke flags such as `--with-music`, `--with-voip`, `--with-power`, `--with-rtc`, or `--with-lvgl-soak` when the task calls for them.
 
-7. **Handle failures.** If validation fails, run:
+   `target deploy` automatically:
+   - finds the successful CI run for the exact commit
+   - downloads `yoyopod-rust-device-arm64-<sha>` via `gh run download`
+   - syncs the Pi checkout to the same commit
+   - scps + extracts the worker binaries into `device/*/build/`
+   - restarts `yoyopod-dev.service` and waits for the startup marker
+
+   Add `--wait-for-ci` if CI is still queued or in-progress.
+
+6. **Optional: stage validation (Round 2 work).** Automated on-Pi
+   validation (`yoyopod target validate`) is a stub during the CLI
+   rebuild. Validate manually after deploy:
    ```bash
-   yoyopod remote logs --lines 20
+   yoyopod target status
+   yoyopod target logs --follow
+   ```
+   Exercise the changed surface on the device.
+
+7. **Handle failures.** If deploy fails, run:
+   ```bash
+   yoyopod target logs --lines 20
    ```
    Include the relevant error output in your response.
 
-8. **Report the result.** Include the validated branch, exact SHA, lane state,
-   active runtime owner (`rust` or Python fallback), whether validation passed,
-   and that the dev lane was left running for manual testing when the flow
-   succeeded.
+8. **Report the result.** Include the deployed branch, exact SHA, CI
+   run ID, artifact name, Pi host, lane state, and that the dev lane
+   was left running for manual testing when the flow succeeded.
 
 ## Prod Slot Flow
 
-For packaged releases, prefer a CI-published artifact URL:
-
-```bash
-yoyopod remote release install-url <artifact-url>
-yoyopod remote mode activate prod
-yoyopod remote release status
-```
-
-Add `--first-deploy` to `install-url` when the Pi has no previous prod slot yet.
-
-For a local artifact, use:
-
-```bash
-yoyopod remote release push ./build/releases/<version>.tar.gz
-yoyopod remote mode activate prod
-yoyopod remote release status
-```
-
-Add `--first-deploy` to `release push` when the Pi has no previous prod slot yet.
-
-Prod release commands target `/opt/yoyopod-prod` and do not require `uv` or a repo checkout on the Pi after curl bootstrap. See `docs/operations/SLOT_DEPLOY.md`.
+Prod slot release commands (`yoyopod target release …`) return in Round
+3 of the CLI rebuild. Until then, prod releases are paused; see
+`docs/operations/CLI_REBUILD_ROUNDS.md`. Reinstalling a previously-shipped
+slot can still be done manually via SSH + `install_release.sh`.

--- a/skills/yoyopod-logs/SKILL.md
+++ b/skills/yoyopod-logs/SKILL.md
@@ -4,24 +4,32 @@ description: Tail YoYoPod runtime/service logs from Raspberry Pi
 disable-model-invocation: true
 allowed-tools:
   - Read
-  - Bash(yoyopod remote:*)
+  - Bash(yoyopod target:*)
 argument-hint: "[line_count] [--errors] [--filter <subsystem>] [--follow]"
 ---
 
 ## Config
 
-Use `deploy/pi-deploy.yaml` as the shared deploy contract and `deploy/pi-deploy.local.yaml` for machine-specific overrides such as host, SSH user, dev lane checkout, and branch. The tracked dev default is `/opt/yoyopod-dev/checkout`; prod slots live under `/opt/yoyopod-prod`. `yoyopod remote` merges the files directly, and `yoyopod remote config edit` is the preferred way to create or update the local override.
+Use `deploy/pi-deploy.yaml` as the shared deploy contract and
+`deploy/pi-deploy.local.yaml` for machine-specific overrides such as
+host, SSH user, dev lane checkout, and branch. The tracked dev default
+is `/opt/yoyopod-dev/checkout`; prod slots live under `/opt/yoyopod-prod`.
+`yoyopod target` merges the files directly, and `yoyopod target config
+edit` is the preferred way to create or update the local override.
 
-If the file does not exist yet, run `yoyopod remote config edit` first. That command creates `deploy/pi-deploy.local.yaml` automatically before opening it.
+If the file does not exist yet, run `yoyopod target config edit` first.
+That command creates `deploy/pi-deploy.local.yaml` automatically before
+opening it.
 
 ## Argument Parsing
 
 Parse the arguments string provided after `/yoyopod-logs`:
 
-- **Line count:** If a bare number is present (for example `/yoyopod-logs 100`), map it to `--lines <count>`. Default: 100.
-- **--errors flag:** Pass through to `yoyopod remote logs --errors`.
-- **--filter value:** Pass through to `yoyopod remote logs --filter <value>`.
-- **--follow flag:** Pass through to `yoyopod remote logs --follow`.
+- **Line count:** If a bare number is present (for example
+  `/yoyopod-logs 100`), map it to `--lines <count>`. Default: 100.
+- **--errors flag:** Pass through to `yoyopod target logs --errors`.
+- **--filter value:** Pass through to `yoyopod target logs --filter <value>`.
+- **--follow flag:** Pass through to `yoyopod target logs --follow`.
 
 Multiple flags can be combined.
 
@@ -29,15 +37,19 @@ Multiple flags can be combined.
 
 1. **Build the helper command.** Use:
    ```bash
-   yoyopod remote logs ...
+   yoyopod target logs ...
    ```
-   Add `--lines`, `--errors`, `--filter`, and `--follow` based on the parsed arguments.
+   Add `--lines`, `--errors`, `--filter`, and `--follow` based on the
+   parsed arguments.
 
-2. **If lane or runtime ownership matters, also run:**
+2. **If lane state matters, also run:**
    ```bash
-   yoyopod remote mode status
+   yoyopod target mode status
    ```
 
-3. **Present the log output.** Return the raw log lines directly. Do not summarize or truncate unless the user explicitly asks. If the user is debugging Rust ownership, call out whether the logs show `yoyopod-runtime` or the Python fallback.
+3. **Present the log output.** Return the raw log lines directly. Do
+   not summarize or truncate unless the user explicitly asks.
 
-After presenting the logs, remind the user they can ask follow-up questions about the log content, such as "why did the call drop?" or "what errors happened in the last minute?"
+After presenting the logs, remind the user they can ask follow-up
+questions about the log content, such as "why did the call drop?" or
+"what errors happened in the last minute?"

--- a/skills/yoyopod-restart/SKILL.md
+++ b/skills/yoyopod-restart/SKILL.md
@@ -4,33 +4,43 @@ description: Restart the active YoYoPod dev lane service on Raspberry Pi
 disable-model-invocation: true
 allowed-tools:
   - Read
-  - Bash(yoyopod remote:*)
+  - Bash(yoyopod target:*)
 ---
 
 ## Config
 
-Use `deploy/pi-deploy.yaml` as the shared deploy contract and `deploy/pi-deploy.local.yaml` for machine-specific overrides such as host, SSH user, dev lane checkout, and branch. `yoyopod remote restart` is a dev-lane helper and expects the selected checkout to match `/opt/yoyopod-dev/checkout`. Prod slots live under `/opt/yoyopod-prod` and should be managed with `yoyopod remote release ...`.
+Use `deploy/pi-deploy.yaml` as the shared deploy contract and
+`deploy/pi-deploy.local.yaml` for machine-specific overrides such as
+host, SSH user, dev lane checkout, and branch. `yoyopod target restart`
+is a dev-lane helper and expects the selected checkout to match
+`/opt/yoyopod-dev/checkout`. Prod slot management (`target release …`)
+returns in Round 3 of the CLI rebuild; see
+`docs/operations/CLI_REBUILD_ROUNDS.md`.
 
-If the file does not exist yet, run `yoyopod remote config edit` first. That command creates `deploy/pi-deploy.local.yaml` automatically before opening it.
+If the file does not exist yet, run `yoyopod target config edit` first.
+That command creates `deploy/pi-deploy.local.yaml` automatically before
+opening it.
 
 ## Steps
 
-1. **Check lane ownership first.**
+1. **Check lane state first.**
    ```bash
-   yoyopod remote mode status
+   yoyopod target mode status
    ```
 
 2. **Restart and verify the dev lane service.** Run:
    ```bash
-   yoyopod remote restart
+   yoyopod target restart
    ```
 
-3. **Handle failures.** If the restart fails because prod is active, use `yoyopod remote mode activate dev` before retrying. For other failures, run:
+3. **Handle failures.** If the restart fails because prod is active, use
+   `yoyopod target mode activate dev` before retrying. For other
+   failures, run:
    ```bash
-   yoyopod remote logs --lines 20
+   yoyopod target logs --lines 20
    ```
    Include the relevant error output in your response.
 
-Report whether the dev lane restart succeeded and whether the service came up
-as `yoyopod-runtime` or the Python fallback. For prod, report
-`yoyopod remote release status` instead of using this skill.
+Report whether the dev lane restart succeeded and whether
+`yoyopod-runtime` came up. For prod slot operations, fall back to
+direct SSH and `systemctl` until Round 3 restores the CLI commands.

--- a/skills/yoyopod-rust-artifact/SKILL.md
+++ b/skills/yoyopod-rust-artifact/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoyopod-rust-artifact
-description: Deploy and test Rust runtime/worker binaries from GitHub Actions artifacts instead of building on Raspberry Pi
+description: Manual fallback for fetching CI Rust artifacts onto the Pi (prefer /yoyopod-deploy)
 disable-model-invocation: true
 allowed-tools:
   - Read
@@ -14,27 +14,36 @@ allowed-tools:
   - Bash(chmod:*)
   - Bash(ssh:*)
   - Bash(scp:*)
-  - Bash(yoyopod remote:*)
+  - Bash(yoyopod target:*)
 ---
+
+## Prefer `/yoyopod-deploy`
+
+`yoyopod target deploy` (skill `/yoyopod-deploy`) replaces this entire
+flow with a single command. It:
+
+- verifies the worktree is clean and the commit is pushed
+- finds the successful CI run for the exact commit
+- runs `gh run download` for `yoyopod-rust-device-arm64-<sha>`
+- syncs the Pi checkout
+- scps + extracts the worker binaries into `device/*/build/`
+- restarts `yoyopod-dev.service` and verifies startup
+
+Use this skill only when you need to do part of that flow manually —
+for example debugging a half-broken Pi state, swapping a single
+artifact, or working around a `gh` CLI auth issue.
 
 ## Rule
 
-Rust binaries for hardware validation must come from GitHub Actions artifacts
-for the exact commit being tested. Do not run `cargo build`,
-`yoyopod build rust-runtime`, `yoyopod build rust-ui-host`,
-or any other Rust compile on the Raspberry Pi Zero 2W unless the user explicitly
-overrides this rule.
-
-Native C shim work is different only for LVGL:
-`yoyopod remote sync --clean-native` may still rebuild the LVGL C shim on the
-Pi when native/CMake inputs change.
+Rust binaries for hardware validation must come from GitHub Actions
+artifacts for the exact commit being tested. Do not run `cargo build`
+on the Raspberry Pi Zero 2W unless the user explicitly overrides this
+rule.
 
 ## Current Rust Artifact Contract
 
-Use the artifact whose suffix equals the exact commit under test, not a pull
-request merge SHA.
-
-The CI artifact is:
+Use the artifact whose suffix equals the exact commit under test, not a
+pull request merge SHA:
 
 ```bash
 yoyopod-rust-device-arm64-<sha>
@@ -50,17 +59,19 @@ That tarball extracts an install-ready `device/.../build/...` tree:
 
 | Path inside extracted tree | Purpose |
 | --- | --- |
-| `device/runtime/build/yoyopod-runtime` | Top-level Rust runtime entrypoint when `YOYOPOD_DEV_RUNTIME=rust`. |
+| `device/runtime/build/yoyopod-runtime` | Top-level Rust runtime entrypoint. |
 | `device/ui/build/yoyopod-ui-host` | Whisplay UI worker and LVGL renderer. |
 | `device/media/build/yoyopod-media-host` | Rust media/mpv worker. |
 | `device/voip/build/yoyopod-voip-host` | Rust Liblinphone/SIP worker. |
 | `device/network/build/yoyopod-network-host` | Rust SIM7600/PPP/GPS worker. |
+| `device/cloud/build/yoyopod-cloud-host` | Rust cloud MQTT worker. |
+| `device/power/build/yoyopod-power-host` | Rust PiSugar/power worker. |
+| `device/speech/build/yoyopod-speech-host` | Rust speech/Ask worker. |
 
-## Steps
+## Manual Steps (when `/yoyopod-deploy` cannot be used)
 
-1. **Check local git status.** Run `git status --short`. If there are local
-   changes, commit them first or stop and ask the user whether this is a
-   dirty-tree exception.
+1. **Check local git status.** If there are local changes, commit them
+   first or stop and ask the user whether this is a debugging exception.
 
 2. **Resolve branch and commit.**
 
@@ -78,9 +89,10 @@ That tarball extracts an install-ready `device/.../build/...` tree:
    gh run list --workflow CI --branch <branch> --json databaseId,headSha,status,conclusion --limit 20
    ```
 
-   Use only a run whose `headSha` equals the commit from step 2 and whose
-   conclusion is `success`. If the run is still queued or in progress, wait.
-   If it failed, inspect the failed job before hardware deploy.
+   Use only a run whose `headSha` equals the commit from step 2 and
+   whose conclusion is `success`. If the run is still queued or in
+   progress, wait. If it failed, inspect the failed job before any
+   hardware step.
 
 5. **Download and extract the Rust device bundle locally.**
 
@@ -88,49 +100,47 @@ That tarball extracts an install-ready `device/.../build/...` tree:
    mkdir -p .artifacts/rust-device/<sha>
    gh run download <run-id> --name yoyopod-rust-device-arm64-<sha> --dir .artifacts/rust-device/<sha>
    tar -xzf .artifacts/rust-device/<sha>/yoyopod-rust-device-arm64-<sha>.tar.gz -C .artifacts/rust-device/<sha>
-   chmod +x .artifacts/rust-device/<sha>/device/runtime/build/yoyopod-runtime
-   chmod +x .artifacts/rust-device/<sha>/device/ui/build/yoyopod-ui-host
-   chmod +x .artifacts/rust-device/<sha>/device/media/build/yoyopod-media-host
-   chmod +x .artifacts/rust-device/<sha>/device/voip/build/yoyopod-voip-host
-   chmod +x .artifacts/rust-device/<sha>/device/network/build/yoyopod-network-host
    ```
 
 6. **Make sure the Pi dev checkout is on the same commit.**
 
    ```bash
-   yoyopod remote mode activate dev
-   yoyopod remote sync --branch <branch> --sha <sha>
+   yoyopod target mode activate dev
+   # then deploy without artifact (this is the simple-case fallback that
+   # only re-syncs git state; binaries follow in step 7):
+   yoyopod target deploy --sha <sha>
    ```
 
-   Add `--clean-native` only when native C/CMake/shim inputs changed.
-
-7. **Install the CI-built Rust binaries on the Pi.**
+7. **Install the CI-built Rust binaries on the Pi (only if step 6 did
+   not already do it — `yoyopod target deploy` normally does this end
+   to end).**
 
    ```bash
    scp .artifacts/rust-device/<sha>/yoyopod-rust-device-arm64-<sha>.tar.gz <user>@<host>:/tmp/yoyopod-rust-device-arm64-<sha>.tar.gz
-   ssh <user>@<host> 'cd /opt/yoyopod-dev/checkout && tar -xzf /tmp/yoyopod-rust-device-arm64-<sha>.tar.gz && chmod +x device/runtime/build/yoyopod-runtime device/ui/build/yoyopod-ui-host device/media/build/yoyopod-media-host device/voip/build/yoyopod-voip-host device/network/build/yoyopod-network-host'
+   ssh <user>@<host> 'cd /opt/yoyopod-dev/checkout && \
+       tar -xzf /tmp/yoyopod-rust-device-arm64-<sha>.tar.gz && \
+       chmod +x device/runtime/build/yoyopod-runtime \
+                device/ui/build/yoyopod-ui-host \
+                device/media/build/yoyopod-media-host \
+                device/voip/build/yoyopod-voip-host \
+                device/network/build/yoyopod-network-host \
+                device/cloud/build/yoyopod-cloud-host \
+                device/power/build/yoyopod-power-host \
+                device/speech/build/yoyopod-speech-host'
+   yoyopod target restart
    ```
 
-8. **Select the Rust dev-lane owner and restart.** The dev service still has a
-   Python fallback, so set the override before testing the Rust entrypoint:
+8. **Validate.** Automated on-Pi validation returns in Round 2 of the
+   CLI rebuild. Until then, validate manually:
 
    ```bash
-   ssh <user>@<host> 'set -e; sudo touch /etc/default/yoyopod-dev; if sudo grep -q "^YOYOPOD_DEV_RUNTIME=" /etc/default/yoyopod-dev; then sudo sed -i "s/^YOYOPOD_DEV_RUNTIME=.*/YOYOPOD_DEV_RUNTIME=rust/" /etc/default/yoyopod-dev; else printf "%s\n" "YOYOPOD_DEV_RUNTIME=rust" | sudo tee -a /etc/default/yoyopod-dev >/dev/null; fi'
-   yoyopod remote restart
+   yoyopod target status
+   yoyopod target logs --follow
+   journalctl -u yoyopod-dev.service -f
    ```
 
-9. **Validate the Rust path.**
+   Exercise the changed surface on the device.
 
-   ```bash
-   yoyopod remote validate --branch <branch> --sha <sha> --with-rust-ui-host --with-lvgl-soak
-   ```
-
-   For a direct UI worker check, run from the Pi checkout:
-
-   ```bash
-   ssh <user>@<host> 'cd /opt/yoyopod-dev/checkout && YOYOPOD_WHISPLAY_DC_GPIO=27 YOYOPOD_WHISPLAY_RESET_GPIO=4 YOYOPOD_WHISPLAY_BUTTON_GPIO=17 YOYOPOD_WHISPLAY_BUTTON_ACTIVE_LOW=0 /opt/yoyopod-dev/checkout/device/ui/build/yoyopod-ui-host --hardware whisplay'
-   ```
-
-10. **Report exact provenance.** Include the branch, commit SHA, CI run ID,
-    artifact names, Pi host, active runtime owner, command result, and whether
-    the dev service was left running.
+9. **Report exact provenance.** Include the branch, commit SHA, CI run
+   ID, artifact names, Pi host, command result, and whether the dev
+   service was left running.

--- a/skills/yoyopod-screenshot/SKILL.md
+++ b/skills/yoyopod-screenshot/SKILL.md
@@ -4,49 +4,65 @@ description: Capture a screenshot of the active YoYoPod display from Raspberry P
 disable-model-invocation: true
 allowed-tools:
   - Read
-  - Bash(yoyopod remote:*)
+  - Bash(yoyopod target:*)
 argument-hint: "[--readback]"
 ---
 
 ## Config
 
-Use `deploy/pi-deploy.yaml` as the shared deploy contract and `deploy/pi-deploy.local.yaml` for machine-specific overrides such as host, SSH user, dev lane checkout, and branch. Screenshots target the currently running lane; dev normally runs from `/opt/yoyopod-dev/checkout`, and prod runs from `/opt/yoyopod-prod/current`. `yoyopod remote` merges the config files directly.
+Use `deploy/pi-deploy.yaml` as the shared deploy contract and
+`deploy/pi-deploy.local.yaml` for machine-specific overrides such as
+host, SSH user, dev lane checkout, and branch. Screenshots target the
+currently running lane; dev normally runs from `/opt/yoyopod-dev/checkout`,
+and prod runs from `/opt/yoyopod-prod/current`. `yoyopod target` merges
+the config files directly.
 
-If the file does not exist yet, run `yoyopod remote config edit` first. That command creates `deploy/pi-deploy.local.yaml` automatically before opening it.
+If the file does not exist yet, run `yoyopod target config edit` first.
+That command creates `deploy/pi-deploy.local.yaml` automatically before
+opening it.
 
 ## Argument Parsing
 
 Parse the arguments string provided after `/yoyopod-screenshot`:
 
-- **--readback flag:** If `--readback` is present, request LVGL readback. Otherwise use the shadow buffer.
+- **--readback flag:** If `--readback` is present, request LVGL
+  readback. Otherwise use the shadow buffer.
 
 ## Steps
 
-1. **Check which lane/runtime owns the display.**
+1. **Check lane state.**
    ```bash
-   yoyopod remote mode status
+   yoyopod target mode status
    ```
 
 2. **Capture the screenshot to a temporary local PNG.** Run:
    ```bash
-   yoyopod remote screenshot [--readback] --output <local_temp_path>
+   yoyopod target screenshot [--readback] --out <local_temp_path>
    ```
    Use a temporary local path such as `./pi_screenshot.png`.
 
-3. **Display the PNG.** Use the agent's local image viewing tool to show the saved screenshot in the conversation.
+3. **Display the PNG.** Use the agent's local image viewing tool to show
+   the saved screenshot in the conversation.
 
 4. **Explain what was captured.** After showing the image:
-   - Default mode: "This is the shadow buffer - what the app sent to the display."
-   - `--readback`: "This is the requested LVGL readback path - what LVGL actually rendered if the native snapshot succeeded."
+   - Default mode: "This is the shadow buffer — what the app sent to
+     the display."
+   - `--readback`: "This is the requested LVGL readback path — what
+     LVGL actually rendered if the native snapshot succeeded."
 
-   Remind the user they can ask follow-up questions about what they see, such as "why is the status bar missing?" or "what screen is this?"
+   Remind the user they can ask follow-up questions about what they
+   see, such as "why is the status bar missing?" or "what screen is
+   this?"
 
-5. **If the user is debugging screenshot fidelity, verify the capture path in logs.** Run:
+5. **If the user is debugging screenshot fidelity, verify the capture
+   path in logs.** Run:
    ```bash
-   yoyopod remote logs --lines 20
+   yoyopod target logs --lines 20
    ```
    Confirm one of these outcomes:
    - `Saved screenshot via LVGL readback` means the readback path succeeded.
-   - `Saved screenshot via shadow buffer` means the capture used the shadow path instead.
+   - `Saved screenshot via shadow buffer` means the capture used the
+     shadow path instead.
 
-6. **Clean up.** Delete the temporary local screenshot file after displaying it.
+6. **Clean up.** Delete the temporary local screenshot file after
+   displaying it.

--- a/skills/yoyopod-status/SKILL.md
+++ b/skills/yoyopod-status/SKILL.md
@@ -1,43 +1,50 @@
 ---
 name: yoyopod-status
-description: Health check for Raspberry Pi lanes, runtime owner, connectivity, processes, memory, recent logs
+description: Health check for Raspberry Pi lanes, runtime, connectivity, processes, memory, recent logs
 disable-model-invocation: true
 allowed-tools:
   - Read
-  - Bash(yoyopod remote:*)
+  - Bash(yoyopod target:*)
 ---
 
 ## Config
 
-Use `deploy/pi-deploy.yaml` as the shared deploy contract and `deploy/pi-deploy.local.yaml` for machine-specific overrides such as host, SSH user, dev lane checkout, and branch. The tracked dev default is `/opt/yoyopod-dev/checkout`; prod slots live under `/opt/yoyopod-prod`. `yoyopod remote` merges the files directly, and `yoyopod remote config edit` is the preferred way to create or update the local override.
+Use `deploy/pi-deploy.yaml` as the shared deploy contract and
+`deploy/pi-deploy.local.yaml` for machine-specific overrides such as
+host, SSH user, dev lane checkout, and branch. The tracked dev default
+is `/opt/yoyopod-dev/checkout`; prod slots live under `/opt/yoyopod-prod`.
+`yoyopod target` merges the files directly, and `yoyopod target config
+edit` is the preferred way to create or update the local override.
 
-If the file does not exist yet, run `yoyopod remote config edit` first. That command creates `deploy/pi-deploy.local.yaml` automatically before opening it.
+If the file does not exist yet, run `yoyopod target config edit` first.
+That command creates `deploy/pi-deploy.local.yaml` automatically before
+opening it.
 
 ## Steps
 
-1. **Check lane ownership first.**
+1. **Check lane state first.**
    ```bash
-   yoyopod remote mode status
+   yoyopod target mode status
    ```
 
 2. **Run the runtime status command.**
    ```bash
-   yoyopod remote status
+   yoyopod target status
    ```
 
 3. **Present the result.** Prefer a compact summary with:
    - active lane and any conflict reasons
-   - active runtime owner when visible (`yoyopod-runtime` or Python fallback)
    - dev service status and prod service status
-   - git branch and commit
+   - whether `yoyopod-runtime` is running, plus its PID
+   - git branch and commit on the Pi checkout
    - Rust artifact presence for runtime/UI/media/VoIP when relevant
-   - music backend status
-   - PiSugar server status
    - PID file state
    - latest startup marker
    - top memory processes
 
-4. **If no supported runtime owner is running,** explicitly suggest the lane-specific action:
+4. **If `yoyopod-runtime` is not running,** explicitly suggest the
+   lane-specific action:
    ```text
-   Run `yoyopod remote mode activate dev` for mutable PR testing, or `yoyopod remote mode activate prod` for the packaged slot lane.
+   Run `yoyopod target mode activate dev` for mutable PR testing, or
+   `yoyopod target mode activate prod` for the packaged slot lane.
    ```

--- a/skills/yoyopod-sync/SKILL.md
+++ b/skills/yoyopod-sync/SKILL.md
@@ -1,54 +1,65 @@
 ---
 name: yoyopod-sync
-description: Rare-case dirty-tree sync escape hatch for Raspberry Pi debugging
+description: Sync a committed branch / SHA to the Raspberry Pi dev lane
 disable-model-invocation: true
 allowed-tools:
   - Read
-  - Bash(yoyopod remote:*)
+  - Bash(yoyopod target:*)
 ---
+
+## What this skill does now
+
+This skill is kept for muscle memory. It is a thin wrapper around
+`yoyopod target deploy`, which is the committed-code sync command.
+
+The Python-era `yoyopod remote sync --dirty-tree` escape hatch was
+deleted in the Round 0 CLI rebuild. The Rust CLI does not support
+syncing uncommitted local state — `target deploy` requires a pushed
+commit so the matching CI artifact (`yoyopod-rust-device-arm64-<sha>`)
+can be downloaded and installed. If you need to test uncommitted work,
+commit to a throwaway branch first, push, then deploy.
 
 ## Config
 
-Use `deploy/pi-deploy.yaml` as the shared deploy contract and `deploy/pi-deploy.local.yaml` for machine-specific overrides such as host, SSH user, and the dev lane checkout. The tracked dev default is `project_dir: /opt/yoyopod-dev/checkout`; prod slots live under `/opt/yoyopod-prod`. `yoyopod remote` merges the files directly, and `yoyopod remote config edit` is the preferred way to create or update the local override.
+Use `deploy/pi-deploy.yaml` as the shared deploy contract and
+`deploy/pi-deploy.local.yaml` for machine-specific overrides such as
+host, SSH user, and the dev lane checkout. The tracked dev default is
+`project_dir: /opt/yoyopod-dev/checkout`; prod slots live under
+`/opt/yoyopod-prod`. `yoyopod target` merges the files directly, and
+`yoyopod target config edit` is the preferred way to create or update
+the local override.
 
-If the file does not exist yet, run `yoyopod remote config edit` first. That command creates `deploy/pi-deploy.local.yaml` automatically before opening it.
+If the file does not exist yet, run `yoyopod target config edit` first.
+That command creates `deploy/pi-deploy.local.yaml` automatically before
+opening it.
 
 ## Steps
 
-1. **Confirm this is really a dirty-tree override.** Only use this skill if the user explicitly wants to validate uncommitted local state or asks for a dirty-tree debugging shortcut. Otherwise stop and recommend `/yoyopod-deploy`.
-
-2. **Switch the board into the dev lane.** Run:
+1. **Switch the board into the dev lane.** Run:
    ```bash
-   yoyopod remote mode status
-   yoyopod remote mode activate dev
+   yoyopod target mode status
+   yoyopod target mode activate dev
    ```
 
-3. **Sync the dirty working tree into `/opt/yoyopod-dev/checkout`.** Run:
+2. **Deploy the committed branch (and optionally exact SHA).** Run:
    ```bash
-   yoyopod remote sync
+   yoyopod target deploy --branch <branch>            # current commit
+   # or:
+   yoyopod target deploy --sha <commit>
    ```
 
-4. **Remember what sync does not do.** Dirty sync can update Python, config,
-   docs, and native C shim sources. It does not create trustworthy Rust
-   binaries for Pi validation. For Rust runtime/worker binaries, use exact-SHA
-   CI artifacts from `skills/yoyopod-rust-artifact/SKILL.md`.
+   Add `--wait-for-ci` if the CI run for that commit is still queued or
+   in-progress.
 
-5. **If branch switching may have stale native CMake caches,** run:
-   ```bash
-   yoyopod remote sync --clean-native
-   ```
+   Add `--clean-native` after native LVGL / CMake input changes so the
+   Pi-side build dir gets cleared.
 
-6. **If the user explicitly wants sync without restart,** run:
+3. **Handle failures.** If deploy fails, run:
    ```bash
-   yoyopod remote sync --skip-restart
-   ```
-
-7. **Handle failures.** If the sync or restart step fails, run:
-   ```bash
-   yoyopod remote logs --lines 20
+   yoyopod target logs --lines 20
    ```
    Include the relevant error output in your response.
 
-8. **Report the result clearly.** Say that this mutated the dev lane checkout,
-   was a dirty-tree validation override, was not the normal committed branch/SHA
-   workflow, and did not replace the exact-artifact Rust validation path.
+4. **Report the result clearly.** Include the branch, SHA, CI run ID,
+   artifact name, Pi host, and whether `yoyopod-dev.service` came up
+   cleanly.


### PR DESCRIPTION
## Summary

Sweep-clean docs, rules, skills, and deploy files to match the
post-Round-0/1 reality. Every active mention of the deleted Python
operator CLI (`yoyopod_cli`, `yoyopod remote …`, `uv run yoyopod`,
`pyproject.toml`, `scripts/quality.py`, `scripts/build_release.py`,
the YOYOPOD_DEV_RUNTIME toggle, the "Python fallback" runtime owner
concept, and the `yoyopod dev profile` subcommand group) has been
replaced with either the current `yoyopod target …` Rust CLI
equivalent or a clear "returns in Round N" pointer to
`docs/operations/CLI_REBUILD_ROUNDS.md`.

I scanned three times before editing, edited in 4 batches (rules → skills → docs/architecture+features+hardware → docs/operations+README → deploy), then re-scanned to confirm zero active CTAs to deleted commands remain. Files still mention the old names in deletion banners, "what was removed" notes, and Round 3 sketches — intentionally — so future readers can trace the rebuild story without git archaeology.

A live systemd bug also surfaced and is fixed in this PR: `yoyopod-dev.service`'s `ExecStartPre` was checking for the now-deleted `pyproject.toml` before starting the runtime; replaced with a `test -d config` check.

## Commits

1. **`rules/`** (8 files) — Rust-only style, `yoyopod target` naming,
   updated dependency direction, dropped Python `RustHostBackend`
   references in voip.md.
2. **`skills/`** (7 files) — all SKILL.md files renamed `yoyopod
   remote` → `yoyopod target`. yoyopod-sync repurposed as a deploy
   alias. yoyopod-rust-artifact positioned as a manual fallback now
   that `/yoyopod-deploy` replaces the multi-step flow.
3. **`docs/` + `deploy/`** (25 files) — heavy rewrites of operations
   docs (paused-state stubs for SLOT_DEPLOY/RELEASE_PROCESS; "in
   transition" pointers for RPI_SMOKE_VALIDATION and PI_PROFILING;
   manual-prereq sections for CONTRIBUTOR_WORKFLOW, DEVELOPMENT_GUIDE,
   SETUP_CONTRACT). Architecture and hardware docs updated to point at
   `cli/` and Round 2/3/4 pointers where capability is currently gone.
   Live systemd unit + deploy YAML + bootstrap script header updated.

## Test plan

- [x] `cargo build --manifest-path cli/Cargo.toml` — passes
- [x] `cargo test --manifest-path cli/Cargo.toml` — 35/35 passing
- [x] `rg 'uv run yoyopod' docs/ rules/ skills/ deploy/ AGENTS.md README.md` — zero hits
- [x] `rg 'YOYOPOD_DEV_RUNTIME' …` — zero hits
- [x] `rg 'Python fallback' …` — zero hits
- [x] `rg 'yoyopod_cli|yoyopod remote ' …` — only historical/explanatory hits remain (all in "was deleted in Round 0" context, deprecation banners, or Round 3 sketches)
- [x] `yoyopod-dev.service` ExecStartPre updated so the unit no longer fails on missing `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)