### PR TITLE
Restructure docs: promote ROADMAP, archive paused capability docs, fix dead links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Project: Rust-first iPod-inspired VoIP + local music device with small-screen bu
 **CLI rebuild in progress.** The Python operator CLI (`yoyopod_cli/`) was
 deleted 2026-05-13. A new Rust CLI is being built at `cli/` in rounds.
 Many `yoyopod ...` commands are temporarily unavailable. See
-`docs/operations/CLI_REBUILD_ROUNDS.md` for the roadmap and workarounds.
+`docs/ROADMAP.md` for the roadmap and workarounds.
 
 Purpose
 - Keep this file small. It is the always-loaded agent brief, not a full design doc.
@@ -15,7 +15,7 @@ Purpose
 
 Guidance order
 1. Current Rust code in `device/` (runtime, workers) and `cli/` (operator CLI)
-2. `docs/operations/CLI_REBUILD_ROUNDS.md` for what's broken right now
+2. `docs/ROADMAP.md` for what's broken right now
 3. `README.md`, `docs/README.md`, and current operation docs
 4. `rules/` for constraints and style
 5. `skills/` for deploy/debug playbooks (many are stale during the rebuild)
@@ -32,7 +32,7 @@ Read these rules first
 - `rules/deploy.md`
 
 Canonical deploy/debug skills (NOTE: many call deleted yoyopod_cli
-commands during the rebuild — see CLI_REBUILD_ROUNDS.md)
+commands during the rebuild — see ROADMAP.md)
 - `skills/yoyopod-deploy/SKILL.md`
 - `skills/yoyopod-sync/SKILL.md`
 - `skills/yoyopod-logs/SKILL.md`
@@ -40,7 +40,7 @@ commands during the rebuild — see CLI_REBUILD_ROUNDS.md)
 - `skills/yoyopod-status/SKILL.md`
 - `skills/yoyopod-screenshot/SKILL.md`
 - `skills/yoyopod-rust-artifact/SKILL.md`
-- `docs/operations/SLOT_DEPLOY.md` for prod slot/OTA-ready flow
+- `docs/operations/archive/SLOT_DEPLOY.md` for prod slot/OTA-ready flow
 
 Current Runtime Status
 - Rust is the only runtime. The top-level Rust entrypoint is
@@ -57,7 +57,7 @@ Current Runtime Status
   screen set. The only C dependency in the LVGL display path is the pinned
   upstream LVGL native library.
 - The operator CLI is in transition from Python to Rust; see
-  `docs/operations/CLI_REBUILD_ROUNDS.md`. Rust CLI source: `cli/`.
+  `docs/ROADMAP.md`. Rust CLI source: `cli/`.
 - Dev service runs the Rust runtime directly through `yoyopod-runtime`.
 
 Pi Lanes And Bootstrap
@@ -65,7 +65,7 @@ Pi Lanes And Bootstrap
   service `yoyopod-dev.service`.
 - Prod lane: immutable packaged slots under `/opt/yoyopod-prod`, service
   `yoyopod-prod.service`. New prod release builds are blocked until Round 3
-  of the CLI rebuild (see CLI_REBUILD_ROUNDS.md).
+  of the CLI rebuild (see ROADMAP.md).
 - Check lane ownership first with `yoyopod target mode status`; dev/prod
   services should not own hardware together.
 - Dev deploy loop: `yoyopod target mode activate dev`, then
@@ -87,13 +87,12 @@ Source Of Truth
 - `deploy/systemd/yoyopod-dev.service`
 - `deploy/systemd/yoyopod-prod.service`
 - `cli/` (Rust operator CLI, in-progress)
-- `docs/operations/CLI_REBUILD_ROUNDS.md`
+- `docs/ROADMAP.md`
 - `docs/operations/DEV_PROD_LANES.md`
 - `docs/operations/PI_DEV_WORKFLOW.md` (some content stale during rebuild)
-- `docs/operations/SLOT_DEPLOY.md` (stale during rebuild; Round 3)
-- `docs/architecture/DISPLAY_HAL_ARCHITECTURE.md`
-- `docs/design/WHISPLAY_SIMULATION_PARITY_CONTRACT.md`
+- `docs/operations/archive/SLOT_DEPLOY.md` (stale during rebuild; Round 3)
 - `docs/architecture/SYSTEM_ARCHITECTURE.md`
+- `docs/architecture/CANONICAL_STRUCTURE.md`
 
 High-Value Commands
 - Rust device workspace check: `cargo check --manifest-path device/Cargo.toml --workspace --locked`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This repository contains the software that runs the current YoYoPod prototype:
 - `device/{ui,media,voip,network,cloud,power,speech}/` - Rust domain sidecar hosts for UI, media, VoIP, network, cloud, power, and speech/Ask.
 - `cli/` - Rust operator CLI for dev-machine to Pi orchestration. Under
   active rebuild (the Python CLI was retired 2026-05-13); see
-  [docs/operations/CLI_REBUILD_ROUNDS.md](docs/operations/CLI_REBUILD_ROUNDS.md).
+  [docs/ROADMAP.md](docs/ROADMAP.md).
 - `apps/` - future web and mobile applications.
 - `packages/` - future shared contracts, SDKs, and app packages.
 
@@ -83,7 +83,7 @@ cargo build --manifest-path device/Cargo.toml --release -p yoyopod-runtime
 
 Setup tooling (`yoyopod setup host`, `yoyopod setup verify-host`) is on
 the rebuild roadmap. See
-[docs/operations/CLI_REBUILD_ROUNDS.md](docs/operations/CLI_REBUILD_ROUNDS.md).
+[docs/ROADMAP.md](docs/ROADMAP.md).
 
 ### Fresh Raspberry Pi Install
 
@@ -121,9 +121,9 @@ of the CLI rebuild. For now, validate manually after deploy via
 `journalctl -u yoyopod-dev.service -f` and hardware inspection.
 
 For deeper deploy, lane, and troubleshooting flows, read [CLI Rebuild
-Rounds](docs/operations/CLI_REBUILD_ROUNDS.md), [Dev/Prod
+Rounds](docs/ROADMAP.md), [Dev/Prod
 Lanes](docs/operations/DEV_PROD_LANES.md), [Slot
-Deploy](docs/operations/SLOT_DEPLOY.md), and [Pi Dev
+Deploy](docs/operations/archive/SLOT_DEPLOY.md), and [Pi Dev
 Workflow](docs/operations/PI_DEV_WORKFLOW.md).
 
 ## Read More
@@ -131,16 +131,16 @@ Workflow](docs/operations/PI_DEV_WORKFLOW.md).
 - [Documentation Guide](docs/README.md)
 - [Contributor Workflow](docs/operations/CONTRIBUTOR_WORKFLOW.md)
 - [Development Guide](docs/operations/DEVELOPMENT_GUIDE.md)
-- [Release Process](docs/operations/RELEASE_PROCESS.md)
-- [Slot Deploy](docs/operations/SLOT_DEPLOY.md)
+- [Release Process](docs/operations/archive/RELEASE_PROCESS.md)
+- [Slot Deploy](docs/operations/archive/SLOT_DEPLOY.md)
 - [Pi Dev Workflow](docs/operations/PI_DEV_WORKFLOW.md)
-- [Pi Smoke Validation](docs/operations/RPI_SMOKE_VALIDATION.md)
+- [Pi Smoke Validation](docs/operations/archive/RPI_SMOKE_VALIDATION.md)
 - [System Architecture](docs/architecture/SYSTEM_ARCHITECTURE.md)
 - [Power Module](docs/hardware/POWER_MODULE.md)
 - [Design Docs](docs/design/README.md)
 - [Feature Docs](docs/features/README.md)
 
