### PR TITLE
docs: complete all remaining sections — the full yoyopod docs site

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -18,13 +18,15 @@ Run from this directory:
 
 ## Content layout
 
-- `src/content/docs/ui/` — the **UI System Guide**, the flagship section:
-  full authored pages covering hardware → driver → LVGL → framework → input →
-  playbook.
-- Everything else (`product/`, `architecture/`, `hardware/`, `features/`,
-  `operations/`) is **stub pages**: they summarize and link to the canonical
-  Markdown under `docs/` in the repo root. Do not duplicate canonical docs
-  here — update the summary and keep the link.
+- `src/content/docs/ui/` — the **UI System Guide** flagship section:
+  hardware → driver → LVGL → framework → input → playbook.
+- `src/content/docs/runtime/` — the **Runtime & Workers Guide** flagship
+  section: protocol → supervisor → the six domain workers.
+- The other sections (`product/`, `architecture/`, `hardware/`,
+  `features/`, `operations/`) are curated pages **condensed from the
+  canonical Markdown** under `docs/` in the repo root. The repo docs stay
+  the source of truth — each page carries a "Canonical source" note; keep
+  content condensed, never wholesale-duplicated.
 - `public/mockups/` — copied snapshots of the design mockups; canonical
   source is `device/ui/assets/ui/`. Refresh with `npm run sync:mockups`.
 - `src/assets/diagrams/` — hand-authored theme-aware SVG diagrams, inlined

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -2,7 +2,6 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
-const stub = { text: 'Stub', variant: 'caution' };
 
 // https://astro.build/config
 export default defineConfig({
@@ -127,44 +126,44 @@ export default defineConfig({
 				{
 					label: 'Product',
 					items: [
-						{ label: 'Product Definition', slug: 'product/definition', badge: stub },
-						{ label: 'Positioning', slug: 'product/positioning', badge: stub },
-						{ label: 'Roadmap', slug: 'product/roadmap', badge: stub },
+						{ label: 'Product Definition', slug: 'product/definition' },
+						{ label: 'Positioning', slug: 'product/positioning' },
+						{ label: 'Roadmap', slug: 'product/roadmap' },
 					],
 				},
 				{
 					label: 'Architecture',
 					items: [
-						{ label: 'Canonical Structure', slug: 'architecture/canonical-structure', badge: stub },
-						{ label: 'Work Areas', slug: 'architecture/work-areas', badge: stub },
+						{ label: 'Canonical Structure', slug: 'architecture/canonical-structure' },
+						{ label: 'Work Areas', slug: 'architecture/work-areas' },
 					],
 				},
 				{
 					label: 'Hardware',
 					items: [
-						{ label: 'Audio Stack', slug: 'hardware/audio-stack', badge: stub },
-						{ label: 'Power Module', slug: 'hardware/power-module', badge: stub },
+						{ label: 'Audio Stack', slug: 'hardware/audio-stack' },
+						{ label: 'Power Module', slug: 'hardware/power-module' },
 					],
 				},
 				{
 					label: 'Features',
 					items: [
-						{ label: 'Cloud Provisioning & Backend', slug: 'features/cloud-provisioning', badge: stub },
-						{ label: 'Cloud Voice Worker', slug: 'features/cloud-voice-worker', badge: stub },
-						{ label: 'Local-First Music', slug: 'features/local-first-music', badge: stub },
-						{ label: 'Remote Playback', slug: 'features/remote-playback', badge: stub },
-						{ label: 'MPV Dependencies', slug: 'features/mpv-dependencies', badge: stub },
+						{ label: 'Cloud Provisioning & Backend', slug: 'features/cloud-provisioning' },
+						{ label: 'Cloud Voice Worker', slug: 'features/cloud-voice-worker' },
+						{ label: 'Local-First Music', slug: 'features/local-first-music' },
+						{ label: 'Remote Playback', slug: 'features/remote-playback' },
+						{ label: 'MPV Dependencies', slug: 'features/mpv-dependencies' },
 					],
 				},
 				{
 					label: 'Operations',
 					items: [
-						{ label: 'Development Guide', slug: 'operations/development-guide', badge: stub },
-						{ label: 'Pi Dev Workflow', slug: 'operations/pi-dev-workflow', badge: stub },
-						{ label: 'Dev/Prod Lanes', slug: 'operations/dev-prod-lanes', badge: stub },
-						{ label: 'Quality Gates', slug: 'operations/quality-gates', badge: stub },
-						{ label: 'Setup Contract', slug: 'operations/setup-contract', badge: stub },
-						{ label: 'Contributor Workflow', slug: 'operations/contributor-workflow', badge: stub },
+						{ label: 'Development Guide', slug: 'operations/development-guide' },
+						{ label: 'Pi Dev Workflow', slug: 'operations/pi-dev-workflow' },
+						{ label: 'Dev/Prod Lanes', slug: 'operations/dev-prod-lanes' },
+						{ label: 'Quality Gates', slug: 'operations/quality-gates' },
+						{ label: 'Setup Contract', slug: 'operations/setup-contract' },
+						{ label: 'Contributor Workflow', slug: 'operations/contributor-workflow' },
 					],
 				},
 			],

--- a/website/src/content/docs/architecture/canonical-structure.md
+++ b/website/src/content/docs/architecture/canonical-structure.md
@@ -1,25 +1,71 @@
 ---
 title: Canonical Structure
-description: Config topology, package ownership, and board overlay rules.
+description: The config topology, its three rules (composition, secrets, board overlays), and the migration template.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/architecture/CANONICAL_STRUCTURE.md`](https://github.com/attmous/yoyopod/blob/main/docs/architecture/CANONICAL_STRUCTURE.md)
-in the repository.
+Where configuration lives, who owns it, and the rules that keep it
+composable. The goals: split authored config by ownership, compose it
+into one typed runtime model, keep mutable user data out of tracked
+config, and make secret boundaries explicit and validated.
+
+## The config topology
+
+| Path | Owns |
+| --- | --- |
+| `config/app/core.yaml` | app shell: `app`, `ui`, `logging`, `diagnostics` |
+| `config/audio/music.yaml` | music policy, startup volume, media runtime paths |
+| `config/device/hardware.yaml` | shared hardware truth: `input`, `display`, `communication_audio`, `media_audio`, `voice_audio` |
+| `config/power/backend.yaml` | PiSugar transport, watchdog, polling, shutdown policy |
+| `config/network/cellular.yaml` | cellular modem policy + transport |
+| `config/voice/assistant.yaml` | voice policy + assistant defaults |
+| `config/communication/calling.yaml` | non-secret SIP identity + calling policy |
+| `config/communication/messaging.yaml` | messaging policy, message-store paths, voice notes |
+| `config/communication/integrations/liblinphone_factory.conf` | repo-owned Liblinphone defaults |
+| `config/people/directory.yaml` | paths for mutable people data + bootstrap seeds |
+| `config/people/contacts.seed.yaml` | tracked bootstrap seed data only |
+
+Untracked secrets: `config/communication/calling.secrets.yaml`. Mutable
+runtime data lives under `data/` (`data/communication/`, `data/media/`,
+`data/people/`) — never in tracked config.
+
+## The three rules
+
+1. **Composition** — the runtime consumes one composed, typed model, not
+   ad-hoc YAML reads. (In the Rust runtime this is `RuntimeConfig::load`
+   — see [Configuration Wiring](/runtime/configuration/).)
+2. **Secret boundary** — tracked config must never contain SIP
+   credentials; validation rejects `sip_password` or a tracked
+   `secrets:` block. Credentials go in `calling.secrets.yaml` or env
+   vars.
+3. **Board overlays** — overrides mirror the same relative path under
+   `config/boards/<board>/`; the only supported board is `rpi-zero-2w`.
+
+## The migration template
+
+When a new domain gets its own configuration, follow the established
+seven steps: choose one public seam · split tracked config into
+`config/<domain>/` · keep shared hardware truth in
+`device/hardware.yaml` unless truly domain-owned · define the app-facing
+seam · route mutable user data into `data/` · mirror the structure under
+`config/boards/<board>/` · add focused build + Pi validation checks.
+
+## Validation layout
+
+The repo no longer carries separate unit-test trees: Rust workspace
+checks live with `device/Cargo.toml` and `cli/Cargo.toml`; hardware
+validation runs behind `yoyopod target deploy` and (Round 2)
+`yoyopod target validate` — see the [Roadmap](/product/roadmap/).
+
+:::caution[The historical half]
+The canonical document's "Canonical Package Ownership" section and its
+per-domain migration patterns describe the **retired Python layout**
+(`yoyopod/integrations/…`, `.py` seams). The current per-domain homes are
+the Rust `device/*` crates — see [Work Areas](/architecture/work-areas/)
+and the runtime guide's [Source Map](/runtime/advanced/source-map/). The
+config topology and rules above remain current.
 :::
 
-Configuration lives in a YAML tree under `config/` (app, audio, cloud,
-communication, device, network, people, power, voice), with per-board
-overrides under `config/boards/` — today only `rpi-zero-2w`. The canonical
-structure document defines which package owns which config file, how board
-overlays compose with the base tree, and where new configuration must go so
-that ownership stays unambiguous.
-
-:::caution[Partially superseded]
-The config wiring is now documented in depth at
-[Configuration Wiring](/runtime/configuration/). The canonical document's
-"Canonical Package Ownership" section describes the **retired Python
-layout** and no longer matches the Rust crates — see the runtime guide's
-[Known Gaps](/runtime/gaps/).
+:::note[Canonical source]
+Condensed from
+[`docs/architecture/CANONICAL_STRUCTURE.md`](https://github.com/attmous/yoyopod/blob/main/docs/architecture/CANONICAL_STRUCTURE.md).
 :::

--- a/website/src/content/docs/architecture/work-areas.md
+++ b/website/src/content/docs/architecture/work-areas.md
@@ -1,18 +1,45 @@
 ---
 title: Work Areas
-description: Where Rust-first work belongs, by area of the codebase.
+description: Where a change belongs — the Rust crate ownership map and the monorepo boundaries.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/architecture/WORK_AREAS.md`](https://github.com/attmous/yoyopod/blob/main/docs/architecture/WORK_AREAS.md)
-in the repository.
-:::
+yoyopod is Rust-first for the device runtime. This is the routing table:
+for any change, the directory that owns it.
 
-A routing table for contributors and agents: for each kind of change —
-runtime behavior, a worker host, the operator CLI, deploy tooling,
-configuration, docs — the work-areas document names the directory that owns
-it and the constraints that apply there. Read it before starting work to
-avoid landing changes in the wrong layer. For runtime and worker-host
-changes specifically, the
-[Runtime & Workers Guide](/runtime/) documents each crate in depth.
+## The device crates
+
+| Area | Owns | Deep docs |
+| --- | --- | --- |
+| `device/runtime/` | process supervision, config loading, event routing, state composition, UI snapshot delivery | [Runtime Guide](/runtime/) |
+| `device/ui/` | Whisplay/LVGL rendering and button-facing UI behavior | [UI System Guide](/ui/) |
+| `device/media/` | local music playback and mpv process control | [profile](/runtime/workers/media/) |
+| `device/voip/` | SIP, calls, voice messages via Liblinphone | [profile](/runtime/workers/voip/) |
+| `device/network/` | cellular modem, PPP, GPS | [profile](/runtime/workers/network/) |
+| `device/cloud/` | MQTT/cloud telemetry and command transport | [profile](/runtime/workers/cloud/) |
+| `device/power/` | power/battery integration | [profile](/runtime/workers/power/) |
+| `device/speech/` | cloud speech, TTS, Ask worker | [profile](/runtime/workers/speech/) |
+
+## The monorepo boundaries
+
+- `apps/` — future web/mobile applications. **Device runtime code must
+  never depend on `apps/`.**
+- `packages/` — shared app/cloud contracts and SDKs; shared contracts
+  should flow through `packages/contracts/` *when that package exists*
+  (it is intended, not guaranteed present).
+- `cli/` — the Rust operator CLI (`yoyopod target …`); rebuilding in
+  rounds, status in the [Roadmap](/product/roadmap/).
+- `deploy/` — systemd units, installer scripts, slot/release packaging.
+
+## Disposable output — never work from, never commit
+
+`device/target/` · `device/*/build/` · `cli/target/` · `logs/` · local
+`data/`. Don't commit runtime models, preview bundles, audio files,
+fonts, or build artifacts — large assets belong in a release artifact or
+a package download step, only after deciding they're part of the source
+contract. Clean with `git clean -fdX` (from a clean worktree only — it
+deletes *all* ignored local files).
+
+:::note[Canonical source]
+Condensed from
+[`docs/architecture/WORK_AREAS.md`](https://github.com/attmous/yoyopod/blob/main/docs/architecture/WORK_AREAS.md).
+:::

--- a/website/src/content/docs/features/cloud-provisioning.md
+++ b/website/src/content/docs/features/cloud-provisioning.md
@@ -1,15 +1,63 @@
 ---
 title: Cloud Provisioning & Backend
-description: Device claiming, authentication, config sync, and MQTT telemetry.
+description: How the device is provisioned, what it publishes over MQTT, and how backend commands reach the runtime.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/features/CLOUD_PROVISIONING_AND_BACKEND.md`](https://github.com/attmous/yoyopod/blob/main/docs/features/CLOUD_PROVISIONING_AND_BACKEND.md)
-in the repository.
-:::
+The cloud domain is the device ↔ backend link. The mechanics live in the
+[telegraph desk profile](/runtime/workers/cloud/); this page carries the
+provisioning and contract view.
 
-How a device is claimed and authenticated against the backend, how
-configuration syncs down to the device, and how telemetry flows up over
-MQTT via the `device/cloud` worker host. The document defines the
-provisioning contract and the backend endpoints the device depends on.
+## The division of labor
+
+- **The device** loads provisioned secrets, runs the MQTT client when
+  provisioning is valid, publishes requested telemetry, receives backend
+  commands, and persists an operator-visible status snapshot.
+- **The backend/dashboard** own claiming, household/parent flows, and
+  policy. The device never talks to the dashboard directly — it consumes
+  provisioned secrets and the command channel.
+
+## Provisioning
+
+Identity is two runtime-only secrets — `device_id` + `device_secret` —
+in `config/cloud/device.secrets.yaml` (fallback
+`/etc/yoyopod/cloud/`). Both present → `provisioned`; neither →
+`unprovisioned`; a partial pair → `invalid_provisioning`. Backend
+settings (broker host/port/TLS/transport, status paths, battery report
+interval) live in `cloud/backend.yaml`, all overridable via
+`YOYOPOD_CLOUD_*` env vars.
+
+## The MQTT contract
+
+| Topic | Direction | Carries |
+| --- | --- | --- |
+| `yoyopod/{device_id}/evt` | device → backend | events + telemetry |
+| `yoyopod/{device_id}/ack` | device → backend | command acknowledgements |
+| `yoyopod/{device_id}/cmd` | backend → device | commands |
+
+Worker protocol: the runtime sends explicit `cloud.publish_*` commands
+(heartbeat, battery, connectivity, playback, generic event/telemetry)
+and `cloud.ack`; the host emits `cloud.ready`, `cloud.snapshot`,
+`cloud.command` (inbound, forwarded to the runtime), `cloud.error`,
+`cloud.stopped`. The *runtime* decides what is telemetry-worthy — a
+[house rule](/runtime/routing-and-policies/#everything-interesting-is-telegraphed);
+the desk only transports.
+
+## Implemented vs. intended
+
+**Implemented:** battery, heartbeat, connectivity, generic event and
+telemetry publishes, command ack, store-and-forward queueing while
+offline.
+
+**Configured or backend-supported but not fully wired:** HTTP/REST sync
+(`api_base_url` is config-only — [gap #3](/runtime/gaps/)), location
+telemetry, PTT start/finish events, richer backend command types beyond
+fetch/config + generic routing. Treat these as the intended surface, not
+the current one.
+
+See [Remote Playback](/features/remote-playback/) for the fully-specified
+command/ack/event contract that *is* live.
+
+:::note[Canonical source]
+Condensed from
+[`docs/features/CLOUD_PROVISIONING_AND_BACKEND.md`](https://github.com/attmous/yoyopod/blob/main/docs/features/CLOUD_PROVISIONING_AND_BACKEND.md).
+:::

--- a/website/src/content/docs/features/cloud-voice-worker.md
+++ b/website/src/content/docs/features/cloud-voice-worker.md
@@ -1,15 +1,86 @@
 ---
 title: Cloud Voice Worker
-description: Cloud STT/TTS worker setup, secrets, and smoke validation.
+description: Setting up the cloud STT/TTS/Ask worker — the environment file, the variables, and the smoke tests.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/features/CLOUD_VOICE_WORKER.md`](https://github.com/attmous/yoyopod/blob/main/docs/features/CLOUD_VOICE_WORKER.md)
-in the repository.
+The runbook for enabling cloud voice — the OpenAI-backed STT/TTS/Ask
+behind the Ask screen. The worker itself is documented in
+[the interpreter profile](/runtime/workers/speech/); this page is the
+setup and verification path.
+
+:::danger[The API key is a device secret]
+Never commit it to repo config. And note the disclosure obligation: TTS
+output is AI-generated — with cloud TTS enabled, yoyopod is an AI-voice
+device and must be treated (and disclosed) as one.
 :::
 
-The Ask flow's speech-to-text and text-to-speech run through a cloud voice
-worker, paired on-device with the `device/speech` host. The document covers
-worker setup, secret management, and the smoke validation used to confirm a
-working voice path end to end.
+## Setup: the lane environment file
+
+Configuration lives in the systemd lane defaults — `/etc/default/
+yoyopod-dev` (dev) or `/etc/default/yoyopod-prod` (prod). The file must
+be group-readable for the deploy user but **not world-readable**:
+
+```bash
+sudo touch /etc/default/yoyopod-dev
+sudo chgrp "$USER" /etc/default/yoyopod-dev
+sudo chmod 640 /etc/default/yoyopod-dev
+sudoedit /etc/default/yoyopod-dev
+```
+
+Key variables:
+
+| Variable | Example |
+| --- | --- |
+| `OPENAI_API_KEY` | `sk-…` |
+| `YOYOPOD_VOICE_MODE` | `cloud` |
+| `YOYOPOD_VOICE_WORKER_ENABLED` | `true` |
+| `YOYOPOD_VOICE_WORKER_PROVIDER` | `openai` |
+| `YOYOPOD_STT_BACKEND` / `YOYOPOD_TTS_BACKEND` | `cloud-worker` |
+| `YOYOPOD_CLOUD_TTS_MODEL` / `_VOICE` | `gpt-4o-mini-tts` / `coral` |
+| `YOYOPOD_CLOUD_TTS_INSTRUCTIONS` | "Speak warmly and calmly for a child…" |
+| `YOYOPOD_CLOUD_ASK_MODEL` | `gpt-4.1-mini` |
+| `YOYOPOD_CLOUD_ASK_TIMEOUT_SECONDS` | `12` |
+| `YOYOPOD_CLOUD_ASK_MAX_HISTORY_TURNS` / `_MAX_RESPONSE_CHARS` | `4` / `480` |
+
+Apply with `sudo systemctl restart yoyopod-dev.service`. If the key is
+missing or invalid, cloud voice degrades but local controls keep
+working — the Ask screen's offline state is the visible result.
+
+## Verify
+
+```bash
+systemctl is-active yoyopod-dev.service
+journalctl -u yoyopod-dev.service -n 120 --no-pager | grep -E "voice worker"
+# expected: Cloud voice worker ready: provider=openai
+```
+
+## The Ask smoke test
+
+Open Ask from the hub (not quick PTT) → ask *"why is the sky blue?"* →
+confirm the answer in the configured voice → ask a second question
+without leaving Ask → confirm → back out and verify no stale answer →
+then use quick PTT ("play music", "make it louder") to confirm command
+mode still works alongside.
+
+## Driving the worker directly
+
+The binary ships in the CI artifact with the other workers. From the Pi
+checkout:
+
+```bash
+set -a; . /etc/default/yoyopod-dev; set +a
+YOYOPOD_VOICE_WORKER_PROVIDER=openai device/speech/build/yoyopod-speech-host
+```
+
+It speaks newline-delimited JSON envelopes on stdin/stdout — the same
+[wire](/runtime/protocol/) as everything else. Preferred hardware
+validation: `yoyopod target deploy`, then
+`yoyopod target logs --follow --filter speech`.
+
+:::note[Canonical source]
+Condensed from
+[`docs/features/CLOUD_VOICE_WORKER.md`](https://github.com/attmous/yoyopod/blob/main/docs/features/CLOUD_VOICE_WORKER.md).
+(The canonical doc's "Go worker" phrasing is stale — the binary is the
+Rust `yoyopod-speech-host`.) Automated on-device voice validation is
+paused until the Round-2 follow-up — see the [Roadmap](/product/roadmap/).
+:::

--- a/website/src/content/docs/features/local-first-music.md
+++ b/website/src/content/docs/features/local-first-music.md
@@ -1,15 +1,46 @@
 ---
 title: Local-First Music
-description: The direction for on-device music storage and playback.
+description: The decision — Listen is local-first and local-only, via an app-owned mpv backend and a filesystem library.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/features/LOCAL_FIRST_MUSIC_PLAN.md`](https://github.com/attmous/yoyopod/blob/main/docs/features/LOCAL_FIRST_MUSIC_PLAN.md)
-in the repository.
-:::
+This page records a product decision, and the shape that follows from it.
 
-Music on yoyopod is local-first: tracks live on the device and play through
-the app-managed `mpv` pipeline, with the cloud used for import rather than
-streaming. This plan document lays out the direction, the library layout,
-and how it interacts with remote playback commands from the backend.
+## The decision
+
+**Listen is local-first and local-only.** Spotify, Amazon Music, and
+other streaming providers are not active Listen sources. Music on
+yoyopod means on-device files, played by an app-owned mpv backend over a
+filesystem library. Streaming providers must not be treated as active
+sources unless a separate, explicit decision reverses this.
+
+## The product shape
+
+The Listen root opens a small local library menu — **Playlists**,
+**Recent**, **Shuffle**. `Artists` and `Albums` views are deferred until
+the local-first baseline is stable. (The UI treatment — the wheel and
+the arc hero — is specified in the
+[UI guide's design gallery](/ui/mockups/).)
+
+## The backend contract
+
+- **Playlists** are `.m3u` files discovered anywhere under
+  `audio.music_dir` (`config/audio/music.yaml`).
+- **Recents** are recorded by yoyopod itself from mpv track-change
+  events — capped, local-only.
+- **Shuffle** builds its queue from filesystem track paths.
+- Metadata falls back to local tag reads when mpv's metadata is sparse.
+
+The cloud enters only as an *import* path, never a streaming path: the
+backend can push tracks into the local library via `store_media`
+([Remote Playback](/features/remote-playback/)), after which they're
+ordinary local files.
+
+The full mechanics: [the record library](/runtime/workers/media/)
+(process + cache), [Audio Stack](/hardware/audio-stack/) (signal path),
+[MPV Dependencies](/features/mpv-dependencies/) (install contract).
+
+:::note[Canonical source]
+Condensed from
+[`docs/features/LOCAL_FIRST_MUSIC_PLAN.md`](https://github.com/attmous/yoyopod/blob/main/docs/features/LOCAL_FIRST_MUSIC_PLAN.md)
+(decision dated 2026-04-07).
+:::

--- a/website/src/content/docs/features/mpv-dependencies.md
+++ b/website/src/content/docs/features/mpv-dependencies.md
@@ -1,14 +1,72 @@
 ---
 title: MPV Dependencies
-description: What the mpv playback integration requires on the device image.
+description: The install, config, and validation contract for mpv as yoyopod's local-only playback engine.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/features/MPV_DEPENDENCIES.md`](https://github.com/attmous/yoyopod/blob/main/docs/features/MPV_DEPENDENCIES.md)
-in the repository.
+mpv is the app-managed, local-only playback engine — spawned and
+supervised by the media host, never a separate daemon. This page is the
+install-and-verify contract for the Pi image.
+
+## System packages
+
+| Package | Purpose |
+| --- | --- |
+| `mpv` | the playback engine + its JSON IPC server |
+| `alsa-utils` | device inspection and audio smoke testing |
+
+## The config contract
+
+```yaml
+# config/audio/music.yaml
+audio:
+  music_dir: /home/tifo/Music          # source of truth for library scanning
+  recent_tracks_file: data/media/recent_tracks.json
+  mpv_socket: /tmp/yoyopod-mpv.sock
+  mpv_binary: mpv
+  default_volume: 100
+```
+
+```yaml
+# config/device/hardware.yaml
+media_audio:
+  alsa_device: default                  # source of truth for mpv's ALSA route
+```
+
+`.m3u` playlists can live anywhere under `music_dir`. mpv's division of
+labor with the media host: mpv does playback, state/progress, and push
+events; the host does scanning, playlist discovery, recents, shuffle,
+and the one-button UX ([the record library](/runtime/workers/media/)).
+
+:::note[One discrepancy in the canonical doc]
+Its header names the Whisplay audio device as `hw:1`, while the config
+examples and the verified [Audio Stack](/hardware/audio-stack/) route
+through `alsa_device: default` → **card 0** `wm8960-soundcard`. Trust
+the Audio Stack page (verified with `aplay -l` on the device); the
+`hw:1` note appears to predate the current image.
 :::
 
-The media host drives an `mpv` process for all music playback. This document
-lists the packages and versions the device image must provide, how mpv is
-invoked and controlled, and the known integration pitfalls.
+## Validation on device
+
+```bash
+yoyopod target deploy --branch <branch>
+yoyopod target logs --filter music --lines 100
+ssh <user>@<host> 'pgrep -af mpv'
+```
+
+Expected: mpv starts cleanly under app control, playlists visible,
+tracks audible through the configured ALSA device, and the host reaches
+mpv over the IPC socket.
+
+## Product guidance
+
+Keep mpv as the local playback engine; keep the product
+[local-first](/features/local-first-music/); do not treat streaming
+providers as active sources without an explicit reversal of that
+decision.
+
+:::note[Canonical source]
+Condensed from
+[`docs/features/MPV_DEPENDENCIES.md`](https://github.com/attmous/yoyopod/blob/main/docs/features/MPV_DEPENDENCIES.md)
+(last updated 2026-04-07). mpv reference: the
+[mpv manual](https://mpv.io/manual/stable/).
+:::

--- a/website/src/content/docs/features/remote-playback.md
+++ b/website/src/content/docs/features/remote-playback.md
@@ -1,15 +1,72 @@
 ---
 title: Remote Playback
-description: The backend-issued playback and media import contract.
+description: The live MQTT command/ack/event contract — backend-driven playback, the asset cache, and device-local media import.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/features/REMOTE_PLAYBACK.md`](https://github.com/attmous/yoyopod/blob/main/docs/features/REMOTE_PLAYBACK.md)
-in the repository.
-:::
+The fully-specified, validated-on-hardware contract by which the backend
+plays music on a device and imports media into its local library.
 
-The contract by which the backend can start playback on a device and import
-media into its local library: message shapes, the media worker's
-responsibilities, and how remote commands reconcile with what the child is
-doing on the device.
+## The contract
+
+Three topics ([Cloud Provisioning](/features/cloud-provisioning/)), with
+a strict separation rule: **`ack` carries command acceptance only, `evt`
+carries lifecycle only** — an ack/nack is never replayed as a lifecycle
+event.
+
+| Element | Values |
+| --- | --- |
+| Accepted commands | `play_track` · `pause` · `resume` · `stop` · `store_media` |
+| ACK payload | `{command_id, status: "ack", payload: {command}}` |
+| NACK payload | `{command_id, status: "nack", reason: "invalid_command"}` |
+| Playback lifecycle (`type: "playback"`) | `buffering` · `playing` · `paused` · `stopped` · `completed` · `failed` |
+| Import lifecycle (`type: "media_library"`) | `imported` · `failed` |
+
+## The asset cache
+
+Remote tracks are fetched into a bounded local cache **before** mpv ever
+sees them — playback always runs from a local file, never the signed
+backend URL, so short token lifetimes can't interrupt a song:
+
+- cache key includes the sanitized `track_id`; checksums verified when
+  provided,
+- downloads run off the coordinator thread before the mpv load,
+- LRU pruning by file mtime — and a just-fetched asset is protected from
+  immediately evicting itself even when over cap.
+
+Config: `remote_cache_dir` + `remote_cache_max_bytes`
+(512 MiB default, 32 MiB floor — see
+[the record library](/runtime/workers/media/)).
+
+## Device-local media import (`store_media`)
+
+The backend finalizes an uploaded household track → sends `store_media`
+over the same dispatcher → the device downloads through the same cache
+path → persists it under `music_dir/dashboard_uploads/` and updates
+`Dashboard Uploads.m3u` → emits `media_library.imported` (or `failed`).
+The backend stays the policy authority; the result surfaces as ordinary
+local files in Listen — the import path that keeps
+[local-first](/features/local-first-music/) honest.
+
+## Session behavior worth knowing
+
+One active remote session; a new valid `play_track` interrupts the
+current one. Pending downloads are correlated by `commandId` +
+activation generation, so a stale stop can't clear the *next* session. A
+`stop` during buffering discards the pending asset — playback never
+starts after a stop was acked. Duplicate `commandId`s are acked as
+duplicates and not replayed (including `store_media`).
+
+## Validated on hardware
+
+The full sequence — ack → buffering → playing → paused → resume → stop,
+plus `store_media` → `imported` and cached-asset replays — was observed
+end-to-end on a real device. (One operational note from that run: the
+device image logged VoIP recovery warnings from an unavailable
+Liblinphone backend; it does not affect playback or import.)
+
+:::note[Canonical source]
+Condensed from
+[`docs/features/REMOTE_PLAYBACK.md`](https://github.com/attmous/yoyopod/blob/main/docs/features/REMOTE_PLAYBACK.md)
+— whose header still says "yoyo-py"; the behavior described is the
+current Rust runtime's.
+:::

--- a/website/src/content/docs/hardware/audio-stack.md
+++ b/website/src/content/docs/hardware/audio-stack.md
@@ -1,18 +1,73 @@
 ---
 title: Audio Stack
-description: WM8960 codec, ALSA routing, and the mpv and Liblinphone audio paths.
+description: How music (mpv) and calls (Liblinphone) travel separate software paths that converge on one WM8960 codec.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/hardware/AUDIO_STACK.md`](https://github.com/attmous/yoyopod/blob/main/docs/hardware/AUDIO_STACK.md)
-in the repository.
-:::
+Two independent audio paths share one piece of hardware. Understanding
+which path a sound takes is the first step of every audio debug.
 
-Audio runs through the WM8960 codec on the Whisplay HAT over I2S. Music
-playback is an app-managed `mpv` process writing to the ALSA `default`
-device (card 0, `wm8960-soundcard`); calls go through Liblinphone to the
-same codec. The microphone and speaker are part of the Whisplay bundle. The
-audio-stack document maps the full routing, the relevant config keys under
-`config/device/hardware.yaml` (communication, media, and voice audio), and
-the debugging paths when sound goes missing.
+## The two paths
+
+**Music:**
+
+```
+yoyopod-runtime → media-host → mpv (--idle --no-video
+  --input-ipc-server=/tmp/yoyopod-mpv.sock --audio-device=alsa/default)
+  → ALSA "default" → card 0 wm8960-soundcard → bcm2835 I2S → WM8960
+  → speaker / headphone
+```
+
+**Calls:**
+
+```
+yoyopod-runtime → voip-host → Liblinphone → ALSA wm8960-soundcard
+```
+
+Separate stacks, same codec. There is **no music daemon** — mpv is
+spawned and supervised by the media host and dies with it. (No Mopidy,
+no GStreamer.)
+
+The media host does the library work — filesystem scanning, `.m3u`
+discovery, recents, shuffle queues — and hands mpv *paths*; it never
+decodes audio itself. mpv pushes property events (`path`, `metadata`,
+`duration`, `media-title`, `pause`, `idle-active`) over its IPC socket,
+which is how Now Playing stays current without polling.
+
+## The volume path
+
+One app-facing volume, written to two places: the system mixer (via
+`amixer`) **and** mpv. ALSA control priority: `Master` → `Speaker` →
+`Headphone`; on the production image the active controls are `Speaker`,
+`Headphone`, and `Playback` (verified at 100% / +6.00 dB).
+
+## Hardware facts
+
+From `aplay -l` on the device: **card 0** = `wm8960-soundcard`
+(device 0: `bcm2835-i2s-wm8960-hifi`) — everything routes here. HDMI
+audio exists on card 1 and is unused.
+
+## Config
+
+| File | Keys |
+| --- | --- |
+| `config/audio/music.yaml` | `audio.music_dir` (`/home/tifo/Music`), `recent_tracks_file`, `mpv_socket`, `mpv_binary`, `default_volume` |
+| `config/device/hardware.yaml` | `media_audio.alsa_device` (`default`), plus `communication_audio.*` and `voice_audio.*` device ids |
+
+## Troubleshooting
+
+- **Quiet audio** → check *both* the yoyopod shared volume and the ALSA
+  `Speaker`/`Headphone` levels — they multiply.
+- **Wrong Now Playing** → inspect the media host's snapshot and the mpv
+  IPC events; the UI only renders what the snapshot says.
+- **Which path is broken?** Music dead but calls fine (or vice versa)
+  localizes the fault immediately — the paths only share the codec.
+
+See also: the [media worker profile](/runtime/workers/media/) for the
+process mechanics, and [MPV Dependencies](/features/mpv-dependencies/)
+for the install contract.
+
+:::note[Canonical source]
+Condensed from
+[`docs/hardware/AUDIO_STACK.md`](https://github.com/attmous/yoyopod/blob/main/docs/hardware/AUDIO_STACK.md)
+(last verified 2026-04-08 against the live device).
+:::

--- a/website/src/content/docs/hardware/power-module.md
+++ b/website/src/content/docs/hardware/power-module.md
@@ -1,17 +1,80 @@
 ---
 title: Power Module
-description: PiSugar 3 battery, RTC, watchdog, and the power safety policy.
+description: The PiSugar 3 subsystem — telemetry, the safety-driven shutdown, the hardware watchdog, RTC, and troubleshooting.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/hardware/POWER_MODULE.md`](https://github.com/attmous/yoyopod/blob/main/docs/hardware/POWER_MODULE.md)
-in the repository.
+The PiSugar 3 HAT owns power truth: battery telemetry, charging state,
+the RTC, and a hardware watchdog. The runtime side is documented in the
+runtime guide ([the boiler room](/runtime/workers/power/) and the
+[low-battery house rule](/runtime/routing-and-policies/#low-battery-ends-the-show--safely));
+this page carries the hardware-level contract and field troubleshooting.
+
+## Responsibilities
+
+UPS telemetry · low-battery warning · graceful delayed shutdown with
+persisted shutdown state · screen timeout and wake-on-activity ·
+uptime/screen-on tracking · RTC read/sync/alarm · the software-fed
+hardware watchdog · the Power Status UI.
+
+## Transports
+
+`pisugar-server` over the Unix socket `/tmp/pisugar-server.sock` or TCP
+`127.0.0.1:8423`; `power.transport: auto` tries the socket first. The
+watchdog bypasses the server entirely — raw I²C via `i2cget`/`i2cset`
+(bus 1, address `0x57` on the Zero 2W).
+
+## The data model
+
+A power snapshot carries: **battery** (level %, voltage, charging,
+power-plugged, allow-charging, output-enabled, temperature), **RTC**
+(time, alarm enabled/time/repeat-mask, adjust-ppm), and **shutdown**
+(safe-shutdown level + delay), plus availability and error fields.
+
+## Config (`config/power/backend.yaml`, defaults)
+
+| Group | Keys (defaults) |
+| --- | --- |
+| Backend | `enabled`, `backend: pisugar`, `transport: auto`, socket/TCP endpoints, `timeout_seconds` |
+| Polling | `poll_interval_seconds: 30` |
+| Safety | `low_battery_warning_percent: 20`, `warning_cooldown: 300 s`, `auto_shutdown_enabled`, `critical_shutdown_percent: 10`, `shutdown_delay_seconds: 15`, `shutdown_command`, `shutdown_state_file` |
+| Watchdog | `watchdog_enabled` (default off), `timeout_seconds`, `feed_interval_seconds`, I²C bus/address |
+
+:::caution[This file has two readers]
+The runtime reads the safety thresholds from this same file for its
+shutdown policy — see the
+[dual-reader callout](/runtime/configuration/#the-worker--config-map).
 :::
 
-Power comes from a PiSugar 3 battery HAT on the I2C bus (`i2c-1`, addresses
-`0x57`/`0x68`), managed through `pisugar-server` and owned by the
-`device/power` worker. The power module document covers battery telemetry,
-the RTC, the software watchdog, shutdown safety policy, and the
-inactivity-driven display backlight timeout — plus the config keys in
-`config/power/backend.yaml`.
+## The safety policy, in rules
+
+No decision is made if PiSugar (or the battery %) is unavailable —
+absence of data never triggers a shutdown. External power restoration
+cancels a pending shutdown. Below warning → a cooldown-protected
+warning. Below critical with auto-shutdown enabled → **one** delayed
+shutdown: overlay shown, watchdog *suppressed* (not disabled — it stays
+a recovery backstop), state file written, system shutdown command run.
+
+## Field troubleshooting
+
+- Query PiSugar directly: `pisugar-shell` → `get battery`, `get model`,
+  `get rtc_time`.
+- `i2cdetect -y 1` should show `0x57` and `0x68`. **If `0x57` drops but
+  `0x68` responds, suspect pogo-pin contact** under the GPIO header —
+  clean the pads, reseat, power-cycle, restart `pisugar-server`.
+- Watchdog failures → confirm `i2c-tools` installed and the bus/address
+  match config.
+- Shutdowns too aggressive → raise `critical_shutdown_percent` or the
+  delay, and verify charging/external-power reporting first.
+
+Dependencies on the Pi: `pisugar-server`, `i2c-tools`. The runtime's
+systemd unit orders itself `After=pisugar-server.service`.
+
+:::note[Canonical source — with a caveat]
+Condensed from
+[`docs/hardware/POWER_MODULE.md`](https://github.com/attmous/yoyopod/blob/main/docs/hardware/POWER_MODULE.md).
+Parts of the canonical doc still reference the retired Python module
+paths and deleted `yoyopod pi power` commands (returning in Round 4 —
+see the [Roadmap](/product/roadmap/)); the current implementation lives
+in `device/power/`. The config keys, safety policy, and troubleshooting
+above are verified against the Rust code.
+:::

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -53,7 +53,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 </CardGrid>
 
 :::note
-Sections marked **Stub** summarize and link to the canonical Markdown documents
-in the repository — the repo docs remain the source of truth while this site
-grows around them.
+Every section is fully authored. Pages that condense a canonical Markdown
+document in the repository say so in a "Canonical source" note — the repo
+docs remain the source of truth, and this site is the navigable view of
+them.
 :::

--- a/website/src/content/docs/operations/contributor-workflow.md
+++ b/website/src/content/docs/operations/contributor-workflow.md
@@ -1,15 +1,71 @@
 ---
 title: Contributor Workflow
-description: From a fresh checkout to a credible pull request.
+description: From fresh checkout to a credible PR — the reading order, the fast loop, and the honesty norms.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/operations/CONTRIBUTOR_WORKFLOW.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/CONTRIBUTOR_WORKFLOW.md)
-in the repository.
-:::
+The shortest path to a contribution that reviewers can trust.
 
-The end-to-end contributor path: branch, build, validate against the
-quality gates, and open a PR that reviewers can trust. It also defines
-what belongs in a PR description and how contributions interact with the
-staged rebuild rounds tracked in the [Roadmap](/product/roadmap/).
+## Read first, in this order
+
+Repo `README.md` → `docs/README.md` →
+[Development Guide](/operations/development-guide/) →
+[System overview](/runtime/overview/) →
+[Quality Gates](/operations/quality-gates/) → `rules/project.md` +
+`rules/architecture.md`.
+
+## The fast local loop
+
+```bash
+cargo check --manifest-path device/Cargo.toml --workspace --locked
+cargo test  --manifest-path cli/Cargo.toml
+# targeted while iterating:
+cargo check --manifest-path device/Cargo.toml -p yoyopod-ui --locked
+```
+
+## Pick your doc path
+
+| Working on… | Follow |
+| --- | --- |
+| Runtime / orchestration | `device/runtime/` → the worker crate → [Runtime Guide](/runtime/) → `rules/architecture.md` |
+| Pi / setup | [Setup Contract](/operations/setup-contract/) → [Development Guide](/operations/development-guide/) → [Pi Dev Workflow](/operations/pi-dev-workflow/) → `rules/deploy.md` |
+| UI / design | the [UI System Guide](/ui/) → `rules/design-fidelity.md` → `rules/lvgl.md` |
+| Docs / guidance | READMEs → this page → `rules/project.md` |
+
+## Before opening a PR
+
+Run the relevant Rust checks (workspace `cargo check --locked`; the CLI
+trio if you touched `cli/`). For hardware work: `target deploy` +
+`target status` + `target logs --follow`, with eyes on the change. **If
+your change is outside the currently gated surface, say so plainly in
+the PR.**
+
+## What a good PR looks like here
+
+One coherent problem slice · updates docs when the contract changes ·
+states what is now *enforced* vs. still *debt* · avoids fake
+completeness · leaves the repo more navigable than it found it.
+
+## Contributor traps
+
+- Treating the staged quality gate as whole-repo cleanliness.
+- Treating the setup contract as fully solved (it isn't — Round 4+).
+- Mixing unrelated cleanup into architecture PRs.
+- Moving complexity into a new file and calling it architecture.
+- Updating plan docs while leaving source-of-truth docs stale.
+
+Current hotspots where extra care pays: `device/runtime/` (supervision),
+`device/ui/` + LVGL scene code (visual fidelity on hardware),
+`cli/yoyopod/` (active rebuild), duplicated domain models drifting
+across `device/` crates, and docs wording that overstates rebuilt-CLI
+guarantees.
+
+## If you only remember one thing
+
+Be honest about the repo's current state — real foundation progress,
+still alpha. Land executable improvements without pretending the
+remaining debt disappeared.
+
+:::note[Canonical source]
+Condensed from
+[`docs/operations/CONTRIBUTOR_WORKFLOW.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/CONTRIBUTOR_WORKFLOW.md).
+:::

--- a/website/src/content/docs/operations/dev-prod-lanes.md
+++ b/website/src/content/docs/operations/dev-prod-lanes.md
@@ -1,17 +1,76 @@
 ---
 title: Dev/Prod Lanes
-description: The two deployment lanes on the device and how to switch between them.
+description: The two deploy lanes on a board — mutable dev checkout vs immutable prod slots — and the commands that switch them.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/operations/DEV_PROD_LANES.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/DEV_PROD_LANES.md)
-in the repository.
-:::
+Every board hosts two lanes, **mutually exclusive** — only one runs at a
+time, and lane-switch commands stop the other first (they share the
+hardware, audio, and PID file).
 
-Each device carries two lanes: a mutable dev lane (a git checkout at
-`/opt/yoyopod-dev/checkout` run by `yoyopod-dev.service`) and an immutable
-prod lane (versioned slots under `/opt/yoyopod-prod` with `current`/
-`previous` symlinks and a rollback unit). The document explains lane
-activation via `yoyopod target mode activate`, the systemd units involved,
-and the guarantees each lane provides.
+| Lane | Nature | Runs |
+| --- | --- | --- |
+| **Dev** | mutable git checkout for fast hardware testing | `yoyopod-dev.service` → the checkout's built binaries |
+| **Prod** | immutable versioned slots for packaged releases | `yoyopod-prod.service` → `/opt/yoyopod-prod/current/bin/launch` |
+
+## The paths
+
+```text
+/opt/yoyopod-dev/{checkout, state, logs, tmp, bin}
+/opt/yoyopod-prod/{releases/<version>, current -> releases/<v>,
+                   previous -> releases/<v>, state, tmp, bin}
+```
+
+`previous` is the rollback target (`yoyopod-prod-rollback.service`
+flips to it on prod failure) — **never delete it**. Tracked defaults
+live in `deploy/pi-deploy.yaml`; per-board overrides in the gitignored
+`pi-deploy.local.yaml`.
+
+## Lane commands
+
+```bash
+yoyopod target mode status            # always check first
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>
+yoyopod target mode activate prod
+```
+
+`mode status` also reports stray `yoyopod-*` processes holding hardware
+— `mode activate` cleans them up. To stop a lane outright (until
+`mode deactivate` is ported): `sudo systemctl stop yoyopod-dev.service`.
+
+## Fresh board bootstrap
+
+Run the installer **on the Pi** (don't clone a bootstrap checkout):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/attmous/yoyopod/main/deploy/scripts/install_pi.sh | sudo -E bash -s --
+# then seed the dev lane:
+sudo chown -R <user>:<user> /opt/yoyopod-dev
+sudo -u <user> git clone <repo-url> /opt/yoyopod-dev/checkout
+yoyopod target mode activate dev
+```
+
+Migrating a board with an old `~/yoyopod-core` checkout: add
+`--migrate` — it preserves the old config/logs for reference but does
+**not** copy the legacy checkout into the dev lane. `~/yoyopod-core` is
+archive; live truth is `/opt/yoyopod-dev/checkout`.
+
+## Pitfalls
+
+- Never run both lane services together.
+- Never mutate a prod release dir in place — publish a new version and
+  flip `current` (blocked until Round 3 anyway —
+  [Roadmap](/product/roadmap/)).
+- The running app reads config bundled into its active lane — merge
+  local config drift into the repo before publishing a prod slot.
+- After big branch switches, `--clean-native`.
+
+The future OTA poller is guarded: `prod-ota-guard.sh` skips OTA whenever
+the dev lane is active, so OTA can't mutate prod while a board is
+intentionally in dev.
+
+:::note[Canonical source]
+Condensed from
+[`docs/operations/DEV_PROD_LANES.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/DEV_PROD_LANES.md).
+Prod slot publishing and `target release status` return in Round 3.
+:::

--- a/website/src/content/docs/operations/development-guide.md
+++ b/website/src/content/docs/operations/development-guide.md
@@ -1,15 +1,92 @@
 ---
 title: Development Guide
-description: Toolchain setup, running the workspace, validation, and daily workflow.
+description: Toolchain, configuration, running, validation, and the Pi workflow — the operational reference hub.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/operations/DEVELOPMENT_GUIDE.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/DEVELOPMENT_GUIDE.md)
-in the repository.
+The day-one reference: how to build, run, and validate yoyopod from a
+fresh checkout. Reading order for newcomers: repo `README.md` →
+`docs/README.md` → [Contributor Workflow](/operations/contributor-workflow/)
+→ [System overview](/runtime/overview/) → the [Roadmap](/product/roadmap/).
+
+## Toolchain
+
+```bash
+rustup default stable
+rustup component add rustfmt clippy
+cargo build --manifest-path cli/Cargo.toml --release
+cargo install --path cli/yoyopod          # optional: `yoyopod` into ~/.cargo/bin
+cargo build --manifest-path device/Cargo.toml --release -p yoyopod-runtime
+```
+
+`gh` must be authenticated — `yoyopod target deploy` uses it to fetch CI
+artifacts. Pi system dependencies (mpv, liblinphone, ALSA, i2c-tools,
+pisugar-server, ppp) are the [Setup Contract](/operations/setup-contract/)'s
+department.
+
+## Running
+
+```bash
+# validate config without hardware:
+cargo run --manifest-path device/Cargo.toml -p yoyopod-runtime -- --config-dir config --dry-run
+# run the runtime locally:
+device/target/release/yoyopod-runtime --config-dir config
+```
+
+:::caution[Two different "yoyopod"s]
+The installed `yoyopod` binary is the **dev-machine operator CLI** — it
+does *not* launch the runtime. The app runtime runs on the Pi via
+`yoyopod-dev.service` / `yoyopod-prod.service`.
 :::
 
-The day-one document: installing the Rust toolchain, building the `device/`
-workspace and the `cli/` workspace, running tests and clippy the way CI does,
-and the daily edit–build–validate loop. Pair it with the
-[Quality Gates](/operations/quality-gates/) before opening a PR.
+## Configuration
+
+Tracked config lives under `config/` — the full topology and ownership
+rules are on [Canonical Structure](/architecture/canonical-structure/),
+and the per-worker wiring on
+[Configuration Wiring](/runtime/configuration/). Secrets go in
+`calling.secrets.yaml` (untracked) or env; mutable data (contacts,
+recent tracks) lives under `data/`, seeded from tracked seed files.
+
+One behavior worth knowing: contacts may carry both `sip_address` and
+`phone_number`; the runtime prefers SIP while GSM is disabled, and
+backend sync replaces the cloud-managed subset while preserving
+local-only contacts.
+
+## Validation
+
+```bash
+cargo check --manifest-path device/Cargo.toml --workspace --locked
+cargo test  --manifest-path cli/Cargo.toml
+cargo clippy --manifest-path cli/Cargo.toml --all-targets
+```
+
+The full policy — what counts as verification and what to report — is
+[Quality Gates](/operations/quality-gates/).
+
+## The Pi workflow, in one block
+
+```bash
+yoyopod target config edit                 # one-time per machine
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>    # or --sha <commit>
+yoyopod target status
+yoyopod target logs --follow --filter ERROR
+```
+
+Details, flags, and troubleshooting:
+[Pi Dev Workflow](/operations/pi-dev-workflow/). App logs land in
+`logs/yoyopod.log` + `logs/yoyopod_errors.log`; deploy connection
+defaults live in `deploy/pi-deploy.yaml` with machine-specific values in
+the gitignored `pi-deploy.local.yaml`.
+
+## Paused during the CLI rebuild
+
+Per the [Roadmap](/product/roadmap/): `yoyopod setup …` automation
+(install manually), `yoyopod dev profile` (use `cargo flamegraph` /
+`samply` / `perf`), and `yoyopod target validate` (Round 2 — validate
+manually via journalctl until it lands).
+
+:::note[Canonical source]
+Condensed from
+[`docs/operations/DEVELOPMENT_GUIDE.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/DEVELOPMENT_GUIDE.md).
+:::

--- a/website/src/content/docs/operations/pi-dev-workflow.md
+++ b/website/src/content/docs/operations/pi-dev-workflow.md
@@ -1,16 +1,82 @@
 ---
 title: Pi Dev Workflow
-description: The day-to-day loop from your dev machine to a running device.
+description: The everyday dev-machine-to-board loop — commit, push, deploy, verify — with its inspection and troubleshooting commands.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/operations/PI_DEV_WORKFLOW.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/PI_DEV_WORKFLOW.md)
-in the repository.
+The default contract, five steps: finish the change locally → commit →
+push (CI must build `rust-device-arm64` for that exact commit) → deploy
+that commit to the Pi → verify with your own eyes.
+
+:::caution[No dirty-tree deploys]
+`target deploy` installs the CI artifact for the **exact pushed
+commit** — an uncommitted tree has no artifact and cannot deploy. This
+is a feature: the binaries on the board always correspond to a commit.
 :::
 
-The core loop: push a branch, let CI build the arm64 bundle, then
-`yoyopod target deploy --branch <branch>` to sync the device's dev-lane
-checkout at `/opt/yoyopod-dev/checkout`, restart `yoyopod-dev.service`, and
-verify startup. The document covers the supporting commands — logs, status,
-screenshots — and what to do when a deploy goes sideways.
+## One-time setup
+
+```bash
+cargo build --manifest-path cli/Cargo.toml --release
+cargo install --path cli/yoyopod
+yoyopod target config edit        # host/user → pi-deploy.local.yaml
+gh auth status                    # must pass
+```
+
+Keep `host`/`user` out of the tracked `deploy/pi-deploy.yaml`; the
+stable board checkout is `project_dir: /opt/yoyopod-dev/checkout` — one
+checkout, always (native LVGL rebuilds are expensive; ad-hoc per-branch
+checkouts on the board are unsupported). Env fallbacks exist:
+`YOYOPOD_PI_HOST`, `YOYOPOD_PI_USER`, `YOYOPOD_PI_PROJECT_DIR`.
+
+## The daily loop
+
+```bash
+yoyopod target mode status
+yoyopod target mode activate dev          # if needed
+git add -p && git commit -m '…'
+git push
+yoyopod target deploy --branch <branch>   # or --sha <commit>
+yoyopod target status
+yoyopod target logs --follow
+```
+
+Two flags to know: `--wait-for-ci` when CI is still running (30-minute
+timeout), and `--clean-native` after native LVGL/CMake input changes
+(wipes the board's build dir).
+
+## Inspection
+
+| Command | Shows |
+| --- | --- |
+| `target status` | deployed SHA, processes, log tail |
+| `target logs --lines 200` / `--errors` / `--filter comm` / `--follow` | remote logs, filtered |
+| `target screenshot` (`--readback` for LVGL readback) | the glass, into `logs/screenshots/` |
+| `target restart` | restart + startup verification |
+
+Until Round 2 lands `target validate`
+([Roadmap](/product/roadmap/)), validate manually:
+`yoyopod target logs --follow` plus
+`ssh <user>@<host> 'journalctl -u yoyopod-dev.service -f'`.
+
+## When deploy fails
+
+```bash
+yoyopod target logs --lines 200 --errors
+ssh <user>@<host> 'systemctl status yoyopod-dev.service --no-pager -l'
+```
+
+| Symptom | Cause → fix |
+| --- | --- |
+| artifact fetch fails | `gh` not authenticated → `gh auth login` |
+| "CI in progress" | rerun with `--wait-for-ci` |
+| CI failed | fix the commit — never deploy a broken build |
+| service won't start | prod lane active → `target mode activate dev` |
+| sync errors | checkout ownership wrong → check `/opt/yoyopod-dev/checkout` |
+
+Also: retry transient `github.com` blips before treating them as real
+failures.
+
+:::note[Canonical source]
+Condensed from
+[`docs/operations/PI_DEV_WORKFLOW.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/PI_DEV_WORKFLOW.md).
+:::

--- a/website/src/content/docs/operations/quality-gates.md
+++ b/website/src/content/docs/operations/quality-gates.md
@@ -1,15 +1,75 @@
 ---
 title: Quality Gates
-description: The verification required before merging.
+description: The verification policy — which checks count, how hardware validation works today, and what to report.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/operations/QUALITY_GATES.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/QUALITY_GATES.md)
-in the repository.
+What counts as verification before a change merges — and just as
+important, what to *say* about what you ran.
+
+## Rust build checks
+
+Focused, per changed crate:
+
+```bash
+cargo check --manifest-path device/Cargo.toml -p yoyopod-runtime --locked
+cargo check --manifest-path device/Cargo.toml -p yoyopod-ui --locked
+# …same pattern for -p yoyopod-media / -voip / -network / etc.
+```
+
+Broad workspace change:
+
+```bash
+cargo check --manifest-path device/Cargo.toml --workspace --locked
+```
+
+CLI changes get all three:
+
+```bash
+cargo check  --manifest-path cli/Cargo.toml
+cargo test   --manifest-path cli/Cargo.toml
+cargo clippy --manifest-path cli/Cargo.toml --all-targets
+```
+
+:::caution[Native LVGL / Whisplay changes]
+For hardware-facing features, local checks are not parity — validate
+against the **CI-built ARM artifact for the exact commit** before
+claiming hardware works. (The UI guide's rule: never rebuild LVGL on
+the Pi.)
 :::
 
-The pre-merge bar: per-workspace `cargo check`, `cargo test`, and
-`cargo clippy` mirroring CI exactly, plus any area-specific validation the
-change touches. Running the gate locally before pushing is expected — CI is
-the backstop, not the first line.
+## Hardware checks
+
+The Pi is the real validation target for runtime, display, input,
+audio, SIP, modem, and power:
+
+```bash
+git rev-parse HEAD                       # know your exact commit
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>
+```
+
+Until Round 2 restores `target validate`
+([Roadmap](/product/roadmap/)): `target status`, `target logs --follow`,
+`journalctl -u yoyopod-dev.service -f` — and exercise the changed
+surface with human eyes.
+
+## Reporting — say what actually ran
+
+Every hardware validation report should state:
+
+- the branch and **exact commit SHA**
+- the artifact name + CI run ID it deployed
+- the Pi command results
+- whether the dev service was left running
+- the manual validation steps performed, and their outcomes
+
+The norm behind the checklist: report checks that ran, not checks that
+should have run. If your change is outside the currently gated surface,
+say so plainly — see
+[Contributor Workflow](/operations/contributor-workflow/).
+
+:::note[Canonical source]
+Condensed from
+[`docs/operations/QUALITY_GATES.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/QUALITY_GATES.md)
+(titled "Verification Policy" in the document itself).
+:::

--- a/website/src/content/docs/operations/setup-contract.md
+++ b/website/src/content/docs/operations/setup-contract.md
@@ -1,16 +1,78 @@
 ---
 title: Setup Contract
-description: What a dev machine and a device must have before work starts.
+description: The baseline contract — required dependencies, repo-owned vs machine-local ownership, and manual bringup for dev machine and Pi.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/operations/SETUP_CONTRACT.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/SETUP_CONTRACT.md)
-in the repository.
-:::
+Automated setup (`yoyopod setup …`) was deleted in Round 0 of the CLI
+rebuild and returns in Round 4+ — until then, bringup is manual, and
+this contract is what "correctly set up" means.
 
-The prerequisites contract for both sides: toolchain and credentials on the
-development machine, and OS image, packages, services (such as
-`pisugar-server`), and directory layout on the Pi. If a workflow fails
-mysteriously, check the contract first — most breakage is a missing
-prerequisite.
+## Ownership rules
+
+| The repo owns | The machine owns (never tracked) |
+| --- | --- |
+| the Rust dependency graph (`Cargo.toml`/`.lock`) | Pi hostname / SSH alias, username |
+| `deploy/pi-deploy.yaml` (generic defaults only) | `pi-deploy.local.yaml` overrides |
+| tracked config under `config/` | secrets and credentials |
+| this dependency list | local audio paths / removable media |
+
+## Dev machine
+
+Rust stable via `rustup` · `gh` authenticated (artifact fetching) ·
+`ssh`/`scp`/`git` for the Pi side · `cmake` only if building LVGL
+locally (rare — CI artifacts normally cover it).
+
+```bash
+cargo build --manifest-path cli/Cargo.toml --release
+cargo install --path cli/yoyopod
+cargo check --manifest-path device/Cargo.toml --workspace --locked
+yoyopod target config edit
+```
+
+## Target Pi
+
+```bash
+sudo apt-get update
+sudo apt-get install -y mpv ffmpeg liblinphone-dev pkg-config cmake \
+    alsa-utils i2c-tools
+sudo apt-get install -y pisugar-server ppp   # hardware-dependent
+
+# one-shot bootstrap (lane dirs + systemd units), run ON the Pi:
+curl -fsSL https://raw.githubusercontent.com/attmous/yoyopod/main/deploy/scripts/install_pi.sh | sudo -E bash -s --
+
+# seed the dev lane:
+sudo chown -R <user>:<user> /opt/yoyopod-dev
+sudo -u <user> git clone <repo-url> /opt/yoyopod-dev/checkout
+
+# then, from the dev machine:
+yoyopod target mode activate dev
+yoyopod target deploy --branch <branch>
+```
+
+## What comes back when
+
+| When | Restores |
+| --- | --- |
+| Round 2 | automated on-Pi validation (`yoyopod target validate …`) |
+| Round 3 | prod slot install + release tooling |
+| Round 4+ | `yoyopod target setup` / `verify-setup` one-shot bootstrap |
+
+## Verify setup before blaming product code
+
+The checklist, in order: local CLI build succeeds → `target config edit`
+shows host/user → `target mode status` reports the expected lane →
+required Pi packages installed → `/opt/yoyopod-dev/checkout` exists →
+`target deploy` succeeds → `journalctl -u yoyopod-dev.service -f` shows
+the runtime alive → remote config comes from `pi-deploy.yaml` + local
+override, not tribal knowledge. Most "product bugs" during bringup fail
+one of these first.
+
+Known gaps in the contract itself: voice-provider credential
+provisioning, board/modem-specific device permissions, and portability
+beyond the Debian-based Pi flow.
+
+:::note[Canonical source]
+Condensed from
+[`docs/operations/SETUP_CONTRACT.md`](https://github.com/attmous/yoyopod/blob/main/docs/operations/SETUP_CONTRACT.md)
+(dated 2026-05-13).
+:::

--- a/website/src/content/docs/product/definition.md
+++ b/website/src/content/docs/product/definition.md
@@ -1,17 +1,61 @@
 ---
 title: Product Definition
-description: What yoyopod is, who it serves, and the experience it commits to.
+description: What yoyopod is, who it serves, and the promise it makes — the first device before a smartphone.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/product/PRODUCT_DEFINITION.md`](https://github.com/attmous/yoyopod/blob/main/docs/product/PRODUCT_DEFINITION.md)
-in the repository.
-:::
+yoyopod is a parent-managed **first independent device** for kids ages
+7–14, built for the gap *before a smartphone*. It gives kids focused
+independence — communication, music, mobility — and gives parents peace
+of mind through reliable calling and live-ish location, without a
+smartphone's distraction, complexity, and screen addiction.
 
-yoyopod is a screen-light audio companion for kids: music, voice messages to
-family, and a spoken question-and-answer assistant, on a pocketable device
-with a single button and a small display. The product definition document
-states the audience, the experience pillars, and what the device deliberately
-does not do (no feeds, no open browsing, no reading required — voice carries
-pre-readers through every flow).
+The positioning line:
+
+> **Safer independence for kids. Peace of mind for parents. Before the
+> smartphone.**
+
+## Core definition
+
+| Attribute | Value |
+| --- | --- |
+| Buyer | parents |
+| User | kids ages 7–14 |
+| Product type | parent-managed connected companion device |
+| Form factor | walkie-talkie-like, tiny screen, minimal input |
+| Anti-goal | **not** a smartphone replacement |
+
+## V1 pillars
+
+1. **Whitelist calls and voice messages** — approved contacts only.
+2. **Live-ish location** — visibility when it matters. (The hedge is
+   deliberate: it is not marketed as real-time tracking.)
+3. **Music and audio** — an everyday audio companion.
+4. **A parent mobile app** — contacts, settings, and device controls
+   stay with the parent.
+
+## The emotional promise
+
+- For the **kid**: independence — a device that feels grown-up and is
+  genuinely theirs.
+- For the **parent**: safety and peace of mind.
+
+Two trust anchors carry that promise: **reliable reachability** and
+**trustworthy location**. Everything else is secondary.
+
+## How the device delivers it
+
+The engineering choices documented across this site all trace back to
+this definition: one button and a small glass
+([UI System Guide](/ui/)) because simplicity *is* the product;
+whitelisted SIP calling and voice notes
+([the switchboard](/runtime/workers/voip/)) because safe communication
+is pillar one; cellular + GPS
+([the radio room](/runtime/workers/network/)) because reachability and
+location are the trust anchors.
+
+:::note[Canonical source]
+Condensed from
+[`docs/product/PRODUCT_DEFINITION.md`](https://github.com/attmous/yoyopod/blob/main/docs/product/PRODUCT_DEFINITION.md)
+— the wording of the positioning line and pillars is deliberate; when in
+doubt, quote the canonical document.
+:::

--- a/website/src/content/docs/product/positioning.md
+++ b/website/src/content/docs/product/positioning.md
@@ -1,15 +1,81 @@
 ---
 title: Positioning
-description: Homepage and landing-page messaging for yoyopod.
+description: The messaging source of truth — chosen headline, value props, the trust questions, and the do-not-say list.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/product/LANDING_PAGE_POSITIONING.md`](https://github.com/attmous/yoyopod/blob/main/docs/product/LANDING_PAGE_POSITIONING.md)
-in the repository.
+The outward-facing story, with the decisions already made. When writing
+anything public about yoyopod, start here.
+
+## The chosen words
+
+| Element | Decision |
+| --- | --- |
+| Hero headline | **"The first device before a smartphone"** |
+| Subheadline | "YoYoPod is a parent-managed companion device for kids ages 7–14, built for safe communication, live location, and everyday audio without the distraction, complexity, or screen addiction of a smartphone." |
+| Primary CTA | "Join the waitlist" |
+| Secondary CTA | "See how it works" |
+| Emotional alternative | "Give them independence. Not a smartphone." |
+
+The three-line positioning block:
+
+> For kids, YoYoPod feels like freedom.
+> For parents, it feels like reassurance.
+> For both, it's a better step before the smartphone years.
+
+## The five value props
+
+| # | Prop | Gist |
+| --- | --- | --- |
+| 1 | Safe communication | calls + voice messages with approved contacts only |
+| 2 | Live location for peace of mind | see the child's live-ish location when out |
+| 3 | Built for independence, not distraction | tiny screen, simple controls, no app rabbit-holes |
+| 4 | Music and audio they enjoy | everyday audio for music and stories |
+| 5 | Parent-managed from a mobile app | contacts, settings, controls stay with the parent |
+
+## The trust section
+
+Built around three questions, in this order:
+
+> Can I reach my child? · Can they reach me? · Can I see where they are?
+>
+> YoYoPod is built around those questions first.
+
+And the contrast list: *communication without app overload · location
+without social media · independence without endless distraction ·
+simplicity without giving up connection.* — "Because most kids don't
+need the internet in their pocket before they need independence."
+
+## Both sides of the device
+
+| Kids get | Parents get |
+| --- | --- |
+| feels grown-up | approved contacts only |
+| easy to carry | live location visibility |
+| simple to use | less distraction than a phone |
+| fun for music and audio | more confidence when kids are out |
+
+## How it works (the three-step story)
+
+1. Parents set up approved contacts and settings in the app.
+2. Kids carry it as an everyday companion — listening, calling, getting
+   around.
+3. Parents can reach them, hear from them, and check location when it
+   matters.
+
+## Anti-positioning — what yoyopod is *not*
+
+Not a smartphone replacement · not a toy · not a screen-first device ·
+not another addictive kids gadget. *"It's a simpler first step."*
+
+:::caution[The do-not-say list]
+Do **not** market yoyopod as: *AI for kids* · *a new communication
+platform* · *a smart wearable* · *an educational device*. Each dilutes
+the sharpest truth: **it is the first device before a smartphone.**
 :::
 
-The positioning document holds the outward-facing story: the headline
-messaging for a future landing page, the framing of "screen-light, not
-screen-free", and how yoyopod is presented against tablets and smart speakers
-for the same audience.
+:::note[Canonical source]
+Condensed from
+[`docs/product/LANDING_PAGE_POSITIONING.md`](https://github.com/attmous/yoyopod/blob/main/docs/product/LANDING_PAGE_POSITIONING.md),
+which also carries the full homepage structure (8 sections) and copy
+drafts.
+:::

--- a/website/src/content/docs/product/roadmap.md
+++ b/website/src/content/docs/product/roadmap.md
@@ -1,17 +1,65 @@
 ---
 title: Roadmap
-description: The staged Rust rebuild — what works today and what is paused.
+description: The honesty doc — the staged Rust CLI rebuild, what works today, what is broken, and when it comes back.
 ---
 
-:::note[Canonical source]
-This page is a summary. The authoritative document is
-[`docs/ROADMAP.md`](https://github.com/attmous/yoyopod/blob/main/docs/ROADMAP.md)
-in the repository.
-:::
+The roadmap is the project's **honesty doc**: what is broken today, what
+works, and when it gets fixed. It tracks the **Rust CLI rebuild** — the
+old Python operator CLI (~21k lines) was deleted in one move, and a new
+Rust CLI is being rebuilt at `cli/` in business-need-sized rounds.
 
-The project is being rebuilt in staged rounds after retiring the original
-Python runtime and CLI. The roadmap is the single honest ledger of that
-process: which rebuild rounds are done, which operator CLI commands work
-right now, which are stubbed, and which capabilities (release pipeline, slot
-deploys, OTA) are parked until their round lands. When any other document
-describes a workflow, the roadmap decides whether it is currently real.
+## Round status (as of 2026-07-12)
+
+| Round | Scope | State |
+| --- | --- | --- |
+| 0 | Demolition + scaffolding | ✅ merged |
+| 1 | Daily dev loop (`yoyopod target …` Rust MVP) | ✅ merged |
+| 2 | Restore hardware validation (`yoyopod target validate`) | 🔄 in progress |
+| 3 | Restore prod release pipeline | ⏳ not started |
+| 4+ | Diagnostics (`pi voip/power/network/rust-ui-host`) | ⏳ not started |
+
+Why rounds instead of a port: the runtime went Rust-only, so a
+line-by-line port would rebuild dead assumptions (e.g. `target sync` as
+`git pull + restart`, valid only when source files *were* the
+executable). Each round restores a capability shaped for current reality.
+
+## What works today
+
+- The dev runtime: `yoyopod-dev.service` execs
+  `device/runtime/build/yoyopod-runtime` directly — no Python anywhere.
+- CI's `rust-device-arm64` job producing the
+  `yoyopod-rust-device-arm64-<sha>` artifact.
+- The Round-1 CLI: `target config edit`, `target mode
+  {status, activate}`, **`target deploy`** (the centerpiece: push → find
+  the CI artifact for the exact commit → sync the Pi → install binaries →
+  restart → verify), `target {status, restart, logs, screenshot}`.
+- All Rust workspace commands (`cargo check/build/test`).
+
+## What is broken today
+
+- **Prod slot builds** — CI `slot-arm64` and `release.yml` are disabled;
+  no new release tarballs until Round 3.
+- **Diagnostics** (`pi voip/power/network/rust-ui-host`) — gone with the
+  Python CLI; SSH manually until Round 4+.
+- **VoIP + cloud-voice validation stages** — `yoyopod-on-pi validate
+  {voip, cloud-voice}` are stubs (exit 2), the Round-2 follow-up.
+
+## Workarounds during the gap
+
+| Need | Do this instead |
+| --- | --- |
+| Validate a Rust change on hardware | `yoyopod target deploy`, then SSH: `journalctl -u yoyopod-dev.service -f` |
+| Ship a prod release | **You can't.** Plan release windows around the rebuild. |
+| Read the battery | SSH and query PiSugar directly (`pisugar-shell`), or the `device/power/` crate |
+
+The Round-2 architecture decision — validation stages living in the
+on-Pi companion binary `yoyopod-on-pi` rather than driving SSH from the
+dev machine — is documented in the runtime guide's
+[Testing & Validation](/runtime/testing/).
+
+:::note[Canonical source]
+Condensed from
+[`docs/ROADMAP.md`](https://github.com/attmous/yoyopod/blob/main/docs/ROADMAP.md)
+— a dated snapshot; when this page and the canonical doc disagree, the
+canonical doc (and then the code) wins.
+:::


### PR DESCRIPTION
## What

The final slice: converts all 16 remaining stub pages into fully authored documentation and removes every Stub badge. With this PR, **every section of the docs site is real** — two flagship guides (UI System, Runtime & Workers) plus complete Product, Architecture, Hardware, Features, and Operations sections.

## Contents

Each page is condensed from its canonical `docs/*.md` (kept as source of truth, cited in a "Canonical source" note on every page):

- **Product** — definition (buyer/user/pillars, deliberate messaging preserved verbatim incl. "the first device before a smartphone" and the "live-ish" hedge), positioning (chosen headline/CTAs, five value props, the do-not-say list), roadmap (the rebuild-rounds ledger: what works, what's broken, workarounds)
- **Architecture** — canonical structure (config topology + composition/secrets/board rules + migration template; the Python package-ownership half explicitly flagged historical), work areas (the Rust crate ownership map, cross-linked into both guides)
- **Hardware** — audio stack (both signal paths to the WM8960, volume path, verified hardware facts, troubleshooting), power module (PiSugar transports, config keys, safety policy, field troubleshooting incl. the pogo-pin diagnosis)
- **Features** — cloud provisioning (MQTT contract, implemented-vs-intended honesty), cloud voice worker (env-file runbook + smoke tests), local-first music (the decision page), remote playback (the hardware-validated command/ack/event contract), mpv dependencies
- **Operations** — development guide, Pi dev workflow, dev/prod lanes, quality gates, setup contract, contributor workflow — all with copy-paste command blocks and paused-status flags tied to the roadmap rounds

## Reviewer notes

- Known-stale spots in canonical docs (retired Python paths in POWER_MODULE, the "Go worker" phrasing, `yoyo-py`, the `hw:1` audio-device discrepancy) are **flagged on the derived pages** rather than silently repeated — the site tells the truth about its sources.
- Sidebar de-stubbed; landing note and website README updated to the completed state.
- Site-only change; no Rust, no canonical `docs/*.md` edits.
- Verified: clean build (58 pages + search index), all 18 converted routes render full pages, zero stub badges in the rendered sidebar.

Builds on #451 (site + UI guide) and #454 (Runtime & Workers guide), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)