### PR TITLE
Restore SIGUSR1/USR2 screenshot capture lost in the Rust rewrite

### DIFF
--- a/cli/yoyopod/src/commands/target/screenshot.rs
+++ b/cli/yoyopod/src/commands/target/screenshot.rs
@@ -125,7 +125,11 @@ fn build_ready_check(pi: &PiPaths, attempts: u32) -> String {
 }
 
 fn build_clear(pi: &PiPaths) -> String {
-    format!("rm -f {}", shell_quote(&pi.screenshot_path))
+    // The runtime runs as root under systemd, so the previous PNG in sticky
+    // /tmp may not be removable by the SSH user; fall back to sudo like
+    // build_signal does.
+    let path = shell_quote(&pi.screenshot_path);
+    format!("rm -f {path} 2>/dev/null || sudo rm -f {path}")
 }
 
 fn build_signal(pi: &PiPaths, readback: bool) -> String {

--- a/device/Cargo.lock
+++ b/device/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +457,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -902,6 +936,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1069,19 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1461,6 +1518,32 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2209,6 +2292,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "signal-hook",
  "thiserror",
  "time",
  "yoyopod-protocol",
@@ -2236,6 +2320,7 @@ dependencies = [
  "cmake",
  "embedded-graphics",
  "libloading",
+ "png",
  "ron",
  "rppal",
  "serde",

--- a/device/protocol/src/ui/mod.rs
+++ b/device/protocol/src/ui/mod.rs
@@ -117,6 +117,7 @@ pub enum UiCommand {
     PollInput,
     Health,
     Animate(AnimationRequest),
+    Screenshot { path: String, prefer_readback: bool },
     Shutdown,
     WorkerStop,
 }
@@ -151,6 +152,13 @@ impl UiCommand {
             "ui.poll_input" => Ok(Self::PollInput),
             "ui.health" => Ok(Self::Health),
             "ui.animate" => Ok(Self::Animate(decode_payload(envelope.payload)?)),
+            "ui.screenshot" => {
+                let payload: ScreenshotPayload = decode_payload(envelope.payload)?;
+                Ok(Self::Screenshot {
+                    path: payload.path,
+                    prefer_readback: payload.prefer_readback,
+                })
+            }
             "ui.shutdown" => Ok(Self::Shutdown),
             "worker.stop" => Ok(Self::WorkerStop),
             other => Err(ProtocolError::InvalidEnvelope(format!(
@@ -186,6 +194,14 @@ impl UiCommand {
                 "ui.animate",
                 None,
                 serde_json::to_value(request).expect("serializing UI animation request"),
+            ),
+            Self::Screenshot {
+                path,
+                prefer_readback,
+            } => WorkerEnvelope::command(
+                "ui.screenshot",
+                None,
+                json!({ "path": path, "prefer_readback": prefer_readback }),
             ),
             Self::Shutdown => WorkerEnvelope::command("ui.shutdown", None, json!({})),
             Self::WorkerStop => WorkerEnvelope::command("worker.stop", None, json!({})),
@@ -333,6 +349,35 @@ impl UiErrorCode {
     }
 }
 
+/// How a screenshot was (or was requested to be) captured on the device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScreenshotMethod {
+    LvglReadback,
+    ShadowBuffer,
+}
+
+impl ScreenshotMethod {
+    /// Human-readable label used in app log lines, e.g.
+    /// `Saved screenshot via LVGL readback -> /tmp/yoyopod_screenshot.png`.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::LvglReadback => "LVGL readback",
+            Self::ShadowBuffer => "shadow buffer",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UiScreenshotCaptured {
+    pub path: String,
+    pub ok: bool,
+    #[serde(default)]
+    pub method: Option<ScreenshotMethod>,
+    #[serde(default)]
+    pub detail: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UiEvent {
     Ready(UiReady),
@@ -340,6 +385,7 @@ pub enum UiEvent {
     Intent(UiIntent),
     ScreenChanged(UiScreenChanged),
     Health(UiHealth),
+    ScreenshotCaptured(UiScreenshotCaptured),
     Error(UiError),
     ShutdownComplete,
 }
@@ -368,6 +414,9 @@ impl UiEvent {
             )?)),
             "ui.screen_changed" => Ok(Self::ScreenChanged(decode_payload(envelope.payload)?)),
             "ui.health" => Ok(Self::Health(decode_payload(envelope.payload)?)),
+            "ui.screenshot_captured" => {
+                Ok(Self::ScreenshotCaptured(decode_payload(envelope.payload)?))
+            }
             "ui.error" => Ok(Self::Error(decode_payload(envelope.payload)?)),
             "ui.shutdown_complete" => Ok(Self::ShutdownComplete),
             other => Err(ProtocolError::InvalidEnvelope(format!(
@@ -383,6 +432,7 @@ impl UiEvent {
             Self::Intent(intent) => WorkerEnvelope::event("ui.intent", intent.to_event_payload()),
             Self::ScreenChanged(changed) => event("ui.screen_changed", changed),
             Self::Health(health) => event("ui.health", health),
+            Self::ScreenshotCaptured(captured) => event("ui.screenshot_captured", captured),
             Self::Error(error) => event("ui.error", error),
             Self::ShutdownComplete => WorkerEnvelope::event("ui.shutdown_complete", json!({})),
         }
@@ -755,6 +805,13 @@ struct SetBacklightPayload {
     brightness: f32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ScreenshotPayload {
+    path: String,
+    #[serde(default)]
+    prefer_readback: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 struct InputActionPayload {
     action: InputAction,
@@ -882,6 +939,10 @@ mod tests {
                 to: 0,
                 duration_ms: 180,
             }),
+            UiCommand::Screenshot {
+                path: "/tmp/yoyopod_screenshot.png".to_string(),
+                prefer_readback: true,
+            },
             UiCommand::Shutdown,
             UiCommand::WorkerStop,
         ];
@@ -933,6 +994,18 @@ mod tests {
                 active_screen: UiScreen::Hub,
                 full_snapshots: 1,
                 patches_per_domain: BTreeMap::new(),
+            }),
+            UiEvent::ScreenshotCaptured(UiScreenshotCaptured {
+                path: "/tmp/yoyopod_screenshot.png".to_string(),
+                ok: true,
+                method: Some(ScreenshotMethod::LvglReadback),
+                detail: String::new(),
+            }),
+            UiEvent::ScreenshotCaptured(UiScreenshotCaptured {
+                path: "/tmp/yoyopod_screenshot.png".to_string(),
+                ok: false,
+                method: None,
+                detail: "LVGL display not initialized".to_string(),
             }),
             UiEvent::Error(UiError::new(UiErrorCode::InvalidCommand, "bad command")),
             UiEvent::ShutdownComplete,

--- a/device/runtime/Cargo.toml
+++ b/device/runtime/Cargo.toml
@@ -18,3 +18,6 @@ serde_yaml = "0.9"
 thiserror = "2.0"
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 yoyopod-protocol = { path = "../protocol" }
+
+[target.'cfg(unix)'.dependencies]
+signal-hook = "0.3"

--- a/device/runtime/src/cli.rs
+++ b/device/runtime/src/cli.rs
@@ -18,6 +18,10 @@ use crate::runtime_loop::RuntimeLoop;
 use crate::state::{RuntimeState, WorkerDomain, WorkerState};
 use crate::worker::{WorkerSpec, WorkerSupervisor};
 
+/// Matches `screenshot_path` in deploy/pi-deploy.yaml; `yoyopod target
+/// screenshot` clears this file, signals the runtime, then waits for it.
+const SCREENSHOT_FILE: &str = "/tmp/yoyopod_screenshot.png";
+
 #[derive(Debug, Clone, Parser)]
 #[command(name = "yoyopod-runtime")]
 #[command(about = "YoYoPod Rust top-level runtime host")]
@@ -65,6 +69,7 @@ fn run_runtime(config: RuntimeConfig, hardware: &str, config_dir: &Path) -> Resu
 
 fn run_runtime_inner(config: &RuntimeConfig, hardware: &str, config_dir: &Path) -> Result<()> {
     let shutdown = install_ctrlc_handler()?;
+    let screenshot_signals = install_screenshot_signal_handlers()?;
 
     let mut workers = WorkerSupervisor::default();
     let state = match start_workers(&mut workers, config, hardware, config_dir) {
@@ -79,6 +84,7 @@ fn run_runtime_inner(config: &RuntimeConfig, hardware: &str, config_dir: &Path) 
 
     let mut runtime = RuntimeLoop::new(state);
     while !shutdown.load(Ordering::SeqCst) && !runtime.shutdown_requested() {
+        forward_screenshot_requests(&screenshot_signals, &mut workers, config);
         runtime.run_once(&mut workers);
         thread::sleep(Duration::from_millis(20));
     }
@@ -95,6 +101,7 @@ fn start_workers(
 ) -> Result<RuntimeState> {
     let mut state = RuntimeState::default();
     state.seed_contacts(config.people.to_contact_items());
+    state.configure_app_log_file(config.log_file.clone());
     state.configure_media_volume(config.media.default_volume);
     state.configure_voice_note_store_dir(config.voip.voice_note_store_dir.clone());
     state.configure_voice_commands(config.voice.to_command_settings());
@@ -276,6 +283,89 @@ fn start_workers(
 
 fn worker_program(config_dir: &Path, raw_program: &str) -> String {
     resolve_worker_program_for_config_dir(config_dir, raw_program)
+}
+
+#[derive(Clone, Default)]
+struct ScreenshotSignals {
+    readback: Arc<AtomicBool>,
+    shadow: Arc<AtomicBool>,
+}
+
+impl ScreenshotSignals {
+    fn take_readback(&self) -> bool {
+        self.readback.swap(false, Ordering::SeqCst)
+    }
+
+    fn take_shadow(&self) -> bool {
+        self.shadow.swap(false, Ordering::SeqCst)
+    }
+
+    fn reset(&self) {
+        self.readback.store(false, Ordering::SeqCst);
+        self.shadow.store(false, Ordering::SeqCst);
+    }
+}
+
+/// SIGUSR1 requests an LVGL-readback-first capture, SIGUSR2 a shadow-first
+/// capture. The handlers only set flags; the runtime loop polls them and
+/// forwards a `ui.screenshot` command to the UI worker.
+fn install_screenshot_signal_handlers() -> Result<ScreenshotSignals> {
+    static SIGNALS: OnceLock<ScreenshotSignals> = OnceLock::new();
+
+    if let Some(existing) = SIGNALS.get() {
+        existing.reset();
+        return Ok(existing.clone());
+    }
+
+    let signals = SIGNALS.get_or_init(ScreenshotSignals::default);
+    register_screenshot_signals(signals)?;
+    Ok(signals.clone())
+}
+
+#[cfg(unix)]
+fn register_screenshot_signals(signals: &ScreenshotSignals) -> Result<()> {
+    signal_hook::flag::register(signal_hook::consts::SIGUSR1, Arc::clone(&signals.readback))
+        .context("register SIGUSR1 screenshot handler")?;
+    signal_hook::flag::register(signal_hook::consts::SIGUSR2, Arc::clone(&signals.shadow))
+        .context("register SIGUSR2 screenshot handler")?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn register_screenshot_signals(_signals: &ScreenshotSignals) -> Result<()> {
+    Ok(())
+}
+
+fn forward_screenshot_requests(
+    signals: &ScreenshotSignals,
+    workers: &mut WorkerSupervisor,
+    config: &RuntimeConfig,
+) {
+    let mut requests = Vec::new();
+    if signals.take_readback() {
+        requests.push((true, "readback-first"));
+    }
+    if signals.take_shadow() {
+        requests.push((false, "shadow-first"));
+    }
+
+    for (prefer_readback, order) in requests {
+        let _ = log_marker(
+            &config.log_file,
+            format!("Screenshot capture requested ({order}) -> {SCREENSHOT_FILE}"),
+        );
+        let envelope = UiCommand::Screenshot {
+            path: SCREENSHOT_FILE.to_string(),
+            prefer_readback,
+        }
+        .into_envelope();
+        if !workers.send_envelope(WorkerDomain::Ui, envelope) {
+            let _ = log_marker(
+                &config.log_file,
+                "Screenshot capture request dropped: UI worker unavailable",
+            );
+        }
+    }
 }
 
 fn install_ctrlc_handler() -> Result<Arc<AtomicBool>> {

--- a/device/runtime/src/event.rs
+++ b/device/runtime/src/event.rs
@@ -3,8 +3,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::{json, Value};
 use yoyopod_protocol::ui::{
     CallIntent, ContactAction, InputAction, ListItemAction, MusicIntent, PowerIntent,
-    RuntimeIntent, UiCommand, UiEvent, UiInputEvent, UiIntent, UiScreen, VoiceFileAction,
-    VoiceIntent, VoiceRecipientAction,
+    RuntimeIntent, UiCommand, UiEvent, UiInputEvent, UiIntent, UiScreen, UiScreenshotCaptured,
+    VoiceFileAction, VoiceIntent, VoiceRecipientAction,
 };
 
 use crate::protocol::{EnvelopeKind, WorkerEnvelope};
@@ -32,6 +32,7 @@ pub enum RuntimeEvent {
     UiScreenChanged {
         screen: UiScreen,
     },
+    UiScreenshotCaptured(UiScreenshotCaptured),
     WorkerError {
         domain: WorkerDomain,
         message: String,
@@ -56,6 +57,9 @@ pub enum RuntimeCommand {
         envelope: WorkerEnvelope,
         success_ack: WorkerEnvelope,
         failure_ack: WorkerEnvelope,
+    },
+    AppendAppLog {
+        line: String,
     },
     Shutdown,
 }
@@ -85,7 +89,7 @@ impl RuntimeEvent {
                 state.mark_worker(*domain, WorkerState::Stopped, reason.clone());
             }
             Self::UiIntent(intent) => state.apply_ui_intent(intent),
-            Self::UiInput(_) | Self::Shutdown | Self::Ignored => {}
+            Self::UiInput(_) | Self::UiScreenshotCaptured(_) | Self::Shutdown | Self::Ignored => {}
         }
     }
 }
@@ -159,6 +163,7 @@ fn runtime_event_from_ui_envelope(envelope: WorkerEnvelope) -> RuntimeEvent {
         Ok(UiEvent::ScreenChanged(changed)) => RuntimeEvent::UiScreenChanged {
             screen: changed.screen,
         },
+        Ok(UiEvent::ScreenshotCaptured(captured)) => RuntimeEvent::UiScreenshotCaptured(captured),
         Ok(UiEvent::Health(_)) => RuntimeEvent::Ignored,
         Ok(UiEvent::Error(error)) => RuntimeEvent::WorkerError {
             domain: WorkerDomain::Ui,
@@ -187,6 +192,9 @@ pub fn commands_for_event(state: &RuntimeState, event: &RuntimeEvent) -> Vec<Run
         RuntimeEvent::VoiceTranscript(snapshot) => commands_for_voice_transcript(state, snapshot),
         RuntimeEvent::VoiceAskResult(snapshot) => commands_for_voice_ask_result(state, snapshot),
         RuntimeEvent::VoiceSpeakResult(snapshot) => commands_for_voice_speak_result(snapshot),
+        RuntimeEvent::UiScreenshotCaptured(captured) => vec![RuntimeCommand::AppendAppLog {
+            line: screenshot_log_line(captured),
+        }],
         RuntimeEvent::Shutdown => vec![RuntimeCommand::Shutdown],
         RuntimeEvent::WorkerReady { .. }
         | RuntimeEvent::CloudSnapshot(_)
@@ -194,6 +202,28 @@ pub fn commands_for_event(state: &RuntimeState, event: &RuntimeEvent) -> Vec<Run
         | RuntimeEvent::WorkerError { .. }
         | RuntimeEvent::WorkerExited { .. }
         | RuntimeEvent::Ignored => Vec::new(),
+    }
+}
+
+/// App log line for a UI screenshot capture result. The success wording is a
+/// contract: skills/yoyopod-screenshot and rules/lvgl.md grep the app log for
+/// `Saved screenshot via LVGL readback` / `Saved screenshot via shadow buffer`.
+fn screenshot_log_line(captured: &UiScreenshotCaptured) -> String {
+    if !captured.ok {
+        let detail = if captured.detail.is_empty() {
+            "unknown error"
+        } else {
+            captured.detail.as_str()
+        };
+        return format!("Screenshot capture failed: {detail}");
+    }
+    match captured.method {
+        Some(method) => format!(
+            "Saved screenshot via {} -> {}",
+            method.label(),
+            captured.path
+        ),
+        None => format!("Saved screenshot -> {}", captured.path),
     }
 }
 

--- a/device/runtime/src/runtime_loop.rs
+++ b/device/runtime/src/runtime_loop.rs
@@ -29,6 +29,7 @@ pub trait LoopIo {
     fn send_worker_envelope(&mut self, domain: WorkerDomain, envelope: WorkerEnvelope) -> bool;
     fn write_power_shutdown_state(&mut self, path: &str, payload: &Value) -> Result<(), String>;
     fn request_system_shutdown(&mut self, command: &str) -> Result<(), String>;
+    fn append_app_log(&mut self, log_file: &str, line: &str) -> Result<(), String>;
 }
 
 #[derive(Debug, Clone)]
@@ -137,6 +138,9 @@ impl RuntimeLoop {
                 };
                 let _ = io.send_worker_envelope(WorkerDomain::Cloud, ack);
             }
+            RuntimeCommand::AppendAppLog { line } => {
+                let _ = io.append_app_log(&self.state.app_log_file, &line);
+            }
             RuntimeCommand::Shutdown => {
                 self.shutdown_requested = true;
             }
@@ -188,6 +192,10 @@ impl LoopIo for WorkerSupervisor {
 
     fn request_system_shutdown(&mut self, command: &str) -> Result<(), String> {
         run_shutdown_command(command)
+    }
+
+    fn append_app_log(&mut self, log_file: &str, line: &str) -> Result<(), String> {
+        crate::logging::log_marker(log_file, line).map_err(|error| error.to_string())
     }
 }
 
@@ -268,6 +276,7 @@ mod tests {
         messages: Vec<(WorkerDomain, WorkerEnvelope)>,
         protocol_errors: Vec<(WorkerDomain, WorkerProtocolError)>,
         sent: Vec<(WorkerDomain, WorkerEnvelope)>,
+        app_log: Vec<(String, String)>,
     }
 
     impl LoopIo for FakeLoopIo {
@@ -293,6 +302,11 @@ mod tests {
         }
 
         fn request_system_shutdown(&mut self, _command: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn append_app_log(&mut self, log_file: &str, line: &str) -> Result<(), String> {
+            self.app_log.push((log_file.to_string(), line.to_string()));
             Ok(())
         }
     }
@@ -332,6 +346,66 @@ mod tests {
         };
         assert!(music.playing);
         assert_eq!(music.title, "Patch Song");
+    }
+
+    #[test]
+    fn ui_screenshot_captured_event_appends_app_log_line() {
+        let mut io = FakeLoopIo {
+            messages: vec![(
+                WorkerDomain::Ui,
+                WorkerEnvelope::event(
+                    "ui.screenshot_captured",
+                    json!({
+                        "path": "/tmp/yoyopod_screenshot.png",
+                        "ok": true,
+                        "method": "lvgl_readback",
+                    }),
+                ),
+            )],
+            ..FakeLoopIo::default()
+        };
+        let mut state = RuntimeState::default();
+        state.configure_app_log_file("logs/custom.log");
+        let mut runtime = RuntimeLoop::new(state);
+
+        runtime.run_once(&mut io);
+
+        assert_eq!(
+            io.app_log,
+            vec![(
+                "logs/custom.log".to_string(),
+                "Saved screenshot via LVGL readback -> /tmp/yoyopod_screenshot.png".to_string(),
+            )]
+        );
+    }
+
+    #[test]
+    fn failed_screenshot_capture_appends_failure_line() {
+        let mut io = FakeLoopIo {
+            messages: vec![(
+                WorkerDomain::Ui,
+                WorkerEnvelope::event(
+                    "ui.screenshot_captured",
+                    json!({
+                        "path": "/tmp/yoyopod_screenshot.png",
+                        "ok": false,
+                        "detail": "LVGL display not initialized",
+                    }),
+                ),
+            )],
+            ..FakeLoopIo::default()
+        };
+        let mut runtime = RuntimeLoop::new(RuntimeState::default());
+
+        runtime.run_once(&mut io);
+
+        assert_eq!(
+            io.app_log,
+            vec![(
+                "logs/yoyopod.log".to_string(),
+                "Screenshot capture failed: LVGL display not initialized".to_string(),
+            )]
+        );
     }
 
     #[test]

--- a/device/runtime/src/state.rs
+++ b/device/runtime/src/state.rs
@@ -608,6 +608,8 @@ pub struct RuntimeState {
     pub voice_worker: WorkerHealth,
     pub loop_iterations: u64,
     pub last_loop_duration_ms: u64,
+    /// App log the runtime appends operational markers to (config `logging.file`).
+    pub app_log_file: String,
 }
 
 impl Default for RuntimeState {
@@ -629,6 +631,7 @@ impl Default for RuntimeState {
             voice_worker: WorkerHealth::default(),
             loop_iterations: 0,
             last_loop_duration_ms: 0,
+            app_log_file: "logs/yoyopod.log".to_string(),
         }
     }
 }
@@ -681,6 +684,13 @@ impl RuntimeState {
 
     pub fn configure_media_volume(&mut self, volume: i32) {
         self.media.volume = volume.clamp(0, 100);
+    }
+
+    pub fn configure_app_log_file(&mut self, app_log_file: impl Into<String>) {
+        let app_log_file = app_log_file.into();
+        if !app_log_file.trim().is_empty() {
+            self.app_log_file = app_log_file;
+        }
     }
 
     pub fn contact_for_voice_label(&self, label: &str) -> Option<&ListItem> {

--- a/device/ui/Cargo.toml
+++ b/device/ui/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 embedded-graphics = "0.8.2"
 libloading = "0.8"
+png = "0.17"
 ron = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/device/ui/src/lib.rs
+++ b/device/ui/src/lib.rs
@@ -7,6 +7,7 @@ pub mod input;
 pub mod renderer;
 pub mod router;
 pub mod scene;
+pub mod screenshot;
 pub mod transport;
 pub mod worker;
 

--- a/device/ui/src/renderer/framebuffer.rs
+++ b/device/ui/src/renderer/framebuffer.rs
@@ -29,6 +29,10 @@ impl Framebuffer {
         self.height
     }
 
+    pub fn pixels(&self) -> &[u16] {
+        &self.pixels
+    }
+
     pub fn clear(&mut self, color: u16) {
         self.pixels.fill(color);
     }

--- a/device/ui/src/renderer/lvgl/ffi.rs
+++ b/device/ui/src/renderer/lvgl/ffi.rs
@@ -32,9 +32,54 @@ pub struct lv_color_t {
     pub red: u8,
 }
 
+/// Leading fields of LVGL 9.x `lv_image_header_t`. Upstream declares three
+/// words of C bitfields; on the little-endian GCC/Clang targets we build for,
+/// bitfields pack LSB-first, which the accessors below rely on.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct lv_image_header_t {
+    /// magic:8 | cf:8 | flags:16
+    pub word0: u32,
+    /// w:16 | h:16
+    pub word1: u32,
+    /// stride:16 | reserved:16
+    pub word2: u32,
+}
+
+impl lv_image_header_t {
+    pub fn color_format(&self) -> u32 {
+        (self.word0 >> 8) & 0xFF
+    }
+
+    pub fn width(&self) -> usize {
+        (self.word1 & 0xFFFF) as usize
+    }
+
+    pub fn height(&self) -> usize {
+        ((self.word1 >> 16) & 0xFFFF) as usize
+    }
+
+    pub fn stride(&self) -> usize {
+        (self.word2 & 0xFFFF) as usize
+    }
+}
+
+/// Leading fields of LVGL 9.x `lv_draw_buf_t`. Later LVGL revisions may append
+/// fields; snapshots are only read through this prefix, never constructed or
+/// sized on the Rust side.
+#[repr(C)]
+pub struct lv_draw_buf_t {
+    pub header: lv_image_header_t,
+    pub data_size: u32,
+    pub data: *mut u8,
+    pub unaligned_data: *mut c_void,
+}
+
 pub type LvDisplayFlushCb = unsafe extern "C" fn(*mut lv_display_t, *const lv_area_t, *mut u8);
 pub type LvStyleSelector = u32;
 
+/// `lv_color_format_t` value for native RGB565 (LVGL 9.x).
+pub const LV_COLOR_FORMAT_RGB565: u32 = 0x12;
 pub const LV_DISPLAY_RENDER_MODE_PARTIAL: i32 = 0;
 pub const LV_LABEL_LONG_MODE_DOTS: i32 = 1;
 pub const LV_LABEL_LONG_MODE_CLIP: i32 = 4;
@@ -127,4 +172,7 @@ unsafe extern "C" {
     pub fn lv_image_set_src(obj: *mut lv_obj_t, src: *const c_void);
 
     pub fn lv_screen_load(screen: *mut lv_obj_t);
+
+    pub fn lv_snapshot_take(obj: *mut lv_obj_t, cf: u32) -> *mut lv_draw_buf_t;
+    pub fn lv_draw_buf_destroy(draw_buf: *mut lv_draw_buf_t);
 }

--- a/device/ui/src/renderer/lvgl/mod.rs
+++ b/device/ui/src/renderer/lvgl/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod ffi;
 pub(crate) mod flush;
 pub(crate) mod icons;
 pub(crate) mod lifecycle;
+pub(crate) mod snapshot;
 
 use std::ffi::CString;
 use std::ptr::{self, NonNull};

--- a/device/ui/src/renderer/lvgl/snapshot.rs
+++ b/device/ui/src/renderer/lvgl/snapshot.rs
@@ -1,0 +1,76 @@
+use std::ptr::NonNull;
+
+use anyhow::{anyhow, bail, Result};
+
+use crate::renderer::lvgl::ffi;
+use crate::renderer::lvgl::NativeLvglFacade;
+use crate::screenshot::Rgb565Image;
+
+impl NativeLvglFacade {
+    /// Render the active LVGL screen into a fresh RGB565 buffer via
+    /// `lv_snapshot_take` — the readback capture path, independent of the
+    /// shadow framebuffer maintained by the flush callback.
+    pub(crate) fn snapshot_active_screen(&mut self) -> Result<Rgb565Image> {
+        let display = self
+            .display
+            .ok_or_else(|| anyhow!("LVGL display not initialized"))?;
+        let screen = unsafe { ffi::lv_display_get_screen_active(display.as_ptr()) };
+        let screen = NonNull::new(screen).ok_or_else(|| anyhow!("LVGL has no active screen"))?;
+
+        let draw_buf =
+            unsafe { ffi::lv_snapshot_take(screen.as_ptr(), ffi::LV_COLOR_FORMAT_RGB565) };
+        let draw_buf =
+            NonNull::new(draw_buf).ok_or_else(|| anyhow!("lv_snapshot_take returned no buffer"))?;
+        let image = image_from_draw_buf(unsafe { draw_buf.as_ref() });
+        unsafe {
+            ffi::lv_draw_buf_destroy(draw_buf.as_ptr());
+        }
+        image
+    }
+}
+
+fn image_from_draw_buf(draw_buf: &ffi::lv_draw_buf_t) -> Result<Rgb565Image> {
+    let header = &draw_buf.header;
+    if header.color_format() != ffi::LV_COLOR_FORMAT_RGB565 {
+        bail!(
+            "LVGL snapshot returned color format {:#x} instead of RGB565",
+            header.color_format()
+        );
+    }
+
+    let width = header.width();
+    let height = header.height();
+    if width == 0 || height == 0 {
+        bail!("LVGL snapshot has empty dimensions {width}x{height}");
+    }
+    if draw_buf.data.is_null() {
+        bail!("LVGL snapshot has no pixel data");
+    }
+
+    let row_bytes = width * 2;
+    let stride = match header.stride() {
+        0 => row_bytes,
+        stride if stride >= row_bytes => stride,
+        stride => bail!("LVGL snapshot stride {stride} is smaller than row size {row_bytes}"),
+    };
+    let data_size = draw_buf.data_size as usize;
+    let needed = stride * (height - 1) + row_bytes;
+    if data_size < needed {
+        bail!("LVGL snapshot buffer holds {data_size} bytes, expected at least {needed}");
+    }
+
+    // LVGL renders native RGB565: little-endian u16 values in memory.
+    let data = unsafe { std::slice::from_raw_parts(draw_buf.data, data_size) };
+    let mut pixels = Vec::with_capacity(width * height);
+    for row in 0..height {
+        let start = row * stride;
+        for pair in data[start..start + row_bytes].chunks_exact(2) {
+            pixels.push(u16::from_le_bytes([pair[0], pair[1]]));
+        }
+    }
+    Ok(Rgb565Image {
+        width,
+        height,
+        pixels,
+    })
+}

--- a/device/ui/src/renderer/lvgl_renderer.rs
+++ b/device/ui/src/renderer/lvgl_renderer.rs
@@ -40,6 +40,11 @@ impl LvglRenderer {
     pub fn initialize_display(&mut self, framebuffer: &Framebuffer) -> Result<()> {
         self.facade.ensure_display_registered(framebuffer)
     }
+
+    /// Capture the active screen via LVGL's native snapshot (readback path).
+    pub fn readback_rgb565(&mut self) -> Result<crate::screenshot::Rgb565Image> {
+        self.facade.snapshot_active_screen()
+    }
 }
 
 #[cfg(feature = "native-lvgl")]
@@ -174,6 +179,10 @@ impl LvglRenderer {
     }
 
     pub fn initialize_display(&mut self, _framebuffer: &Framebuffer) -> Result<()> {
+        anyhow::bail!("native-lvgl feature is disabled for this build")
+    }
+
+    pub fn readback_rgb565(&mut self) -> Result<crate::screenshot::Rgb565Image> {
         anyhow::bail!("native-lvgl feature is disabled for this build")
     }
 }

--- a/device/ui/src/screenshot.rs
+++ b/device/ui/src/screenshot.rs
@@ -1,0 +1,295 @@
+//! Screenshot capture for `yoyopod target screenshot`.
+//!
+//! The runtime forwards SIGUSR1/SIGUSR2 as a `ui.screenshot` command; this
+//! module renders the requested capture (LVGL readback or the shadow
+//! framebuffer) to a PNG and writes it atomically so the CLI never scp's a
+//! half-written file.
+
+use std::fs;
+use std::io::BufWriter;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use yoyopod_protocol::ui::{ScreenshotMethod, UiScreenshotCaptured};
+
+use crate::renderer::Framebuffer;
+
+/// A full-frame RGB565 capture.
+pub struct Rgb565Image {
+    pub width: usize,
+    pub height: usize,
+    pub pixels: Vec<u16>,
+}
+
+impl Rgb565Image {
+    pub fn from_framebuffer(framebuffer: &Framebuffer) -> Self {
+        Self {
+            width: framebuffer.width(),
+            height: framebuffer.height(),
+            pixels: framebuffer.pixels().to_vec(),
+        }
+    }
+
+    fn to_rgb888(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(self.pixels.len() * 3);
+        for &pixel in &self.pixels {
+            let red = ((pixel >> 11) & 0x1F) as u8;
+            let green = ((pixel >> 5) & 0x3F) as u8;
+            let blue = (pixel & 0x1F) as u8;
+            bytes.push((red << 3) | (red >> 2));
+            bytes.push((green << 2) | (green >> 4));
+            bytes.push((blue << 3) | (blue >> 2));
+        }
+        bytes
+    }
+}
+
+/// Capture order mirrors the Python supervisor: the preferred method first,
+/// the other as fallback, first fully-written PNG wins.
+pub(crate) fn capture(
+    mut readback: impl FnMut() -> Result<Rgb565Image>,
+    mut shadow: impl FnMut() -> Result<Rgb565Image>,
+    path: &str,
+    prefer_readback: bool,
+) -> UiScreenshotCaptured {
+    let order = if prefer_readback {
+        [
+            ScreenshotMethod::LvglReadback,
+            ScreenshotMethod::ShadowBuffer,
+        ]
+    } else {
+        [
+            ScreenshotMethod::ShadowBuffer,
+            ScreenshotMethod::LvglReadback,
+        ]
+    };
+
+    let mut failures = Vec::new();
+    for method in order {
+        let attempt = match method {
+            ScreenshotMethod::LvglReadback => readback(),
+            ScreenshotMethod::ShadowBuffer => shadow(),
+        }
+        .and_then(|image| write_png_atomic(Path::new(path), &image));
+        match attempt {
+            Ok(()) => {
+                return UiScreenshotCaptured {
+                    path: path.to_string(),
+                    ok: true,
+                    method: Some(method),
+                    detail: String::new(),
+                }
+            }
+            Err(error) => failures.push(format!("{}: {error:#}", method.label())),
+        }
+    }
+
+    UiScreenshotCaptured {
+        path: path.to_string(),
+        ok: false,
+        method: None,
+        detail: failures.join("; "),
+    }
+}
+
+fn write_png_atomic(path: &Path, image: &Rgb565Image) -> Result<()> {
+    if image.width == 0 || image.height == 0 {
+        bail!("screenshot image is empty");
+    }
+    if image.pixels.len() != image.width * image.height {
+        bail!(
+            "screenshot pixel count {} does not match {}x{}",
+            image.pixels.len(),
+            image.width,
+            image.height
+        );
+    }
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create screenshot directory {}", parent.display()))?;
+        }
+    }
+
+    let tmp_path = temp_sibling(path);
+    if let Err(error) = write_png(&tmp_path, image) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(error);
+    }
+    fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "move screenshot {} into place at {}",
+            tmp_path.display(),
+            path.display()
+        )
+    })
+}
+
+fn temp_sibling(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map(|name| name.to_os_string())
+        .unwrap_or_else(|| "screenshot.png".into());
+    name.push(".tmp");
+    path.with_file_name(name)
+}
+
+fn write_png(path: &Path, image: &Rgb565Image) -> Result<()> {
+    let file =
+        fs::File::create(path).with_context(|| format!("create screenshot {}", path.display()))?;
+    let mut encoder = png::Encoder::new(
+        BufWriter::new(file),
+        image.width as u32,
+        image.height as u32,
+    );
+    encoder.set_color(png::ColorType::Rgb);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder.write_header().context("write PNG header")?;
+    writer
+        .write_image_data(&image.to_rgb888())
+        .context("write PNG pixel data")?;
+    writer.finish().context("finalize PNG")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn solid_image(width: usize, height: usize, pixel: u16) -> Rgb565Image {
+        Rgb565Image {
+            width,
+            height,
+            pixels: vec![pixel; width * height],
+        }
+    }
+
+    fn temp_png(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "yoyopod-screenshot-{}-{name}.png",
+            std::process::id()
+        ))
+    }
+
+    fn decode_png(path: &Path) -> (u32, u32, Vec<u8>) {
+        let decoder = png::Decoder::new(fs::File::open(path).unwrap());
+        let mut reader = decoder.read_info().unwrap();
+        let mut buffer = vec![0; reader.output_buffer_size()];
+        let info = reader.next_frame(&mut buffer).unwrap();
+        buffer.truncate(info.buffer_size());
+        (info.width, info.height, buffer)
+    }
+
+    #[test]
+    fn rgb565_expands_to_full_range_rgb888() {
+        let image = Rgb565Image {
+            width: 4,
+            height: 1,
+            pixels: vec![0xF800, 0x07E0, 0x001F, 0xFFFF],
+        };
+        assert_eq!(
+            image.to_rgb888(),
+            vec![255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 255]
+        );
+    }
+
+    #[test]
+    fn shadow_first_capture_writes_decodable_png() {
+        let path = temp_png("shadow-first");
+        let _ = fs::remove_file(&path);
+
+        let captured = capture(
+            || bail!("readback must not run for shadow-first capture"),
+            || Ok(solid_image(4, 3, 0xF800)),
+            path.to_str().unwrap(),
+            false,
+        );
+
+        assert!(captured.ok);
+        assert_eq!(captured.method, Some(ScreenshotMethod::ShadowBuffer));
+        let (width, height, pixels) = decode_png(&path);
+        assert_eq!((width, height), (4, 3));
+        assert_eq!(&pixels[..3], &[255, 0, 0]);
+        assert!(!temp_sibling(&path).exists());
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn readback_first_capture_prefers_readback() {
+        let path = temp_png("readback-first");
+        let _ = fs::remove_file(&path);
+
+        let captured = capture(
+            || Ok(solid_image(2, 2, 0x001F)),
+            || Ok(solid_image(2, 2, 0xF800)),
+            path.to_str().unwrap(),
+            true,
+        );
+
+        assert!(captured.ok);
+        assert_eq!(captured.method, Some(ScreenshotMethod::LvglReadback));
+        let (_, _, pixels) = decode_png(&path);
+        assert_eq!(&pixels[..3], &[0, 0, 255]);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn failed_readback_falls_back_to_shadow() {
+        let path = temp_png("readback-fallback");
+        let _ = fs::remove_file(&path);
+
+        let captured = capture(
+            || bail!("native-lvgl feature is disabled for this build"),
+            || Ok(solid_image(2, 2, 0x07E0)),
+            path.to_str().unwrap(),
+            true,
+        );
+
+        assert!(captured.ok);
+        assert_eq!(captured.method, Some(ScreenshotMethod::ShadowBuffer));
+        assert!(path.exists());
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn capture_reports_failure_when_both_methods_fail() {
+        let path = temp_png("both-fail");
+        let _ = fs::remove_file(&path);
+
+        let captured = capture(
+            || bail!("readback unavailable"),
+            || bail!("shadow unavailable"),
+            path.to_str().unwrap(),
+            false,
+        );
+
+        assert!(!captured.ok);
+        assert_eq!(captured.method, None);
+        assert!(captured.detail.contains("readback unavailable"));
+        assert!(captured.detail.contains("shadow unavailable"));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn mismatched_pixel_count_is_rejected() {
+        let path = temp_png("bad-image");
+        let _ = fs::remove_file(&path);
+
+        let captured = capture(
+            || bail!("readback unavailable"),
+            || {
+                Ok(Rgb565Image {
+                    width: 4,
+                    height: 4,
+                    pixels: vec![0; 3],
+                })
+            },
+            path.to_str().unwrap(),
+            false,
+        );
+
+        assert!(!captured.ok);
+        assert!(!path.exists());
+        assert!(!temp_sibling(&path).exists());
+    }
+}

--- a/device/ui/src/transport/dispatcher.rs
+++ b/device/ui/src/transport/dispatcher.rs
@@ -10,6 +10,7 @@ pub(crate) enum AppEvent {
     PollInput,
     Health,
     Animate(AnimationRequest),
+    Screenshot { path: String, prefer_readback: bool },
     Shutdown,
 }
 
@@ -32,6 +33,13 @@ pub(crate) fn dispatch_command(command: yoyopod_protocol::ui::UiCommand) -> Disp
         yoyopod_protocol::ui::UiCommand::PollInput => AppEvent::PollInput,
         yoyopod_protocol::ui::UiCommand::Health => AppEvent::Health,
         yoyopod_protocol::ui::UiCommand::Animate(request) => AppEvent::Animate(request),
+        yoyopod_protocol::ui::UiCommand::Screenshot {
+            path,
+            prefer_readback,
+        } => AppEvent::Screenshot {
+            path,
+            prefer_readback,
+        },
         yoyopod_protocol::ui::UiCommand::Shutdown | yoyopod_protocol::ui::UiCommand::WorkerStop => {
             AppEvent::Shutdown
         }

--- a/device/ui/src/worker.rs
+++ b/device/ui/src/worker.rs
@@ -3,7 +3,9 @@ use std::sync::mpsc::RecvTimeoutError;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use yoyopod_protocol::ui::{UiError, UiErrorCode, UiEvent, UiHealth, UiScreen, UiScreenChanged};
+use yoyopod_protocol::ui::{
+    UiError, UiErrorCode, UiEvent, UiHealth, UiScreen, UiScreenChanged, UiScreenshotCaptured,
+};
 
 use crate::application::UiRuntime;
 use crate::engine::Engine;
@@ -12,6 +14,7 @@ use crate::input::{ButtonTiming, OneButtonMachine};
 use crate::renderer::{Framebuffer, LvglRenderer, Renderer};
 use crate::router;
 use crate::scene::load_scene_defaults;
+use crate::screenshot::{self, Rgb565Image};
 use crate::transport::{codec, dispatcher, handshake, inbound, outbound};
 use crate::RenderMode;
 
@@ -51,6 +54,21 @@ impl RenderState {
 
     pub fn last_ui_renderer(&self) -> &str {
         &self.last_ui_renderer
+    }
+
+    pub fn capture_screenshot(
+        &mut self,
+        path: &str,
+        prefer_readback: bool,
+    ) -> UiScreenshotCaptured {
+        let renderer = &mut self.renderer;
+        let framebuffer = &self.framebuffer;
+        screenshot::capture(
+            || renderer.readback_rgb565(),
+            || Ok(Rgb565Image::from_framebuffer(framebuffer)),
+            path,
+            prefer_readback,
+        )
     }
 }
 
@@ -307,6 +325,15 @@ where
             context
                 .ui_runtime
                 .start_animation(request, outbound::monotonic_millis());
+        }
+        dispatcher::AppEvent::Screenshot {
+            path,
+            prefer_readback,
+        } => {
+            let captured = context
+                .render_state
+                .capture_screenshot(&path, prefer_readback);
+            outbound::emit_event(context.output, UiEvent::ScreenshotCaptured(captured))?;
         }
         dispatcher::AppEvent::Shutdown => {
             handshake::emit_shutdown_complete(context.output)?;

--- a/rules/lvgl.md
+++ b/rules/lvgl.md
@@ -70,9 +70,14 @@ Do not rebuild LVGL on the Pi.
 - `yoyopod target screenshot` defaults to the shadow-first path via `SIGUSR2`.
 - `yoyopod target screenshot --readback` requests LVGL readback via `SIGUSR1`.
 - The CLI clears the previous remote PNG before capture and waits for a fresh file.
-- Both screenshot signals also append freeze diagnostics to `logs/yoyopod_errors.log`:
-  - an all-thread backtrace dump
-  - a structured runtime snapshot logged before the screenshot is queued
+- The runtime (`device/runtime/src/cli.rs`) registers both signals next to its
+  SIGINT handler and forwards a `ui.screenshot` command to the UI worker, which
+  captures via `lv_snapshot_take` (readback) or the RGB565 shadow framebuffer,
+  falls back to the other path on failure, and writes the PNG atomically
+  (temp file + rename) to `/tmp/yoyopod_screenshot.png`.
+- The runtime appends `Screenshot capture requested (…)` to the app log when a
+  signal arrives. The Python-era freeze diagnostics (all-thread backtrace dump
+  to `logs/yoyopod_errors.log`) were not ported to the Rust runtime.
 - To confirm which path actually succeeded, check the app log:
   - `Saved screenshot via LVGL readback` means native LVGL snapshotting succeeded.
   - `Saved screenshot via shadow buffer` means the RGB565 framebuffer path was used instead.


### PR DESCRIPTION
## Problem

`yoyopod target screenshot` fails its readiness gate: the Rust runtime never registers SIGUSR1/SIGUSR2, so `/proc/<pid>/status` SigCgt is missing the 0x200/0x800 bits the CLI checks for. The handlers lived in the Python supervisor's `main.py` (added in 6fa98221, last touched in c40f6f49) and were dropped with the Python runtime in a5094baf — never ported.

## Change

The display now lives in the UI worker process, so capture crosses the worker protocol:

- **runtime**: register SIGUSR1 (readback-first) and SIGUSR2 (shadow-first) next to the existing SIGINT handler via `signal-hook` flags; the run loop polls them and forwards a new `ui.screenshot` command to the UI worker, logging `Screenshot capture requested (…)` to the app log.
- **protocol**: new `UiCommand::Screenshot { path, prefer_readback }` and `UiEvent::ScreenshotCaptured` result event (round-trip tested).
- **ui**: capture via `lv_snapshot_take` (LVGL readback, FFI verified against pinned LVGL 9.5.0 headers) or the RGB565 shadow framebuffer, fall back to the other path on failure, write the PNG atomically (`.tmp` + rename) to `/tmp/yoyopod_screenshot.png`.
- **runtime**: on the result event, append `Saved screenshot via LVGL readback|shadow buffer -> …` to the app log — the lines `skills/yoyopod-screenshot` and `rules/lvgl.md` grep for.
- **cli**: `build_clear` gets the same `|| sudo` fallback as `build_signal` — the runtime runs as root under systemd, so the stale PNG in sticky `/tmp` isn't removable by the SSH user.
- **rules/lvgl.md**: describe the Rust capture flow; note the Python-era freeze diagnostics (thread backtrace dump) were not ported.

## Verification

Deployed the CI artifact for 75607f7c to rpi-zero (dev lane):

- SigCgt went `0000000100000442` → `0000000100000e42` (exactly +SIGUSR1/+SIGUSR2)
- `yoyopod target screenshot` → PNG of the live hub screen, log: `Saved screenshot via shadow buffer`
- `yoyopod target screenshot --readback` → matching PNG, log: `Saved screenshot via LVGL readback`
- Local gate: fmt/tests/clippy clean on touched crates (yoyopod-network `sim7600_alias_*` failures are pre-existing Windows-only symlink issues, confirmed on a clean tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)