-Historical notes are kept under [docs/archive](docs/archive). Current code and current runtime docs are the source of truth when older plans drift.
+When docs disagree, trust current code and the most recently merged PRs. The [`docs/ROADMAP.md`](docs/ROADMAP.md) tracks the current rebuild rounds; paused capability docs live under [`docs/operations/archive/`](docs/operations/archive/README.md).
 
 ## License
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,7 +1,7 @@
 # yoyopod CLI (Rust)
 
 The Rust replacement for the retired Python `yoyopod_cli`. See
-[../docs/operations/CLI_REBUILD_ROUNDS.md](../docs/operations/CLI_REBUILD_ROUNDS.md)
+[../docs/ROADMAP.md](../docs/ROADMAP.md)
 for the full rebuild plan; this README covers the **Round 1 MVP**.
 
 ## What's here in Round 1
@@ -170,4 +170,4 @@ preflight) and re-enable the disabled CI jobs.
 Round 4+: on-Pi diagnostics (`pi voip`, `pi power`, `pi network`) as
 needed.
 
-See [../docs/operations/CLI_REBUILD_ROUNDS.md](../docs/operations/CLI_REBUILD_ROUNDS.md).
+See [../docs/ROADMAP.md](../docs/ROADMAP.md).

--- a/cli/yoyopod/src/commands/target/validate.rs
+++ b/cli/yoyopod/src/commands/target/validate.rs
@@ -14,7 +14,7 @@ use super::TargetContext;
 pub fn run(_ctx: &TargetContext, _args: ValidateArgs) -> Result<i32> {
     eprintln!(
         "target validate: blocked on Round 2 of the CLI rebuild.\n\
-         See docs/operations/CLI_REBUILD_ROUNDS.md.\n\
+         See docs/ROADMAP.md.\n\
          Until then, validate manually after `yoyopod target deploy`:\n\
            journalctl -u yoyopod-dev.service -f\n\
            systemctl status yoyopod-dev.service\n\

--- a/deploy/docker/slot-builder.Dockerfile
+++ b/deploy/docker/slot-builder.Dockerfile
@@ -5,7 +5,7 @@
 # reintroduces a Rust slot builder.
 #
 # Do not invoke this file. It is kept in-tree as a reference for the Round 3
-# rewrite. See docs/operations/CLI_REBUILD_ROUNDS.md.
+# rewrite. See docs/ROADMAP.md.
 #
 # The historical contents are preserved below for context but commented out
 # so any accidental `docker build` fails loud rather than producing a broken
@@ -50,4 +50,4 @@
 FROM scratch
 LABEL deprecated="true"
 LABEL replacement="Round 3 of CLI rebuild"
-LABEL see="docs/operations/CLI_REBUILD_ROUNDS.md"
+LABEL see="docs/ROADMAP.md"

--- a/deploy/scripts/bootstrap_pi.sh
+++ b/deploy/scripts/bootstrap_pi.sh
@@ -180,7 +180,7 @@ Next steps on the dev machine:
 
   # For prod slot installs:
   # The prod release CLI (yoyopod target release ...) returns in Round 3
-  # of the CLI rebuild; see docs/operations/CLI_REBUILD_ROUNDS.md.
+  # of the CLI rebuild; see docs/ROADMAP.md.
   # Reinstalling a previously-shipped slot still works manually via
   # SSH + /opt/yoyopod-prod/bin/install-release.sh.
 

--- a/deploy/scripts/install_release.sh
+++ b/deploy/scripts/install_release.sh
@@ -3,7 +3,7 @@
 #
 # Install one self-contained slot artifact into /opt/yoyopod-prod and flip it live.
 # The artifact is the tar.gz that Round 3 of the CLI rebuild will produce
-# (see docs/operations/CLI_REBUILD_ROUNDS.md). Until then, only
+# (see docs/ROADMAP.md). Until then, only
 # previously-shipped slot tarballs can be reinstalled with this script.
 
 set -euo pipefail
@@ -199,7 +199,7 @@ PY
 _preflight_slot() {
     # Slot preflight was previously a Python check that imported
     # yoyopod_cli.health from the slot's bundled app/. That module no longer
-    # exists; see docs/operations/CLI_REBUILD_ROUNDS.md. Round 3 of the CLI
+    # exists; see docs/ROADMAP.md. Round 3 of the CLI
     # rebuild restores preflight as a Rust binary (yoyopod health preflight)
     # bundled inside future slot tarballs.
     #

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,83 +1,93 @@
-# YoYoPod Core Documentation Guide
+# YoYoPod Documentation
 
 This page is the entry point for repo documentation.
 
-If you are new here, read these first:
+If you are new here:
 
 1. [`../README.md`](../README.md) for the repo overview and quick start
-2. [`operations/DEVELOPMENT_GUIDE.md`](operations/DEVELOPMENT_GUIDE.md) for setup, running, validation, and daily workflow
-3. [`architecture/SYSTEM_ARCHITECTURE.md`](architecture/SYSTEM_ARCHITECTURE.md) for the current runtime shape
-4. [`architecture/WORK_AREAS.md`](architecture/WORK_AREAS.md) for where active Rust-first work belongs
-5. [`architecture/CANONICAL_STRUCTURE.md`](architecture/CANONICAL_STRUCTURE.md) for config and package ownership
+2. [`ROADMAP.md`](ROADMAP.md) for the current rebuild state — which CLI
+   commands work today and which are paused
+3. [`operations/DEVELOPMENT_GUIDE.md`](operations/DEVELOPMENT_GUIDE.md) for setup, running, validation, and daily workflow
+4. [`architecture/SYSTEM_ARCHITECTURE.md`](architecture/SYSTEM_ARCHITECTURE.md) for the current runtime shape
 
 ## Source Of Truth
 
 When docs disagree, trust sources in this order:
 
-1. Current Rust runtime and host code in `device/`
+1. Current Rust runtime and worker host code in `device/`
 2. Current Rust operator CLI in `cli/` and deploy tooling under `deploy/`
-3. [`operations/CLI_REBUILD_ROUNDS.md`](operations/CLI_REBUILD_ROUNDS.md)
-   for what's currently broken or paused during the CLI rebuild
-4. Current runtime, operations, hardware, feature, and design docs
-   under the folders below
-5. Rules and agent guidance in `../rules/`, `../AGENTS.md`, and
-   `../skills/`
+3. [`ROADMAP.md`](ROADMAP.md) — what's currently broken or paused
+4. Current operations, architecture, hardware, features, and design
+   docs in the folders below
+5. Rules and agent guidance in [`../rules/`](../rules/),
+   [`../AGENTS.md`](../AGENTS.md), and [`../skills/`](../skills/)
 
-The retired Python app runtime and the Python operator CLI have both
-been deleted. The repo is Rust-only.
-
-Plan docs are useful context, but they are not automatically the
-current implementation contract.
+The repo is Rust-only end to end. The retired Python app runtime and
+the Python operator CLI have both been deleted. Plan docs are useful
+context, but they are not automatically the current implementation
+contract.
 
 ## Folder Map
 
-- [`architecture/`](architecture/README.md) - current runtime topology, package/config ownership, event flow, display/input contracts, and cross-screen UI contracts.
-- [`operations/`](operations/README.md) - contributor workflow, setup, quality gates, release flow, dev/prod lanes, Pi validation, profiling, and OTA/deploy operations.
-- [`hardware/`](hardware/README.md) - audio, power, deployed Pi dependencies, and board bringup notes.
-- [`features/`](features/README.md) - cloud provisioning, cloud voice, local music, mpv, and remote playback contracts.
-- [`design/`](design/README.md) - active screen/UI design targets, parity contracts, and visual previews.
-- [`product/`](product/README.md) - product definition, V1 scope, positioning copy, and research material.
-- [`assets/`](assets/) - images and media used by docs.
-- [`../apps/`](../apps/) - future web and mobile applications.
-- [`../packages/`](../packages/) - future shared contracts, SDKs, and app packages.
+- [`architecture/`](architecture/README.md) — runtime topology,
+  package/config ownership, event flow
+- [`operations/`](operations/README.md) — contributor workflow, setup,
+  quality gates, dev/prod lanes, daily Pi workflow
+- [`operations/archive/`](operations/archive/README.md) — paused
+  capability docs (release pipeline, slot deploy, OTA, hardware
+  validation, profiling) — return as rebuild rounds land
+- [`hardware/`](hardware/README.md) — audio and power module
+  integration notes for Pi Zero 2W + Whisplay + PiSugar
+- [`features/`](features/README.md) — cloud provisioning, cloud voice,
+  local music, mpv, and remote playback contracts
+- [`design/`](design/README.md) — UI design targets and visual previews
+- [`product/`](product/README.md) — product definition and positioning
+- [`assets/`](assets/) — images and media used in docs
 
 ## Recommended Reading Paths
 
 ### New Developer
 
 1. [`../README.md`](../README.md)
-2. [`operations/CONTRIBUTOR_WORKFLOW.md`](operations/CONTRIBUTOR_WORKFLOW.md)
-3. [`operations/DEVELOPMENT_GUIDE.md`](operations/DEVELOPMENT_GUIDE.md)
-4. [`architecture/SYSTEM_ARCHITECTURE.md`](architecture/SYSTEM_ARCHITECTURE.md)
-5. [`architecture/CANONICAL_STRUCTURE.md`](architecture/CANONICAL_STRUCTURE.md)
+2. [`ROADMAP.md`](ROADMAP.md)
+3. [`operations/CONTRIBUTOR_WORKFLOW.md`](operations/CONTRIBUTOR_WORKFLOW.md)
+4. [`operations/DEVELOPMENT_GUIDE.md`](operations/DEVELOPMENT_GUIDE.md)
+5. [`architecture/SYSTEM_ARCHITECTURE.md`](architecture/SYSTEM_ARCHITECTURE.md)
 6. [`../rules/project.md`](../rules/project.md)
 
-### Working On Runtime Code
+### Working On Runtime Or Worker Code
 
 1. [`architecture/WORK_AREAS.md`](architecture/WORK_AREAS.md)
 2. [`architecture/SYSTEM_ARCHITECTURE.md`](architecture/SYSTEM_ARCHITECTURE.md)
 3. [`architecture/RUNTIME_EVENT_FLOW.md`](architecture/RUNTIME_EVENT_FLOW.md)
-4. The subsystem doc under [`architecture/`](architecture/README.md), [`features/`](features/README.md), or [`hardware/`](hardware/README.md)
+4. The subsystem doc under
+   [`features/`](features/README.md) or
+   [`hardware/`](hardware/README.md)
 5. [`../AGENTS.md`](../AGENTS.md)
 6. Relevant files under `device/`
 
+### Working On The Rust CLI
+
+1. [`ROADMAP.md`](ROADMAP.md)
+2. [`../cli/README.md`](../cli/README.md)
+3. Relevant files under `cli/yoyopod/src/`
+
 ### Working On Raspberry Pi Deployment
 
-1. [`operations/CONTRIBUTOR_WORKFLOW.md`](operations/CONTRIBUTOR_WORKFLOW.md)
-2. [`operations/CLI_REBUILD_ROUNDS.md`](operations/CLI_REBUILD_ROUNDS.md) — current rebuild state
+1. [`ROADMAP.md`](ROADMAP.md)
+2. [`operations/CONTRIBUTOR_WORKFLOW.md`](operations/CONTRIBUTOR_WORKFLOW.md)
 3. [`operations/SETUP_CONTRACT.md`](operations/SETUP_CONTRACT.md)
 4. [`operations/DEV_PROD_LANES.md`](operations/DEV_PROD_LANES.md)
 5. [`operations/PI_DEV_WORKFLOW.md`](operations/PI_DEV_WORKFLOW.md)
-6. [`operations/RPI_SMOKE_VALIDATION.md`](operations/RPI_SMOKE_VALIDATION.md)
-7. [`operations/SLOT_DEPLOY.md`](operations/SLOT_DEPLOY.md) — paused; Round 3
+6. Paused docs in [`operations/archive/`](operations/archive/README.md)
+   when their subject matter is your blocker
 
 ### Working On UI Or Design
 
 1. [`design/README.md`](design/README.md)
-2. [`architecture/DISPLAY_HAL_ARCHITECTURE.md`](architecture/DISPLAY_HAL_ARCHITECTURE.md)
-3. [`architecture/INPUT_HAL_ARCHITECTURE.md`](architecture/INPUT_HAL_ARCHITECTURE.md)
-4. [`architecture/CROSS_SCREEN_OVERLAYS.md`](architecture/CROSS_SCREEN_OVERLAYS.md)
-5. [`../rules/design-fidelity.md`](../rules/design-fidelity.md)
+2. [`../rules/design-fidelity.md`](../rules/design-fidelity.md)
+3. [`../rules/lvgl.md`](../rules/lvgl.md)
+4. Relevant files under `device/ui/`
 
 ### Working On Music, Voice, Or Cloud Features
 
@@ -89,20 +99,19 @@ current implementation contract.
 
 ## Current Contracts
 
-These docs describe current implementation contracts:
+Authoritative implementation contracts as of today:
 
-- [`operations/CLI_REBUILD_ROUNDS.md`](operations/CLI_REBUILD_ROUNDS.md)
+- [`ROADMAP.md`](ROADMAP.md)
 - [`architecture/SYSTEM_ARCHITECTURE.md`](architecture/SYSTEM_ARCHITECTURE.md)
 - [`architecture/WORK_AREAS.md`](architecture/WORK_AREAS.md)
 - [`architecture/CANONICAL_STRUCTURE.md`](architecture/CANONICAL_STRUCTURE.md)
 - [`architecture/RUNTIME_EVENT_FLOW.md`](architecture/RUNTIME_EVENT_FLOW.md)
-- [`architecture/DISPLAY_HAL_ARCHITECTURE.md`](architecture/DISPLAY_HAL_ARCHITECTURE.md)
-- [`architecture/INPUT_HAL_ARCHITECTURE.md`](architecture/INPUT_HAL_ARCHITECTURE.md)
+- [`operations/CONTRIBUTOR_WORKFLOW.md`](operations/CONTRIBUTOR_WORKFLOW.md)
+- [`operations/DEVELOPMENT_GUIDE.md`](operations/DEVELOPMENT_GUIDE.md)
 - [`operations/SETUP_CONTRACT.md`](operations/SETUP_CONTRACT.md)
 - [`operations/QUALITY_GATES.md`](operations/QUALITY_GATES.md)
 - [`operations/DEV_PROD_LANES.md`](operations/DEV_PROD_LANES.md)
 - [`operations/PI_DEV_WORKFLOW.md`](operations/PI_DEV_WORKFLOW.md)
-- [`operations/SLOT_DEPLOY.md`](operations/SLOT_DEPLOY.md) (paused; Round 3)
 - [`hardware/POWER_MODULE.md`](hardware/POWER_MODULE.md)
 - [`hardware/AUDIO_STACK.md`](hardware/AUDIO_STACK.md)
 - [`features/CLOUD_PROVISIONING_AND_BACKEND.md`](features/CLOUD_PROVISIONING_AND_BACKEND.md)
@@ -111,5 +120,6 @@ These docs describe current implementation contracts:
 
 ## Historical Context
 
-Historical planning archives were removed from the tracked repo. Use merged PRs
-and current docs for rationale; when docs disagree, trust current code.
+Historical planning archives were removed from the tracked repo. Use
+merged PRs, [`ROADMAP.md`](ROADMAP.md), and current docs for rationale;
+when docs disagree, trust current code.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,15 +1,29 @@
-# CLI Rebuild Rounds
+# YoYoPod Roadmap
 
-Status as of 2026-05-13.
+This is the project's living roadmap. It tracks the rounds of the Rust
+CLI rebuild — what's done, what's paused, when each gap closes.
+
+The most recent rebuild milestone is summarised at the top; rounds in
+detail follow.
+
+Status as of 2026-05-14:
+
+| Round | Scope | State |
+|---|---|---|
+| 0 | Demolition + scaffolding | ✅ merged |
+| 1 | Daily dev loop (`yoyopod target …` Rust MVP) | ✅ merged |
+| 2 | Restore hardware validation (`yoyopod target validate`) | ⏳ not started |
+| 3 | Restore prod release pipeline | ⏳ not started |
+| 4+ | Diagnostics (`pi voip/power/network/rust-ui-host`) | ⏳ not started |
 
 ## What happened
 
-The Python operator CLI (`yoyopod_cli/`, ~21k LOC) was deleted in one move.
-A new Rust CLI is being built from scratch at `cli/`, in rounds, on a
-business-need basis. Each round restores a slice of capability.
+The Python operator CLI (`yoyopod_cli/`, ~21k LOC) was deleted in one
+move. A new Rust CLI is being built from scratch at `cli/`, in rounds,
+on a business-need basis. Each round restores a slice of capability.
 
-This document is the honesty doc: what is broken today, what works, when
-it gets fixed.
+This document is the honesty doc: what is broken today, what works,
+when it gets fixed.
 
 ## Why
 
@@ -51,15 +65,15 @@ reality, not historical reality.
 
 ## Rounds
 
-### Round 0 — Demolition + scaffolding (this PR)
+### Round 0 — Demolition + scaffolding ✅
 
-Delete `yoyopod_cli/`, `scripts/build_release.py`, `pyproject.toml`,
-`.python-version`, `scripts/quality.py`. Neuter `install_release.sh`
-preflight. Mark `deploy/docker/slot-builder.Dockerfile` deprecated.
-Disable CI jobs that depended on the deleted code. Scaffold the Rust
-workspace at `cli/`. Write this document.
+Deleted `yoyopod_cli/`, `scripts/build_release.py`, `pyproject.toml`,
+`.python-version`, `scripts/quality.py`. Neutered `install_release.sh`
+preflight. Marked `deploy/docker/slot-builder.Dockerfile` deprecated.
+Disabled CI jobs that depended on the deleted code. Scaffolded the
+Rust workspace at `cli/`. Wrote this document.
 
-### Round 1 — Daily dev loop (this PR)
+### Round 1 — Daily dev loop ✅
 
 Rust binary at `cli/yoyopod/` with nine commands covering the inner
 dev loop:
@@ -72,11 +86,11 @@ yoyopod target {status, restart, logs, screenshot}
 yoyopod target validate   (stub — see Round 2)
 ```
 
-`target deploy` is the centrepiece: it pushes, finds the CI run for the
-exact commit, downloads the `yoyopod-rust-device-arm64-<sha>` artifact,
-syncs the Pi checkout, scps and extracts the binaries, restarts the dev
-service, and verifies startup. Replaces the manual flow that
-`skills/yoyopod-rust-artifact/SKILL.md` used to document.
+`target deploy` is the centrepiece: it pushes, finds the CI run for
+the exact commit, downloads the `yoyopod-rust-device-arm64-<sha>`
+artifact, syncs the Pi checkout, scps and extracts the binaries,
+restarts the dev service, and verifies startup. Replaces the manual
+flow that `skills/yoyopod-rust-artifact/SKILL.md` used to document.
 
 ### Round 2 — Restore hardware validation
 
@@ -117,8 +131,7 @@ painful enough to fix. Each is its own small round.
 
 ## Pointers
 
-- Rust CLI source: `cli/`
-- Rust CLI docs: `cli/README.md`
-- Roadmap (this file): `docs/operations/CLI_REBUILD_ROUNDS.md`
-- Previously authoritative `skills/yoyopod-*` docs are temporarily out
-  of date until each round restores the capability they document.
+- Rust CLI source: [`../cli/`](../cli/)
+- Rust CLI docs: [`../cli/README.md`](../cli/README.md)
+- Paused capability docs: [`operations/archive/`](operations/archive/)
+- This file: `docs/ROADMAP.md`

--- a/docs/architecture/CANONICAL_STRUCTURE.md
+++ b/docs/architecture/CANONICAL_STRUCTURE.md
@@ -174,7 +174,7 @@ the runtime/CLI ownership split:
 - target hardware deploy + manual exercise stays behind `yoyopod target deploy`
 - automated on-Pi validation (`yoyopod target validate`) is a Round 2
   deliverable of the CLI rebuild; see
-  [`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md)
+  [`../ROADMAP.md`](../ROADMAP.md)
 
 ## Exemplar: Call + Contacts
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,18 @@
+# Architecture Docs
+
+Runtime topology, package/config ownership, event flow, and the
+cross-cutting structural contracts that define how YoYoPod is composed.
+
+- [`SYSTEM_ARCHITECTURE.md`](SYSTEM_ARCHITECTURE.md) - current runtime
+  shape: the Rust runtime, the worker hosts, and the operator CLI
+- [`WORK_AREAS.md`](WORK_AREAS.md) - where active Rust-first work
+  belongs by area
+- [`CANONICAL_STRUCTURE.md`](CANONICAL_STRUCTURE.md) - config topology,
+  package ownership, validation layout, and board overlay rules
+- [`RUNTIME_EVENT_FLOW.md`](RUNTIME_EVENT_FLOW.md) - how runtime events
+  flow from worker hosts through `yoyopod-runtime` into app state
+
+For the operator-side view (deploy / lanes / hardware validation), see
+[`../operations/README.md`](../operations/README.md). For UI design
+constraints, see [`../design/README.md`](../design/README.md). For the
+current rebuild status, see [`../ROADMAP.md`](../ROADMAP.md).

--- a/docs/architecture/SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM_ARCHITECTURE.md
@@ -72,7 +72,7 @@ produces a single binary, `yoyopod`, used from the dev machine for
 target orchestration (deploy, restart, logs, screenshot, mode).
 
 The Python CLI was retired in Round 0 of the CLI rebuild; see
-[`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md).
+[`../ROADMAP.md`](../ROADMAP.md).
 Active code must not depend on a `yoyopod_cli` Python package.
 
 ## Packaging
@@ -87,6 +87,6 @@ When docs disagree, trust sources in this order:
 1. Current Rust runtime and hosts under `device/`
 2. Current operator CLI under `cli/` and deploy tooling under `deploy/`
 3. Current operations and architecture docs (especially
-   [`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md))
+   [`../ROADMAP.md`](../ROADMAP.md))
 4. `rules/`, `AGENTS.md`, and `skills/`
 5. Historical plans and archived material

