### PR TITLE
ui: implement backdrop variant styling — fix accent flood-filled screens

### DIFF
--- a/device/ui/src/renderer/lvgl/mod.rs
+++ b/device/ui/src/renderer/lvgl/mod.rs
@@ -424,13 +424,25 @@ impl LvglFacade for NativeLvglFacade {
         accent_rgb: u32,
     ) -> Result<()> {
         let node = self.widget_node_mut(widget)?;
-        styling::apply_variant_raw(node.obj, node.role, variant, accent_rgb);
+        node.variant = Some(variant);
+        // The engine sends variant and accent as independent prop changes
+        // (and the renderer passes accent_rgb=0 on variant-only updates),
+        // so prefer the accent already recorded on the node.
+        let accent = node.accent_rgb.unwrap_or(accent_rgb);
+        styling::apply_variant_raw(node.obj, node.role, variant, accent);
         Ok(())
     }
 
     fn set_accent(&mut self, widget: WidgetId, rgb: u32) -> Result<()> {
         let node = self.widget_node_mut(widget)?;
-        styling::apply_accent_raw(node.obj, node.role, rgb);
+        node.accent_rgb = Some(rgb);
+        if node.role == roles::SCENE_BACKDROP {
+            // Backdrop fill depends on the (variant, accent) pair.
+            let variant = node.variant.unwrap_or("solid");
+            styling::apply_variant_raw(node.obj, node.role, variant, rgb);
+        } else {
+            styling::apply_accent_raw(node.obj, node.role, rgb);
+        }
         Ok(())
     }
 

