### PR TITLE
Round 2: restore hardware validation — yoyopod-on-pi + target validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
             -p yoyopod-media \
             -p yoyopod-voip \
             -p yoyopod-network \
+            -p yoyopod-on-pi \
             -p yoyopod-power \
             -p yoyopod-speech \
             --features yoyopod-ui/whisplay-hardware,yoyopod-ui/native-lvgl,yoyopod-voip/native-liblinphone
@@ -151,6 +152,7 @@ jobs:
             "${bundle_root}/device/media/build" \
             "${bundle_root}/device/voip/build" \
             "${bundle_root}/device/network/build" \
+            "${bundle_root}/device/onpi/build" \
             "${bundle_root}/device/power/build" \
             "${bundle_root}/device/speech/build"
           cp target/release/yoyopod-runtime "${bundle_root}/device/runtime/build/yoyopod-runtime"
@@ -159,6 +161,7 @@ jobs:
           cp target/release/yoyopod-media-host "${bundle_root}/device/media/build/yoyopod-media-host"
           cp target/release/yoyopod-voip-host "${bundle_root}/device/voip/build/yoyopod-voip-host"
           cp target/release/yoyopod-network-host "${bundle_root}/device/network/build/yoyopod-network-host"
+          cp target/release/yoyopod-on-pi "${bundle_root}/device/onpi/build/yoyopod-on-pi"
           cp target/release/yoyopod-power-host "${bundle_root}/device/power/build/yoyopod-power-host"
           cp target/release/yoyopod-speech-host "${bundle_root}/device/speech/build/yoyopod-speech-host"
           tar -C "${bundle_root}" -czf "target/${bundle_name}.tar.gz" device

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,11 @@ Verification Policy
 - For hardware work, exact-commit CI artifacts (`yoyopod-rust-device-arm64-<sha>`)
   and Pi results matter most. Always report the commit SHA, artifact names,
   and hardware command/result.
-- Automated on-Pi validation (`yoyopod target validate`) returns in Round 2
-  of the CLI rebuild. Until then, validate manually after `target deploy`
-  via systemd status + journalctl + hardware inspection.
+- Automated on-Pi validation: `yoyopod target validate` runs the staged
+  suite (deploy, smoke, stability + optional soaks) via the `yoyopod-on-pi`
+  binary shipped in the CI artifact. The voip / cloud-voice stages are a
+  Round 2 follow-up; validate those manually via journalctl + hardware
+  inspection.
 
 Hardware
 - The supported hardware is the Raspberry Pi Zero 2W + PiSugar Whisplay
@@ -121,4 +123,4 @@ Hardware
   supported.
 
 Guardrails
-- Prefer `yoyopod remote` over ad-hoc SSH sequences.
+- Prefer `yoyopod target` over ad-hoc SSH sequences.

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,9 +18,28 @@ Single binary, `yoyopod`. Nine commands all under `yoyopod target ...`:
 | `target restart` | implemented |
 | `target logs [--lines N] [--follow] [--errors] [--filter PATTERN]` | implemented |
 | `target screenshot [--out PATH] [--readback]` | implemented |
-| `target validate` | **stub** (returns exit 2 with a "blocked on Round 2" message) |
+| `target validate [--sha S] [--with-lvgl-soak] [--with-navigation]` | implemented (Round 2; voip / cloud-voice stages still pending) |
 
 Everything else from the old Python CLI returns in later rounds.
+
+### What `target validate` does (Round 2)
+
+Enforces the same committed-code contract as `target deploy`, then over
+SSH: syncs the Pi checkout to the pushed revision, verifies the
+CI-built binaries are installed, and runs the staged validation suite
+via the on-Pi companion binary shipped inside the artifact bundle:
+
+```
+device/onpi/build/yoyopod-on-pi validate deploy
+device/onpi/build/yoyopod-on-pi validate smoke
+device/onpi/build/yoyopod-on-pi validate stability
+# --with-lvgl-soak   adds: validate lvgl
+# --with-navigation  adds: validate navigation
+```
+
+The `voip` and `cloud-voice` stages are not ported yet (Round 2
+follow-up); `--with-voip` is rejected with a clear message until then.
+The on-Pi binary source lives at `../device/onpi/`.
 
 ## Install
 
@@ -141,7 +160,7 @@ cli/
                 ├── logs.rs      # logs
                 ├── screenshot.rs
                 ├── deploy.rs    # the big one