--- a/docs/architecture/WORK_AREAS.md
+++ b/docs/architecture/WORK_AREAS.md
@@ -27,7 +27,7 @@ where a change belongs.
 ## Operator CLI And Deploy Areas
 
 - `cli/` owns the Rust operator CLI (`yoyopod target …`). See
-  [`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md)
+  [`../ROADMAP.md`](../ROADMAP.md)
   for the current rebuild status.
 - `deploy/` owns systemd unit files, installer scripts, and slot/release
   packaging primitives.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,13 +1,14 @@
 # Design Docs
 
-UI design targets and visual references for YoYoPod (Whisplay,
-240x280 portrait).
+UI design targets and visual references for YoYoPod on Whisplay
+(240x280 portrait, single side button).
 
-- [`ASK_SCREEN_DESIGN_SPEC.md`](ASK_SCREEN_DESIGN_SPEC.md) - design
-  target for the unified Ask experience
-- [`previews/`](previews/) - static HTML visual references
+- [`previews/`](previews/) - static HTML visual references for each
+  screen / interaction
 
-For implementation constraints, read
-[`../architecture/DISPLAY_HAL_ARCHITECTURE.md`](../architecture/DISPLAY_HAL_ARCHITECTURE.md),
-[`../architecture/INPUT_HAL_ARCHITECTURE.md`](../architecture/INPUT_HAL_ARCHITECTURE.md),
-and [`../../rules/design-fidelity.md`](../../rules/design-fidelity.md).
+For implementation constraints, read:
+
+- [`../../rules/design-fidelity.md`](../../rules/design-fidelity.md)
+- [`../../rules/lvgl.md`](../../rules/lvgl.md)
+
+For the Whisplay runtime path, see code under `device/ui/`.

--- a/docs/features/CLOUD_VOICE_WORKER.md
+++ b/docs/features/CLOUD_VOICE_WORKER.md
@@ -112,4 +112,4 @@ yoyopod target logs --follow --filter speech
 
 Automated on-Pi voice validation (`yoyopod target validate
 --with-cloud-voice`) returns in Round 2 of the CLI rebuild. See
-[`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md).
+[`../ROADMAP.md`](../ROADMAP.md).