--- a/device/ui/src/renderer/styling/accent.rs
+++ b/device/ui/src/renderer/styling/accent.rs
@@ -11,10 +11,9 @@ pub(crate) fn apply_accent_raw(obj: NonNull<ffi::lv_obj_t>, role: &'static str, 
     let accent = unsafe { ffi::lv_color_hex(rgb & 0xFFFFFF) };
     unsafe {
         match role {
-            roles::SCENE_BACKDROP => {
-                ffi::lv_obj_set_style_bg_color(obj.as_ptr(), accent, SELECTOR);
-                ffi::lv_obj_set_style_bg_opa(obj.as_ptr(), theme::OPA_COVER, SELECTOR);
-            }
+            // roles::SCENE_BACKDROP is handled by `apply_variant_raw`: its
+            // fill depends on the (variant, accent) pair, so the facade
+            // restyles it there whenever either prop changes.
             roles::FX_HALO | roles::FX_PULSE | roles::FX_GLOW | roles::FX_SPINNER => {
                 ffi::lv_obj_set_style_bg_color(
                     obj.as_ptr(),

--- a/device/ui/src/renderer/styling/mod.rs
+++ b/device/ui/src/renderer/styling/mod.rs
@@ -24,9 +24,11 @@ pub(crate) use tuning::apply_role_tuning_raw;
 pub(crate) use variants::apply_variant_raw;
 
 /// Accent share (percent) mixed into the dark background for
-/// accent-driven backdrops. Kept subtle so status chrome and hero
-/// content stay legible on the 240x280 panel.
-const BACKDROP_ACCENT_PERCENT: u8 = 22;
+/// accent-driven backdrops. Kept to a whisper: on the physical panel
+/// saturation reads much stronger than in captures — 22% still read
+/// as "a green screen" on hardware, 8% reads as a dark UI with a
+/// hint of the active card's identity.
+const BACKDROP_ACCENT_PERCENT: u8 = 8;
 
 /// Resolve the background fill for a scene backdrop from its variant.
 ///
@@ -82,11 +84,11 @@ mod tests {
 
     #[test]
     fn accent_drift_tints_the_dark_base() {
-        // listen accent 0x00FF88 at 22% over 0x2A2D35:
-        // r = (0*22 + 42*78) / 100 = 32  (0x20)
-        // g = (255*22 + 45*78) / 100 = 91 (0x5B)
-        // b = (136*22 + 53*78) / 100 = 71 (0x47)
-        assert_eq!(backdrop_bg_rgb("accent_drift", 0x00FF88), 0x205B47);
+        // listen accent 0x00FF88 at 8% over 0x2A2D35:
+        // r = (0*8 + 42*92) / 100 = 38  (0x26)
+        // g = (255*8 + 45*92) / 100 = 61 (0x3D)
+        // b = (136*8 + 53*92) / 100 = 59 (0x3B)
+        assert_eq!(backdrop_bg_rgb("accent_drift", 0x00FF88), 0x263D3B);
     }
 
     #[test]

--- a/device/ui/src/renderer/styling/mod.rs
+++ b/device/ui/src/renderer/styling/mod.rs
@@ -23,7 +23,32 @@ pub(crate) use tuning::apply_role_tuning_raw;
 #[cfg(feature = "native-lvgl")]
 pub(crate) use variants::apply_variant_raw;
 
-#[cfg(feature = "native-lvgl")]
+/// Accent share (percent) mixed into the dark background for
+/// accent-driven backdrops. Kept subtle so status chrome and hero
+/// content stay legible on the 240x280 panel.
+const BACKDROP_ACCENT_PERCENT: u8 = 22;
+
+/// Resolve the background fill for a scene backdrop from its variant.
+///
+/// `solid` and `vignette` backdrops carry the base color in their accent
+/// prop (see `scene::Backdrop::element`), so they pass through. Gradient
+/// carries its `from` color the same way until a scene actually uses the
+/// preset and the `to` stop is threaded through the prop pipeline.
+/// `accent_drift` is the fix for the flood-filled hub/talk/ask screens:
+/// the card accent tints the dark base instead of replacing it.
+#[cfg_attr(not(feature = "native-lvgl"), allow(dead_code))]
+pub(crate) fn backdrop_bg_rgb(variant: &str, accent_rgb: u32) -> u32 {
+    match variant {
+        "accent_drift" => mix_u24(
+            accent_rgb & 0xFFFFFF,
+            style::BACKGROUND_RGB,
+            100 - BACKDROP_ACCENT_PERCENT,
+        ),
+        _ => accent_rgb & 0xFFFFFF,
+    }
+}
+
+#[cfg_attr(not(feature = "native-lvgl"), allow(dead_code))]
 pub(crate) fn mix_u24(primary_rgb: u32, secondary_rgb: u32, secondary_ratio_percent: u8) -> u32 {
     let secondary_ratio = u32::from(secondary_ratio_percent.min(100));
     let primary_ratio = 100 - secondary_ratio;
@@ -39,4 +64,50 @@ pub(crate) fn mix_u24(primary_rgb: u32, secondary_rgb: u32, secondary_ratio_perc
         / 100)
         & 0xFF;
     (red << 16) | (green << 8) | blue
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mix_full_secondary_returns_secondary() {
+        assert_eq!(mix_u24(0x00FF88, 0x2A2D35, 100), 0x2A2D35);
+    }
+
+    #[test]
+    fn mix_zero_secondary_returns_primary() {
+        assert_eq!(mix_u24(0x00FF88, 0x2A2D35, 0), 0x00FF88);
+    }
+
+    #[test]
+    fn accent_drift_tints_the_dark_base() {
+        // listen accent 0x00FF88 at 22% over 0x2A2D35:
+        // r = (0*22 + 42*78) / 100 = 32  (0x20)
+        // g = (255*22 + 45*78) / 100 = 91 (0x5B)
+        // b = (136*22 + 53*78) / 100 = 71 (0x47)
+        assert_eq!(backdrop_bg_rgb("accent_drift", 0x00FF88), 0x205B47);
+    }
+
+    #[test]
+    fn accent_drift_stays_near_the_base() {
+        let tinted = backdrop_bg_rgb("accent_drift", 0x00FF88);
+        let green = (tinted >> 8) & 0xFF;
+        // The old bug flood-filled the raw accent (green channel 255).
+        assert!(
+            green < 0x80,
+            "backdrop should be a subtle tint: {tinted:#08x}"
+        );
+    }
+
+    #[test]
+    fn solid_and_vignette_pass_the_base_through() {
+        assert_eq!(backdrop_bg_rgb("solid", 0x2A2D35), 0x2A2D35);
+        assert_eq!(backdrop_bg_rgb("vignette", 0x2A2D35), 0x2A2D35);
+    }
+
+    #[test]
+    fn alpha_bits_are_stripped() {
+        assert_eq!(backdrop_bg_rgb("solid", 0xFF2A2D35), 0x2A2D35);
+    }
 }

--- a/device/ui/src/renderer/styling/variants/mod.rs
+++ b/device/ui/src/renderer/styling/variants/mod.rs
@@ -10,11 +10,17 @@ pub(crate) fn apply_variant_raw(
     variant: &'static str,
     accent_rgb: u32,
 ) {
-    let _ = accent_rgb;
     const SELECTOR: ffi::LvStyleSelector = 0;
     unsafe {
         match (role, variant) {
-            (roles::SCENE_BACKDROP, "solid" | "gradient" | "accent_drift" | "vignette") => {}
+            (roles::SCENE_BACKDROP, "solid" | "gradient" | "accent_drift" | "vignette") => {
+                ffi::lv_obj_set_style_bg_color(
+                    obj.as_ptr(),
+                    ffi::lv_color_hex(super::backdrop_bg_rgb(variant, accent_rgb)),
+                    SELECTOR,
+                );
+                ffi::lv_obj_set_style_bg_opa(obj.as_ptr(), theme::OPA_COVER, SELECTOR);
+            }
             (roles::MODAL, "loading") => {
                 ffi::lv_obj_set_style_border_color(
                     obj.as_ptr(),

--- a/device/ui/src/renderer/widgets/registry.rs
+++ b/device/ui/src/renderer/widgets/registry.rs
@@ -33,6 +33,10 @@ pub(crate) struct WidgetNode {
     pub x_offset: i32,
     pub y_offset: i32,
     pub scale_permille: i32,
+    /// Last applied variant/accent props. Backdrop styling depends on the
+    /// pair, but the engine delivers them as independent prop changes.
+    pub variant: Option<WidgetRole>,
+    pub accent_rgb: Option<u32>,
 }
 
 #[derive(Debug, Default)]
@@ -76,6 +80,8 @@ impl WidgetRegistry {
                 x_offset: 0,
                 y_offset: 0,
                 scale_permille: 1000,
+                variant: None,
+                accent_rgb: None,
             },
         );
         if let Some(parent) = parent {


### PR DESCRIPTION
## Summary
Fixes the neon flood-filled hub/talk/ask screens (reported on hardware, photo of green hub). Root cause: `scenes.ron` declares those screens `backdrop: accent_drift`, but `apply_variant_raw` no-op'd all backdrop variants and `apply_accent_raw` painted the raw card accent at 100% opacity — so the entire panel took the accent color (green `0x00FF88` / cyan / amber per card).

- `backdrop_bg_rgb()` (pure, unit-tested): `accent_drift` = 22% accent blended into the dark `0x2A2D35` base; `solid`/`vignette` pass their base through; gradient's `to` stop is a documented follow-up (preset unused by scenes.ron).
- Backdrop fill moved into `apply_variant_raw`; `WidgetNode` now remembers `(variant, accent)` because the engine delivers them as independent `PropChange`s (variant-only updates arrive with `accent_rgb=0`).
- Diagnosis evidence: LVGL readback and shadow-framebuffer screenshots both reproduced the panel exactly → not an SPI/panel/pixel-format issue; the framebuffer genuinely contained the accent.

## Testing
- `cargo test -p yoyopod-ui`: 12 pass (6 new color-logic tests).
- Native-LVGL path compiles in CI; hardware before/after screenshots to follow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)