### PR TITLE
Fix Ask availability state on Wi-Fi

### DIFF
--- a/device/protocol/src/ui/snapshot.rs
+++ b/device/protocol/src/ui/snapshot.rs
@@ -273,6 +273,8 @@ pub struct VoiceRuntimeSnapshot {
     #[serde(default = "default_voice_body")]
     pub body: String,
     #[serde(default)]
+    pub ask_unavailable: bool,
+    #[serde(default)]
     pub capture_in_flight: bool,
     #[serde(default)]
     pub ptt_active: bool,
@@ -298,6 +300,7 @@ impl Default for VoiceRuntimeSnapshot {
             phase: default_voice_phase(),
             headline: default_voice_headline(),
             body: default_voice_body(),
+            ask_unavailable: false,
             capture_in_flight: false,
             ptt_active: false,
             recording_duration_ms: 0,

--- a/device/runtime/src/event.rs
+++ b/device/runtime/src/event.rs
@@ -69,6 +69,9 @@ impl RuntimeEvent {
         match self {
             Self::WorkerReady { domain } => {
                 state.mark_worker(*domain, WorkerState::Running, "ready");
+                if *domain == WorkerDomain::Voice {
+                    state.mark_ask_available();
+                }
             }
             Self::CloudSnapshot(snapshot) => state.apply_cloud_snapshot(snapshot),
             Self::CloudCommand(_) => {}
@@ -90,16 +93,22 @@ impl RuntimeEvent {
             }
             Self::VoiceTranscript(snapshot) => state.apply_voice_transcript(snapshot),
             Self::VoiceAskResult(snapshot) => state.apply_voice_ask_result(snapshot),
-            Self::VoiceSpeakResult(_) => {}
+            Self::VoiceSpeakResult(_) => state.mark_ask_available(),
             Self::UiScreenChanged { screen } => {
                 state.current_screen = *screen;
             }
             Self::WorkerError { domain, message } => {
                 state.mark_worker(*domain, WorkerState::Degraded, message.clone());
+                if *domain == WorkerDomain::Voice {
+                    state.mark_ask_unavailable();
+                }
                 state.fail_overlay_for(*domain);
             }
             Self::WorkerExited { domain, reason } => {
                 state.mark_worker(*domain, WorkerState::Stopped, reason.clone());
+                if *domain == WorkerDomain::Voice {
+                    state.mark_ask_unavailable();
+                }
             }
             Self::UiIntent(intent) => state.apply_ui_intent(intent),
             Self::UiInput(_) | Self::UiScreenshotCaptured(_) | Self::Shutdown | Self::Ignored => {}
@@ -202,13 +211,25 @@ pub fn commands_for_event(state: &RuntimeState, event: &RuntimeEvent) -> Vec<Run
         RuntimeEvent::VoipSnapshot(snapshot) => commands_for_voip_snapshot(state, snapshot),
         RuntimeEvent::NetworkSnapshot(snapshot) => commands_for_network_snapshot(snapshot),
         RuntimeEvent::PowerSnapshot(snapshot) => commands_for_power_snapshot(state, snapshot),
-        RuntimeEvent::VoiceTranscript(snapshot) => commands_for_voice_transcript(state, snapshot),
-        RuntimeEvent::VoiceAskResult(snapshot) => commands_for_voice_ask_result(state, snapshot),
-        RuntimeEvent::VoiceSpeakResult(snapshot) => commands_for_voice_speak_result(snapshot),
+        RuntimeEvent::VoiceTranscript(snapshot) => with_ask_log(
+            commands_for_voice_transcript(state, snapshot),
+            "transcript_received",
+        ),
+        RuntimeEvent::VoiceAskResult(snapshot) => with_ask_log(
+            commands_for_voice_ask_result(state, snapshot),
+            "answer_received",
+        ),
+        RuntimeEvent::VoiceSpeakResult(snapshot) => {
+            with_ask_log(commands_for_voice_speak_result(snapshot), "audio_ready")
+        }
         RuntimeEvent::UiScreenshotCaptured(captured) => vec![RuntimeCommand::AppendAppLog {
             line: screenshot_log_line(captured),
         }],
         RuntimeEvent::Shutdown => vec![RuntimeCommand::Shutdown],
+        RuntimeEvent::WorkerError {
+            domain: WorkerDomain::Voice,
+            ..
+        } => with_ask_log(Vec::new(), "failed"),
         RuntimeEvent::WorkerError { domain, .. }
             if state.overlay.pending_domain == Some(*domain) =>
         {
@@ -228,6 +249,13 @@ pub fn commands_for_event(state: &RuntimeState, event: &RuntimeEvent) -> Vec<Run
         | RuntimeEvent::WorkerExited { .. }
         | RuntimeEvent::Ignored => Vec::new(),
     }
+}
+
+fn with_ask_log(mut commands: Vec<RuntimeCommand>, stage: &str) -> Vec<RuntimeCommand> {
+    commands.push(RuntimeCommand::AppendAppLog {
+        line: format!("Ask pipeline stage={stage}"),
+    });
+    commands
 }
 
 /// App log line for a UI screenshot capture result. The success wording is a
@@ -1529,6 +1557,56 @@ mod tests {
         );
         assert!(message_types.contains(&"voice.cancel"));
         assert!(message_types.contains(&"voip.stop_voice_note_playback"));
+    }
+
+    #[test]
+    fn voice_failure_is_the_explicit_ask_offline_signal_and_is_safe_to_log() {
+        let mut state = RuntimeState::default();
+        state.network.connected = false;
+        let failure = RuntimeEvent::WorkerError {
+            domain: WorkerDomain::Voice,
+            message: "provider rejected secret request details".to_string(),
+        };
+
+        let diagnostics = commands_for_event(&state, &failure);
+        assert_eq!(
+            diagnostics,
+            vec![RuntimeCommand::AppendAppLog {
+                line: "Ask pipeline stage=failed".to_string(),
+            }]
+        );
+        assert!(!format!("{diagnostics:?}").contains("secret"));
+
+        failure.apply(&mut state);
+        assert!(state.voice.ask_unavailable);
+        assert!(state.ui_snapshot().voice.ask_unavailable);
+        assert_eq!(state.voice.phase, "offline");
+
+        RuntimeEvent::UiIntent(UiIntent::Voice(VoiceIntent::AskStart)).apply(&mut state);
+        assert!(!state.voice.ask_unavailable);
+        assert_eq!(state.voice.phase, "listening");
+    }
+
+    #[test]
+    fn voice_pipeline_results_emit_stage_diagnostics_without_user_content() {
+        let state = RuntimeState::default();
+        let event = RuntimeEvent::VoiceAskResult(json!({"answer": "private answer"}));
+
+        let diagnostics = commands_for_event(&state, &event);
+
+        assert!(diagnostics.iter().any(|command| matches!(
+            command,
+            RuntimeCommand::AppendAppLog { line } if line == "Ask pipeline stage=answer_received"
+        )));
+        let log_text = diagnostics
+            .iter()
+            .filter_map(|command| match command {
+                RuntimeCommand::AppendAppLog { line } => Some(line.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!log_text.contains("private answer"));
     }
 
     #[test]

--- a/device/runtime/src/state.rs
+++ b/device/runtime/src/state.rs
@@ -279,6 +279,7 @@ pub struct VoiceRuntimeState {
     pub phase: String,
     pub headline: String,
     pub body: String,
+    pub ask_unavailable: bool,
     pub status_text: String,
     pub file_path: String,
     pub duration_ms: i32,
@@ -310,6 +311,7 @@ impl Default for VoiceRuntimeState {
             phase: "idle".to_string(),
             headline: "Ask".to_string(),
             body: "Ask me anything...".to_string(),
+            ask_unavailable: false,
             status_text: String::new(),
             file_path: String::new(),
             duration_ms: 0,
@@ -445,6 +447,24 @@ impl VoiceRuntimeState {
         self.headline = headline.into();
         self.body = body.into();
         self.status_text.clear();
+    }
+
+    fn mark_ask_available(&mut self) {
+        self.ask_unavailable = false;
+    }
+
+    fn mark_ask_unavailable(&mut self) {
+        self.ask_unavailable = true;
+        self.ask_capture_active = false;
+        self.ask_transcribe_requested = false;
+        self.pending_ask_question.clear();
+        self.playback_active = false;
+        self.playback_paused = false;
+        self.set_interaction(
+            "offline",
+            "Ask unavailable",
+            "I can't think right now - try again soon.",
+        );
     }
 }
 
@@ -712,6 +732,14 @@ impl RuntimeState {
         let health = self.worker_health_mut(domain);
         health.state = state;
         health.last_reason = reason.into();
+    }
+
+    pub fn mark_ask_available(&mut self) {
+        self.voice.mark_ask_available();
+    }
+
+    pub fn mark_ask_unavailable(&mut self) {
+        self.voice.mark_ask_unavailable();
     }
 
     pub fn resolve_overlay_for(&mut self, domain: WorkerDomain) {
@@ -1222,6 +1250,7 @@ impl RuntimeState {
     fn apply_voice_intent(&mut self, intent: &VoiceIntent) {
         match intent {
             VoiceIntent::AskStart => {
+                self.voice.mark_ask_available();
                 self.voice.ask_capture_active = true;
                 self.voice.ask_transcribe_requested = false;
                 self.voice.playback_active = false;
@@ -1238,6 +1267,7 @@ impl RuntimeState {
                     .set_interaction("thinking", "Thinking", "Just a moment...");
             }
             VoiceIntent::AskCancel => {
+                self.voice.mark_ask_available();
                 self.voice.ask_capture_active = false;
                 self.voice.ask_transcribe_requested = false;
                 self.voice.pending_ask_question.clear();
@@ -1315,6 +1345,7 @@ impl RuntimeState {
     }
 
     pub fn apply_voice_transcript(&mut self, payload: &Value) {
+        self.voice.mark_ask_available();
         self.voice.ask_capture_active = false;
         self.voice.ask_transcribe_requested = false;
         let transcript = string_field(payload, "text")
@@ -1401,6 +1432,7 @@ impl RuntimeState {
     }
 
     pub fn apply_voice_ask_result(&mut self, payload: &Value) {
+        self.voice.mark_ask_available();
         self.voice.ask_capture_active = false;
         self.voice.ask_transcribe_requested = false;
         let answer_from_payload = string_field(payload, "answer");
@@ -1786,6 +1818,7 @@ impl RuntimeState {
                 "phase": self.voice.phase,
                 "headline": self.voice.headline,
                 "body": voice_body_text(&self.voice),
+                "ask_unavailable": self.voice.ask_unavailable,
                 "capture_in_flight": self.voice.ask_capture_active || self.voice.phase == "recording",
                 "ptt_active": self.voice.phase == "recording",
                 "recording_duration_ms": self.voice.duration_ms,

--- a/device/ui/src/application/runtime.rs
+++ b/device/ui/src/application/runtime.rs
@@ -134,6 +134,12 @@ impl UiRuntime {
             }
             self.commit_pending_wheel_roll();
         }
+        if self.active_screen == UiScreen::Ask
+            && action == InputAction::PttPress
+            && self.snapshot.voice.ask_unavailable
+        {
+            self.clear_local_ask_failure();
+        }
         let previous_screen = self.active_screen;
         let route_state = input_router::InputRouteState {
             active_screen: self.active_screen,
@@ -187,6 +193,37 @@ impl UiRuntime {
             self.home_mode = next;
             self.dirty.focus = true;
         }
+    }
+
+    pub fn advance_ask_state(&mut self, now_ms: u64) -> bool {
+        if self.active_screen != UiScreen::Ask || !self.snapshot.voice.ask_unavailable {
+            self.ask_offline_started_ms = None;
+            return false;
+        }
+
+        let started_ms = *self.ask_offline_started_ms.get_or_insert(now_ms);
+        if now_ms.saturating_sub(started_ms) < ASK_FAILURE_VISIBLE_MS {
+            return false;
+        }
+
+        self.clear_local_ask_failure();
+        self.intents.push(UiIntent::Voice(
+            yoyopod_protocol::ui::VoiceIntent::AskCancel,
+        ));
+        true
+    }
+
+    fn clear_local_ask_failure(&mut self) {
+        self.ask_offline_started_ms = None;
+        self.snapshot.voice.ask_unavailable = false;
+        self.snapshot.voice.phase = "idle".to_string();
+        self.snapshot.voice.headline = "Ask".to_string();
+        self.snapshot.voice.body = "Ask me anything...".to_string();
+        self.snapshot.voice.capture_in_flight = false;
+        self.snapshot.voice.ptt_active = false;
+        self.snapshot.voice.playback_active = false;
+        self.snapshot.voice.playback_paused = false;
+        self.dirty.voice = true;
     }
 
     pub fn advance_system_overlay(&mut self, now_ms: u64) -> bool {
@@ -805,6 +842,7 @@ fn scene_cache_entry(entry: &HistoryEntry) -> crate::scene::SceneCacheEntry {
 
 const STATUS_BAR_PREVIEW_STAGE_MS: u64 = 5_000;
 const STATUS_BAR_PREVIEW_STAGE_COUNT: u8 = 6;
+const ASK_FAILURE_VISIBLE_MS: u64 = 4_000;
 
 fn current_status_time() -> (i64, String) {
     let now = OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc());
@@ -1572,7 +1610,6 @@ mod tests {
     fn ask_captures_the_physical_hold_and_release_end_to_end() {
         let mut runtime = UiRuntime::default();
         runtime.active_screen = UiScreen::Ask;
-        runtime.snapshot.network.connected = true;
 
         assert!(runtime.wants_ptt_passthrough());
         runtime.handle_input(InputAction::PttPress, 400);
@@ -1599,6 +1636,44 @@ mod tests {
         assert_eq!(
             runtime.take_intents(),
             vec![UiIntent::Voice(VoiceIntent::AskStop)]
+        );
+    }
+
+    #[test]
+    fn ask_failure_returns_to_idle_after_four_seconds() {
+        let mut runtime = UiRuntime::default();
+        runtime.active_screen = UiScreen::Ask;
+        runtime.snapshot.voice.ask_unavailable = true;
+        runtime.snapshot.voice.phase = "offline".to_string();
+
+        assert!(!runtime.advance_ask_state(1_000));
+        assert!(!runtime.advance_ask_state(4_999));
+        assert!(runtime.take_intents().is_empty());
+
+        assert!(runtime.advance_ask_state(5_000));
+        assert!(!runtime.snapshot.voice.ask_unavailable);
+        assert_eq!(runtime.snapshot.voice.phase, "idle");
+        assert_eq!(
+            runtime.take_intents(),
+            vec![UiIntent::Voice(VoiceIntent::AskCancel)]
+        );
+    }
+
+    #[test]
+    fn ptt_retries_immediately_during_an_ask_failure() {
+        let mut runtime = UiRuntime::default();
+        runtime.active_screen = UiScreen::Ask;
+        runtime.snapshot.voice.ask_unavailable = true;
+        runtime.snapshot.voice.phase = "offline".to_string();
+        runtime.advance_ask_state(1_000);
+
+        runtime.handle_input(InputAction::PttPress, 2_000);
+
+        assert!(!runtime.snapshot.voice.ask_unavailable);
+        assert!(runtime.ask_offline_started_ms.is_none());
+        assert_eq!(
+            runtime.take_intents(),
+            vec![UiIntent::Voice(VoiceIntent::AskStart)]
         );
     }
 

--- a/device/ui/src/application/state.rs
+++ b/device/ui/src/application/state.rs
@@ -38,6 +38,7 @@ pub struct UiRuntime {
     pub(crate) system_overlay: SystemOverlayState,
     pub(crate) system_overlay_preview: Option<SystemOverlayPreview>,
     pub(crate) companion_preview: Option<CompanionVariant>,
+    pub(crate) ask_offline_started_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -229,6 +230,7 @@ impl Default for UiRuntime {
             system_overlay: SystemOverlayState::default(),
             system_overlay_preview: None,
             companion_preview: None,
+            ask_offline_started_ms: None,
         }
     }
 }

--- a/device/ui/src/components/screens/ask.rs
+++ b/device/ui/src/components/screens/ask.rs
@@ -70,14 +70,13 @@ pub fn scene(props: &AskProps) -> Scene {
 
 fn ask_phase(snapshot: &RuntimeSnapshot) -> AskPhase {
     let phase = snapshot.voice.phase.trim().to_ascii_lowercase();
-    if !snapshot.network.connected && !matches!(phase.as_str(), "listening" | "recording") {
-        return AskPhase::Offline;
-    }
     if snapshot.voice.ptt_active
         || snapshot.voice.capture_in_flight
         || matches!(phase.as_str(), "listening" | "recording")
     {
         AskPhase::Listening
+    } else if snapshot.voice.ask_unavailable {
+        AskPhase::Offline
     } else if phase == "thinking" {
         AskPhase::Thinking
     } else if snapshot.voice.playback_active || matches!(phase.as_str(), "reply" | "answering") {
@@ -104,8 +103,7 @@ mod tests {
 
     #[test]
     fn ask_uses_full_bleed_butter_and_no_focus_cursor() {
-        let mut snapshot = RuntimeSnapshot::default();
-        snapshot.network.connected = true;
+        let snapshot = RuntimeSnapshot::default();
         let props = props_from(&snapshot, 0, crate::scene::defaults_for(UiScreen::Ask));
         let scene = scene(&props);
         assert_eq!(scene.backdrop, Backdrop::Solid(ASK_STAGE_BUTTER));
@@ -116,7 +114,6 @@ mod tests {
     #[test]
     fn ask_state_tracks_runtime_voice_phase() {
         let mut snapshot = RuntimeSnapshot::default();
-        snapshot.network.connected = true;
         snapshot.voice.phase = "thinking".to_string();
         assert_eq!(
             props_from(&snapshot, 0, crate::scene::defaults_for(UiScreen::Ask))
@@ -131,6 +128,42 @@ mod tests {
                 .model
                 .phase,
             AskPhase::Answering
+        );
+    }
+
+    #[test]
+    fn cellular_disconnect_does_not_make_cloud_ask_offline() {
+        let mut snapshot = RuntimeSnapshot::default();
+        snapshot.network.connected = false;
+
+        assert_eq!(
+            props_from(&snapshot, 0, crate::scene::defaults_for(UiScreen::Ask))
+                .model
+                .phase,
+            AskPhase::Idle
+        );
+
+        snapshot.voice.ask_unavailable = true;
+        assert_eq!(
+            props_from(&snapshot, 0, crate::scene::defaults_for(UiScreen::Ask))
+                .model
+                .phase,
+            AskPhase::Offline
+        );
+    }
+
+    #[test]
+    fn a_fresh_capture_takes_priority_over_the_previous_failure() {
+        let mut snapshot = RuntimeSnapshot::default();
+        snapshot.voice.ask_unavailable = true;
+        snapshot.voice.ptt_active = true;
+        snapshot.voice.phase = "listening".to_string();
+
+        assert_eq!(
+            props_from(&snapshot, 0, crate::scene::defaults_for(UiScreen::Ask))
+                .model
+                .phase,
+            AskPhase::Listening
         );
     }
 }

--- a/device/ui/src/worker.rs
+++ b/device/ui/src/worker.rs
@@ -318,6 +318,7 @@ where
             context.ui_runtime.advance_status_bar(now_ms);
             context.ui_runtime.advance_animations(now_ms);
             context.ui_runtime.advance_home_state(now_ms);
+            context.ui_runtime.advance_ask_state(now_ms);
             context.ui_runtime.advance_system_overlay(now_ms);
             if context.render_state.engine.animation_frame_dirty(now_ms) {
                 context.ui_runtime.mark_animation_frame();


### PR DESCRIPTION
## Summary
- decouple the Ask offline surface from cellular PPP status so Wi-Fi-backed OpenAI requests remain available
- carry an explicit Ask-unavailable state from real voice worker failures through the shared runtime/UI protocol
- retry immediately on a fresh hold and return the transient failure surface to Idle after four seconds
- add privacy-safe Ask pipeline stage diagnostics and regression coverage

## Local validation
- `cargo fmt --manifest-path device/Cargo.toml --all -- --check`
- `cargo check --manifest-path device/Cargo.toml --workspace --locked`
- `cargo test --manifest-path device/Cargo.toml -p yoyopod-protocol -p yoyopod-runtime -p yoyopod-ui --locked` (152 passed)
- `cargo test --manifest-path device/Cargo.toml --workspace --exclude yoyopod-network --locked` (all passed)

## Known unchanged Windows baseline
- the full workspace test command reaches two existing SIM7600 symlink tests in `yoyopod-network` that use Linux device-link names invalid on Windows
- strict `-D warnings` clippy also reports the existing protocol `large_enum_variant` and `derivable_impls` warnings

## Hardware gate
- pending exact-SHA ARM64 CI artifact deployment and Ask exercise on `yoyopod-003`