--- a/docs/hardware/POWER_MODULE.md
+++ b/docs/hardware/POWER_MODULE.md
@@ -32,7 +32,7 @@ CLI diagnostics for the power module (`yoyopod pi power battery`,
 `yoyopod pi power rtc …`) were deleted in Round 0 of the CLI rebuild
 and return in Round 4. Until then, query PiSugar state via the
 PiSugar server directly. See
-[`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md).
+[`../ROADMAP.md`](../ROADMAP.md).
 
 Runtime flow:
 
@@ -210,7 +210,7 @@ CLI helpers for RTC operations (`yoyopod pi power rtc …`,
 `yoyopod target rtc …`) were deleted in Round 0 and return in Round 4
 of the CLI rebuild. Until then, drive the PiSugar RTC directly via the
 `pisugar-server` daemon or the device file under `/dev/`. See
-[`../operations/CLI_REBUILD_ROUNDS.md`](../operations/CLI_REBUILD_ROUNDS.md).
+[`../ROADMAP.md`](../ROADMAP.md).
 
 ## Watchdog Support
 
@@ -352,6 +352,6 @@ Not yet productized:
 ## Related Documents
 
 - `README.md`
-- `docs/operations/RPI_SMOKE_VALIDATION.md`
+- `docs/operations/archive/RPI_SMOKE_VALIDATION.md`
 - `docs/operations/PI_DEV_WORKFLOW.md`
 - `deploy/systemd/yoyopod-prod.service`

--- a/docs/operations/CONTRIBUTOR_WORKFLOW.md
+++ b/docs/operations/CONTRIBUTOR_WORKFLOW.md
@@ -22,7 +22,7 @@ If you are new here, read in this order:
 
 Automated host setup tooling (`yoyopod setup host` / `verify-host`) was
 deleted in Round 0 of the CLI rebuild and has not yet been ported back.
-See [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md). Until then, install
+See [`../ROADMAP.md`](../ROADMAP.md). Until then, install
 dependencies manually:
 
 - a Rust stable toolchain via `rustup`
@@ -74,7 +74,7 @@ Read:
 1. [`SETUP_CONTRACT.md`](SETUP_CONTRACT.md)
 2. [`DEVELOPMENT_GUIDE.md`](DEVELOPMENT_GUIDE.md)
 3. [`PI_DEV_WORKFLOW.md`](PI_DEV_WORKFLOW.md)
-4. [`RPI_SMOKE_VALIDATION.md`](RPI_SMOKE_VALIDATION.md)
+4. [`archive/RPI_SMOKE_VALIDATION.md`](archive/RPI_SMOKE_VALIDATION.md)
 5. `rules/deploy.md`
 
 Baseline commands:
@@ -92,7 +92,7 @@ verifies startup in one step.
 
 Automated on-Pi validation (`yoyopod target validate`) is a Round 1
 stub during the CLI rebuild; validate manually after deploy. See
-[`RPI_SMOKE_VALIDATION.md`](RPI_SMOKE_VALIDATION.md).
+[`archive/RPI_SMOKE_VALIDATION.md`](archive/RPI_SMOKE_VALIDATION.md).
 
 ### Docs and contributor guidance work
 
@@ -157,7 +157,7 @@ These are good places to be extra careful:
 - `device/runtime/` — top-level runtime supervision
 - `device/ui/` + LVGL scene controllers — visual fidelity on real hardware
 - `cli/yoyopod/` — operator surface (under active rebuild; see
-  CLI_REBUILD_ROUNDS.md)
+  [`../ROADMAP.md`](../ROADMAP.md))
 - duplicated domain/state models that drift across `device/` crates
 - setup/docs wording that overstates what the rebuilt CLI guarantees today
 

--- a/docs/operations/DEVELOPMENT_GUIDE.md
+++ b/docs/operations/DEVELOPMENT_GUIDE.md
@@ -9,7 +9,7 @@ If you are new here, read these first:
 2. [`README.md`](../README.md)
 3. [`CONTRIBUTOR_WORKFLOW.md`](CONTRIBUTOR_WORKFLOW.md)
 4. [`SYSTEM_ARCHITECTURE.md`](../architecture/SYSTEM_ARCHITECTURE.md)
-5. [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md)
+5. [`../ROADMAP.md`](../ROADMAP.md)
 
 ## Source of truth
 
@@ -20,7 +20,7 @@ For current behaviour, trust:
 - this guide for setup and workflow
 - [`SYSTEM_ARCHITECTURE.md`](../architecture/SYSTEM_ARCHITECTURE.md) for
   runtime topology
-- [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md) for what's broken
+- [`../ROADMAP.md`](../ROADMAP.md) for what's broken
   during the CLI rebuild
 - [`../AGENTS.md`](../../AGENTS.md) and `rules/` for repo guidance
 
@@ -62,7 +62,7 @@ Core Raspberry Pi packages and services:
 
 Automated host/Pi setup commands (`yoyopod setup …`) were deleted in
 Round 0 of the CLI rebuild; install manually until they return. See
-[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
+[`../ROADMAP.md`](../ROADMAP.md).
 
 ## Configuration
 
@@ -192,8 +192,8 @@ environment has seen brief `github.com` reachability blips.
 The detailed deploy and validation flows live in:
 
 - [`PI_DEV_WORKFLOW.md`](PI_DEV_WORKFLOW.md)
-- [`RPI_SMOKE_VALIDATION.md`](RPI_SMOKE_VALIDATION.md)
-- `rules/deploy.md`
+- [`archive/RPI_SMOKE_VALIDATION.md`](archive/RPI_SMOKE_VALIDATION.md)
+- `../../rules/deploy.md`
 
 ## Logging
 
@@ -251,9 +251,9 @@ Current contributor, runtime, and setup docs:
 - `docs/operations/CONTRIBUTOR_WORKFLOW.md`
 - `docs/operations/QUALITY_GATES.md`
 - `docs/operations/SETUP_CONTRACT.md`
-- `docs/operations/CLI_REBUILD_ROUNDS.md`
+- `docs/ROADMAP.md`
 - `docs/operations/PI_DEV_WORKFLOW.md`
-- `docs/operations/RPI_SMOKE_VALIDATION.md`
+- `docs/operations/archive/RPI_SMOKE_VALIDATION.md`
 - `docs/architecture/SYSTEM_ARCHITECTURE.md`
 - `docs/hardware/POWER_MODULE.md`
 - `docs/features/LOCAL_FIRST_MUSIC_PLAN.md`

--- a/docs/operations/DEV_PROD_LANES.md
+++ b/docs/operations/DEV_PROD_LANES.md
@@ -86,7 +86,7 @@ yoyopod target mode activate prod
 
 `yoyopod target release status` (prod slot status) returns in Round 3
 of the CLI rebuild; see
-[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md). Until then, check prod
+[`../ROADMAP.md`](../ROADMAP.md). Until then, check prod
 state directly via `systemctl status yoyopod-prod.service` over SSH.
 
 `yoyopod target mode deactivate` is not yet ported; stop a lane

--- a/docs/operations/PI_DEV_WORKFLOW.md
+++ b/docs/operations/PI_DEV_WORKFLOW.md
@@ -5,8 +5,8 @@ This guide covers the normal dev-machine-to-board loop for YoYoPod.
 For fresh-board bootstrap, lane structure, and rollback, read:
 
 - [`DEV_PROD_LANES.md`](DEV_PROD_LANES.md)
-- [`SLOT_DEPLOY.md`](SLOT_DEPLOY.md) (paused; pointer to Round 3 work)
-- [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md) for what's broken
+- [`archive/SLOT_DEPLOY.md`](archive/SLOT_DEPLOY.md) (paused; pointer to Round 3 work)
+- [`../ROADMAP.md`](../ROADMAP.md) for what's broken
   during the CLI rebuild
 
 The default contract is:
@@ -172,10 +172,10 @@ Common causes:
 
 ## Related Docs
 
-- [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md) for the rebuild
+- [`../ROADMAP.md`](../ROADMAP.md) for the rebuild
   roadmap
 - [`DEV_PROD_LANES.md`](DEV_PROD_LANES.md) for lane structure
-- [`SLOT_DEPLOY.md`](SLOT_DEPLOY.md) for the (paused) prod slot flow
+- [`archive/SLOT_DEPLOY.md`](archive/SLOT_DEPLOY.md) for the (paused) prod slot flow
 - [`SETUP_CONTRACT.md`](SETUP_CONTRACT.md) for system dependencies
 - [`QUALITY_GATES.md`](QUALITY_GATES.md) for what passes for
   verification today

--- a/docs/operations/QUALITY_GATES.md
+++ b/docs/operations/QUALITY_GATES.md
@@ -58,7 +58,7 @@ journalctl -u yoyopod-dev.service -f
 
 Exercise the changed surface on the device with human eyes.
 
-See [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
+See [`../ROADMAP.md`](../ROADMAP.md).
 
 ## Reporting
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,17 +1,41 @@
 # Operations Docs
 
-Setup, validation, deployment, release, and Pi operations live here.
+Setup, deploy, and daily-workflow operations for YoYoPod on the Pi.
 
-- [`CONTRIBUTOR_WORKFLOW.md`](CONTRIBUTOR_WORKFLOW.md) - shortest contributor path and PR checklist
-- [`DEVELOPMENT_GUIDE.md`](DEVELOPMENT_GUIDE.md) - setup, local running, validation, and daily workflow
-- [`SETUP_CONTRACT.md`](SETUP_CONTRACT.md) - executable setup and dependency contract
-- [`QUALITY_GATES.md`](QUALITY_GATES.md) - staged quality gate and audit contract
-- [`RELEASE_PROCESS.md`](RELEASE_PROCESS.md) - versioning, artifacts, and GitHub release flow
-- [`DEV_PROD_LANES.md`](DEV_PROD_LANES.md) - split dev/prod lane paths, services, and activation
-- [`SLOT_DEPLOY.md`](SLOT_DEPLOY.md) - prod slot deploy, rollback, and OTA-ready operations
-- [`OTA_ROADMAP.md`](OTA_ROADMAP.md) - future OTA daemon extension points
-- [`PI_DEV_WORKFLOW.md`](PI_DEV_WORKFLOW.md) - day-to-day Raspberry Pi workflow
-- [`RPI_SMOKE_VALIDATION.md`](RPI_SMOKE_VALIDATION.md) - CI-safe and on-device validation checklist
-- [`PI_PROFILING_WORKFLOW.md`](PI_PROFILING_WORKFLOW.md) - bounded profiling and Pi investigation workflow
+For the current state of the operator CLI and which capabilities are
+temporarily paused, read [`../ROADMAP.md`](../ROADMAP.md) first.
 
-For hardware-specific dependencies and board notes, use [`../hardware/README.md`](../hardware/README.md).
+## Active
+
+- [`CONTRIBUTOR_WORKFLOW.md`](CONTRIBUTOR_WORKFLOW.md) - shortest
+  contributor path from fresh checkout to a credible PR
+- [`DEVELOPMENT_GUIDE.md`](DEVELOPMENT_GUIDE.md) - toolchain, running,
+  validation, and daily workflow detail
+- [`SETUP_CONTRACT.md`](SETUP_CONTRACT.md) - dev-machine + Pi setup
+  prerequisites (manual today; full CLI bootstrap returns in a later
+  round)
+- [`QUALITY_GATES.md`](QUALITY_GATES.md) - what counts as
+  pre-merge verification today
+- [`DEV_PROD_LANES.md`](DEV_PROD_LANES.md) - dev/prod lane paths,
+  systemd services, and lane activation
+- [`PI_DEV_WORKFLOW.md`](PI_DEV_WORKFLOW.md) - day-to-day
+  dev-machine-to-Pi loop via `yoyopod target …`
+
+## Paused / in transition
+
+These docs cover capabilities that are temporarily unavailable while
+the operator CLI is being rebuilt in Rust. They return as the
+corresponding round of the rebuild lands.
+
+See [`archive/README.md`](archive/README.md). At a glance:
+
+| File | Restored by |
+|---|---|
+| [`archive/RPI_SMOKE_VALIDATION.md`](archive/RPI_SMOKE_VALIDATION.md) | Round 2 |
+| [`archive/PI_PROFILING_WORKFLOW.md`](archive/PI_PROFILING_WORKFLOW.md) | Round 2 + ongoing |
+| [`archive/RELEASE_PROCESS.md`](archive/RELEASE_PROCESS.md) | Round 3 |
+| [`archive/SLOT_DEPLOY.md`](archive/SLOT_DEPLOY.md) | Round 3 |
+| [`archive/OTA_ROADMAP.md`](archive/OTA_ROADMAP.md) | Round 3 + later |
+
+For hardware-specific dependencies and board notes, see
+[`../hardware/README.md`](../hardware/README.md).

--- a/docs/operations/SETUP_CONTRACT.md
+++ b/docs/operations/SETUP_CONTRACT.md
@@ -3,7 +3,7 @@
 This document defines the baseline setup contract for YoYoPod Core. As
 of 2026-05-13, automated setup commands (`yoyopod setup …`,
 `yoyopod target setup …`) were deleted in Round 0 of the CLI rebuild;
-see [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md). Until the
+see [`../ROADMAP.md`](../ROADMAP.md). Until the
 relevant rounds restore them, follow the manual steps below.
 
 ## Why this exists
@@ -148,7 +148,7 @@ The tracked deploy contract must stay generic:
 | Round 3 | Prod slot install + release tooling |
 | Round 4+ | `yoyopod target setup` / `verify-setup` style one-shot bootstrap |
 
-See [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
+See [`../ROADMAP.md`](../ROADMAP.md).
 
 ## Verification before blaming product code
 

--- a/docs/operations/archive/OTA_ROADMAP.md
+++ b/docs/operations/archive/OTA_ROADMAP.md
@@ -4,7 +4,7 @@ The slot-deploy foundation was originally designed so a future OTA
 daemon could be added without changing the core deploy pieces. As of
 2026-05-13, slot-deploy itself is paused while the CLI is rebuilt in
 Rust; see
-[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md). Round 3 restores the
+[`../../ROADMAP.md`](../../ROADMAP.md). Round 3 restores the
 slot pipeline. The OTA work below sits on top of Round 3.
 
 ## Recommended build order for OTA (once Round 3 lands)

--- a/docs/operations/archive/PI_PROFILING_WORKFLOW.md
+++ b/docs/operations/archive/PI_PROFILING_WORKFLOW.md
@@ -6,7 +6,7 @@ The Python profiling helpers (`yoyopod dev profile …`,
 `yoyopod build voice-worker`, `yoyopod remote validate`,
 `yoyopod remote sync`) were deleted in Round 0 of the CLI rebuild.
 Hardware profiling now uses native Rust tools directly. See
-[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
+[`../../ROADMAP.md`](../../ROADMAP.md).
 
 ## When to profile
 

--- a/docs/operations/archive/README.md
+++ b/docs/operations/archive/README.md
@@ -1,0 +1,27 @@
+# Archived Operations Docs
+
+This folder holds operations docs whose subject — prod releases, slot
+deploy, OTA, on-Pi automated validation, Python-era profiling — is
+**currently paused** while the operator CLI is being rebuilt in Rust.
+See [`../../ROADMAP.md`](../../ROADMAP.md).
+
+Each file documents either:
+- a contract that's still on disk but has no live CLI commands today
+  (slot layout, release flow, OTA wiring), or
+- a workflow whose tools were retired (Python profiling helpers,
+  `yoyopod pi validate …`).
+
+These docs return to active status when the relevant round of the
+rebuild lands. Round 3 reintroduces release/slot tooling; Round 2
+restores hardware validation.
+
+| File | Subject | Restored by |
+|---|---|---|
+| [`RELEASE_PROCESS.md`](RELEASE_PROCESS.md) | Versioning, artifacts, GitHub release workflow | Round 3 |
+| [`SLOT_DEPLOY.md`](SLOT_DEPLOY.md) | Prod slot install + rollback flow | Round 3 |
+| [`OTA_ROADMAP.md`](OTA_ROADMAP.md) | OTA daemon extension points on top of slot deploy | Round 3 + later |
+| [`RPI_SMOKE_VALIDATION.md`](RPI_SMOKE_VALIDATION.md) | Manual + automated on-Pi validation flow | Round 2 |
+| [`PI_PROFILING_WORKFLOW.md`](PI_PROFILING_WORKFLOW.md) | Hardware profiling workflow | Round 2 (validation) + ongoing |
+
+For the day-to-day workflow that currently works, see
+[`../PI_DEV_WORKFLOW.md`](../PI_DEV_WORKFLOW.md).

--- a/docs/operations/archive/RELEASE_PROCESS.md
+++ b/docs/operations/archive/RELEASE_PROCESS.md
@@ -3,7 +3,7 @@
 **Status: paused as of 2026-05-13.**
 
 The Python release pipeline was deleted in Round 0 of the CLI rebuild
-([`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md)). New prod slot builds
+([`../../ROADMAP.md`](../../ROADMAP.md)). New prod slot builds
 are blocked until Round 3 reintroduces the Rust slot builder, manifest
 schema, and preflight tooling. CI's `slot-arm64` and `release` jobs are
 disabled (`if: ${{ false }}`) until then.