-                └── validate.rs  # Round 2 stub
+                └── validate.rs  # SSH orchestration of yoyopod-on-pi
 ```
 
 No async runtime. All SSH and subprocess work is synchronous and
@@ -161,8 +180,9 @@ command shape, deploy pre-checks, and the major shell-builder outputs.
 
 ## Roadmap
 
-Round 2 (next): restore on-Pi validation in Rust so `target validate`
-stops being a stub.
+Round 2 (in progress): base validation stages are restored via the
+`yoyopod-on-pi` companion binary; the `voip` and `cloud-voice` stage
+ports are the remaining follow-up.
 
 Round 3: restore the prod release pipeline (slot builder, manifest,
 preflight) and re-enable the disabled CI jobs.

--- a/cli/yoyopod/src/cli.rs
+++ b/cli/yoyopod/src/cli.rs
@@ -68,7 +68,7 @@ pub enum TargetCommand {
     Mode(ModeCommand),
     /// Push, fetch CI artifact, sync Pi, install binaries, restart and verify.
     Deploy(DeployArgs),
-    /// (Round 1 stub) Run staged Pi validation. Returns in Round 2.
+    /// Run staged on-Pi validation (deploy, smoke, stability + optional soaks).
     Validate(ValidateArgs),
 }
 
@@ -141,14 +141,23 @@ pub struct DeployArgs {
 
 #[derive(Debug, Args)]
 pub struct ValidateArgs {
+    /// Pin validation to a specific commit (must be reachable from origin/<branch>).
     #[arg(long, default_value = "")]
     pub sha: String,
+
+    /// (Not yet ported — Round 2 follow-up.) SIP registration check.
     #[arg(long)]
     pub with_voip: bool,
+
+    /// Add the UI/LVGL navigation soak stage.
     #[arg(long)]
     pub with_lvgl_soak: bool,
+
+    /// Add the full one-button navigation stage.
     #[arg(long)]
     pub with_navigation: bool,
+
+    /// (Returns with Round 4+ diagnostics.) Standalone rust-ui-host probe.
     #[arg(long)]
     pub with_rust_ui_host: bool,
 }

--- a/cli/yoyopod/src/commands/target/deploy.rs
+++ b/cli/yoyopod/src/commands/target/deploy.rs
@@ -64,7 +64,10 @@ pub fn run(
         println!("artifact: {artifact_name}");
         println!("local-artifact-dir: {}", local_artifact_dir.display());
         println!("would: ensure CI run for sha is successful, download {tarball_name}");
-        println!("would: ssh sync + extract + restart + verify on {}", ctx.conn.ssh_target());
+        println!(
+            "would: ssh sync + extract + restart + verify on {}",
+            ctx.conn.ssh_target()
+        );
         return Ok(0);
     }
 
@@ -113,6 +116,7 @@ pub fn run(
          device/media/build/yoyopod-media-host device/voip/build/yoyopod-voip-host \
          device/network/build/yoyopod-network-host device/cloud/build/yoyopod-cloud-host \
          device/power/build/yoyopod-power-host device/speech/build/yoyopod-speech-host \
+         && {{ [ ! -f device/onpi/build/yoyopod-on-pi ] || chmod +x device/onpi/build/yoyopod-on-pi; }} \
          && rm -f {tarball}",
         tarball = shell_quote(&remote_tarball)
     );
@@ -135,7 +139,7 @@ pub fn run(
     Ok(0)
 }
 
-fn require_local_clean_tree() -> Result<()> {
+pub(super) fn require_local_clean_tree() -> Result<()> {
     require_git(
         &["git", "diff", "--quiet"],
         "Local worktree has uncommitted changes. Commit or stash them before `yoyopod target deploy`.",
@@ -154,7 +158,7 @@ fn capture_head_sha() -> Result<String> {
     Ok(out.stdout.trim().to_string())
 }
 
-fn require_branch_pushed(branch: &str) -> Result<()> {
+pub(super) fn require_branch_pushed(branch: &str) -> Result<()> {
     require_git(
         &["git", "fetch", "--quiet", "origin", branch],
         &format!("Failed to fetch `origin/{branch}` before deploy."),
@@ -168,16 +172,10 @@ fn require_branch_pushed(branch: &str) -> Result<()> {
     )
 }
 
-fn require_local_not_ahead(branch: &str) -> Result<()> {
+pub(super) fn require_local_not_ahead(branch: &str) -> Result<()> {
     // If a local branch with the same name exists, ensure it's not ahead of origin.
     let local_ref = format!("refs/heads/{branch}");
-    let check = run_local_capture([
-        "git",
-        "show-ref",
-        "--verify",
-        "--quiet",
-        local_ref.as_str(),
-    ])?;
+    let check = run_local_capture(["git", "show-ref", "--verify", "--quiet", local_ref.as_str()])?;
     if !check.status.success() {
         return Ok(());
     }
@@ -197,7 +195,7 @@ fn require_local_not_ahead(branch: &str) -> Result<()> {
     Ok(())
 }
 
-fn require_sha_reachable(branch: &str, sha: &str) -> Result<()> {
+pub(super) fn require_sha_reachable(branch: &str, sha: &str) -> Result<()> {
     let origin_branch = format!("origin/{branch}");
     require_git(
         &[
@@ -316,7 +314,7 @@ fn download_artifact(run_id: &str, artifact_name: &str, dest: &Path) -> Result<(
     Ok(())
 }
 
-fn build_pi_sync(branch: &str, sha: &str, clean_native: bool) -> String {
+pub(super) fn build_pi_sync(branch: &str, sha: &str, clean_native: bool) -> String {
     let br = shell_quote(branch);
     let origin_br = shell_quote(&format!("origin/{branch}"));
     let mut steps = vec![

--- a/cli/yoyopod/src/commands/target/mod.rs
+++ b/cli/yoyopod/src/commands/target/mod.rs
@@ -76,7 +76,10 @@ pub fn dispatch(args: TargetArgs, dry_run: bool) -> Result<i32> {
             validate_connection(&ctx.conn)?;
             deploy::run(&ctx, &base, &local, a)
         }
-        TargetCommand::Validate(a) => validate::run(&ctx, a),
+        TargetCommand::Validate(a) => {
+            validate_connection(&ctx.conn)?;
+            validate::run(&ctx, a)
+        }
     }
 }
 

--- a/cli/yoyopod/src/commands/target/validate.rs
+++ b/cli/yoyopod/src/commands/target/validate.rs
@@ -1,24 +1,156 @@
-//! `yoyopod target validate` — Round 1 stub.
+//! `yoyopod target validate` — run staged on-Pi validation over SSH.
 //!
-//! The real implementation depends on on-Pi validation stages (`pi
-//! validate smoke`, etc.) being available. Those are deleted as of Round
-//! 0 and return in Round 2. Until then this command prints a clear
-//! "blocked" message and exits non-zero so automated callers fail loud.
+//! Round 2 of the CLI rebuild. Mirrors the deleted `remote_validate.py`:
+//! enforce the committed-code contract locally, sync the Pi checkout to
+//! the pushed revision, verify the CI-built binaries are installed, then
+//! run the `yoyopod-on-pi validate ...` stages shipped inside the
+//! `yoyopod-rust-device-arm64-<sha>` artifact.
+//!
+//! Base stages: deploy, smoke, stability. `--with-lvgl-soak` and
+//! `--with-navigation` add their soaks. The voip and cloud-voice stages
+//! are not ported yet (Round 2 follow-up) and are rejected up front.
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 
 use crate::cli::ValidateArgs;
+use crate::quoting::shell_quote;
+use crate::ssh::{run_remote, RemoteWorkdir};
 
-use super::TargetContext;
+use super::deploy::{
+    build_pi_sync, require_branch_pushed, require_local_clean_tree, require_local_not_ahead,
+    require_sha_reachable,
+};
+use super::{maybe_dry_run, TargetContext};
 
