### PR TITLE
UI: speak focused labels

### DIFF
--- a/device/onpi/src/ui_host.rs
+++ b/device/onpi/src/ui_host.rs
@@ -147,6 +147,32 @@ fn expect_screen(supervisor: &mut UiHostSupervisor, screen: &str) -> Result<Stri
     Ok(observed)
 }
 
+fn expect_focus_label(supervisor: &mut UiHostSupervisor, label: &str) -> Result<String> {
+    let event = read_until(supervisor, &["ui.focus_changed"])?;
+    let observed = event
+        .payload
+        .get("label")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    if observed != label {
+        bail!(
+            "expected spoken focus label {label:?}, got {}",
+            if observed.is_empty() {
+                event.payload.to_string()
+            } else {
+                format!("{observed:?}")
+            }
+        );
+    }
+    Ok(observed)
+}
+
+fn expect_focus_cleared(supervisor: &mut UiHostSupervisor) -> Result<()> {
+    read_until(supervisor, &["ui.focus_cleared"])?;
+    Ok(())
+}
+
 fn request_health(supervisor: &mut UiHostSupervisor) -> Result<Value> {
     supervisor.send(UiCommand::Health)?;
     let event = read_until(supervisor, &["ui.health"])?;
@@ -237,9 +263,8 @@ pub fn ui_smoke_check(worker: &Path, hardware: &str, hold_seconds: f64) -> Check
 /// Drive semantic one-button navigation through the worker protocol.
 ///
 /// Focus the hub first, then for each cycle: select into the active card,
-/// back out to the hub, and advance the hub selection. Cycle 0 lands on
-/// `listen`; later cycles on `talk` — matching the hub card order the Python
-/// suite validated and the Home idle/focused interaction contract.
+/// back out to the hub, and advance the hub selection. Every semantic focus
+/// transition must emit the same spoken label the child sees on the display.
 pub fn ui_navigation_check(
     worker: &Path,
     cycles: u32,
@@ -263,24 +288,42 @@ pub fn ui_navigation_check(
             // Home starts idle: the first press reveals/focuses the deck, while
             // the following double-press opens the focused destination.
             supervisor.send(UiCommand::InputAction(InputAction::Advance))?;
+            let mut spoken_labels = vec![expect_focus_label(&mut supervisor, "Listen")?];
             pump_ticks(&mut supervisor, hold_seconds)?;
 
             let mut visited = vec!["hub".to_string()];
-            let mut expected_selected_screen = "listen";
+            let hub_routes = [
+                ("Listen", "listen", Some("Playlists")),
+                ("Talk", "talk", Some("No contacts yet. Ask a grown-up!")),
+                ("Ask", "ask", None),
+                ("Setup", "setup", Some("Volume, level 5")),
+            ];
+            let mut hub_index = 0_usize;
             for _cycle in 0..cycles.max(1) {
+                let (hub_label, selected_screen, selected_focus) = hub_routes[hub_index];
                 supervisor.send(UiCommand::InputAction(InputAction::Select))?;
-                visited.push(expect_screen(&mut supervisor, expected_selected_screen)?);
+                if let Some(label) = selected_focus {
+                    spoken_labels.push(expect_focus_label(&mut supervisor, label)?);
+                } else {
+                    expect_focus_cleared(&mut supervisor)?;
+                }
+                visited.push(expect_screen(&mut supervisor, selected_screen)?);
                 pump_ticks(&mut supervisor, hold_seconds)?;
                 pump_ticks(&mut supervisor, idle_seconds)?;
 
                 supervisor.send(UiCommand::InputAction(InputAction::Back))?;
+                spoken_labels.push(expect_focus_label(&mut supervisor, hub_label)?);
                 visited.push(expect_screen(&mut supervisor, "hub")?);
                 pump_ticks(&mut supervisor, hold_seconds)?;
 
                 supervisor.send(UiCommand::InputAction(InputAction::Advance))?;
+                hub_index = (hub_index + 1) % hub_routes.len();
+                spoken_labels.push(expect_focus_label(
+                    &mut supervisor,
+                    hub_routes[hub_index].0,
+                )?);
                 let health = request_health(&mut supervisor)?;
                 require_healthy_ui(&health)?;
-                expected_selected_screen = "talk";
                 pump_ticks(&mut supervisor, hold_seconds)?;
             }
 
@@ -289,9 +332,10 @@ pub fn ui_navigation_check(
             require_healthy_ui(&health)?;
             Ok(format!(
                 "binary={}, protocol=ui.runtime_snapshot/ui.input_action, \
-                 visited={}, frames={}, active_screen={}",
+                 visited={}, spoken_focus={}, frames={}, active_screen={}",
                 worker.display(),
                 visited.join(","),
+                spoken_labels.join(","),
                 health.get("frames").cloned().unwrap_or(Value::Null),
                 health.get("active_screen").cloned().unwrap_or(Value::Null),
             ))

--- a/device/protocol/src/ui/mod.rs
+++ b/device/protocol/src/ui/mod.rs
@@ -406,6 +406,8 @@ pub enum UiEvent {
     Ready(UiReady),
     Input(UiInputEvent),
     Intent(UiIntent),
+    FocusChanged(UiFocusChanged),
+    FocusCleared,
     ScreenChanged(UiScreenChanged),
     Health(UiHealth),
     ScreenshotCaptured(UiScreenshotCaptured),
@@ -435,6 +437,8 @@ impl UiEvent {
             "ui.intent" => Ok(Self::Intent(UiIntent::from_event_payload(
                 &envelope.payload,
             )?)),
+            "ui.focus_changed" => Ok(Self::FocusChanged(decode_payload(envelope.payload)?)),
+            "ui.focus_cleared" => Ok(Self::FocusCleared),
             "ui.screen_changed" => Ok(Self::ScreenChanged(decode_payload(envelope.payload)?)),
             "ui.health" => Ok(Self::Health(decode_payload(envelope.payload)?)),
             "ui.screenshot_captured" => {
@@ -453,11 +457,28 @@ impl UiEvent {
             Self::Ready(ready) => event("ui.ready", ready),
             Self::Input(input) => event("ui.input", input),
             Self::Intent(intent) => WorkerEnvelope::event("ui.intent", intent.to_event_payload()),
+            Self::FocusChanged(changed) => event("ui.focus_changed", changed),
+            Self::FocusCleared => WorkerEnvelope::event("ui.focus_cleared", json!({})),
             Self::ScreenChanged(changed) => event("ui.screen_changed", changed),
             Self::Health(health) => event("ui.health", health),
             Self::ScreenshotCaptured(captured) => event("ui.screenshot_captured", captured),
             Self::Error(error) => event("ui.error", error),
             Self::ShutdownComplete => WorkerEnvelope::event("ui.shutdown_complete", json!({})),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UiFocusChanged {
+    pub request_id: String,
+    pub label: String,
+}
+
+impl UiFocusChanged {
+    pub fn new(request_id: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            request_id: request_id.into(),
+            label: label.into(),
         }
     }
 }
@@ -1152,6 +1173,8 @@ mod tests {
                 duration_ms: 7,
             }),
             UiEvent::Intent(UiIntent::Runtime(RuntimeIntent::Shutdown)),
+            UiEvent::FocusChanged(UiFocusChanged::new("ui-focus-7", "Mama")),
+            UiEvent::FocusCleared,
             UiEvent::ScreenChanged(UiScreenChanged {
                 screen: UiScreen::Hub,
                 title: "Hub".to_string(),

--- a/device/runtime/src/event.rs
+++ b/device/runtime/src/event.rs
@@ -3,8 +3,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::{json, Value};
 use yoyopod_protocol::ui::{
     CallIntent, ContactAction, InputAction, ListItemAction, MusicIntent, PowerIntent,
-    RuntimeIntent, SystemIntent, UiCommand, UiEvent, UiInputEvent, UiIntent, UiScreen,
-    UiScreenshotCaptured, VoiceFileAction, VoiceIntent, VoiceRecipientAction,
+    RuntimeIntent, SystemIntent, UiCommand, UiEvent, UiFocusChanged, UiInputEvent, UiIntent,
+    UiScreen, UiScreenshotCaptured, VoiceFileAction, VoiceIntent, VoiceRecipientAction,
 };
 
 use crate::protocol::{EnvelopeKind, WorkerEnvelope};
@@ -27,8 +27,14 @@ pub enum RuntimeEvent {
     VoiceTranscript(Value),
     VoiceAskResult(Value),
     VoiceSpeakResult(Value),
+    VoiceFocusPromptResult {
+        request_id: Option<String>,
+        payload: Value,
+    },
     UiInput(UiInputEvent),
     UiIntent(UiIntent),
+    UiFocusChanged(UiFocusChanged),
+    UiFocusCleared,
     UiScreenChanged {
         screen: UiScreen,
     },
@@ -94,6 +100,7 @@ impl RuntimeEvent {
             Self::VoiceTranscript(snapshot) => state.apply_voice_transcript(snapshot),
             Self::VoiceAskResult(snapshot) => state.apply_voice_ask_result(snapshot),
             Self::VoiceSpeakResult(_) => state.mark_ask_available(),
+            Self::VoiceFocusPromptResult { .. } => {}
             Self::UiScreenChanged { screen } => {
                 state.current_screen = *screen;
             }
@@ -111,6 +118,12 @@ impl RuntimeEvent {
                 }
             }
             Self::UiIntent(intent) => state.apply_ui_intent(intent),
+            Self::UiFocusChanged(changed) => {
+                state.focus_prompt_request_id = Some(changed.request_id.clone());
+            }
+            Self::UiFocusCleared => {
+                state.focus_prompt_request_id = None;
+            }
             Self::UiInput(_) | Self::UiScreenshotCaptured(_) | Self::Shutdown | Self::Ignored => {}
         }
     }
@@ -127,6 +140,7 @@ pub fn runtime_event_from_worker(
     let WorkerEnvelope {
         kind,
         message_type,
+        request_id,
         payload,
         ..
     } = envelope;
@@ -150,7 +164,7 @@ pub fn runtime_event_from_worker(
             Some(RuntimeEvent::PowerSnapshot(payload))
         }
         EnvelopeKind::Result if domain == WorkerDomain::Voice => {
-            Some(voice_event_from_message(&message_type, payload))
+            Some(voice_event_from_message(&message_type, request_id, payload))
         }
         EnvelopeKind::Command | EnvelopeKind::Result | EnvelopeKind::Heartbeat => {
             Some(RuntimeEvent::Ignored)
@@ -182,6 +196,8 @@ fn runtime_event_from_ui_envelope(envelope: WorkerEnvelope) -> RuntimeEvent {
                 RuntimeEvent::UiIntent(intent)
             }
         }
+        Ok(UiEvent::FocusChanged(changed)) => RuntimeEvent::UiFocusChanged(changed),
+        Ok(UiEvent::FocusCleared) => RuntimeEvent::UiFocusCleared,
         Ok(UiEvent::ScreenChanged(changed)) => RuntimeEvent::UiScreenChanged {
             screen: changed.screen,
         },
@@ -222,6 +238,12 @@ pub fn commands_for_event(state: &RuntimeState, event: &RuntimeEvent) -> Vec<Run
         RuntimeEvent::VoiceSpeakResult(snapshot) => {
             with_ask_log(commands_for_voice_speak_result(snapshot), "audio_ready")
         }
+        RuntimeEvent::VoiceFocusPromptResult {
+            request_id,
+            payload,
+        } => commands_for_voice_focus_prompt_result(state, request_id.as_deref(), payload),
+        RuntimeEvent::UiFocusChanged(changed) => commands_for_ui_focus_changed(state, changed),
+        RuntimeEvent::UiFocusCleared => cancel_focus_prompt_commands(),
         RuntimeEvent::UiScreenshotCaptured(captured) => vec![RuntimeCommand::AppendAppLog {
             line: screenshot_log_line(captured),
         }],
@@ -299,7 +321,7 @@ fn runtime_event_from_message(
         WorkerDomain::Voip => voip_event_from_message(message_type, payload),
         WorkerDomain::Network => network_event_from_message(message_type, payload),
         WorkerDomain::Power => power_event_from_message(message_type, payload),
-        WorkerDomain::Voice => voice_event_from_message(message_type, payload),
+        WorkerDomain::Voice => voice_event_from_message(message_type, None, payload),
     }
 }
 
@@ -378,7 +400,11 @@ fn power_event_from_message(message_type: &str, payload: Value) -> RuntimeEvent 
     }
 }
 
-fn voice_event_from_message(message_type: &str, payload: Value) -> RuntimeEvent {
+fn voice_event_from_message(
+    message_type: &str,
+    request_id: Option<String>,
+    payload: Value,
+) -> RuntimeEvent {
     match message_type {
         "voice.ready" => RuntimeEvent::WorkerReady {
             domain: WorkerDomain::Voice,
@@ -402,12 +428,69 @@ fn voice_event_from_message(message_type: &str, payload: Value) -> RuntimeEvent 
         "voice.transcribe.result" | "voice.transcript" => RuntimeEvent::VoiceTranscript(payload),
         "voice.ask.result" => RuntimeEvent::VoiceAskResult(payload),
         "voice.speak.result" => RuntimeEvent::VoiceSpeakResult(payload),
+        "voice.focus_prompt.result" => RuntimeEvent::VoiceFocusPromptResult {
+            request_id,
+            payload,
+        },
         "voice.error" => RuntimeEvent::WorkerError {
             domain: WorkerDomain::Voice,
             message: worker_error_message(message_type, &payload),
         },
         _ => RuntimeEvent::Ignored,
     }
+}
+
+fn commands_for_ui_focus_changed(
+    state: &RuntimeState,
+    changed: &UiFocusChanged,
+) -> Vec<RuntimeCommand> {
+    if !state.settings.speak_names
+        || changed.request_id.trim().is_empty()
+        || changed.label.trim().is_empty()
+    {
+        return Vec::new();
+    }
+    let mut envelope = WorkerEnvelope::command(
+        "voice.focus_prompt",
+        Some(changed.request_id.clone()),
+        state.voice.speak_payload(&changed.label),
+    );
+    envelope.deadline_ms = state.voice.speech_settings.request_timeout_ms;
+    vec![
+        worker_command(
+            WorkerDomain::Voip,
+            "voip.stop_focus_prompt_playback",
+            empty_payload(),
+        ),
+        RuntimeCommand::WorkerCommand {
+            domain: WorkerDomain::Voice,
+            envelope,
+        },
+        RuntimeCommand::AppendAppLog {
+            line: format!(
+                "UI focus prompt request_id={} label={:?}",
+                changed.request_id, changed.label
+            ),
+        },
+    ]
+}
+
+fn cancel_focus_prompt_commands() -> Vec<RuntimeCommand> {
+    vec![
+        worker_command(
+            WorkerDomain::Voice,
+            "voice.cancel_focus_prompt",
+            empty_payload(),
+        ),
+        worker_command(
+            WorkerDomain::Voip,
+            "voip.stop_focus_prompt_playback",
+            empty_payload(),
+        ),
+        RuntimeCommand::AppendAppLog {
+            line: "UI focus prompt cleared".to_string(),
+        },
+    ]
 }
 
 fn commands_for_ui_intent(state: &RuntimeState, intent: &UiIntent) -> Vec<RuntimeCommand> {
@@ -835,6 +918,29 @@ fn commands_for_voice_speak_result(payload: &Value) -> Vec<RuntimeCommand> {
             )]
         })
         .unwrap_or_default()
+}
+
+fn commands_for_voice_focus_prompt_result(
+    state: &RuntimeState,
+    request_id: Option<&str>,
+    payload: &Value,
+) -> Vec<RuntimeCommand> {
+    if request_id.is_none() || state.focus_prompt_request_id.as_deref() != request_id {
+        return Vec::new();
+    }
+    let Some(file_path) = string_field(payload, "audio_path") else {
+        return Vec::new();
+    };
+    vec![
+        worker_command(
+            WorkerDomain::Voip,
+            "voip.play_focus_prompt",
+            json!({ "file_path": file_path }),
+        ),
+        RuntimeCommand::AppendAppLog {
+            line: "UI focus prompt audio ready".to_string(),
+        },
+    ]
 }
 
 fn commands_for_voice_command(
@@ -1427,7 +1533,86 @@ mod tests {
     use super::*;
     use yoyopod_protocol::ui::{
         ListItemAction, MusicIntent, PlaylistTrackAction, SettingsIntent, SystemIntent, UiEvent,
+        UiFocusChanged,
     };
+
+    #[test]
+    fn focus_change_routes_through_cancellable_prompt_pipeline() {
+        let changed = UiFocusChanged::new("ui-focus-3", "Mama");
+        let envelope = UiEvent::FocusChanged(changed.clone()).into_envelope();
+        let event = runtime_event_from_worker(WorkerDomain::Ui, envelope).unwrap();
+        assert_eq!(event, RuntimeEvent::UiFocusChanged(changed));
+
+        let commands = commands_for_event(&RuntimeState::default(), &event);
+        assert_eq!(commands.len(), 3);
+        assert!(matches!(
+            &commands[0],
+            RuntimeCommand::WorkerCommand { domain: WorkerDomain::Voip, envelope }
+                if envelope.message_type == "voip.stop_focus_prompt_playback"
+        ));
+        assert!(matches!(
+            &commands[1],
+            RuntimeCommand::WorkerCommand { domain: WorkerDomain::Voice, envelope }
+                if envelope.message_type == "voice.focus_prompt"
+                    && envelope.request_id.as_deref() == Some("ui-focus-3")
+                    && envelope.payload["text"] == "Mama"
+        ));
+        assert!(matches!(
+            &commands[2],
+            RuntimeCommand::AppendAppLog { line }
+                if line.contains("request_id=ui-focus-3") && line.contains("Mama")
+        ));
+    }
+
+    #[test]
+    fn focus_prompt_audio_uses_its_isolated_voip_channel() {
+        let event = runtime_event_from_worker(
+            WorkerDomain::Voice,
+            WorkerEnvelope::result(
+                "voice.focus_prompt.result",
+                Some("ui-focus-3".to_string()),
+                json!({"audio_path": "/tmp/focus.wav"}),
+            ),
+        )
+        .unwrap();
+        let mut state = RuntimeState::default();
+        state.focus_prompt_request_id = Some("ui-focus-3".to_string());
+        let commands = commands_for_event(&state, &event);
+
+        assert!(matches!(
+            &commands[0],
+            RuntimeCommand::WorkerCommand { domain: WorkerDomain::Voip, envelope }
+                if envelope.message_type == "voip.play_focus_prompt"
+                    && envelope.payload["file_path"] == "/tmp/focus.wav"
+        ));
+
+        state.focus_prompt_request_id = Some("ui-focus-4".to_string());
+        assert!(commands_for_event(&state, &event).is_empty());
+    }
+
+    #[test]
+    fn focus_clear_cancels_only_focus_prompt_work_and_playback() {
+        let event =
+            runtime_event_from_worker(WorkerDomain::Ui, UiEvent::FocusCleared.into_envelope())
+                .unwrap();
+        let commands = commands_for_event(&RuntimeState::default(), &event);
+        let message_types = commands
+            .iter()
+            .filter_map(|command| match command {
+                RuntimeCommand::WorkerCommand { envelope, .. } => {
+                    Some(envelope.message_type.as_str())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            message_types,
+            vec![
+                "voice.cancel_focus_prompt",
+                "voip.stop_focus_prompt_playback"
+            ]
+        );
+    }
 
     #[test]
     fn typed_music_intent_routes_to_media_command() {

--- a/device/runtime/src/state.rs
+++ b/device/runtime/src/state.rs
@@ -647,6 +647,7 @@ pub struct OverlayRuntimeState {
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeState {
     pub current_screen: UiScreen,
+    pub focus_prompt_request_id: Option<String>,
     pub media: MediaState,
     pub call: CallRuntimeState,
     pub voice: VoiceRuntimeState,
@@ -672,6 +673,7 @@ impl Default for RuntimeState {
     fn default() -> Self {
         Self {
             current_screen: UiScreen::Hub,
+            focus_prompt_request_id: None,
             media: MediaState::default(),
             call: CallRuntimeState::default(),
             voice: VoiceRuntimeState::default(),
@@ -1586,6 +1588,9 @@ impl RuntimeState {
     }
 
     fn apply_voice_note_playback_snapshot(&mut self, playback: &Value) {
+        if playback.get("purpose").and_then(Value::as_str) == Some("focus_prompt") {
+            return;
+        }
         let was_playing = self.voice.playback_active;
         if let Some(playing) = playback.get("playing").and_then(Value::as_bool) {
             self.voice.playback_active = playing;

--- a/device/speech/src/worker.rs
+++ b/device/speech/src/worker.rs
@@ -59,6 +59,7 @@ where
     let (work_tx, work_rx) = mpsc::channel::<WorkCompletion>();
     let input_rx = spawn_input_reader(input);
     let mut active: Option<ActiveRequest> = None;
+    let mut next_generation = 0_u64;
     let mut input_closed = false;
     loop {
         drain_completed(output, &work_rx, &mut active)?;
@@ -104,6 +105,7 @@ where
             Arc::clone(&provider),
             &work_tx,
             &mut active,
+            &mut next_generation,
             envelope,
         )? {
             break;
@@ -145,12 +147,15 @@ where
 
 struct ActiveRequest {
     request_id: Option<String>,
+    generation: u64,
+    kind: RequestKind,
     context: SpeechRequestContext,
     cancel_acknowledged: bool,
 }
 
 struct WorkCompletion {
     request_id: Option<String>,
+    generation: u64,
     context: SpeechRequestContext,
     envelope: WorkerEnvelope,
 }
@@ -159,6 +164,13 @@ struct WorkStart {
     request_id: Option<String>,
     deadline_ms: u64,
     result_type: &'static str,
+    kind: RequestKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequestKind {
+    General,
+    FocusPrompt,
 }
 
 fn handle_command<W, P>(
@@ -166,6 +178,7 @@ fn handle_command<W, P>(
     provider: Arc<P>,
     work_tx: &mpsc::Sender<WorkCompletion>,
     active: &mut Option<ActiveRequest>,
+    next_generation: &mut u64,
     envelope: WorkerEnvelope,
 ) -> Result<bool>
 where
@@ -200,7 +213,9 @@ where
                     request_id,
                     deadline_ms: envelope.deadline_ms,
                     result_type: "voice.transcribe.result",
+                    kind: RequestKind::General,
                 },
+                next_generation,
                 move |provider, context| provider.transcribe(&context, request),
             )?;
         }
@@ -224,7 +239,47 @@ where
                     request_id,
                     deadline_ms: envelope.deadline_ms,
                     result_type: "voice.speak.result",
+                    kind: RequestKind::General,
                 },
+                next_generation,
+                move |provider, context| provider.speak(&context, request),
+            )?;
+        }
+        "voice.focus_prompt" => {
+            let request = match decode_payload::<SpeakRequest>(envelope.payload) {
+                Ok(request) => request,
+                Err(error) => {
+                    emit(
+                        output,
+                        &voice_error(request_id, "invalid_payload", error.to_string(), false),
+                    )?;
+                    return Ok(false);
+                }
+            };
+            if request_id.as_deref().is_none_or(str::is_empty) {
+                emit(
+                    output,
+                    &voice_error(
+                        request_id,
+                        "invalid_payload",
+                        "voice.focus_prompt requires request_id",
+                        false,
+                    ),
+                )?;
+                return Ok(false);
+            }
+            start_work(
+                output,
+                provider,
+                work_tx,
+                active,
+                WorkStart {
+                    request_id,
+                    deadline_ms: envelope.deadline_ms,
+                    result_type: "voice.focus_prompt.result",
+                    kind: RequestKind::FocusPrompt,
+                },
+                next_generation,
                 move |provider, context| provider.speak(&context, request),
             )?;
         }
@@ -248,11 +303,14 @@ where
                     request_id,
                     deadline_ms: envelope.deadline_ms,
                     result_type: "voice.ask.result",
+                    kind: RequestKind::General,
                 },
+                next_generation,
                 move |provider, context| provider.ask(&context, request),
             )?;
         }
         "voice.cancel" => handle_cancel(output, active, request_id, envelope.payload)?,
+        "voice.cancel_focus_prompt" => handle_focus_prompt_cancel(output, active, request_id)?,
         "voice.shutdown" | "worker.stop" => {
             if let Some(active) = active.as_ref() {
                 active.context.cancel();
@@ -286,6 +344,7 @@ fn start_work<W, P, F, T>(
     work_tx: &mpsc::Sender<WorkCompletion>,
     active: &mut Option<ActiveRequest>,
     spec: WorkStart,
+    next_generation: &mut u64,
     work: F,
 ) -> Result<()>
 where
@@ -294,7 +353,10 @@ where
     F: FnOnce(Arc<P>, SpeechRequestContext) -> Result<T> + Send + 'static,
     T: serde::Serialize,
 {
-    if active.is_some() {
+    if active
+        .as_ref()
+        .is_some_and(|active| active.kind == RequestKind::General)
+    {
         emit(
             output,
             &voice_error(
@@ -306,9 +368,16 @@ where
         )?;
         return Ok(());
     }
+    if let Some(active) = active.as_ref() {
+        active.context.cancel();
+    }
+    *next_generation = next_generation.wrapping_add(1);
+    let generation = *next_generation;
     let context = SpeechRequestContext::new(spec.deadline_ms);
     *active = Some(ActiveRequest {
         request_id: spec.request_id.clone(),
+        generation,
+        kind: spec.kind,
         context: context.clone(),
         cancel_acknowledged: false,
     });
@@ -319,6 +388,7 @@ where
             completion_envelope(spec.result_type, spec.request_id.clone(), result, &context);
         let _ = work_tx.send(WorkCompletion {
             request_id: spec.request_id,
+            generation,
             context,
             envelope,
         });
@@ -406,6 +476,35 @@ where
     Ok(())
 }
 
+fn handle_focus_prompt_cancel<W>(
+    output: &mut W,
+    active: &mut Option<ActiveRequest>,
+    request_id: Option<String>,
+) -> Result<()>
+where
+    W: Write,
+{
+    let matched = active
+        .as_ref()
+        .is_some_and(|active| active.kind == RequestKind::FocusPrompt);
+    if let Some(active) = active.as_mut().filter(|_| matched) {
+        active.context.cancel();
+        active.cancel_acknowledged = true;
+    }
+    emit(
+        output,
+        &WorkerEnvelope::result(
+            "voice.focus_prompt.cancelled",
+            request_id,
+            json!({
+                "cancelled": matched,
+                "reason": if matched { "cancel_requested" } else { "not_active" },
+            }),
+        ),
+    )?;
+    Ok(())
+}
+
 fn drain_completed<W>(
     output: &mut W,
     work_rx: &mpsc::Receiver<WorkCompletion>,
@@ -430,7 +529,7 @@ where
 {
     let is_active = active
         .as_ref()
-        .map(|active| active.request_id == completion.request_id)
+        .map(|active| active.generation == completion.generation)
         .unwrap_or(false);
     let cancel_already_acknowledged = active
         .as_ref()
@@ -498,11 +597,97 @@ where
 mod tests {
     use super::*;
 
+    fn work_start(request_id: &str, kind: RequestKind) -> WorkStart {
+        WorkStart {
+            request_id: Some(request_id.to_string()),
+            deadline_ms: 5_000,
+            result_type: "voice.focus_prompt.result",
+            kind,
+        }
+    }
+
+    #[test]
+    fn newer_focus_prompt_preempts_the_previous_generation() {
+        let provider = Arc::new(MockProvider);
+        let (work_tx, _work_rx) = mpsc::channel();
+        let mut active = None;
+        let mut generation = 0;
+        let mut output = Vec::new();
+
+        start_work(
+            &mut output,
+            Arc::clone(&provider),
+            &work_tx,
+            &mut active,
+            work_start("focus-1", RequestKind::FocusPrompt),
+            &mut generation,
+            |_, _| Ok(json!({"audio_path": "first.wav"})),
+        )
+        .unwrap();
+        let first_context = active.as_ref().unwrap().context.clone();
+
+        start_work(
+            &mut output,
+            provider,
+            &work_tx,
+            &mut active,
+            work_start("focus-2", RequestKind::FocusPrompt),
+            &mut generation,
+            |_, _| Ok(json!({"audio_path": "second.wav"})),
+        )
+        .unwrap();
+
+        assert!(first_context.is_cancelled());
+        assert_eq!(
+            active.as_ref().unwrap().request_id.as_deref(),
+            Some("focus-2")
+        );
+        assert_eq!(active.as_ref().unwrap().generation, 2);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn focus_prompt_never_interrupts_general_speech_work() {
+        let provider = Arc::new(MockProvider);
+        let (work_tx, _work_rx) = mpsc::channel();
+        let mut active = None;
+        let mut generation = 0;
+        let mut output = Vec::new();
+
+        start_work(
+            &mut output,
+            Arc::clone(&provider),
+            &work_tx,
+            &mut active,
+            work_start("ask", RequestKind::General),
+            &mut generation,
+            |_, _| Ok(json!({"answer": "hello"})),
+        )
+        .unwrap();
+        start_work(
+            &mut output,
+            provider,
+            &work_tx,
+            &mut active,
+            work_start("focus", RequestKind::FocusPrompt),
+            &mut generation,
+            |_, _| Ok(json!({"audio_path": "focus.wav"})),
+        )
+        .unwrap();
+
+        assert_eq!(active.as_ref().unwrap().request_id.as_deref(), Some("ask"));
+        let envelope = WorkerEnvelope::decode(&output).unwrap();
+        assert_eq!(envelope.message_type, "voice.error");
+        assert_eq!(envelope.payload["code"], "busy");
+    }
+
     #[test]
     fn cancel_without_request_id_cancels_the_single_active_request() {
         let context = SpeechRequestContext::new(5_000);
         let mut active = Some(ActiveRequest {
             request_id: None,
+            generation: 1,
+            kind: RequestKind::General,
             context: context.clone(),
             cancel_acknowledged: false,
         });

--- a/device/ui/src/application/accessibility.rs
+++ b/device/ui/src/application/accessibility.rs
@@ -1,0 +1,235 @@
+use yoyopod_protocol::ui::{ListItemSnapshot, RuntimeSnapshot, UiScreen};
+
+use super::options;
+use super::state::HomeMode;
+use super::UiRuntime;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FocusDescriptor {
+    pub key: String,
+    pub label: String,
+}
+
+impl FocusDescriptor {
+    fn new(key: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            label: label.into(),
+        }
+    }
+}
+
+pub(crate) fn focused_item(runtime: &UiRuntime) -> Option<FocusDescriptor> {
+    let snapshot = &runtime.snapshot;
+    let focus = runtime.focus_index;
+    match runtime.active_screen {
+        UiScreen::Hub if runtime.home_mode == HomeMode::Focused => snapshot
+            .hub
+            .cards
+            .get(focus)
+            .or_else(|| snapshot.hub.cards.first())
+            .map(|card| FocusDescriptor::new(card.key.clone(), card.title.clone())),
+        UiScreen::Hub => None,
+        UiScreen::Listen => list_item(options::listen_items(snapshot).get(focus)),
+        UiScreen::Playlists => list_or_empty(&snapshot.music.playlists, focus, "No playlists"),
+        UiScreen::PlaylistTracks => {
+            let tracks = runtime
+                .selected_playlist
+                .as_ref()
+                .and_then(|playlist| snapshot.music.playlist_tracks.get(&playlist.id))
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            list_or_empty(tracks, focus, "No tracks")
+        }
+        UiScreen::RecentTracks => {
+            list_or_empty(&snapshot.music.recent_tracks, focus, "No recent tracks")
+        }
+        UiScreen::NowPlaying => Some(static_item(
+            focus,
+            &["Previous", music_play_pause_label(snapshot), "Next"],
+        )),
+        UiScreen::Ask | UiScreen::Loading | UiScreen::Error => None,
+        UiScreen::Talk | UiScreen::Contacts | UiScreen::SetupContacts => list_or_empty(
+            &snapshot.call.contacts,
+            focus,
+            "No contacts yet. Ask a grown-up!",
+        ),
+        UiScreen::CallHistory => list_or_empty(&snapshot.call.history, focus, "No recent calls"),
+        UiScreen::TalkContact => Some(static_item(focus, &["Call", "Hold to record", "Replay"])),
+        UiScreen::Replay => {
+            if runtime.replay_notes().is_empty() {
+                Some(FocusDescriptor::new("empty", "No recordings"))
+            } else {
+                let labels = ["Delete", voice_play_pause_label(snapshot), "Next"];
+                Some(static_item(focus, &labels))
+            }
+        }
+        UiScreen::VoiceNote => voice_note_item(runtime),
+        UiScreen::IncomingCall => Some(static_item(focus, &["Answer call", "Reject call"])),
+        UiScreen::OutgoingCall => Some(FocusDescriptor::new("hang_up", "Hang up")),
+        UiScreen::InCall => Some(static_item(
+            focus,
+            &[
+                if snapshot.call.muted {
+                    "Unmute"
+                } else {
+                    "Mute"
+                },
+                "Hang up",
+            ],
+        )),
+        UiScreen::Setup => setup_root_item(snapshot, focus),
+        UiScreen::SetupVolume => Some(FocusDescriptor::new(
+            "volume",
+            format!("Volume, level {}", snapshot.settings.volume_level),
+        )),
+        UiScreen::SetupCompanion => choice_item(
+            focus,
+            &["Blob", "Owl", "Cat", "Bunny", "Robot"],
+            &snapshot.settings.companion,
+        ),
+        UiScreen::SetupTheme => {
+            choice_item(focus, &["Light", "Dark", "Auto"], &snapshot.settings.theme)
+        }
+        UiScreen::SetupAbout => Some(FocusDescriptor::new("about", "About")),
+    }
+}
+
+fn list_or_empty(
+    items: &[ListItemSnapshot],
+    focus: usize,
+    empty_label: &'static str,
+) -> Option<FocusDescriptor> {
+    if items.is_empty() {
+        Some(FocusDescriptor::new("empty", empty_label))
+    } else {
+        list_item(items.get(focus).or_else(|| items.first()))
+    }
+}
+
+fn list_item(item: Option<&ListItemSnapshot>) -> Option<FocusDescriptor> {
+    item.map(|item| FocusDescriptor::new(item.id.clone(), item.title.clone()))
+}
+
+fn static_item(focus: usize, labels: &[&str]) -> FocusDescriptor {
+    let index = focus.min(labels.len().saturating_sub(1));
+    let label = labels.get(index).copied().unwrap_or_default();
+    FocusDescriptor::new(format!("item_{index}"), label)
+}
+
+fn music_play_pause_label(snapshot: &RuntimeSnapshot) -> &'static str {
+    if snapshot.music.playing {
+        "Pause"
+    } else if snapshot.music.paused {
+        "Resume"
+    } else {
+        "Play"
+    }
+}
+
+fn voice_play_pause_label(snapshot: &RuntimeSnapshot) -> &'static str {
+    if snapshot.voice.playback_active {
+        "Pause"
+    } else if snapshot.voice.playback_paused {
+        "Resume"
+    } else {
+        "Play"
+    }
+}
+
+fn voice_note_item(runtime: &UiRuntime) -> Option<FocusDescriptor> {
+    let labels: &[&str] = match runtime.voice_note_phase().as_str() {
+        "review" => &["Send", "Play", "Again"],
+        "failed" => &["Retry", "Again"],
+        _ => return None,
+    };
+    Some(static_item(runtime.focus_index, labels))
+}
+
+fn setup_root_item(snapshot: &RuntimeSnapshot, focus: usize) -> Option<FocusDescriptor> {
+    let labels = [
+        format!("Volume, level {}", snapshot.settings.volume_level),
+        format!("Companion, {}", snapshot.settings.companion),
+        format!("Contacts, {}", snapshot.call.contacts.len()),
+        format!("Theme, {}", snapshot.settings.theme),
+        format!(
+            "Speak names, {}",
+            if snapshot.settings.speak_names {
+                "on"
+            } else {
+                "off"
+            }
+        ),
+        "About".to_string(),
+    ];
+    let index = focus.min(labels.len().saturating_sub(1));
+    labels
+        .get(index)
+        .map(|label| FocusDescriptor::new(format!("item_{index}"), label.clone()))
+}
+
+fn choice_item(focus: usize, labels: &[&str], current: &str) -> Option<FocusDescriptor> {
+    let index = focus.min(labels.len().saturating_sub(1));
+    labels.get(index).map(|label| {
+        let spoken = if label.eq_ignore_ascii_case(current) {
+            format!("{label}, current")
+        } else {
+            (*label).to_string()
+        };
+        FocusDescriptor::new(format!("item_{index}"), spoken)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yoyopod_protocol::ui::VoiceNoteSummarySnapshot;
+
+    #[test]
+    fn dynamic_lists_speak_the_rendered_item_and_empty_state() {
+        let mut runtime = UiRuntime {
+            active_screen: UiScreen::Playlists,
+            ..UiRuntime::default()
+        };
+        assert_eq!(focused_item(&runtime).unwrap().label, "No playlists");
+
+        runtime.snapshot.music.playlists = vec![ListItemSnapshot::new(
+            "bedtime",
+            "Bedtime songs",
+            "3 tracks",
+            "playlist",
+        )];
+        assert_eq!(focused_item(&runtime).unwrap().label, "Bedtime songs");
+    }
+
+    #[test]
+    fn transport_labels_follow_live_playback_state() {
+        let mut runtime = UiRuntime {
+            active_screen: UiScreen::NowPlaying,
+            focus_index: 1,
+            ..UiRuntime::default()
+        };
+        assert_eq!(focused_item(&runtime).unwrap().label, "Play");
+
+        runtime.snapshot.music.playing = true;
+        assert_eq!(focused_item(&runtime).unwrap().label, "Pause");
+    }
+
+    #[test]
+    fn replay_has_a_spoken_empty_state() {
+        let mut runtime = UiRuntime {
+            active_screen: UiScreen::Replay,
+            ..UiRuntime::default()
+        };
+        assert_eq!(focused_item(&runtime).unwrap().label, "No recordings");
+
+        let contact = ListItemSnapshot::new("mama", "Mama", "", "mono:M");
+        runtime.selected_contact = Some(contact.clone());
+        runtime
+            .snapshot
+            .call
+            .voice_notes_by_contact
+            .insert(contact.id, vec![VoiceNoteSummarySnapshot::default()]);
+        assert_eq!(focused_item(&runtime).unwrap().label, "Delete");
+    }
+}

--- a/device/ui/src/application/mod.rs
+++ b/device/ui/src/application/mod.rs
@@ -1,3 +1,4 @@
+pub mod accessibility;
 pub mod focus;
 pub mod input_router;
 pub mod intents;

--- a/device/ui/src/application/options.rs
+++ b/device/ui/src/application/options.rs
@@ -7,9 +7,9 @@ pub struct TalkContactAction {
 
 pub fn listen_items(_snapshot: &RuntimeSnapshot) -> Vec<ListItemSnapshot> {
     vec![
-        ListItemSnapshot::new("playlists", "Playlists", "Saved mixes", "playlist"),
-        ListItemSnapshot::new("recent_tracks", "Recent", "Recently played", "recent"),
-        ListItemSnapshot::new("shuffle", "Shuffle All", "Start music", "shuffle"),
+        ListItemSnapshot::new("playlists", "Playlists", "", "icon_playlists"),
+        ListItemSnapshot::new("recent_tracks", "Recents", "", "icon_recents"),
+        ListItemSnapshot::new("shuffle", "Shuffle all", "", "icon_shuffle"),
     ]
 }
 

--- a/device/ui/src/application/runtime.rs
+++ b/device/ui/src/application/runtime.rs
@@ -1,6 +1,7 @@
 use time::OffsetDateTime;
 use yoyopod_protocol::ui::{
-    AnimationRequest, InputAction, RuntimeSnapshot, RuntimeSnapshotPatch, SystemIntent, UiIntent,
+    AnimationRequest, InputAction, RuntimeSnapshot, RuntimeSnapshotPatch, SystemIntent, UiEvent,
+    UiFocusChanged, UiIntent,
 };
 
 use crate::animation;
@@ -67,6 +68,7 @@ impl UiRuntime {
         navigator::clamp_focus(self);
         self.reconcile_pending_wheel_roll(pending_identity);
         self.dirty.mark_full();
+        self.refresh_focus_accessibility();
     }
 
     pub fn apply_patch(&mut self, patch: RuntimeSnapshotPatch) {
@@ -99,6 +101,7 @@ impl UiRuntime {
         if self.focus_index != previous_focus {
             self.dirty.focus = true;
         }
+        self.refresh_focus_accessibility();
     }
 
     pub fn handle_input(&mut self, action: InputAction, now_ms: u64) {
@@ -125,6 +128,7 @@ impl UiRuntime {
             }
             self.dirty.input = true;
             self.dirty.focus = true;
+            self.refresh_focus_accessibility();
             return;
         }
         if self.pending_wheel_roll.is_some() {
@@ -163,6 +167,7 @@ impl UiRuntime {
         navigator::clamp_focus(self);
         self.dirty.input = true;
         self.dirty.focus = true;
+        self.refresh_focus_accessibility();
     }
 
     pub(crate) fn wake_home_from_ambient(&mut self, now_ms: u64) -> bool {
@@ -174,6 +179,7 @@ impl UiRuntime {
         self.home_mode = HomeMode::Idle;
         self.dirty.input = true;
         self.dirty.focus = true;
+        self.refresh_focus_accessibility();
         true
     }
 
@@ -192,6 +198,7 @@ impl UiRuntime {
         if let Some(next) = next {
             self.home_mode = next;
             self.dirty.focus = true;
+            self.refresh_focus_accessibility();
         }
     }
 
@@ -372,6 +379,7 @@ impl UiRuntime {
             self.commit_pending_wheel_roll();
             navigator::clamp_focus(self);
             self.dirty.focus = true;
+            self.refresh_focus_accessibility();
         }
         if had_transitions || had_wheel_roll {
             self.dirty.animation = true;
@@ -399,6 +407,7 @@ impl UiRuntime {
         navigator::apply_runtime_preemption(self);
         self.dirty.overlay = true;
         self.dirty.navigation = true;
+        self.refresh_focus_accessibility();
     }
 
     pub fn scene_graph(&self, now_ms: u64) -> SceneGraph {
@@ -506,6 +515,44 @@ impl UiRuntime {
 
     pub fn take_intents(&mut self) -> Vec<UiIntent> {
         std::mem::take(&mut self.intents)
+    }
+
+    pub fn take_accessibility_events(&mut self) -> Vec<UiEvent> {
+        std::mem::take(&mut self.accessibility_events)
+    }
+
+    pub(crate) fn refresh_focus_accessibility(&mut self) {
+        let descriptor = super::accessibility::focused_item(self);
+        if !self.snapshot.settings.speak_names || descriptor.is_none() {
+            if self.last_focus_identity.take().is_some() {
+                self.accessibility_events.push(UiEvent::FocusCleared);
+            }
+            return;
+        }
+
+        let descriptor = descriptor.expect("focus descriptor checked above");
+        if descriptor.label.trim().is_empty() {
+            return;
+        }
+        let identity = format!(
+            "{}|{}|{}|{}|{}",
+            self.active_screen.as_str(),
+            self.route_key(self.active_screen).unwrap_or_default(),
+            self.focus_index,
+            descriptor.key,
+            descriptor.label,
+        );
+        if self.last_focus_identity.as_deref() == Some(identity.as_str()) {
+            return;
+        }
+
+        self.focus_prompt_sequence = self.focus_prompt_sequence.wrapping_add(1);
+        self.last_focus_identity = Some(identity);
+        self.accessibility_events
+            .push(UiEvent::FocusChanged(UiFocusChanged::new(
+                format!("ui-focus-{}", self.focus_prompt_sequence),
+                descriptor.label,
+            )));
     }
 
     pub fn wants_ptt_passthrough(&self) -> bool {
@@ -947,8 +994,8 @@ mod tests {
     use crate::scene::roles;
     use yoyopod_protocol::ui::{
         CallIntent, ContactAction, ListItemSnapshot, MusicIntent, OverlayRuntimeSnapshot,
-        PlaylistTrackAction, SettingsIntent, SystemIntent, VoiceIntent, VoiceNoteSummarySnapshot,
-        VoiceRecipientAction,
+        PlaylistTrackAction, SettingsIntent, SettingsRuntimeSnapshot, SystemIntent, UiEvent,
+        UiFocusChanged, VoiceIntent, VoiceNoteSummarySnapshot, VoiceRecipientAction,
     };
 
     fn contact(id: &str, title: &str) -> ListItemSnapshot {
@@ -979,6 +1026,90 @@ mod tests {
             .children
             .iter()
             .find_map(|child| find_role(child, role))
+    }
+
+    #[test]
+    fn focused_home_card_emits_one_spoken_label_per_focus_change() {
+        let mut runtime = UiRuntime::default();
+
+        runtime.handle_input(InputAction::Advance, 100);
+        assert_eq!(
+            runtime.take_accessibility_events(),
+            vec![UiEvent::FocusChanged(UiFocusChanged::new(
+                "ui-focus-1",
+                "Listen"
+            ))]
+        );
+
+        runtime.handle_input(InputAction::Advance, 200);
+        assert_eq!(
+            runtime.take_accessibility_events(),
+            vec![UiEvent::FocusChanged(UiFocusChanged::new(
+                "ui-focus-2",
+                "Talk"
+            ))]
+        );
+
+        runtime.refresh_focus_accessibility();
+        assert!(runtime.take_accessibility_events().is_empty());
+    }
+
+    #[test]
+    fn wheel_speaks_only_after_the_visible_roll_commits() {
+        let mut runtime = UiRuntime {
+            active_screen: UiScreen::Playlists,
+            ..UiRuntime::default()
+        };
+        runtime.snapshot.music.playlists = vec![
+            ListItemSnapshot::new("morning", "Morning songs", "", "playlist"),
+            ListItemSnapshot::new("bedtime", "Bedtime songs", "", "playlist"),
+        ];
+        runtime.refresh_focus_accessibility();
+        runtime.take_accessibility_events();
+
+        runtime.handle_input(InputAction::Advance, 100);
+        assert!(runtime.take_accessibility_events().is_empty());
+
+        runtime.advance_animations(280);
+        assert_eq!(
+            runtime.take_accessibility_events(),
+            vec![UiEvent::FocusChanged(UiFocusChanged::new(
+                "ui-focus-2",
+                "Bedtime songs"
+            ))]
+        );
+    }
+
+    #[test]
+    fn speak_names_toggle_cancels_and_restores_the_current_prompt() {
+        let mut runtime = UiRuntime {
+            active_screen: UiScreen::Setup,
+            focus_index: 4,
+            ..UiRuntime::default()
+        };
+        runtime.refresh_focus_accessibility();
+        runtime.take_accessibility_events();
+
+        runtime.apply_patch(RuntimeSnapshotPatch::Settings(SettingsRuntimeSnapshot {
+            speak_names: false,
+            ..runtime.snapshot.settings.clone()
+        }));
+        assert_eq!(
+            runtime.take_accessibility_events(),
+            vec![UiEvent::FocusCleared]
+        );
+
+        runtime.apply_patch(RuntimeSnapshotPatch::Settings(SettingsRuntimeSnapshot {
+            speak_names: true,
+            ..runtime.snapshot.settings.clone()
+        }));
+        assert_eq!(
+            runtime.take_accessibility_events(),
+            vec![UiEvent::FocusChanged(UiFocusChanged::new(
+                "ui-focus-2",
+                "Speak names, on"
+            ))]
+        );
     }
 
     #[test]

--- a/device/ui/src/application/state.rs
+++ b/device/ui/src/application/state.rs
@@ -5,8 +5,8 @@ use crate::DirtyRegion;
 use std::collections::BTreeMap;
 
 use yoyopod_protocol::ui::{
-    ListItemSnapshot, RuntimeSnapshot, RuntimeSnapshotDomain, UiIntent, UiScreen, VoiceFileAction,
-    VoiceNoteSummarySnapshot, VoiceRecipientAction,
+    ListItemSnapshot, RuntimeSnapshot, RuntimeSnapshotDomain, UiEvent, UiIntent, UiScreen,
+    VoiceFileAction, VoiceNoteSummarySnapshot, VoiceRecipientAction,
 };
 
 use super::intents;
@@ -39,6 +39,9 @@ pub struct UiRuntime {
     pub(crate) system_overlay_preview: Option<SystemOverlayPreview>,
     pub(crate) companion_preview: Option<CompanionVariant>,
     pub(crate) ask_offline_started_ms: Option<u64>,
+    pub(crate) last_focus_identity: Option<String>,
+    pub(crate) focus_prompt_sequence: u64,
+    pub(crate) accessibility_events: Vec<UiEvent>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -231,6 +234,9 @@ impl Default for UiRuntime {
             system_overlay_preview: None,
             companion_preview: None,
             ask_offline_started_ms: None,
+            last_focus_identity: None,
+            focus_prompt_sequence: 0,
+            accessibility_events: Vec::new(),
         }
     }
 }

--- a/device/ui/src/components/screens/listen.rs
+++ b/device/ui/src/components/screens/listen.rs
@@ -35,11 +35,7 @@ pub fn props_from(
 }
 
 pub fn items(_snapshot: &RuntimeSnapshot) -> Vec<ListItemSnapshot> {
-    vec![
-        ListItemSnapshot::new("playlists", "Playlists", "", "icon_playlists"),
-        ListItemSnapshot::new("recent_tracks", "Recents", "", "icon_recents"),
-        ListItemSnapshot::new("shuffle", "Shuffle all", "", "icon_shuffle"),
-    ]
+    crate::application::options::listen_items(_snapshot)
 }
 
 pub fn scene(props: &ListenProps) -> Scene {

--- a/device/ui/src/transport/outbound.rs
+++ b/device/ui/src/transport/outbound.rs
@@ -25,6 +25,20 @@ pub(crate) fn emit_intents<W: Write>(output: &mut W, intents: Vec<UiIntent>) -> 
     Ok(())
 }
 
+pub(crate) fn emit_accessibility_events<W: Write>(
+    output: &mut W,
+    events: Vec<UiEvent>,
+) -> Result<()> {
+    for event in events {
+        debug_assert!(matches!(
+            event,
+            UiEvent::FocusChanged(_) | UiEvent::FocusCleared
+        ));
+        emit_event(output, event)?;
+    }
+    Ok(())
+}
+
 pub(crate) fn emit_input_action<W: Write>(
     output: &mut W,
     action: InputAction,

--- a/device/ui/src/worker.rs
+++ b/device/ui/src/worker.rs
@@ -253,6 +253,7 @@ where
     }
     watchdog.runtime_stalled_emitted = true;
     ui_runtime.mark_runtime_stalled();
+    outbound::emit_accessibility_events(output, ui_runtime.take_accessibility_events())?;
     outbound::emit_event(
         output,
         UiEvent::Error(UiError::new(
@@ -299,12 +300,20 @@ where
             context
                 .ui_runtime
                 .note_system_overlay_snapshot_received(outbound::monotonic_millis());
+            outbound::emit_accessibility_events(
+                context.output,
+                context.ui_runtime.take_accessibility_events(),
+            )?;
         }
         dispatcher::AppEvent::RuntimePatch(patch) => {
             context.ui_runtime.apply_patch(patch);
             context
                 .ui_runtime
                 .note_system_overlay_snapshot_received(outbound::monotonic_millis());
+            outbound::emit_accessibility_events(
+                context.output,
+                context.ui_runtime.take_accessibility_events(),
+            )?;
         }
         dispatcher::AppEvent::InputAction(action) => {
             *context.input_events += 1;
@@ -312,6 +321,10 @@ where
             outbound::emit_input_action(context.output, action, "command", now_ms, 0)?;
             context.ui_runtime.handle_input(action, now_ms);
             outbound::emit_intents(context.output, context.ui_runtime.take_intents())?;
+            outbound::emit_accessibility_events(
+                context.output,
+                context.ui_runtime.take_accessibility_events(),
+            )?;
         }
         dispatcher::AppEvent::Tick => {
             let now_ms = outbound::monotonic_millis();
@@ -320,6 +333,7 @@ where
             context.ui_runtime.advance_home_state(now_ms);
             context.ui_runtime.advance_ask_state(now_ms);
             context.ui_runtime.advance_system_overlay(now_ms);
+            context.ui_runtime.refresh_focus_accessibility();
             if context.render_state.engine.animation_frame_dirty(now_ms) {
                 context.ui_runtime.mark_animation_frame();
             }
@@ -332,6 +346,10 @@ where
                 now_ms,
             )?;
             outbound::emit_intents(context.output, context.ui_runtime.take_intents())?;
+            outbound::emit_accessibility_events(
+                context.output,
+                context.ui_runtime.take_accessibility_events(),
+            )?;
         }
         dispatcher::AppEvent::PollInput => {
             let now_ms = outbound::monotonic_millis();
@@ -344,6 +362,10 @@ where
                 now_ms,
             )?;
             outbound::emit_intents(context.output, context.ui_runtime.take_intents())?;
+            outbound::emit_accessibility_events(
+                context.output,
+                context.ui_runtime.take_accessibility_events(),
+            )?;
         }
         dispatcher::AppEvent::Health => {
             outbound::emit_event(

--- a/device/voip/src/host.rs
+++ b/device/voip/src/host.rs
@@ -454,6 +454,11 @@ impl VoipHost {
         self.voice_note_playback.play(file_path, duration_ms)
     }
 
+    pub fn play_focus_prompt(&mut self, file_path: &str, duration_ms: i32) -> Result<bool, String> {
+        self.voice_note_playback
+            .play_focus_prompt(file_path, duration_ms)
+    }
+
     pub fn pause_voice_note_playback(&mut self) -> Result<(), String> {
         self.voice_note_playback.pause()
     }
@@ -464,6 +469,10 @@ impl VoipHost {
 
     pub fn stop_voice_note_playback(&mut self) {
         self.voice_note_playback.stop();
+    }
+
+    pub fn stop_focus_prompt_playback(&mut self) -> bool {
+        self.voice_note_playback.stop_focus_prompt()
     }
 
     pub fn refresh_voice_note_playback(&mut self) -> bool {

--- a/device/voip/src/playback.rs
+++ b/device/voip/src/playback.rs
@@ -2,6 +2,24 @@ use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::time::Instant;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PlaybackPurpose {
+    #[default]
+    None,
+    VoiceNote,
+    FocusPrompt,
+}
+
+impl PlaybackPurpose {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::VoiceNote => "voice_note",
+            Self::FocusPrompt => "focus_prompt",
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct VoiceNotePlayback {
     current: Option<Child>,
@@ -11,6 +29,7 @@ pub struct VoiceNotePlayback {
     run_started_at: Option<Instant>,
     paused: bool,
     published_bucket: u64,
+    purpose: PlaybackPurpose,
 }
 
 impl std::fmt::Debug for VoiceNotePlayback {
@@ -20,6 +39,7 @@ impl std::fmt::Debug for VoiceNotePlayback {
             .field("playing", &self.is_playing())
             .field("paused", &self.is_paused())
             .field("current_file_path", &self.current_file_path)
+            .field("purpose", &self.purpose)
             .finish()
     }
 }
@@ -42,9 +62,29 @@ impl VoiceNotePlayback {
     }
 
     pub fn play(&mut self, file_path: &str, duration_ms: i32) -> Result<(), String> {
+        self.play_for(file_path, duration_ms, PlaybackPurpose::VoiceNote)
+            .map(|_| ())
+    }
+
+    pub fn play_focus_prompt(&mut self, file_path: &str, duration_ms: i32) -> Result<bool, String> {
+        self.play_for(file_path, duration_ms, PlaybackPurpose::FocusPrompt)
+    }
+
+    fn play_for(
+        &mut self,
+        file_path: &str,
+        duration_ms: i32,
+        purpose: PlaybackPurpose,
+    ) -> Result<bool, String> {
         let file_path = file_path.trim();
         if file_path.is_empty() {
             return Err("voice-note playback requires file_path".to_string());
+        }
+        if purpose == PlaybackPurpose::FocusPrompt
+            && self.current.is_some()
+            && self.purpose == PlaybackPurpose::VoiceNote
+        {
+            return Ok(false);
         }
         self.stop();
         let command = Self::command_for(file_path);
@@ -61,7 +101,8 @@ impl VoiceNotePlayback {
         self.run_started_at = Some(Instant::now());
         self.paused = false;
         self.published_bucket = 0;
-        Ok(())
+        self.purpose = purpose;
+        Ok(true)
     }
 
     pub fn pause(&mut self) -> Result<(), String> {
@@ -124,6 +165,14 @@ impl VoiceNotePlayback {
         self.reset();
     }
 
+    pub fn stop_focus_prompt(&mut self) -> bool {
+        if self.purpose != PlaybackPurpose::FocusPrompt {
+            return false;
+        }
+        self.stop();
+        true
+    }
+
     pub fn is_playing(&self) -> bool {
         self.current.is_some() && !self.paused
     }
@@ -149,6 +198,7 @@ impl VoiceNotePlayback {
         self.run_started_at = None;
         self.paused = false;
         self.published_bucket = 0;
+        self.purpose = PlaybackPurpose::None;
     }
 
     pub fn payload(&self) -> serde_json::Value {
@@ -165,6 +215,7 @@ impl VoiceNotePlayback {
             "elapsed_ms": elapsed_ms,
             "duration_ms": self.duration_ms,
             "progress_permille": progress_permille,
+            "purpose": self.purpose.as_str(),
         })
     }
 }
@@ -216,4 +267,27 @@ fn resume_process(pid: u32) -> Result<(), String> {
 #[cfg(not(unix))]
 fn resume_process(_pid: u32) -> Result<(), String> {
     Err("voice-note resume is only supported on the device runtime".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn focus_stop_cannot_stop_voice_note_playback() {
+        let mut playback = VoiceNotePlayback::default();
+        playback.purpose = PlaybackPurpose::VoiceNote;
+
+        assert!(!playback.stop_focus_prompt());
+        assert_eq!(playback.purpose, PlaybackPurpose::VoiceNote);
+    }
+
+    #[test]
+    fn focus_stop_resets_only_the_prompt_owner() {
+        let mut playback = VoiceNotePlayback::default();
+        playback.purpose = PlaybackPurpose::FocusPrompt;
+
+        assert!(playback.stop_focus_prompt());
+        assert_eq!(playback.payload()["purpose"], "none");
+    }
 }

--- a/device/voip/src/worker.rs
+++ b/device/voip/src/worker.rs
@@ -506,6 +506,34 @@ where
                 write_session_snapshot(host, output)?;
             }
         }
+        "voip.play_focus_prompt" => {
+            let file_path = envelope.payload["file_path"].as_str().unwrap_or("").trim();
+            let duration_ms = envelope.payload["duration_ms"].as_i64().unwrap_or_default() as i32;
+            if file_path.is_empty() {
+                write_envelope_to(
+                    output,
+                    &WorkerEnvelope::error(
+                        "voip.error",
+                        envelope.request_id,
+                        "invalid_command",
+                        "voip.play_focus_prompt requires file_path",
+                    ),
+                )?;
+            } else {
+                let playing = host
+                    .play_focus_prompt(file_path, duration_ms)
+                    .map_err(|error| anyhow!(error))?;
+                write_envelope_to(
+                    output,
+                    &WorkerEnvelope::result(
+                        "voip.play_focus_prompt",
+                        envelope.request_id,
+                        json!({"playing": playing}),
+                    ),
+                )?;
+                write_session_snapshot(host, output)?;
+            }
+        }
         "voip.pause_voice_note_playback" => {
             host.pause_voice_note_playback()
                 .map_err(|error| anyhow!(error))?;
@@ -543,6 +571,20 @@ where
                 ),
             )?;
             write_session_snapshot(host, output)?;
+        }
+        "voip.stop_focus_prompt_playback" => {
+            let stopped = host.stop_focus_prompt_playback();
+            write_envelope_to(
+                output,
+                &WorkerEnvelope::result(
+                    "voip.stop_focus_prompt_playback",
+                    envelope.request_id,
+                    json!({"stopped": stopped}),
+                ),
+            )?;
+            if stopped {
+                write_session_snapshot(host, output)?;
+            }
         }
         "voip.delete_voice_note" => {
             let message_id = envelope.payload["message_id"].as_str().unwrap_or("").trim();


### PR DESCRIPTION
## Summary
- emit typed focus-changed/focus-cleared UI events with rendered labels for every focusable screen and spoken empty states
- honor Speak Names without duplicate prompts, including wheel animation commit timing and stale-result suppression
- make focus TTS interruptible and lower priority than Ask/general speech
- isolate focus prompt playback so it cannot stop or masquerade as voice-note playback
- extend the on-Pi navigation stage to verify spoken focus labels through the real UI worker protocol

## Verification
- `cargo check --manifest-path device/Cargo.toml --workspace --locked`
- `cargo test --manifest-path device/Cargo.toml -p yoyopod-protocol -p yoyopod-ui -p yoyopod-runtime -p yoyopod-speech -p yoyopod-voip -p yoyopod-on-pi --locked` (180 passed)
- `git diff --check`

## Known host-only baseline issue
- Full Windows workspace tests reach two existing SIM7600 symlink tests in `yoyopod-network` that fail because Linux `/dev/serial/by-*` link names are invalid Windows filenames. All changed crates pass.

## Hardware gate
- Exact-SHA artifact deployment and `yoyopod-003` navigation/LVGL validation will run after CI publishes the ARM64 artifact.