--- a/docs/operations/archive/RPI_SMOKE_VALIDATION.md
+++ b/docs/operations/archive/RPI_SMOKE_VALIDATION.md
@@ -5,7 +5,7 @@
 Automated hardware validation commands (`yoyopod target validate` and
 the `yoyopod pi validate …` suite) were deleted in Round 0 of the CLI
 rebuild and have not yet been ported back. See
-[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
+[`../../ROADMAP.md`](../../ROADMAP.md).
 
 Until Round 2 restores `yoyopod target validate`, validation is split
 between local Rust checks and a manual hardware exercise loop.
@@ -84,11 +84,11 @@ in the report.
 | Round 3 | Slot install preflight (`yoyopod health preflight`) |
 | Round 4+ | Diagnostics (`yoyopod pi voip check`, `pi power battery`, etc.) |
 
-See [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
+See [`../../ROADMAP.md`](../../ROADMAP.md).
 
 ## Related Docs
 
-- [`PI_DEV_WORKFLOW.md`](PI_DEV_WORKFLOW.md) for the daily deploy loop
-- [`DEV_PROD_LANES.md`](DEV_PROD_LANES.md) for lane structure
-- [`QUALITY_GATES.md`](QUALITY_GATES.md) for verification policy
-- `rules/deploy.md` for the policy that backs hardware validation
+- [`../PI_DEV_WORKFLOW.md`](../PI_DEV_WORKFLOW.md) for the daily deploy loop
+- [`../DEV_PROD_LANES.md`](../DEV_PROD_LANES.md) for lane structure
+- [`../QUALITY_GATES.md`](../QUALITY_GATES.md) for verification policy
+- `../../../rules/deploy.md` for the policy that backs hardware validation

--- a/docs/operations/archive/SLOT_DEPLOY.md
+++ b/docs/operations/archive/SLOT_DEPLOY.md
@@ -6,7 +6,7 @@ The prod slot/OTA CLI commands (`yoyopod target release …`) were
 deleted as part of Round 0 of the CLI rebuild and have not been ported
 back. New prod slot builds and installs through the CLI are blocked
 until Round 3; see
-[`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md).
+[`../../ROADMAP.md`](../../ROADMAP.md).
 
 This doc documents the slot layout, services, and rollback wiring that
 remain in place on previously-bootstrapped Pis. The contract is stable
@@ -91,8 +91,7 @@ Round 3 reintroduces:
 
 ## Related Docs
 
-- [`CLI_REBUILD_ROUNDS.md`](CLI_REBUILD_ROUNDS.md)
-- [`DEV_PROD_LANES.md`](DEV_PROD_LANES.md)
-- [`PI_DEV_WORKFLOW.md`](PI_DEV_WORKFLOW.md)
+- [`../../ROADMAP.md`](../../ROADMAP.md)
+- [`../DEV_PROD_LANES.md`](../DEV_PROD_LANES.md)
+- [`../PI_DEV_WORKFLOW.md`](../PI_DEV_WORKFLOW.md)
 - [`RELEASE_PROCESS.md`](RELEASE_PROCESS.md)
-- [`DEPLOYED_PI_DEPENDENCIES.md`](../hardware/DEPLOYED_PI_DEPENDENCIES.md)

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,7 +1,8 @@
 # Product Docs
 
-This folder captures the current product-definition artifacts for YoYoPod V1.
+Product-definition artefacts for YoYoPod V1.
 
-- [`PRODUCT_DEFINITION.md`](PRODUCT_DEFINITION.md) - crisp product definition and positioning core
-- [`V1_SCOPE_MANIFESTO.md`](V1_SCOPE_MANIFESTO.md) - what V1 is, is not, and must prioritize
-- [`LANDING_PAGE_POSITIONING.md`](LANDING_PAGE_POSITIONING.md) - homepage messaging, value props, and positioning copy
+- [`PRODUCT_DEFINITION.md`](PRODUCT_DEFINITION.md) - crisp product
+  definition and positioning core
+- [`LANDING_PAGE_POSITIONING.md`](LANDING_PAGE_POSITIONING.md) -
+  homepage messaging, value props, and positioning copy

--- a/rules/architecture.md
+++ b/rules/architecture.md
@@ -2,7 +2,7 @@
 
 YoYoPod is Rust-only. The runtime, the workers, and the operator CLI
 are all Rust. The Python operator CLI was retired in Round 0 of the
-CLI rebuild (`docs/operations/CLI_REBUILD_ROUNDS.md`); active code must
+CLI rebuild (`docs/ROADMAP.md`); active code must
 not depend on it.
 
 ```text

--- a/rules/code-style.md
+++ b/rules/code-style.md
@@ -2,7 +2,7 @@
 
 The codebase is Rust-only across the runtime (`device/`) and the
 operator CLI (`cli/`). No Python remains as of the Round 0 rebuild
-(`docs/operations/CLI_REBUILD_ROUNDS.md`).
+(`docs/ROADMAP.md`).
 
 ## Rust (device/ and cli/)
 

--- a/rules/deploy.md
+++ b/rules/deploy.md
@@ -53,7 +53,7 @@ journalctl -u yoyopod-dev.service -f
 Exercise the changed surface on the device. Don't claim a hardware pass
 without a real human-eyes check of the running app.
 
-See `docs/operations/CLI_REBUILD_ROUNDS.md`.
+See `docs/ROADMAP.md`.
 
 ## Stable Pi Checkout Path
 

--- a/rules/design-fidelity.md
+++ b/rules/design-fidelity.md
@@ -90,7 +90,7 @@ For Whisplay UI work, the standard loop is:
 
 Automated on-Pi validation (`yoyopod target validate`) is a Round 1 stub
 during the CLI rebuild. Validate manually until Round 2 restores it; see
-`docs/operations/CLI_REBUILD_ROUNDS.md`.
+`docs/ROADMAP.md`.
 
 Dirty-tree deploys are not supported by `yoyopod target deploy` — the
 CI-artifact contract requires a pushed commit. If you need to test

--- a/rules/project.md
+++ b/rules/project.md
@@ -35,7 +35,7 @@ yoyopod target logs --follow
 Host setup, Pi bootstrap, code quality gates, and per-stage on-Pi
 validation (`pi validate deploy/smoke/voip/navigation/stability`) are
 all part of the CLI rebuild roadmap; see
-`docs/operations/CLI_REBUILD_ROUNDS.md`. Until they return, set up host
+`docs/ROADMAP.md`. Until they return, set up host
 dependencies manually and validate Rust changes after `target deploy`
 via `journalctl -u yoyopod-dev.service -f`.
 

--- a/skills/yoyopod-deploy/SKILL.md
+++ b/skills/yoyopod-deploy/SKILL.md
@@ -89,5 +89,5 @@ opening it.
 
 Prod slot release commands (`yoyopod target release …`) return in Round
 3 of the CLI rebuild. Until then, prod releases are paused; see
-`docs/operations/CLI_REBUILD_ROUNDS.md`. Reinstalling a previously-shipped
+`docs/ROADMAP.md`. Reinstalling a previously-shipped
 slot can still be done manually via SSH + `install_release.sh`.

--- a/skills/yoyopod-restart/SKILL.md
+++ b/skills/yoyopod-restart/SKILL.md
@@ -15,7 +15,7 @@ host, SSH user, dev lane checkout, and branch. `yoyopod target restart`
 is a dev-lane helper and expects the selected checkout to match
 `/opt/yoyopod-dev/checkout`. Prod slot management (`target release …`)
 returns in Round 3 of the CLI rebuild; see
-`docs/operations/CLI_REBUILD_ROUNDS.md`.
+`docs/ROADMAP.md`.
 
 If the file does not exist yet, run `yoyopod target config edit` first.
 That command creates `deploy/pi-deploy.local.yaml` automatically before


### PR DESCRIPTION
## Summary

After the Round 0/1 rebuild and the two prior cleanup PRs, the doc tree had structural rot:

- The single most important doc in the repo (the rebuild roadmap) was buried two levels deep at `docs/operations/CLI_REBUILD_ROUNDS.md`.
- Five "paused" / "in transition" operations docs sat as peers of the active workflow docs even though they mostly redirected readers elsewhere.
- `docs/architecture/` had no `README.md` (every other folder did).
- The docs index and several folder READMEs linked to 6 files that don't exist (`DISPLAY_HAL_ARCHITECTURE.md`, `INPUT_HAL_ARCHITECTURE.md`, `CROSS_SCREEN_OVERLAYS.md`, `ASK_SCREEN_DESIGN_SPEC.md`, `DEPLOYED_PI_DEPENDENCIES.md`, `WHISPLAY_SIMULATION_PARITY_CONTRACT.md`, `V1_SCOPE_MANIFESTO.md`).
- An unrelated dead `docs/archive/` link existed in the repo-root README.

This PR rationalises the tree.

> **Stacked on PR #440** (strip-non-canonical-hardware). The diff against `main` will look correct once both #440 and this PR merge.

## New tree

```
docs/
├── README.md                          (rewritten)
├── ROADMAP.md                         (NEW — promoted from operations/)
├── architecture/
│   ├── README.md                      (NEW)
│   └── …
├── operations/
│   ├── README.md                      (rewritten)
│   ├── CONTRIBUTOR_WORKFLOW.md
│   ├── DEVELOPMENT_GUIDE.md
│   ├── SETUP_CONTRACT.md
│   ├── QUALITY_GATES.md
│   ├── DEV_PROD_LANES.md
│   ├── PI_DEV_WORKFLOW.md
│   └── archive/                       (NEW subfolder)
│       ├── README.md                  (NEW)
│       ├── RELEASE_PROCESS.md         (moved)
│       ├── SLOT_DEPLOY.md             (moved)
│       ├── OTA_ROADMAP.md             (moved)
│       ├── RPI_SMOKE_VALIDATION.md    (moved)
│       └── PI_PROFILING_WORKFLOW.md   (moved)
├── features/                          (unchanged)
├── hardware/                          (unchanged)
├── design/
│   └── README.md                      (rewritten — dead links removed)
└── product/
    └── README.md                      (rewritten — dead link removed)
```

## Commits

1. **Promote CLI_REBUILD_ROUNDS to ROADMAP.md + archive paused docs** — the structural moves. Renames, new folder, new READMEs (`architecture/README.md`, `operations/archive/README.md`). Each archived doc's internal `CLI_REBUILD_ROUNDS.md` reference rewritten to point at the new `../../ROADMAP.md`.
2. **Rewrite index READMEs** — `docs/README.md`, `docs/design/README.md`, `docs/product/README.md` rewritten to match the restructured tree and drop links to 6 non-existent files.
3. **Rewrite inbound links** — every other file that linked to the old paths updated. Covers `AGENTS.md`, repo-root `README.md`, `cli/README.md`, `cli/yoyopod/src/commands/target/validate.rs` (the Round 2 stub message), `deploy/`, all `rules/`, the architecture / features / hardware / operations docs that weren't moved, and the two skills (`yoyopod-deploy`, `yoyopod-restart`) that had inline pointers.

## Verification

A custom python walker (see commit 3) checked every `[text](target)` link across every `*.md` in the repo (excluding caches and worktrees):

```
all markdown links resolve ✓
```

- `cargo build --manifest-path cli/Cargo.toml` — passes
- `cargo test --manifest-path cli/Cargo.toml` — 35/35 passing
- `cargo check --manifest-path device/Cargo.toml --workspace --locked` — passes

## What's deleted vs. moved

**Moved (5 files)** — each goes from `docs/operations/` to `docs/operations/archive/`. Content preserved; only internal links rewritten:
- `SLOT_DEPLOY.md`
- `RELEASE_PROCESS.md`
- `OTA_ROADMAP.md`
- `RPI_SMOKE_VALIDATION.md`
- `PI_PROFILING_WORKFLOW.md`

**Renamed + promoted (1 file)**:
- `docs/operations/CLI_REBUILD_ROUNDS.md` → `docs/ROADMAP.md`

**Created (3 files)**:
- `docs/architecture/README.md`
- `docs/operations/archive/README.md`
- `docs/operations/README.md` (this was rewritten, not strictly new — included for completeness)

**Deleted (0 files)** — no content was lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)