-pub fn run(_ctx: &TargetContext, _args: ValidateArgs) -> Result<i32> {
-    eprintln!(
-        "target validate: blocked on Round 2 of the CLI rebuild.\n\
-         See docs/ROADMAP.md.\n\
-         Until then, validate manually after `yoyopod target deploy`:\n\
-           journalctl -u yoyopod-dev.service -f\n\
-           systemctl status yoyopod-dev.service\n\
-         and inspect the device behaviour directly."
-    );
-    Ok(2)
+const ON_PI_BINARY: &str = "device/onpi/build/yoyopod-on-pi";
+
+/// Binaries the base stages exercise; checked before any stage runs so a
+/// half-deployed checkout fails loudly instead of mid-validation.
+const REQUIRED_BINARIES: [&str; 5] = [
+    "device/runtime/build/yoyopod-runtime",
+    "device/ui/build/yoyopod-ui-host",
+    "device/cloud/build/yoyopod-cloud-host",
+    "device/media/build/yoyopod-media-host",
+    ON_PI_BINARY,
+];
+
+pub fn run(ctx: &TargetContext, args: ValidateArgs) -> Result<i32> {
+    if args.with_voip {
+        bail!(
+            "--with-voip: the VoIP validation stage has not been ported to Rust yet \
+             (Round 2 follow-up; see docs/ROADMAP.md)."
+        );
+    }
+    if args.with_rust_ui_host {
+        bail!(
+            "--with-rust-ui-host: the rust-ui-host diagnostic returns with the Round 4+ \
+             diagnostics (see docs/ROADMAP.md)."
+        );
+    }
+
+    let branch = ctx.conn.branch.clone();
+
+    // Committed-code contract, fail-fast even in dry-run (matches deploy).
+    require_local_clean_tree()?;
+    require_branch_pushed(&branch)?;
+    if args.sha.is_empty() {
+        require_local_not_ahead(&branch)?;
+    } else {
+        require_sha_reachable(&branch, &args.sha)?;
+    }
+
+    let remote_cmd = build_validate_script(&branch, &args);
+    if let Some(rc) = maybe_dry_run(ctx, "validate", &remote_cmd) {
+        return Ok(rc);
+    }
+    run_remote(&ctx.conn, &remote_cmd, true, RemoteWorkdir::Default)
+}
+
+fn require_executable(path: &str) -> String {
+    let quoted_path = shell_quote(path);
+    let message = shell_quote(&format!(
+        "Missing executable CI-built binary at {path}. Deploy the GitHub Actions \
+         artifact yoyopod-rust-device-arm64-<sha> for this exact commit \
+         (`yoyopod target deploy`) before Pi validation; do not build Rust \
+         binaries on the Pi."
+    ));
+    format!("test -x {quoted_path} || (echo {message} >&2 && exit 1)")
+}
+
+fn build_validate_script(branch: &str, args: &ValidateArgs) -> String {
+    // Same checkout sync the old remote validate performed.
+    let mut steps = vec![build_pi_sync(branch, &args.sha, false)];
+    for binary in REQUIRED_BINARIES {
+        steps.push(require_executable(binary));
+    }
+    steps.push(format!("{ON_PI_BINARY} validate deploy"));
+    steps.push(format!("{ON_PI_BINARY} validate smoke"));
+    steps.push(format!("{ON_PI_BINARY} validate stability"));
+    if args.with_lvgl_soak {
+        steps.push(format!("{ON_PI_BINARY} validate lvgl"));
+    }
+    if args.with_navigation {
+        steps.push(format!("{ON_PI_BINARY} validate navigation"));
+    }
+    steps.join(" && ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_args() -> ValidateArgs {
+        ValidateArgs {
+            sha: String::new(),
+            with_voip: false,
+            with_lvgl_soak: false,
+            with_navigation: false,
+            with_rust_ui_host: false,
+        }
+    }
+
+    #[test]
+    fn base_script_runs_deploy_smoke_stability() {
+        let script = build_validate_script("main", &base_args());
+        assert!(script.contains("git checkout --force -B main origin/main"));
+        assert!(script.contains("device/onpi/build/yoyopod-on-pi validate deploy"));
+        assert!(script.contains("device/onpi/build/yoyopod-on-pi validate smoke"));
+        assert!(script.contains("device/onpi/build/yoyopod-on-pi validate stability"));
+        assert!(!script.contains("validate lvgl"));
+        assert!(!script.contains("validate navigation"));
+    }
+
+    #[test]
+    fn script_checks_binaries_before_stages() {
+        let script = build_validate_script("main", &base_args());
+        let binary_check = script
+            .find("test -x device/onpi/build/yoyopod-on-pi")
+            .expect("on-pi binary check present");
+        let first_stage = script
+            .find("validate deploy")
+            .expect("deploy stage present");
+        assert!(binary_check < first_stage);
+    }
+
+    #[test]
+    fn sha_pins_the_checkout() {
+        let mut args = base_args();
+        args.sha = "abc123".to_string();
+        let script = build_validate_script("main", &args);
+        assert!(script.contains("git merge-base --is-ancestor abc123 origin/main"));
+        assert!(script.contains("git reset --hard abc123"));
+    }
+
+    #[test]
+    fn optional_stages_append_after_base() {
+        let mut args = base_args();
+        args.with_lvgl_soak = true;
+        args.with_navigation = true;
+        let script = build_validate_script("main", &args);
+        let stability = script.find("validate stability").unwrap();
+        let lvgl = script.find("validate lvgl").unwrap();
+        let navigation = script.find("validate navigation").unwrap();
+        assert!(stability < lvgl);
+        assert!(lvgl < navigation);
+    }
 }

--- a/cli/yoyopod/src/repo.rs
+++ b/cli/yoyopod/src/repo.rs
@@ -10,13 +10,29 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 
+/// Strip Windows' verbatim path prefix (`\\?\`) that `canonicalize`
+/// produces. Tools we shell out to can't handle it: scp parses the
+/// colon in `\\?\C:\...` as a `host:path` separator and aborts with
+/// "hostname contains invalid characters".
+fn strip_verbatim_prefix(path: PathBuf) -> PathBuf {
+    let text = path.to_string_lossy();
+    if let Some(rest) = text.strip_prefix(r"\\?\UNC\") {
+        return PathBuf::from(format!(r"\\{rest}"));
+    }
+    if let Some(rest) = text.strip_prefix(r"\\?\") {
+        return PathBuf::from(rest.to_string());
+    }
+    path
+}
+
 /// Find the repository root by walking up from `start` until `.git` is found.
 ///
 /// Returns an error if no enclosing repository is found.
 pub fn find_repo_root(start: &Path) -> Result<PathBuf> {
-    let mut current = start
+    let canonical = start
         .canonicalize()
         .with_context(|| format!("canonicalize {}", start.display()))?;
+    let mut current = strip_verbatim_prefix(canonical);
 
     loop {
         if current.join(".git").exists() {
@@ -51,7 +67,8 @@ mod tests {
         let tmp = tempdir().unwrap();
         fs::create_dir(tmp.path().join(".git")).unwrap();
         let found = find_repo_root(tmp.path()).unwrap();
-        assert_eq!(found, tmp.path().canonicalize().unwrap());
+        let expected = strip_verbatim_prefix(tmp.path().canonicalize().unwrap());
+        assert_eq!(found, expected);
     }
 
     #[test]
@@ -61,7 +78,32 @@ mod tests {
         let sub = tmp.path().join("a/b/c");
         fs::create_dir_all(&sub).unwrap();
         let found = find_repo_root(&sub).unwrap();
-        assert_eq!(found, tmp.path().canonicalize().unwrap());
+        let expected = strip_verbatim_prefix(tmp.path().canonicalize().unwrap());
+        assert_eq!(found, expected);
+    }
+
+    #[test]
+    fn repo_root_has_no_verbatim_prefix() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir(tmp.path().join(".git")).unwrap();
+        let found = find_repo_root(tmp.path()).unwrap();
+        assert!(!found.to_string_lossy().starts_with(r"\\?\"));
+    }
+
+    #[test]
+    fn strip_verbatim_handles_drive_and_unc() {
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from(r"\\?\C:\repo\file.tar.gz")),
+            PathBuf::from(r"C:\repo\file.tar.gz")
+        );
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from(r"\\?\UNC\server\share\x")),
+            PathBuf::from(r"\\server\share\x")
+        );
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from("/plain/unix/path")),
+            PathBuf::from("/plain/unix/path")
+        );
     }
 
     #[test]

--- a/device/Cargo.lock
+++ b/device/Cargo.lock
@@ -2176,6 +2176,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoyopod-on-pi"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde_json",
+ "yoyopod-protocol",
+]
+
+[[package]]
 name = "yoyopod-power"
 version = "0.1.0"
 dependencies = [

--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "harness",
     "media",
     "network",
+    "onpi",
     "protocol",
     "power",
     "runtime",

--- a/device/onpi/Cargo.toml
+++ b/device/onpi/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "yoyopod-on-pi"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[[bin]]
+name = "yoyopod-on-pi"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
+serde_json = "1.0"
+yoyopod-protocol = { path = "../protocol" }

--- a/device/onpi/src/checks.rs
+++ b/device/onpi/src/checks.rs
@@ -1,0 +1,343 @@
+//! Individual validation checks shared by the stages.
+//!
+//! Ports the deleted `yoyopod_cli/pi/validate/` checks to Rust, adjusted
+//! for the Rust-only runtime: the Python-era virtualenv and console-script
+//! entrypoint checks are gone; the entrypoint contract is now "the CI-built
+//! worker binaries exist and are executable".
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use crate::proc::run_with_timeout;
+use crate::report::CheckResult;
+
+const DRY_RUN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The eight CI-built worker binaries, as repo-relative paths.
+pub const WORKER_BINARIES: [&str; 8] = [
+    "device/runtime/build/yoyopod-runtime",
+    "device/ui/build/yoyopod-ui-host",
+    "device/cloud/build/yoyopod-cloud-host",
+    "device/media/build/yoyopod-media-host",
+    "device/voip/build/yoyopod-voip-host",
+    "device/network/build/yoyopod-network-host",
+    "device/power/build/yoyopod-power-host",
+    "device/speech/build/yoyopod-speech-host",
+];
+
+fn binary_name(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+/// Resolve a repo-relative path, preferring the slot layout (`app/<path>`)
+/// when it exists. Prod slots nest the checkout under `app/`.
+pub fn slot_aware_path(relative: &Path) -> PathBuf {
+    let slot_candidate = Path::new("app").join(relative);
+    if slot_candidate.exists() {
+        return slot_candidate;
+    }
+    relative.to_path_buf()
+}
+
+pub fn default_runtime_worker() -> PathBuf {
+    slot_aware_path(&Path::new("device/runtime/build").join(binary_name("yoyopod-runtime")))
+}
+
+pub fn default_ui_worker() -> PathBuf {
+    slot_aware_path(&Path::new("device/ui/build").join(binary_name("yoyopod-ui-host")))
+}
+
+/// Capture the execution environment. Pass on ARM Linux, warn elsewhere.
+pub fn environment_check() -> CheckResult {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+    let details = format!(
+        "os={os}, arch={arch}, validator={}",
+        env!("CARGO_PKG_VERSION")
+    );
+    if os == "linux" && (arch.contains("arm") || arch.contains("aarch")) {
+        CheckResult::pass("environment", details)
+    } else {
+        CheckResult::warn("environment", details)
+    }
+}
+
+/// Run the Rust runtime's config/load path without starting hardware workers.
+pub fn runtime_dry_run_check(config_dir: &Path, worker: Option<&Path>) -> CheckResult {
+    let default_worker = default_runtime_worker();
+    let runtime_worker = worker.unwrap_or(&default_worker);
+    if !runtime_worker.exists() {
+        return CheckResult::fail(
+            "rust-runtime",
+            format!(
+                "missing Rust runtime binary at {}",
+                runtime_worker.display()
+            ),
+        );
+    }
+
+    let mut command = Command::new(runtime_worker);
+    command.arg("--config-dir").arg(config_dir).arg("--dry-run");
+    let output = match run_with_timeout(&mut command, DRY_RUN_TIMEOUT) {
+        Ok(output) => output,
+        Err(error) => return CheckResult::fail("rust-runtime", error.to_string()),
+    };
+
+    if output.timed_out {
+        return CheckResult::fail(
+            "rust-runtime",
+            format!("dry-run timed out after {}s", DRY_RUN_TIMEOUT.as_secs()),
+        );
+    }
+    if output.exit_code != Some(0) {
+        let mut details = output.stderr.trim().to_string();
+        if details.is_empty() {
+            details = output.stdout.trim().to_string();
+        }
+        if details.is_empty() {
+            details = format!("dry-run exited {:?}", output.exit_code);
+        }
+        return CheckResult::fail("rust-runtime", details);
+    }
+
+    let payload: serde_json::Value = match serde_json::from_str(&output.stdout) {
+        Ok(payload) => payload,
+        Err(error) => {
+            return CheckResult::fail(
+                "rust-runtime",
+                format!("dry-run did not emit JSON config: {error}"),
+            );
+        }
+    };
+    let configured_workers = payload
+        .get("worker_paths")
+        .and_then(|paths| paths.as_object())
+        .map(|paths| paths.len())
+        .unwrap_or(0);
+    CheckResult::pass(
+        "rust-runtime",
+        format!(
+            "binary={}, dry_run=ok, worker_paths={configured_workers}",
+            runtime_worker.display()
+        ),
+    )
+}
+
+/// Repo-relative config files the runtime requires.
+pub fn required_config_files(config_dir: &Path) -> Vec<PathBuf> {
+    [
+        "app/core.yaml",
+        "audio/music.yaml",
+        "device/hardware.yaml",
+        "voice/assistant.yaml",
+        "communication/calling.yaml",
+        "communication/messaging.yaml",
+        "communication/integrations/liblinphone_factory.conf",
+        "people/directory.yaml",
+        "people/contacts.seed.yaml",
+    ]
+    .iter()
+    .map(|suffix| config_dir.join(suffix))
+    .collect()
+}
+
+/// Validate that the tracked runtime config files are present.
+pub fn config_files_check(config_dir: &Path) -> CheckResult {
+    let required = required_config_files(config_dir);
+    let missing: Vec<String> = required
+        .iter()
+        .filter(|path| !path.exists())
+        .map(|path| path.display().to_string())
+        .collect();
+    if !missing.is_empty() {
+        return CheckResult::fail(
+            "config",
+            format!("missing required config files: {}", missing.join(", ")),
+        );
+    }
+    CheckResult::pass(
+        "config",
+        required
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+    )
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|meta| meta.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.exists()
+}
+
+/// Validate that every CI-built worker binary is present and executable.
+pub fn worker_binaries_check() -> CheckResult {
+    let mut missing: Vec<String> = Vec::new();
+    let mut found: Vec<String> = Vec::new();
+    for relative in WORKER_BINARIES {
+        let path = slot_aware_path(Path::new(relative));
+        if path.exists() && is_executable(&path) {
+            found.push(path.display().to_string());
+        } else {
+            missing.push(path.display().to_string());
+        }
+    }
+    if !missing.is_empty() {
+        return CheckResult::fail(
+            "worker_binaries",
+            format!(
+                "missing or non-executable CI-built binaries: {}. Deploy the \
+                 yoyopod-rust-device-arm64-<sha> artifact for this commit; do \
+                 not build Rust binaries on the Pi.",
+                missing.join(", ")
+            ),
+        );
+    }
+    CheckResult::pass("worker_binaries", found.join(", "))
+}
+
+/// Validate that the systemd lane units are present in the checkout.
+pub fn systemd_units_check() -> CheckResult {
+    let units = [
+        "deploy/systemd/yoyopod-dev.service",
+        "deploy/systemd/yoyopod-prod.service",
+    ];
+    let missing: Vec<&str> = units
+        .iter()
+        .copied()
+        .filter(|unit| !slot_aware_path(Path::new(unit)).exists())
+        .collect();
+    if !missing.is_empty() {
+        return CheckResult::fail(
+            "systemd_units",
+            format!("missing systemd unit files: {}", missing.join(", ")),
+        );
+    }
+    CheckResult::pass("systemd_units", units.join(", "))
+}
+
+/// Runtime file paths whose parents must be reachable and writable.
+pub struct RuntimePaths {
+    pub log_file: PathBuf,
+    pub error_log_file: PathBuf,
+    pub pid_file: PathBuf,
+    pub screenshot_path: PathBuf,
+}
+
+impl Default for RuntimePaths {
+    fn default() -> Self {
+        // Mirrors the tracked deploy contract (deploy/pi-deploy.yaml).
+        Self {
+            log_file: PathBuf::from("logs/yoyopod.log"),
+            error_log_file: PathBuf::from("logs/yoyopod_errors.log"),
+            pid_file: PathBuf::from("/opt/yoyopod-dev/state/yoyopod.pid"),
+            screenshot_path: PathBuf::from("/tmp/yoyopod_screenshot.png"),
+        }
+    }
+}
+
+fn nearest_existing_parent(path: &Path) -> PathBuf {
+    let mut candidate = if path.is_dir() {
+        path.to_path_buf()
+    } else {
+        path.parent().map(Path::to_path_buf).unwrap_or_default()
+    };
+    while !candidate.as_os_str().is_empty() && !candidate.exists() {
+        match candidate.parent() {
+            Some(parent) => candidate = parent.to_path_buf(),
+            None => break,
+        }
+    }
+    if candidate.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        candidate
+    }
+}
+
+fn is_writable_dir(dir: &Path) -> bool {
+    let probe = dir.join(format!(".yoyopod-validate-probe-{}", std::process::id()));
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Validate that runtime file parents are reachable and writable.
+pub fn runtime_paths_check(paths: &RuntimePaths) -> CheckResult {
+    let path_map = [
+        ("log", &paths.log_file),
+        ("error_log", &paths.error_log_file),
+        ("pid", &paths.pid_file),
+        ("screenshot", &paths.screenshot_path),
+    ];
+
+    let mut details: Vec<String> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+    for (name, path) in path_map {
+        let parent = nearest_existing_parent(path);
+        details.push(format!("{name}_parent={}", parent.display()));
+        if !is_writable_dir(&parent) {
+            failures.push(format!("{name}_parent_not_writable={}", parent.display()));
+        }
+    }
+
+    if !failures.is_empty() {
+        return CheckResult::fail("runtime_paths", failures.join(", "));
+    }
+    CheckResult::pass("runtime_paths", details.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::CheckStatus;
+
+    #[test]
+    fn required_config_files_are_rooted_at_config_dir() {
+        let files = required_config_files(Path::new("config"));
+        assert_eq!(files.len(), 9);
+        assert!(files.iter().all(|path| path.starts_with("config")));
+        assert!(files
+            .iter()
+            .any(|path| path.ends_with("communication/integrations/liblinphone_factory.conf")));
+    }
+
+    #[test]
+    fn nearest_existing_parent_walks_up() {
+        let missing = Path::new("definitely/not/a/real/path/file.log");
+        let parent = nearest_existing_parent(missing);
+        assert!(parent.exists());
+    }
+
+    #[test]
+    fn environment_check_reports_os_and_arch() {
+        let result = environment_check();
+        assert_eq!(result.name, "environment");
+        assert!(result.details.contains("os="));
+        assert!(result.details.contains("arch="));
+    }
+
+    #[test]
+    fn runtime_dry_run_fails_on_missing_binary() {
+        let result = runtime_dry_run_check(Path::new("config"), Some(Path::new("no/such/binary")));
+        assert_eq!(result.status, CheckStatus::Fail);
+        assert!(result.details.contains("missing Rust runtime binary"));
+    }
+}

--- a/device/onpi/src/main.rs
+++ b/device/onpi/src/main.rs
@@ -1,0 +1,150 @@
+//! `yoyopod-on-pi` — on-Pi companion binary for the Rust operator CLI.
+//!
+//! Cross-compiled by CI into the `yoyopod-rust-device-arm64-<sha>` bundle
+//! and executed on the Pi by `yoyopod target validate` over SSH. Round 2
+//! of the CLI rebuild starts with the `validate` stages; Round 4+
+//! diagnostics (`voip`, `power`, `network`) join this binary later.
+
+use std::path::PathBuf;
+
+use clap::{Args, Parser, Subcommand};
+
+mod checks;
+mod proc;
+mod report;
+mod stages;
+mod ui_host;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "yoyopod-on-pi",
+    about = "YoYoPod on-Pi companion: staged hardware validation.",
+    version
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Staged validation of the deployed checkout on this device.
+    #[command(subcommand)]
+    Validate(ValidateStage),
+}
+
+#[derive(Debug, Subcommand)]
+enum ValidateStage {
+    /// Environment + runtime dry-run + one UI snapshot render.
+    Smoke(SmokeArgs),
+    /// Deploy-readiness: config files, worker binaries, units, paths.
+    Deploy(DeployArgs),
+    /// Repeated navigation + idle soak through the UI worker protocol.
+    Stability(SoakArgs),
+    /// One-button navigation across the main screen set.
+    Navigation(NavigationArgs),
+    /// UI/LVGL navigation soak (same driver as stability).
+    Lvgl(SoakArgs),
+    /// SIP registration check (not yet ported — exits 2).
+    Voip,
+    /// Cloud STT/TTS worker check (not yet ported — exits 2).
+    CloudVoice,
+}
+
+#[derive(Debug, Args)]
+struct SmokeArgs {
+    /// Configuration directory to use.
+    #[arg(long, default_value = "config")]
+    config_dir: PathBuf,
+
+    /// UI hardware backend to validate against.
+    #[arg(long, default_value = "whisplay", value_parser = ["whisplay", "mock"])]
+    hardware: String,
+
+    /// How long to keep the rendered snapshot visible.
+    #[arg(long, default_value_t = 0.5)]
+    display_hold_seconds: f64,
+}
+
+#[derive(Debug, Args)]
+struct DeployArgs {
+    /// Configuration directory to validate.
+    #[arg(long, default_value = "config")]
+    config_dir: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct SoakArgs {
+    /// Configuration directory to use.
+    #[arg(long, default_value = "config")]
+    config_dir: PathBuf,
+
+    /// How many full transition cycles to run.
+    #[arg(long, default_value_t = 2)]
+    cycles: u32,
+
+    /// How long to keep each screen active during the soak.
+    #[arg(long, default_value_t = 0.2)]
+    hold_seconds: f64,
+
+    /// How long to idle after each full navigation cycle.
+    #[arg(long, default_value_t = 1.0)]
+    idle_seconds: f64,
+}
+
+#[derive(Debug, Args)]
+struct NavigationArgs {
+    /// Configuration directory to use.
+    #[arg(long, default_value = "config")]
+    config_dir: PathBuf,
+
+    /// How many full navigation cycles to run.
+    #[arg(long, default_value_t = 2)]
+    cycles: u32,
+
+    /// How long to pump after each simulated click or route change.
+    #[arg(long, default_value_t = 0.35)]
+    hold_seconds: f64,
+
+    /// How long to leave each exercised screen idle before the next action.
+    #[arg(long, default_value_t = 3.0)]
+    idle_seconds: f64,
+
+    /// Final idle dwell on the hub after all navigation cycles complete.
+    #[arg(long, default_value_t = 10.0)]
+    tail_idle_seconds: f64,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let code = match cli.command {
+        Command::Validate(stage) => match stage {
+            ValidateStage::Smoke(args) => {
+                stages::smoke(&args.config_dir, &args.hardware, args.display_hold_seconds)
+            }
+            ValidateStage::Deploy(args) => stages::deploy(&args.config_dir),
+            ValidateStage::Stability(args) => stages::stability(
+                &args.config_dir,
+                args.cycles,
+                args.hold_seconds,
+                args.idle_seconds,
+            ),
+            ValidateStage::Navigation(args) => stages::navigation(
+                &args.config_dir,
+                args.cycles,
+                args.hold_seconds,
+                args.idle_seconds,
+                args.tail_idle_seconds,
+            ),
+            ValidateStage::Lvgl(args) => stages::lvgl(
+                &args.config_dir,
+                args.cycles,
+                args.hold_seconds,
+                args.idle_seconds,
+            ),
+            ValidateStage::Voip => stages::voip_stub(),
+            ValidateStage::CloudVoice => stages::cloud_voice_stub(),
+        },
+    };
+    std::process::exit(code);
+}

--- a/device/onpi/src/proc.rs
+++ b/device/onpi/src/proc.rs
@@ -1,0 +1,62 @@
+//! Child-process helper: run a command to completion with a hard timeout.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+
+pub struct TimedOutput {
+    pub timed_out: bool,
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Run `command` with piped stdout/stderr, killing it if it exceeds `timeout`.
+pub fn run_with_timeout(command: &mut Command, timeout: Duration) -> Result<TimedOutput> {
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("spawn {:?}", command.get_program()))?;
+
+    let mut stdout_pipe = child.stdout.take().expect("stdout is piped");
+    let mut stderr_pipe = child.stderr.take().expect("stderr is piped");
+    let stdout_reader = thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stdout_pipe.read_to_string(&mut buf);
+        buf
+    });
+    let stderr_reader = thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stderr_pipe.read_to_string(&mut buf);
+        buf
+    });
+
+    let deadline = Instant::now() + timeout;
+    let mut timed_out = false;
+    let status = loop {
+        if let Some(status) = child.try_wait().context("poll child process")? {
+            break Some(status);
+        }
+        if Instant::now() >= deadline {
+            timed_out = true;
+            let _ = child.kill();
+            let _ = child.wait();
+            break None;
+        }
+        thread::sleep(Duration::from_millis(50));
+    };
+
+    let stdout = stdout_reader.join().unwrap_or_default();
+    let stderr = stderr_reader.join().unwrap_or_default();
+    Ok(TimedOutput {
+        timed_out,
+        exit_code: status.and_then(|s| s.code()),
+        stdout,
+        stderr,
+    })
+}

--- a/device/onpi/src/report.rs
+++ b/device/onpi/src/report.rs
@@ -1,0 +1,105 @@
+//! Result model + summary printer for validation stages.
+//!
+//! Ports `_CheckResult` / `_print_summary` from the deleted
+//! `yoyopod_cli/pi/validate/_common.py`. The summary format is kept
+//! byte-compatible so operators (and log-scraping tooling) see the
+//! same output the Python suite produced.
+
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+impl fmt::Display for CheckStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let text = match self {
+            Self::Pass => "PASS",
+            Self::Warn => "WARN",
+            Self::Fail => "FAIL",
+        };
+        write!(f, "{text}")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CheckResult {
+    pub name: String,
+    pub status: CheckStatus,
+    pub details: String,
+}
+
+impl CheckResult {
+    pub fn pass(name: impl Into<String>, details: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Pass,
+            details: details.into(),
+        }
+    }
+
+    pub fn warn(name: impl Into<String>, details: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Warn,
+            details: details.into(),
+        }
+    }
+
+    pub fn fail(name: impl Into<String>, details: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Fail,
+            details: details.into(),
+        }
+    }
+}
+
+/// Print the compact summary table for one validation stage.
+pub fn print_summary(stage: &str, results: &[CheckResult]) {
+    println!();
+    println!("YoYoPod target validation summary: {stage}");
+    println!("{}", "=".repeat(48));
+    for result in results {
+        println!("[{}] {}: {}", result.status, result.name, result.details);
+    }
+}
+
+/// Stage exit code: 1 when any check failed, 0 otherwise (warns pass).
+pub fn exit_code(results: &[CheckResult]) -> i32 {
+    if results.iter().any(|r| r.status == CheckStatus::Fail) {
+        1
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_code_fails_on_any_fail() {
+        let results = vec![
+            CheckResult::pass("a", "ok"),
+            CheckResult::fail("b", "broken"),
+        ];
+        assert_eq!(exit_code(&results), 1);
+    }
+
+    #[test]
+    fn exit_code_passes_with_warns() {
+        let results = vec![CheckResult::pass("a", "ok"), CheckResult::warn("b", "meh")];
+        assert_eq!(exit_code(&results), 0);
+    }
+
+    #[test]
+    fn status_renders_four_chars() {
+        assert_eq!(CheckStatus::Pass.to_string(), "PASS");
+        assert_eq!(CheckStatus::Warn.to_string(), "WARN");
+        assert_eq!(CheckStatus::Fail.to_string(), "FAIL");
+    }
+}

--- a/device/onpi/src/stages.rs
+++ b/device/onpi/src/stages.rs
@@ -1,0 +1,99 @@
+//! Validation stages: each assembles checks, prints the summary, and
+//! returns the process exit code (0 pass, 1 fail, 2 blocked).
+
+use std::path::Path;
+
+use crate::checks;
+use crate::report::{exit_code, print_summary};
+use crate::ui_host;
+
+pub fn smoke(config_dir: &Path, hardware: &str, display_hold_seconds: f64) -> i32 {
+    let results = vec![
+        checks::environment_check(),
+        checks::runtime_dry_run_check(config_dir, None),
+        ui_host::ui_smoke_check(&checks::default_ui_worker(), hardware, display_hold_seconds),
+    ];
+    print_summary("smoke", &results);
+    exit_code(&results)
+}
+
+pub fn deploy(config_dir: &Path) -> i32 {
+    let results = vec![
+        checks::config_files_check(config_dir),
+        checks::worker_binaries_check(),
+        checks::systemd_units_check(),
+        checks::runtime_paths_check(&checks::RuntimePaths::default()),
+    ];
+    print_summary("deploy", &results);
+    exit_code(&results)
+}
+
+pub fn stability(config_dir: &Path, cycles: u32, hold_seconds: f64, idle_seconds: f64) -> i32 {
+    let results = vec![
+        checks::runtime_dry_run_check(config_dir, None),
+        ui_host::ui_navigation_check(
+            &checks::default_ui_worker(),
+            cycles,
+            hold_seconds,
+            idle_seconds,
+            hold_seconds,
+        ),
+    ];
+    print_summary("stability", &results);
+    exit_code(&results)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn navigation(
+    config_dir: &Path,
+    cycles: u32,
+    hold_seconds: f64,
+    idle_seconds: f64,
+    tail_idle_seconds: f64,
+) -> i32 {
+    let results = vec![
+        checks::runtime_dry_run_check(config_dir, None),
+        ui_host::ui_navigation_check(
+            &checks::default_ui_worker(),
+            cycles,
+            hold_seconds,
+            idle_seconds,
+            tail_idle_seconds,
+        ),
+    ];
+    print_summary("navigation", &results);
+    exit_code(&results)
+}
+
+pub fn lvgl(config_dir: &Path, cycles: u32, hold_seconds: f64, idle_seconds: f64) -> i32 {
+    let results = vec![
+        checks::runtime_dry_run_check(config_dir, None),
+        ui_host::ui_navigation_check(
+            &checks::default_ui_worker(),
+            cycles,
+            hold_seconds,
+            idle_seconds,
+            hold_seconds,
+        ),
+    ];
+    print_summary("lvgl", &results);
+    exit_code(&results)
+}
+
+pub fn voip_stub() -> i32 {
+    eprintln!(
+        "validate voip: not yet ported to Rust (Round 2 follow-up).\n\
+         See docs/ROADMAP.md. Until then, verify SIP registration manually:\n\
+           journalctl -u yoyopod-dev.service | grep -i -E 'sip|regist'"
+    );
+    2
+}
+
+pub fn cloud_voice_stub() -> i32 {
+    eprintln!(
+        "validate cloud-voice: not yet ported to Rust (Round 2 follow-up).\n\
+         See docs/ROADMAP.md. Until then, exercise the voice path manually\n\
+         on-device and watch the speech worker logs."
+    );
+    2
+}

--- a/device/onpi/src/ui_host.rs
+++ b/device/onpi/src/ui_host.rs
@@ -1,0 +1,350 @@
+//! Supervise a `yoyopod-ui-host` worker over the stdin/stdout envelope
+//! protocol and run the UI smoke / navigation checks against it.
+//!
+//! Ports `rust_runtime.py` from the deleted Python validation suite. The
+//! envelope encoding comes straight from `yoyopod-protocol`, so the
+//! validator cannot drift from what the workers actually speak.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::Value;
+use yoyopod_protocol::ui::{InputAction, RuntimeSnapshot, UiCommand};
+use yoyopod_protocol::WorkerEnvelope;
+
+use crate::report::CheckResult;
+
+const EVENT_TIMEOUT: Duration = Duration::from_secs(15);
+const MAX_EVENTS_PER_WAIT: usize = 32;
+const TICK_INTERVAL: Duration = Duration::from_millis(500);
+
+pub struct UiHostSupervisor {
+    child: Child,
+    stdin: ChildStdin,
+    events: Receiver<String>,
+}
+
+impl UiHostSupervisor {
+    /// Spawn the UI host worker and hand back a supervisor for it.
+    pub fn spawn(worker: &Path, hardware: &str) -> Result<Self> {
+        let mut child = Command::new(worker)
+            .arg("--hardware")
+            .arg(hardware)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .with_context(|| format!("spawn UI host {}", worker.display()))?;
+        let stdin = child.stdin.take().expect("stdin is piped");
+        let stdout = child.stdout.take().expect("stdout is piped");
+        let (sender, events) = std::sync::mpsc::channel();
+        thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines() {
+                let Ok(line) = line else { break };
+                if line.trim().is_empty() {
+                    continue;
+                }
+                if sender.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(Self {
+            child,
+            stdin,
+            events,
+        })
+    }
+
+    pub fn send(&mut self, command: UiCommand) -> Result<()> {
+        let encoded = command
+            .into_envelope()
+            .encode()
+            .context("encode UI command envelope")?;
+        self.stdin
+            .write_all(&encoded)
+            .and_then(|()| self.stdin.flush())
+            .context("write UI command to worker stdin")
+    }
+
+    /// Read the next envelope the worker emits, failing after `EVENT_TIMEOUT`.
+    pub fn read_event(&mut self) -> Result<WorkerEnvelope> {
+        let line = match self.events.recv_timeout(EVENT_TIMEOUT) {
+            Ok(line) => line,
+            Err(RecvTimeoutError::Timeout) => {
+                bail!(
+                    "UI host emitted no event within {}s",
+                    EVENT_TIMEOUT.as_secs()
+                )
+            }
+            Err(RecvTimeoutError::Disconnected) => bail!("UI host closed its stdout"),
+        };
+        WorkerEnvelope::decode(line.as_bytes())
+            .map_err(|error| anyhow!("decode UI host envelope: {error}; line: {line}"))
+    }
+
+    pub fn stop(mut self) {
+        let _ = self.send(UiCommand::Shutdown);
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => thread::sleep(Duration::from_millis(50)),
+                Err(_) => break,
+            }
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Read events until one of `event_types` arrives. `ui.error` fails fast.
+fn read_until(supervisor: &mut UiHostSupervisor, event_types: &[&str]) -> Result<WorkerEnvelope> {
+    for _ in 0..MAX_EVENTS_PER_WAIT {
+        let event = supervisor.read_event()?;
+        if event.message_type == "ui.error" {
+            bail!("UI host error: {}", event.payload);
+        }
+        if event_types.contains(&event.message_type.as_str()) {
+            return Ok(event);
+        }
+    }
+    bail!("UI host did not emit any of {event_types:?}")
+}
+
+fn expect_ready(supervisor: &mut UiHostSupervisor) -> Result<()> {
+    let event = supervisor.read_event()?;
+    if event.message_type != "ui.ready" {
+        bail!("expected ui.ready, got {}", event.message_type);
+    }
+    Ok(())
+}
+
+fn expect_screen(supervisor: &mut UiHostSupervisor, screen: &str) -> Result<String> {
+    let event = read_until(supervisor, &["ui.screen_changed"])?;
+    let observed = event
+        .payload
+        .get("screen")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    if observed != screen {
+        bail!(
+            "expected Rust UI screen {screen}, got {}",
+            if observed.is_empty() {
+                event.payload.to_string()
+            } else {
+                observed
+            }
+        );
+    }
+    Ok(observed)
+}
+
+fn request_health(supervisor: &mut UiHostSupervisor) -> Result<Value> {
+    supervisor.send(UiCommand::Health)?;
+    let event = read_until(supervisor, &["ui.health"])?;
+    Ok(event.payload)
+}
+
+fn require_healthy_ui(payload: &Value) -> Result<()> {
+    let frames = payload.get("frames").and_then(Value::as_u64).unwrap_or(0);
+    let renderer = payload
+        .get("last_ui_renderer")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let active_screen = payload
+        .get("active_screen")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if frames < 1 {
+        bail!("UI host rendered no frames: {payload}");
+    }
+    if renderer != "lvgl" {
+        bail!("UI host did not report LVGL renderer: {payload}");
+    }
+    if active_screen.is_empty() {
+        bail!("UI host did not report an active screen: {payload}");
+    }
+    Ok(())
+}
+
+/// Keep the worker ticking for `seconds` of wall time.
+fn pump_ticks(supervisor: &mut UiHostSupervisor, seconds: f64) -> Result<()> {
+    if seconds <= 0.0 {
+        return Ok(());
+    }
+    let deadline = Instant::now() + Duration::from_secs_f64(seconds);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Ok(());
+        }
+        thread::sleep(remaining.min(TICK_INTERVAL));
+        supervisor.send(UiCommand::Tick)?;
+    }
+}
+
+fn format_ui_health(worker: &Path, hardware: &str, payload: &Value) -> String {
+    format!(
+        "binary={}, hardware={hardware}, frames={}, button_events={}, \
+         active_screen={}, last_ui_renderer={}",
+        worker.display(),
+        payload.get("frames").cloned().unwrap_or(Value::Null),
+        payload.get("button_events").cloned().unwrap_or(Value::Null),
+        payload.get("active_screen").cloned().unwrap_or(Value::Null),
+        payload
+            .get("last_ui_renderer")
+            .cloned()
+            .unwrap_or(Value::Null),
+    )
+}
+
+/// Render one runtime snapshot through the UI host and require health.
+pub fn ui_smoke_check(worker: &Path, hardware: &str, hold_seconds: f64) -> CheckResult {
+    if !worker.exists() {
+        return CheckResult::fail(
+            "rust-ui",
+            format!("missing Rust UI host binary at {}", worker.display()),
+        );
+    }
+    let run = || -> Result<String> {
+        let mut supervisor = UiHostSupervisor::spawn(worker, hardware)?;
+        let outcome = (|| {
+            expect_ready(&mut supervisor)?;
+            supervisor.send(UiCommand::RuntimeSnapshot(RuntimeSnapshot::default()))?;
+            read_until(&mut supervisor, &["ui.screen_changed"])?;
+            pump_ticks(&mut supervisor, hold_seconds)?;
+            let health = request_health(&mut supervisor)?;
+            require_healthy_ui(&health)?;
+            Ok(format_ui_health(worker, hardware, &health))
+        })();
+        supervisor.stop();
+        outcome
+    };
+    match run() {
+        Ok(details) => CheckResult::pass("rust-ui", details),
+        Err(error) => CheckResult::fail("rust-ui", error.to_string()),
+    }
+}
+
+/// Drive semantic one-button navigation through the worker protocol.
+///
+/// Each cycle: select into the hub's active card, back out to the hub,
+/// advance the hub selection. Cycle 0 lands on `listen`; later cycles on
+/// `talk` — matching the hub card order the Python suite validated.
+pub fn ui_navigation_check(
+    worker: &Path,
+    cycles: u32,
+    hold_seconds: f64,
+    idle_seconds: f64,
+    tail_idle_seconds: f64,
+) -> CheckResult {
+    if !worker.exists() {
+        return CheckResult::fail(
+            "rust-ui-navigation",
+            format!("missing Rust UI host binary at {}", worker.display()),
+        );
+    }
+    let run = || -> Result<String> {
+        let mut supervisor = UiHostSupervisor::spawn(worker, "whisplay")?;
+        let outcome = (|| {
+            expect_ready(&mut supervisor)?;
+            supervisor.send(UiCommand::RuntimeSnapshot(RuntimeSnapshot::default()))?;
+            expect_screen(&mut supervisor, "hub")?;
+
+            let mut visited = vec!["hub".to_string()];
+            let mut expected_selected_screen = "listen";
+            for _cycle in 0..cycles.max(1) {
+                supervisor.send(UiCommand::InputAction(InputAction::Select))?;
+                visited.push(expect_screen(&mut supervisor, expected_selected_screen)?);
+                pump_ticks(&mut supervisor, hold_seconds)?;
+                pump_ticks(&mut supervisor, idle_seconds)?;
+
+                supervisor.send(UiCommand::InputAction(InputAction::Back))?;
+                visited.push(expect_screen(&mut supervisor, "hub")?);
+                pump_ticks(&mut supervisor, hold_seconds)?;
+
+                supervisor.send(UiCommand::InputAction(InputAction::Advance))?;
+                let health = request_health(&mut supervisor)?;
+                require_healthy_ui(&health)?;
+                expected_selected_screen = "talk";
+                pump_ticks(&mut supervisor, hold_seconds)?;
+            }
+
+            pump_ticks(&mut supervisor, tail_idle_seconds)?;
+            let health = request_health(&mut supervisor)?;
+            require_healthy_ui(&health)?;
+            Ok(format!(
+                "binary={}, protocol=ui.runtime_snapshot/ui.input_action, \
+                 visited={}, frames={}, active_screen={}",
+                worker.display(),
+                visited.join(","),
+                health.get("frames").cloned().unwrap_or(Value::Null),
+                health.get("active_screen").cloned().unwrap_or(Value::Null),
+            ))
+        })();
+        supervisor.stop();
+        outcome
+    };
+    match run() {
+        Ok(details) => CheckResult::pass("rust-ui-navigation", details),
+        Err(error) => CheckResult::fail("rust-ui-navigation", error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn healthy_payload_passes() {
+        let payload = serde_json::json!({
+            "frames": 12,
+            "last_ui_renderer": "lvgl",
+            "active_screen": "hub",
+        });
+        assert!(require_healthy_ui(&payload).is_ok());
+    }
+
+    #[test]
+    fn zero_frames_fails() {
+        let payload = serde_json::json!({
+            "frames": 0,
+            "last_ui_renderer": "lvgl",
+            "active_screen": "hub",
+        });
+        assert!(require_healthy_ui(&payload).is_err());
+    }
+
+    #[test]
+    fn non_lvgl_renderer_fails() {
+        let payload = serde_json::json!({
+            "frames": 4,
+            "last_ui_renderer": "mock",
+            "active_screen": "hub",
+        });
+        assert!(require_healthy_ui(&payload).is_err());
+    }
+
+    #[test]
+    fn missing_active_screen_fails() {
+        let payload = serde_json::json!({
+            "frames": 4,
+            "last_ui_renderer": "lvgl",
+        });
+        assert!(require_healthy_ui(&payload).is_err());
+    }
+
+    #[test]
+    fn smoke_check_fails_fast_on_missing_binary() {
+        let result = ui_smoke_check(Path::new("no/such/ui-host"), "whisplay", 0.1);
+        assert!(result.details.contains("missing Rust UI host binary"));
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,13 +6,13 @@ CLI rebuild — what's done, what's paused, when each gap closes.
 The most recent rebuild milestone is summarised at the top; rounds in
 detail follow.
 
-Status as of 2026-05-14:
+Status as of 2026-07-12:
 
 | Round | Scope | State |
 |---|---|---|
 | 0 | Demolition + scaffolding | ✅ merged |
 | 1 | Daily dev loop (`yoyopod target …` Rust MVP) | ✅ merged |
-| 2 | Restore hardware validation (`yoyopod target validate`) | ⏳ not started |
+| 2 | Restore hardware validation (`yoyopod target validate`) | 🔄 in progress |
 | 3 | Restore prod release pipeline | ⏳ not started |
 | 4+ | Diagnostics (`pi voip/power/network/rust-ui-host`) | ⏳ not started |
 
@@ -56,10 +56,12 @@ reality, not historical reality.
 - **Prod slot install preflight on the Pi.** `install_release.sh` still
   runs end-to-end but the structural preflight is a no-op. Slots
   shipped before the deletion still contain a bundled preflight module.
-- **All `yoyopod pi …` commands** (validate, voip, power, network,
-  rust-ui-host). Gone with the Python CLI. SSH manually or read code.
-- **`target validate`** (the Rust CLI's pre-push check). The Rust version
-  ships as a stub in Round 1 until Round 2 restores on-Pi validation.
+- **Diagnostics** (`pi voip`, `pi power`, `pi network`, `pi
+  rust-ui-host`). Gone with the Python CLI. SSH manually or read code.
+- **VoIP + cloud-voice validation stages.** `yoyopod-on-pi validate
+  {voip, cloud-voice}` are stubs (exit 2) until the Round 2 follow-up
+  ports them. The base stages (deploy, smoke, stability, navigation,
+  lvgl) are restored by the in-flight Round 2 work.
 - **The `yoyopod` console script.** Replaced by the Rust binary
   installed from `cli/`.
 
@@ -92,13 +94,35 @@ artifact, syncs the Pi checkout, scps and extracts the binaries,
 restarts the dev service, and verifies startup. Replaces the manual
 flow that `skills/yoyopod-rust-artifact/SKILL.md` used to document.
 
-### Round 2 — Restore hardware validation
+### Round 2 — Restore hardware validation 🔄 (started 2026-07-12)
 
-Port on-Pi validation stages (`smoke`, `deploy`, `stability`, `lvgl`,
-`navigation`, `voip`, `cloud-voice`) to Rust. Wire `target validate` to
-call them over SSH the way the Python version did, or fold them into
-a `yoyopod-on-pi` cross-compiled binary executed directly. Decision
-deferred to round start.
+**Architecture decision (made at round start, 2026-07-12):** the
+validation stages live in a new on-Pi companion binary, `yoyopod-on-pi`
+(`device/onpi/`), executed on the Pi by `yoyopod target validate` over
+SSH. The alternative (driving stages from the dev machine over
+per-command SSH) was rejected because:
+
+- The stages supervise worker binaries over their stdin/stdout envelope
+  protocol (spawn `yoyopod-ui-host`, send `ui.runtime_snapshot` /
+  `ui.input_action`, assert on `ui.health`). That needs a long-lived
+  process on the Pi, not SSH round-trips.
+- Living in the `device/` workspace, the validator consumes
+  `yoyopod-protocol` directly, so it cannot drift from what the
+  workers actually speak.
+- CI ships it inside the existing `yoyopod-rust-device-arm64-<sha>`
+  bundle, so `target deploy` installs it automatically and validation
+  always matches the deployed commit. Round 4+ diagnostics can join
+  the same binary later.
+
+In flight now: stages `deploy`, `smoke`, `stability`, `navigation`,
+`lvgl` ported to Rust (Python-era venv/entrypoint checks dropped for
+Rust reality), plus `target validate` orchestration with the same
+committed-code contract as `target deploy`.
+
+Round 2 follow-up (next): port the `voip` stage (SIP registration +
+call soak) and the `cloud-voice` stage (STT/TTS worker boundary
+checks) from the old `voip.py` / `cloud_voice.py`. Until then those
+stages exit 2 with a clear message.
 
 Restores: hardware validation as part of the daily loop.
 


### PR DESCRIPTION
## Summary
- New `device/onpi/` crate → `yoyopod-on-pi` binary: ports the deleted Python `pi validate` stages to Rust (deploy, smoke, stability, navigation, lvgl), driving `yoyopod-ui-host` through the typed `yoyopod-protocol` envelope API. `voip` / `cloud-voice` are explicit exit-2 stubs for the Round 2 follow-up.
- CI ships the binary inside the existing `yoyopod-rust-device-arm64-<sha>` bundle; `target deploy` chmods it when present.
- `yoyopod target validate` replaces the Round 1 stub: committed-code contract, Pi checkout sync, binary preflight, then the staged suite over SSH (`--with-lvgl-soak` / `--with-navigation` optional; `--with-voip` rejected until the follow-up port).
- ROADMAP records the on-Pi-binary architecture decision; AGENTS/cli README refreshed.

## Testing
- `cargo test` device workspace (`yoyopod-on-pi`: 12 tests) and cli workspace (39 tests, 4 new) — all green; clippy clean on new code; `--locked` intact.
- Hardware validation of the ported stages runs from this PR's artifact (first bundle to contain `yoyopod-on-pi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)