### PR TITLE
feat(device): manage Bluetooth and synchronized audio

### DIFF
--- a/cli/yoyopod/src/commands/target/deploy.rs
+++ b/cli/yoyopod/src/commands/target/deploy.rs
@@ -162,17 +162,21 @@ pub fn run(
     let dns_file = "/etc/NetworkManager/dnsmasq-shared.d/010-yoyopod-captive.conf";
     let dropin_dir = format!("/etc/systemd/system/{}.d", lane.dev_service);
     let dropin_file = format!("{dropin_dir}/10-wifi-portal-cap.conf");
+    let audio_dropin_file = format!("{dropin_dir}/20-bluetooth-audio.conf");
     let install_portal_prereqs_cmd = format!(
         "sudo -n install -d -m 0755 {dns_dir} && \
          printf 'address=/#/10.42.0.1\\n' | sudo -n tee {dns_file} >/dev/null && \
          sudo -n install -d -m 0755 {dropin_dir} && \
          printf '[Service]\\nAmbientCapabilities=CAP_NET_BIND_SERVICE\\n' \
          | sudo -n tee {dropin_file} >/dev/null && \
+         printf '[Service]\\nEnvironment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc\\n' \
+         | sudo -n tee {audio_dropin_file} >/dev/null && \
          sudo -n systemctl daemon-reload",
         dns_dir = shell_quote(dns_dir),
         dns_file = shell_quote(dns_file),
         dropin_dir = shell_quote(&dropin_dir),
         dropin_file = shell_quote(&dropin_file),
+        audio_dropin_file = shell_quote(&audio_dropin_file),
     );
     let rc = run_remote(
         &ctx.conn,
@@ -588,5 +592,14 @@ mod tests {
         assert!(!dropin.contains("-p a2dp-sink"));
         assert!(!dropin.contains("-p hfp-hf"));
         assert!(!dropin.contains("-p hsp-hs"));
+    }
+
+    #[test]
+    fn dev_service_uses_the_writable_managed_asound_config() {
+        let service = include_str!("../../../../../deploy/systemd/yoyopod-dev.service");
+
+        assert!(
+            service.contains("Environment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc")
+        );
     }
 }

--- a/cli/yoyopod/src/commands/target/deploy.rs
+++ b/cli/yoyopod/src/commands/target/deploy.rs
@@ -199,8 +199,10 @@ pub fn run(
     // speaker or headset; advertising a sink role reverses that direction.
     // Install the explicit role drop-in idempotently and restart BlueALSA only
     // when its configuration changed (or the service is not already active).
+    let service_group_lookup = service_group_lookup_command(&wifi_service_user);
     let bluetooth_prereqs_cmd = format!(
-        "if ! command -v bluealsa >/dev/null 2>&1 || ! command -v aplay >/dev/null 2>&1 || \
+        "{service_group_lookup} && \
+         if ! command -v bluealsa >/dev/null 2>&1 || ! command -v aplay >/dev/null 2>&1 || \
          ! dpkg-query -W libasound2-plugin-bluez >/dev/null 2>&1; then \
            sudo -n apt-get update && \
            sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -223,11 +225,12 @@ pub fn run(
            sudo -n systemctl restart bluealsa.service; \
          fi && \
          systemctl is-active --quiet bluetooth.service bluealsa.service && \
-         sudo -n install -d -m 0750 -o {user} -g {user} \
+         sudo -n install -d -m 0750 -o {user} -g \"$service_group\" \
            /var/lib/yoyopod /var/lib/yoyopod/bluetooth /var/lib/yoyopod/audio",
         bluealsa_dropin_dir = shell_quote(BLUEALSA_DROPIN_DIR),
         bluealsa_dropin_source = shell_quote(BLUEALSA_DROPIN_SOURCE),
         bluealsa_dropin_path = shell_quote(BLUEALSA_DROPIN_PATH),
+        service_group_lookup = service_group_lookup,
         user = shell_quote(&wifi_service_user),
     );
     let rc = run_remote(
@@ -282,6 +285,10 @@ fn validate_wifi_service_user(service_user: &str) -> Result<&str> {
         ));
     }
     Ok(service_user)
+}
+
+fn service_group_lookup_command(service_user: &str) -> String {
+    format!("service_group=$(id -gn {})", shell_quote(service_user))
 }
 
 fn resolve_wifi_service_user(ctx: &TargetContext) -> Result<String> {
@@ -585,6 +592,13 @@ mod tests {
     fn wifi_polkit_rule_normalizes_safe_service_user() {
         let rule = render_wifi_polkit_rule("  raouf  ").expect("valid service user");
         assert!(rule.contains("subject.user === \"raouf\""));
+    }
+
+    #[test]
+    fn service_directory_uses_the_service_users_primary_group() {
+        let command = service_group_lookup_command("yoyopod");
+
+        assert_eq!(command, "service_group=$(id -gn yoyopod)");
     }
 
     #[test]

--- a/cli/yoyopod/src/commands/target/deploy.rs
+++ b/cli/yoyopod/src/commands/target/deploy.rs
@@ -25,6 +25,10 @@ use super::TargetContext;
 const CI_POLL_INTERVAL_SECS: u64 = 20;
 const CI_POLL_TIMEOUT_MINS: u64 = 30;
 const WIFI_POLKIT_RULE_PATH: &str = "/etc/polkit-1/rules.d/90-yoyopod-wifi.rules";
+const BLUEALSA_DROPIN_DIR: &str = "/etc/systemd/system/bluealsa.service.d";
+const BLUEALSA_DROPIN_PATH: &str =
+    "/etc/systemd/system/bluealsa.service.d/20-yoyopod-audio-role.conf";
+const BLUEALSA_DROPIN_SOURCE: &str = "deploy/systemd/bluealsa-yoyopod.conf";
 
 pub fn run(
     ctx: &TargetContext,
@@ -182,8 +186,10 @@ pub fn run(
 
     // Bluetooth audio lives outside the artifact: BlueZ provides radio/device
     // management and BlueALSA exposes paired profiles through stable ALSA PCM
-    // aliases. Only install packages when missing, then make the private local
-    // registry writable by the service account.
+    // aliases. YoYoPod must be the source/gateway so audio flows out to a
+    // speaker or headset; advertising a sink role reverses that direction.
+    // Install the explicit role drop-in idempotently and restart BlueALSA only
+    // when its configuration changed (or the service is not already active).
     let bluetooth_prereqs_cmd = format!(
         "if ! command -v bluealsa >/dev/null 2>&1 || ! command -v aplay >/dev/null 2>&1 || \
          ! dpkg-query -W libasound2-plugin-bluez >/dev/null 2>&1; then \
@@ -192,9 +198,27 @@ pub fn run(
              alsa-utils bluez bluez-alsa-utils libasound2-plugin-bluez; \
          fi && \
          {{ sudo -n rfkill unblock bluetooth || true; }} && \
-         sudo -n systemctl enable --now bluetooth.service bluealsa.service && \
+         bluealsa_restart=0 && \
+         sudo -n install -d -m 0755 {bluealsa_dropin_dir} && \
+         if ! sudo -n cmp -s {bluealsa_dropin_source} {bluealsa_dropin_path}; then \
+           sudo -n install -o root -g root -m 0644 \
+             {bluealsa_dropin_source} {bluealsa_dropin_path} && \
+           bluealsa_restart=1; \
+         fi && \
+         sudo -n systemctl daemon-reload && \
+         sudo -n systemctl enable --now bluetooth.service && \
+         sudo -n systemctl disable --now bluealsa-aplay.service && \
+         sudo -n systemctl enable bluealsa.service && \
+         if [ \"$bluealsa_restart\" -eq 1 ] || \
+            ! systemctl is-active --quiet bluealsa.service; then \
+           sudo -n systemctl restart bluealsa.service; \
+         fi && \
+         systemctl is-active --quiet bluetooth.service bluealsa.service && \
          sudo -n install -d -m 0750 -o {user} -g {user} \
            /var/lib/yoyopod /var/lib/yoyopod/bluetooth /var/lib/yoyopod/audio",
+        bluealsa_dropin_dir = shell_quote(BLUEALSA_DROPIN_DIR),
+        bluealsa_dropin_source = shell_quote(BLUEALSA_DROPIN_SOURCE),
+        bluealsa_dropin_path = shell_quote(BLUEALSA_DROPIN_PATH),
         user = shell_quote(&wifi_service_user),
     );
     let rc = run_remote(
@@ -552,5 +576,17 @@ mod tests {
     fn wifi_polkit_rule_normalizes_safe_service_user() {
         let rule = render_wifi_polkit_rule("  raouf  ").expect("valid service user");
         assert!(rule.contains("subject.user === \"raouf\""));
+    }
+
+    #[test]
+    fn bluealsa_dropin_is_outbound_only() {
+        let dropin = include_str!("../../../../../deploy/systemd/bluealsa-yoyopod.conf");
+
+        assert!(dropin.contains("-p a2dp-source"));
+        assert!(dropin.contains("-p hfp-ag"));
+        assert!(dropin.contains("-p hsp-ag"));
+        assert!(!dropin.contains("-p a2dp-sink"));
+        assert!(!dropin.contains("-p hfp-hf"));
+        assert!(!dropin.contains("-p hsp-hs"));
     }
 }

--- a/cli/yoyopod/src/commands/target/deploy.rs
+++ b/cli/yoyopod/src/commands/target/deploy.rs
@@ -180,6 +180,33 @@ pub fn run(
         return Ok(rc);
     }
 
+    // Bluetooth audio lives outside the artifact: BlueZ provides radio/device
+    // management and BlueALSA exposes paired profiles through stable ALSA PCM
+    // aliases. Only install packages when missing, then make the private local
+    // registry writable by the service account.
+    let bluetooth_prereqs_cmd = format!(
+        "if ! command -v bluealsa >/dev/null 2>&1 || ! command -v aplay >/dev/null 2>&1 || \
+         ! dpkg-query -W libasound2-plugin-bluez >/dev/null 2>&1; then \
+           sudo -n apt-get update && \
+           sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+             alsa-utils bluez bluez-alsa-utils libasound2-plugin-bluez; \
+         fi && \
+         {{ sudo -n rfkill unblock bluetooth || true; }} && \
+         sudo -n systemctl enable --now bluetooth.service bluealsa.service && \
+         sudo -n install -d -m 0750 -o {user} -g {user} \
+           /var/lib/yoyopod /var/lib/yoyopod/bluetooth /var/lib/yoyopod/audio",
+        user = shell_quote(&wifi_service_user),
+    );
+    let rc = run_remote(
+        &ctx.conn,
+        &bluetooth_prereqs_cmd,
+        false,
+        RemoteWorkdir::Default,
+    )?;
+    if rc != 0 {
+        return Ok(rc);
+    }
+
     // 5) Extract + chmod on Pi.
     let extract_cmd = format!(
         "tar -xzf {tarball} && \

--- a/cli/yoyopod/src/commands/target/deploy.rs
+++ b/cli/yoyopod/src/commands/target/deploy.rs
@@ -169,7 +169,7 @@ pub fn run(
          sudo -n install -d -m 0755 {dropin_dir} && \
          printf '[Service]\\nAmbientCapabilities=CAP_NET_BIND_SERVICE\\n' \
          | sudo -n tee {dropin_file} >/dev/null && \
-         printf '[Service]\\nEnvironment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc\\n' \
+         printf '[Service]\\nEnvironment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc\\nEnvironment=ALSA_CONFIG_PATH=/var/lib/yoyopod/audio/asoundrc\\n' \
          | sudo -n tee {audio_dropin_file} >/dev/null && \
          sudo -n systemctl daemon-reload",
         dns_dir = shell_quote(dns_dir),
@@ -595,11 +595,16 @@ mod tests {
     }
 
     #[test]
-    fn dev_service_uses_the_writable_managed_asound_config() {
-        let service = include_str!("../../../../../deploy/systemd/yoyopod-dev.service");
+    fn services_expose_the_writable_managed_asound_config_to_alsa() {
+        let dev_service = include_str!("../../../../../deploy/systemd/yoyopod-dev.service");
+        let prod_service = include_str!("../../../../../deploy/systemd/yoyopod-prod.service");
 
-        assert!(
-            service.contains("Environment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc")
-        );
+        for service in [dev_service, prod_service] {
+            assert!(service
+                .contains("Environment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc"));
+            assert!(
+                service.contains("Environment=ALSA_CONFIG_PATH=/var/lib/yoyopod/audio/asoundrc")
+            );
+        }
     }
 }

--- a/cli/yoyopod/src/commands/target/deploy.rs
+++ b/cli/yoyopod/src/commands/target/deploy.rs
@@ -74,7 +74,7 @@ pub fn run(
         } else {
             ctx.conn.user.as_str()
         };
-        println!("would: install a Wi-Fi-only Polkit rule for service user {service_user}");
+        println!("would: install Wi-Fi and BlueZ authorization for service user {service_user}");
         println!(
             "would: ssh sync + extract + restart + verify on {}",
             ctx.conn.ssh_target()
@@ -200,6 +200,7 @@ pub fn run(
     // Install the explicit role drop-in idempotently and restart BlueALSA only
     // when its configuration changed (or the service is not already active).
     let service_group_lookup = service_group_lookup_command(&wifi_service_user);
+    let bluetooth_user_authorization = bluetooth_user_authorization_command(&wifi_service_user);
     let bluetooth_prereqs_cmd = format!(
         "{service_group_lookup} && \
          if ! command -v bluealsa >/dev/null 2>&1 || ! command -v aplay >/dev/null 2>&1 || \
@@ -208,6 +209,7 @@ pub fn run(
            sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
              alsa-utils bluez bluez-alsa-utils libasound2-plugin-bluez; \
          fi && \
+         {bluetooth_user_authorization} && \
          {{ sudo -n rfkill unblock bluetooth || true; }} && \
          bluealsa_restart=0 && \
          sudo -n install -d -m 0755 {bluealsa_dropin_dir} && \
@@ -230,6 +232,7 @@ pub fn run(
         bluealsa_dropin_dir = shell_quote(BLUEALSA_DROPIN_DIR),
         bluealsa_dropin_source = shell_quote(BLUEALSA_DROPIN_SOURCE),
         bluealsa_dropin_path = shell_quote(BLUEALSA_DROPIN_PATH),
+        bluetooth_user_authorization = bluetooth_user_authorization,
         service_group_lookup = service_group_lookup,
         user = shell_quote(&wifi_service_user),
     );
@@ -289,6 +292,17 @@ fn validate_wifi_service_user(service_user: &str) -> Result<&str> {
 
 fn service_group_lookup_command(service_user: &str) -> String {
     format!("service_group=$(id -gn {})", shell_quote(service_user))
+}
+
+fn bluetooth_user_authorization_command(service_user: &str) -> String {
+    let user = shell_quote(service_user);
+    format!(
+        "if ! getent group bluetooth >/dev/null 2>&1; then \
+           sudo -n groupadd --system bluetooth; \
+         fi && \
+         sudo -n usermod -a -G bluetooth {user} && \
+         id -nG {user} | tr ' ' '\\n' | grep -Fx bluetooth >/dev/null"
+    )
 }
 
 fn resolve_wifi_service_user(ctx: &TargetContext) -> Result<String> {
@@ -599,6 +613,18 @@ mod tests {
         let command = service_group_lookup_command("yoyopod");
 
         assert_eq!(command, "service_group=$(id -gn yoyopod)");
+    }
+
+    #[test]
+    fn bluetooth_runtime_authorization_is_installed_for_the_service_user() {
+        let command = bluetooth_user_authorization_command("yoyopod");
+        let bootstrap = include_str!("../../../../../deploy/scripts/bootstrap_pi.sh");
+
+        assert!(command.contains("groupadd --system bluetooth"));
+        assert!(command.contains("usermod -a -G bluetooth yoyopod"));
+        assert!(command.contains("grep -Fx bluetooth"));
+        assert!(bootstrap.contains("usermod -a -G bluetooth \"${INVOKING_USER}\""));
+        assert!(bootstrap.contains("grep -Fx bluetooth"));
     }
 
     #[test]

--- a/cli/yoyopod/src/commands/target/deploy.rs
+++ b/cli/yoyopod/src/commands/target/deploy.rs
@@ -69,12 +69,10 @@ pub fn run(
         println!("artifact: {artifact_name}");
         println!("local-artifact-dir: {}", local_artifact_dir.display());
         println!("would: ensure CI run for sha is successful, download {tarball_name}");
-        let service_user = if ctx.conn.user.is_empty() {
-            "the SSH-configured remote login user"
-        } else {
-            ctx.conn.user.as_str()
-        };
-        println!("would: install Wi-Fi and BlueZ authorization for service user {service_user}");
+        println!(
+            "would: resolve the effective user of {} and install Wi-Fi and BlueZ authorization",
+            lane.dev_service
+        );
         println!(
             "would: ssh sync + extract + restart + verify on {}",
             ctx.conn.ssh_target()
@@ -103,7 +101,7 @@ pub fn run(
     }
     let polkit_rule_name = format!("yoyopod-wifi-{resolved_sha}.rules");
     let local_polkit_rule = local_artifact_dir.join(&polkit_rule_name);
-    let wifi_service_user = resolve_wifi_service_user(ctx)?;
+    let wifi_service_user = resolve_wifi_service_user(ctx, &lane.dev_service)?;
     std::fs::write(
         &local_polkit_rule,
         render_wifi_polkit_rule(&wifi_service_user)?,
@@ -305,20 +303,30 @@ fn bluetooth_user_authorization_command(service_user: &str) -> String {
     )
 }
 
-fn resolve_wifi_service_user(ctx: &TargetContext) -> Result<String> {
-    if !ctx.conn.user.trim().is_empty() {
-        return Ok(validate_wifi_service_user(&ctx.conn.user)?.to_string());
-    }
-
-    let output = run_remote_capture(&ctx.conn, "id -un", RemoteWorkdir::None)
-        .context("resolve remote service user for Wi-Fi Polkit rule")?;
+fn resolve_wifi_service_user(ctx: &TargetContext, service: &str) -> Result<String> {
+    let command = format!(
+        "systemctl show --property=User --value {}",
+        shell_quote(service)
+    );
+    let output = run_remote_capture(&ctx.conn, &command, RemoteWorkdir::None)
+        .context("resolve effective systemd service user for Wi-Fi and Bluetooth access")?;
     if !output.success() {
         return Err(anyhow!(
-            "could not resolve remote service user for Wi-Fi Polkit rule: {}",
+            "could not resolve effective systemd service user: {}",
             output.stderr.trim()
         ));
     }
-    Ok(validate_wifi_service_user(&output.stdout)?.to_string())
+    normalize_systemd_service_user(&output.stdout)
+}
+
+fn normalize_systemd_service_user(service_user: &str) -> Result<String> {
+    let service_user = service_user.trim();
+    let service_user = if service_user.is_empty() {
+        "root"
+    } else {
+        service_user
+    };
+    Ok(validate_wifi_service_user(service_user)?.to_string())
 }
 
 fn render_wifi_polkit_rule(service_user: &str) -> Result<String> {
@@ -613,6 +621,19 @@ mod tests {
         let command = service_group_lookup_command("yoyopod");
 
         assert_eq!(command, "service_group=$(id -gn yoyopod)");
+    }
+
+    #[test]
+    fn effective_systemd_user_defaults_to_root_and_preserves_named_users() {
+        assert_eq!(
+            normalize_systemd_service_user("\n").expect("root service"),
+            "root"
+        );
+        assert_eq!(
+            normalize_systemd_service_user("yoyopod\n").expect("named service"),
+            "yoyopod"
+        );
+        assert!(normalize_systemd_service_user("bad user").is_err());
     }
 
     #[test]

--- a/cli/yoyopod/src/commands/target/deploy.rs
+++ b/cli/yoyopod/src/commands/target/deploy.rs
@@ -167,6 +167,11 @@ pub fn run(
         "sudo -n install -d -m 0755 {dns_dir} && \
          printf 'address=/#/10.42.0.1\\n' | sudo -n tee {dns_file} >/dev/null && \
          sudo -n install -d -m 0755 {dropin_dir} && \
+         sudo -n install -d -m 0755 /var/lib/yoyopod/audio && \
+         if ! sudo -n test -s /var/lib/yoyopod/audio/asoundrc; then \
+           printf '# Managed by YoYoPod.\\n</usr/share/alsa/alsa.conf>\\n' \
+           | sudo -n tee /var/lib/yoyopod/audio/asoundrc >/dev/null; \
+         fi && \
          printf '[Service]\\nAmbientCapabilities=CAP_NET_BIND_SERVICE\\n' \
          | sudo -n tee {dropin_file} >/dev/null && \
          printf '[Service]\\nEnvironment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc\\nEnvironment=ALSA_CONFIG_PATH=/var/lib/yoyopod/audio/asoundrc\\n' \
@@ -605,6 +610,8 @@ mod tests {
             assert!(
                 service.contains("Environment=ALSA_CONFIG_PATH=/var/lib/yoyopod/audio/asoundrc")
             );
+            assert!(service.contains("test -s /var/lib/yoyopod/audio/asoundrc || printf"));
+            assert!(service.contains("</usr/share/alsa/alsa.conf>"));
         }
     }
 }

--- a/cli/yoyopod/src/commands/target/ops.rs
+++ b/cli/yoyopod/src/commands/target/ops.rs
@@ -49,10 +49,10 @@ pub fn build_startup_verification(pi: &PiPaths, attempts: u32) -> String {
         "test -d \"/proc/$pid\"".to_string(),
         format!(
             "for _ in $(seq 1 {attempts}); do \
-             if test -f {log} && grep -F {marker} {log} | tail -n 1 | grep -F \"pid=$pid\" >/dev/null; \
+             if test -f {log} && grep -aF {marker} {log} | tail -n 1 | grep -aF \"pid=$pid\" >/dev/null; \
              then break; fi; sleep 1; done"
         ),
-        format!("grep -F {marker} {log} | tail -n 1 | grep -F \"pid=$pid\""),
+        format!("grep -aF {marker} {log} | tail -n 1 | grep -aF \"pid=$pid\""),
     ]
     .join(" && ")
 }
@@ -90,4 +90,18 @@ pub fn build_restart(pi: &PiPaths, lane: &LanePaths) -> String {
          sudo systemctl start {dev_service} || exit $?"
     );
     [managed_restart, build_startup_verification(pi, 20)].join(" && ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_startup_verification;
+    use crate::paths::PiPaths;
+
+    #[test]
+    fn startup_verification_treats_runtime_logs_as_text() {
+        let command = build_startup_verification(&PiPaths::default(), 3);
+
+        assert_eq!(command.matches("grep -aF").count(), 4);
+        assert!(!command.contains("grep -F"));
+    }
 }

--- a/deploy/scripts/bootstrap_pi.sh
+++ b/deploy/scripts/bootstrap_pi.sh
@@ -67,6 +67,11 @@ if ! command -v bluealsa >/dev/null 2>&1 \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         alsa-utils bluez bluez-alsa-utils libasound2-plugin-bluez
 fi
+if ! getent group bluetooth >/dev/null 2>&1; then
+    groupadd --system bluetooth
+fi
+usermod -a -G bluetooth "${INVOKING_USER}"
+id -nG "${INVOKING_USER}" | tr ' ' '\n' | grep -Fx bluetooth >/dev/null
 rfkill unblock bluetooth || true
 install -d -m 0755 "${UNIT_DIR}/bluealsa.service.d"
 install -m 0644 -o root -g root \

--- a/deploy/scripts/bootstrap_pi.sh
+++ b/deploy/scripts/bootstrap_pi.sh
@@ -57,6 +57,19 @@ INVOKING_GROUP="$(id -gn "${INVOKING_USER}")"
 
 echo "bootstrap: user=${INVOKING_USER} group=${INVOKING_GROUP} prod_root=${ROOT} dev_root=${DEV_ROOT}"
 
+# Bluetooth audio is a runtime capability, not a build dependency. Keep these
+# packages on the Pi and configure BlueALSA as the bridge used by the stable
+# ALSA aliases managed by the network worker.
+if ! command -v bluealsa >/dev/null 2>&1 \
+    || ! command -v aplay >/dev/null 2>&1 \
+    || ! dpkg-query -W libasound2-plugin-bluez >/dev/null 2>&1; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        alsa-utils bluez bluez-alsa-utils libasound2-plugin-bluez
+fi
+rfkill unblock bluetooth || true
+systemctl enable --now bluetooth.service bluealsa.service
+
 # 1. Create directory skeleton.
 install -d -m 0755 -o root -g root \
     "${ROOT}" "${ROOT}/bin" "${DEV_ROOT}" "${DEV_ROOT}/bin"
@@ -65,6 +78,8 @@ install -d -m 0755 -o "${INVOKING_USER}" -g "${INVOKING_GROUP}" \
 install -d -m 0755 -o "${INVOKING_USER}" -g "${INVOKING_GROUP}" \
     "${DEV_ROOT}/checkout" "${DEV_ROOT}/venv" "${DEV_ROOT}/state" \
     "${DEV_ROOT}/logs" "${DEV_ROOT}/tmp"
+install -d -m 0750 -o "${INVOKING_USER}" -g "${INVOKING_GROUP}" \
+    /var/lib/yoyopod /var/lib/yoyopod/bluetooth /var/lib/yoyopod/audio
 
 # 2. Install rollback helper (owned by root, invoked by systemd).
 install -m 0755 -o root -g root \
@@ -131,6 +146,7 @@ YOYOPOD_ROOT=${ROOT}
 YOYOPOD_STATE_DIR=${ROOT}/state
 YOYOPOD_PID_FILE=${ROOT}/state/yoyopod.pid
 YOYOPOD_SERVICE_NAME=yoyopod-prod.service
+HOME=/home/${INVOKING_USER}
 EOF
 
 cat > "/etc/default/yoyopod-dev" <<EOF
@@ -140,6 +156,7 @@ YOYOPOD_DEV_CHECKOUT=${DEV_ROOT}/checkout
 YOYOPOD_DEV_VENV=${DEV_ROOT}/venv
 YOYOPOD_STATE_DIR=${DEV_ROOT}/state
 YOYOPOD_PID_FILE=${DEV_ROOT}/state/yoyopod.pid
+HOME=/home/${INVOKING_USER}
 EOF
 
 # Patch User=/Group= into the unit (only if not already present).

--- a/deploy/scripts/bootstrap_pi.sh
+++ b/deploy/scripts/bootstrap_pi.sh
@@ -68,7 +68,16 @@ if ! command -v bluealsa >/dev/null 2>&1 \
         alsa-utils bluez bluez-alsa-utils libasound2-plugin-bluez
 fi
 rfkill unblock bluetooth || true
-systemctl enable --now bluetooth.service bluealsa.service
+install -d -m 0755 "${UNIT_DIR}/bluealsa.service.d"
+install -m 0644 -o root -g root \
+    "${REPO_ROOT}/deploy/systemd/bluealsa-yoyopod.conf" \
+    "${UNIT_DIR}/bluealsa.service.d/20-yoyopod-audio-role.conf"
+systemctl daemon-reload
+systemctl enable --now bluetooth.service
+systemctl disable --now bluealsa-aplay.service
+systemctl enable bluealsa.service
+systemctl restart bluealsa.service
+systemctl is-active --quiet bluetooth.service bluealsa.service
 
 # 1. Create directory skeleton.
 install -d -m 0755 -o root -g root \

--- a/deploy/systemd/bluealsa-yoyopod.conf
+++ b/deploy/systemd/bluealsa-yoyopod.conf
@@ -1,0 +1,7 @@
+[Service]
+# YoYoPod is the audio source/gateway. It sends media and call audio to paired
+# speakers/headsets and may receive a headset microphone over HFP/HSP. Do not
+# advertise sink/target roles: those make phones and smart speakers stream
+# their audio into YoYoPod in the wrong direction.
+ExecStart=
+ExecStart=/usr/bin/bluealsa -S -p a2dp-source -p hfp-ag -p hsp-ag

--- a/deploy/systemd/yoyopod-dev.service
+++ b/deploy/systemd/yoyopod-dev.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=YoyoPod dev lane (mutable checkout)
-After=network-online.target sound.target pisugar-server.service
-Wants=network-online.target
+After=network-online.target sound.target bluetooth.service bluealsa.service pisugar-server.service
+Wants=network-online.target bluetooth.service bluealsa.service
 Conflicts=yoyopod-prod.service
 
 [Service]
@@ -10,7 +10,6 @@ Type=simple
 # child of the runtime, which inherits this ambient capability across exec.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 EnvironmentFile=-/etc/default/yoyopod-dev
-Environment=HOME=/root
 WorkingDirectory=/
 ExecStartPre=/usr/bin/env bash -lc 'HOME="$${HOME:-/root}"; DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; install -d -m 700 "$$HOME/.local/share/linphone" "$$HOME/.config/linphone"; install -d -m 755 "$$STATE_DIR"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; test -d "$$CHECKOUT/config"; test -x "$$CHECKOUT/device/runtime/build/yoyopod-runtime"; test -x "$$CHECKOUT/device/ui/build/yoyopod-ui-host"'
 ExecStart=/usr/bin/env bash -lc 'DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; export YOYOPOD_PID_FILE="$${YOYOPOD_PID_FILE:-$$STATE_DIR/yoyopod.pid}"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; cd "$$CHECKOUT"; exec "$$CHECKOUT/device/runtime/build/yoyopod-runtime" --config-dir "$$CHECKOUT/config" --hardware whisplay'

--- a/deploy/systemd/yoyopod-dev.service
+++ b/deploy/systemd/yoyopod-dev.service
@@ -11,6 +11,7 @@ Type=simple
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 EnvironmentFile=-/etc/default/yoyopod-dev
 Environment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc
+Environment=ALSA_CONFIG_PATH=/var/lib/yoyopod/audio/asoundrc
 WorkingDirectory=/
 ExecStartPre=/usr/bin/env bash -lc 'HOME="$${HOME:-/root}"; DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; install -d -m 700 "$$HOME/.local/share/linphone" "$$HOME/.config/linphone"; install -d -m 755 "$$STATE_DIR"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; test -d "$$CHECKOUT/config"; test -x "$$CHECKOUT/device/runtime/build/yoyopod-runtime"; test -x "$$CHECKOUT/device/ui/build/yoyopod-ui-host"'
 ExecStart=/usr/bin/env bash -lc 'DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; export YOYOPOD_PID_FILE="$${YOYOPOD_PID_FILE:-$$STATE_DIR/yoyopod.pid}"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; cd "$$CHECKOUT"; exec "$$CHECKOUT/device/runtime/build/yoyopod-runtime" --config-dir "$$CHECKOUT/config" --hardware whisplay'

--- a/deploy/systemd/yoyopod-dev.service
+++ b/deploy/systemd/yoyopod-dev.service
@@ -10,6 +10,7 @@ Type=simple
 # child of the runtime, which inherits this ambient capability across exec.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 EnvironmentFile=-/etc/default/yoyopod-dev
+Environment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc
 WorkingDirectory=/
 ExecStartPre=/usr/bin/env bash -lc 'HOME="$${HOME:-/root}"; DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; install -d -m 700 "$$HOME/.local/share/linphone" "$$HOME/.config/linphone"; install -d -m 755 "$$STATE_DIR"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; test -d "$$CHECKOUT/config"; test -x "$$CHECKOUT/device/runtime/build/yoyopod-runtime"; test -x "$$CHECKOUT/device/ui/build/yoyopod-ui-host"'
 ExecStart=/usr/bin/env bash -lc 'DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; export YOYOPOD_PID_FILE="$${YOYOPOD_PID_FILE:-$$STATE_DIR/yoyopod.pid}"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; cd "$$CHECKOUT"; exec "$$CHECKOUT/device/runtime/build/yoyopod-runtime" --config-dir "$$CHECKOUT/config" --hardware whisplay'

--- a/deploy/systemd/yoyopod-dev.service
+++ b/deploy/systemd/yoyopod-dev.service
@@ -13,6 +13,7 @@ EnvironmentFile=-/etc/default/yoyopod-dev
 Environment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc
 Environment=ALSA_CONFIG_PATH=/var/lib/yoyopod/audio/asoundrc
 WorkingDirectory=/
+ExecStartPre=/usr/bin/env bash -lc 'install -d -m 0755 /var/lib/yoyopod/audio; test -s /var/lib/yoyopod/audio/asoundrc || printf "# Managed by YoYoPod.\n</usr/share/alsa/alsa.conf>\n" > /var/lib/yoyopod/audio/asoundrc'
 ExecStartPre=/usr/bin/env bash -lc 'HOME="$${HOME:-/root}"; DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; install -d -m 700 "$$HOME/.local/share/linphone" "$$HOME/.config/linphone"; install -d -m 755 "$$STATE_DIR"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; test -d "$$CHECKOUT/config"; test -x "$$CHECKOUT/device/runtime/build/yoyopod-runtime"; test -x "$$CHECKOUT/device/ui/build/yoyopod-ui-host"'
 ExecStart=/usr/bin/env bash -lc 'DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; export YOYOPOD_PID_FILE="$${YOYOPOD_PID_FILE:-$$STATE_DIR/yoyopod.pid}"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; cd "$$CHECKOUT"; exec "$$CHECKOUT/device/runtime/build/yoyopod-runtime" --config-dir "$$CHECKOUT/config" --hardware whisplay'
 Restart=on-failure

--- a/deploy/systemd/yoyopod-prod.service
+++ b/deploy/systemd/yoyopod-prod.service
@@ -14,6 +14,8 @@ Type=simple
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 EnvironmentFile=-/etc/default/yoyopod-prod
 Environment=PYTHONUNBUFFERED=1
+Environment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc
+Environment=ALSA_CONFIG_PATH=/var/lib/yoyopod/audio/asoundrc
 WorkingDirectory=/
 ExecStart=/usr/bin/env bash -lc 'exec "$${YOYOPOD_ROOT:-/opt/yoyopod-prod}/current/bin/launch"'
 Restart=on-failure

--- a/deploy/systemd/yoyopod-prod.service
+++ b/deploy/systemd/yoyopod-prod.service
@@ -17,6 +17,7 @@ Environment=PYTHONUNBUFFERED=1
 Environment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc
 Environment=ALSA_CONFIG_PATH=/var/lib/yoyopod/audio/asoundrc
 WorkingDirectory=/
+ExecStartPre=/usr/bin/env bash -lc 'install -d -m 0755 /var/lib/yoyopod/audio; test -s /var/lib/yoyopod/audio/asoundrc || printf "# Managed by YoYoPod.\n</usr/share/alsa/alsa.conf>\n" > /var/lib/yoyopod/audio/asoundrc'
 ExecStart=/usr/bin/env bash -lc 'exec "$${YOYOPOD_ROOT:-/opt/yoyopod-prod}/current/bin/launch"'
 Restart=on-failure
 RestartSec=5

--- a/deploy/systemd/yoyopod-prod.service
+++ b/deploy/systemd/yoyopod-prod.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=YoyoPod prod lane (slot deploy, OTA-ready)
-After=network-online.target sound.target pisugar-server.service
-Wants=network-online.target
+After=network-online.target sound.target bluetooth.service bluealsa.service pisugar-server.service
+Wants=network-online.target bluetooth.service bluealsa.service
 Conflicts=yoyopod-dev.service
 StartLimitIntervalSec=300
 StartLimitBurst=3

--- a/device/Cargo.lock
+++ b/device/Cargo.lock
@@ -2308,6 +2308,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
+ "getrandom 0.2.17",
  "serde",
 ]
 

--- a/device/network/Cargo.toml
+++ b/device/network/Cargo.toml
@@ -40,7 +40,7 @@ async-signal = "=0.2.13"
 proc-macro-crate = "=3.4.0"
 toml_parser = "=1.0.4"
 indexmap = "=2.7.1"
-uuid = "=1.11.0"
+uuid = { version = "=1.11.0", features = ["v4"] }
 yoyopod-protocol = { path = "../protocol" }
 
 [dev-dependencies]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -10,6 +10,71 @@ use serde::{Deserialize, Serialize};
 use crate::bluetooth::{BluetoothController, BluetoothState};
 
 const DEFAULT_SETTINGS_PATH: &str = "/var/lib/yoyopod/audio/settings.json";
+const DEFAULT_ASOUND_CONFIG_PATH: &str = "/var/lib/yoyopod/audio/asoundrc";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BuiltinAudioDevices {
+    media: String,
+    voip_playback: String,
+    voip_ringer: String,
+    voip_capture: String,
+    voip_media: String,
+}
+
+impl Default for BuiltinAudioDevices {
+    fn default() -> Self {
+        Self {
+            media: "alsa/default".to_string(),
+            voip_playback: "ALSA: wm8960-soundcard".to_string(),
+            voip_ringer: "ALSA: wm8960-soundcard".to_string(),
+            voip_capture: "ALSA: wm8960-soundcard".to_string(),
+            voip_media: "ALSA: wm8960-soundcard".to_string(),
+        }
+    }
+}
+
+impl BuiltinAudioDevices {
+    fn load(config_dir: &Path) -> Self {
+        let hardware = fs::read(config_dir.join("device/hardware.yaml"))
+            .ok()
+            .and_then(|bytes| serde_yaml::from_slice::<serde_yaml::Value>(&bytes).ok())
+            .unwrap_or(serde_yaml::Value::Null);
+        let configured = |path: &[&str], env_name: &str, fallback: &str| {
+            std::env::var(env_name)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .or_else(|| yaml_string(&hardware, path))
+                .unwrap_or_else(|| fallback.to_string())
+        };
+        Self {
+            media: mpv_alsa_device(&configured(
+                &["media_audio", "alsa_device"],
+                "YOYOPOD_ALSA_DEVICE",
+                "default",
+            )),
+            voip_playback: configured(
+                &["communication_audio", "playback_device_id"],
+                "YOYOPOD_PLAYBACK_DEVICE",
+                "ALSA: wm8960-soundcard",
+            ),
+            voip_ringer: configured(
+                &["communication_audio", "ringer_device_id"],
+                "YOYOPOD_RINGER_DEVICE",
+                "ALSA: wm8960-soundcard",
+            ),
+            voip_capture: configured(
+                &["communication_audio", "capture_device_id"],
+                "YOYOPOD_CAPTURE_DEVICE",
+                "ALSA: wm8960-soundcard",
+            ),
+            voip_media: configured(
+                &["communication_audio", "media_device_id"],
+                "YOYOPOD_MEDIA_DEVICE",
+                "ALSA: wm8960-soundcard",
+            ),
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AudioSettings {
@@ -136,21 +201,34 @@ pub struct AudioManager {
     desired: AudioSettings,
     input_meter: Option<AudioInputMeter>,
     last_resolved: Option<AppliedAudio>,
+    builtin: BuiltinAudioDevices,
 }
 
 impl AudioManager {
-    pub fn open() -> Self {
+    pub fn open(config_dir: impl AsRef<Path>) -> Self {
         let settings_path = std::env::var_os("YOYOPOD_AUDIO_SETTINGS_FILE")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(DEFAULT_SETTINGS_PATH));
         let asound_path = std::env::var_os("YOYOPOD_ASOUND_CONFIG")
             .map(PathBuf::from)
-            .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".asoundrc")))
-            .unwrap_or_else(|| PathBuf::from("/home/raouf/.asoundrc"));
-        Self::open_at(settings_path, asound_path)
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_ASOUND_CONFIG_PATH));
+        Self::open_at_with_builtin(
+            settings_path,
+            asound_path,
+            BuiltinAudioDevices::load(config_dir.as_ref()),
+        )
     }
 
+    #[cfg(test)]
     fn open_at(settings_path: PathBuf, asound_path: PathBuf) -> Self {
+        Self::open_at_with_builtin(settings_path, asound_path, BuiltinAudioDevices::default())
+    }
+
+    fn open_at_with_builtin(
+        settings_path: PathBuf,
+        asound_path: PathBuf,
+        builtin: BuiltinAudioDevices,
+    ) -> Self {
         let stored = fs::read(&settings_path)
             .ok()
             .and_then(|bytes| serde_json::from_slice::<StoredAudioSettings>(&bytes).ok());
@@ -161,6 +239,7 @@ impl AudioManager {
             desired: stored.map_or_else(AudioSettings::default, |stored| stored.settings),
             input_meter: None,
             last_resolved: None,
+            builtin,
         }
     }
 
@@ -225,12 +304,18 @@ impl AudioManager {
         route: &AudioRouteLocal,
     ) -> Result<(), AudioOperationError> {
         let (device, volume): (&str, u8) = match target {
-            "media" => (route.media_device.as_str(), self.desired.levels.media),
+            "media" => (route.media_device.as_str(), route.media_volume),
             "communication" => (
                 route.voip_playback_device.as_str(),
-                self.desired.levels.communication,
+                route.communication_volume,
             ),
-            "alerts" => ("alsa/default", self.desired.levels.alerts),
+            "alerts" => (
+                route.voip_ringer_device.as_str(),
+                self.desired
+                    .levels
+                    .alerts
+                    .min(self.desired.levels.max_output),
+            ),
             _ => return Err(AudioOperationError::invalid("Unknown audio test target")),
         };
         let sample = [
@@ -240,12 +325,19 @@ impl AudioManager {
         .into_iter()
         .find(|path| Path::new(path).exists())
         .ok_or_else(|| AudioOperationError::failed("No audio test sound is installed"))?;
-        let alsa_device = local_alsa_device(device);
-        let _ = volume;
-        Command::new("aplay")
-            .args(["-q", "-D", alsa_device, sample])
-            .spawn()
-            .map_err(|_| AudioOperationError::failed("The test sound could not be played"))?;
+        let audio_device = mpv_alsa_device(device);
+        let status = Command::new("mpv")
+            .args(output_test_args(&audio_device, volume, sample))
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map_err(|_| AudioOperationError::failed("The test sound could not be started"))?;
+        if !status.success() {
+            return Err(AudioOperationError::failed(
+                "The selected audio output is not currently available",
+            ));
+        }
         Ok(())
     }
 
@@ -349,7 +441,7 @@ impl AudioManager {
             media_device: if media_fallback
                 || self.desired.routes.media_output_id == "builtin-speaker"
             {
-                "alsa/default"
+                self.builtin.media.as_str()
             } else {
                 "alsa/yoyopod_bt_a2dp"
             }
@@ -362,17 +454,17 @@ impl AudioManager {
             voip_playback_device: if communication_output_fallback
                 || self.desired.routes.communication_output_id == "builtin-speaker"
             {
-                "ALSA: default"
+                self.builtin.voip_playback.as_str()
             } else {
                 "ALSA: yoyopod_bt_sco"
             }
             .to_string(),
             // Safety alerts/ringing always retain the built-in route.
-            voip_ringer_device: "ALSA: default".to_string(),
+            voip_ringer_device: self.builtin.voip_ringer.clone(),
             voip_capture_device: if communication_input_fallback
                 || self.desired.routes.communication_input_id == "builtin-microphone"
             {
-                "ALSA: default"
+                self.builtin.voip_capture.as_str()
             } else {
                 "ALSA: yoyopod_bt_sco"
             }
@@ -380,7 +472,7 @@ impl AudioManager {
             voip_media_device: if communication_output_fallback
                 || self.desired.routes.communication_output_id == "builtin-speaker"
             {
-                "ALSA: default"
+                self.builtin.voip_media.as_str()
             } else {
                 "ALSA: yoyopod_bt_sco"
             }
@@ -548,6 +640,42 @@ fn same_audio_application(left: &AppliedAudio, right: &AppliedAudio) -> bool {
     left.route == right.route && left_state == right_state
 }
 
+fn yaml_string(value: &serde_yaml::Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for segment in path {
+        current = current
+            .as_mapping()?
+            .get(serde_yaml::Value::String((*segment).to_string()))?;
+    }
+    current
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn mpv_alsa_device(device: &str) -> String {
+    if device.starts_with("alsa/") {
+        device.to_string()
+    } else {
+        format!("alsa/{}", local_alsa_device(device))
+    }
+}
+
+fn output_test_args(audio_device: &str, volume: u8, sample: &str) -> Vec<String> {
+    vec![
+        "--no-config".to_string(),
+        "--really-quiet".to_string(),
+        "--no-video".to_string(),
+        "--audio-display=no".to_string(),
+        "--ao=alsa".to_string(),
+        format!("--audio-device={audio_device}"),
+        format!("--volume={}", volume.min(100)),
+        "--volume-max=100".to_string(),
+        sample.to_string(),
+    ]
+}
+
 fn local_alsa_device(device: &str) -> &str {
     device
         .strip_prefix("alsa/")
@@ -673,7 +801,7 @@ mod tests {
             .apply(2, settings, &UnavailableBluetoothController, &state)
             .expect("apply");
 
-        assert_eq!(applied.route.voip_playback_device, "ALSA: default");
+        assert_eq!(applied.route.voip_playback_device, "ALSA: wm8960-soundcard");
         assert_eq!(
             applied.state.applied.routes.communication_output_id,
             "builtin-speaker"
@@ -698,6 +826,46 @@ mod tests {
             .expect("periodic state");
 
         assert!(unchanged.is_none());
+    }
+
+    #[test]
+    fn configured_builtin_devices_are_preserved_in_local_routes() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let builtin = BuiltinAudioDevices {
+            media: "alsa/custom-speaker".to_string(),
+            voip_playback: "ALSA: custom-playback".to_string(),
+            voip_ringer: "ALSA: custom-ringer".to_string(),
+            voip_capture: "ALSA: custom-capture".to_string(),
+            voip_media: "ALSA: custom-media".to_string(),
+        };
+        let mut manager = AudioManager::open_at_with_builtin(
+            directory.path().join("settings.json"),
+            directory.path().join("asoundrc"),
+            builtin,
+        );
+
+        let applied = manager
+            .current(
+                &UnavailableBluetoothController,
+                &BluetoothState::unavailable(),
+            )
+            .expect("route");
+
+        assert_eq!(applied.route.media_device, "alsa/custom-speaker");
+        assert_eq!(applied.route.voip_playback_device, "ALSA: custom-playback");
+        assert_eq!(applied.route.voip_ringer_device, "ALSA: custom-ringer");
+        assert_eq!(applied.route.voip_capture_device, "ALSA: custom-capture");
+        assert_eq!(applied.route.voip_media_device, "ALSA: custom-media");
+    }
+
+    #[test]
+    fn output_test_uses_the_selected_device_and_bounded_level() {
+        let args = output_test_args("alsa/yoyopod_bt_a2dp", 86, "/tmp/test.wav");
+
+        assert!(args.contains(&"--audio-device=alsa/yoyopod_bt_a2dp".to_string()));
+        assert!(args.contains(&"--volume=86".to_string()));
+        assert!(args.contains(&"--volume-max=100".to_string()));
+        assert_eq!(args.last().map(String::as_str), Some("/tmp/test.wav"));
     }
 
     #[test]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -123,7 +123,7 @@ impl AudioOperationError {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppliedAudio {
     pub state: AudioState,
     pub route: AudioRouteLocal,
@@ -135,6 +135,7 @@ pub struct AudioManager {
     desired_revision: u64,
     desired: AudioSettings,
     input_meter: Option<AudioInputMeter>,
+    last_resolved: Option<AppliedAudio>,
 }
 
 impl AudioManager {
@@ -159,6 +160,7 @@ impl AudioManager {
             desired_revision: stored.as_ref().map_or(0, |stored| stored.revision),
             desired: stored.map_or_else(AudioSettings::default, |stored| stored.settings),
             input_meter: None,
+            last_resolved: None,
         }
     }
 
@@ -202,6 +204,19 @@ impl AudioManager {
         bluetooth_state: &BluetoothState,
     ) -> Result<AppliedAudio, AudioOperationError> {
         self.resolve(bluetooth, bluetooth_state)
+    }
+
+    pub fn current_if_changed(
+        &mut self,
+        bluetooth: &dyn BluetoothController,
+        bluetooth_state: &BluetoothState,
+    ) -> Result<Option<AppliedAudio>, AudioOperationError> {
+        let previous = self.last_resolved.clone();
+        let applied = self.resolve(bluetooth, bluetooth_state)?;
+        Ok(previous
+            .as_ref()
+            .is_none_or(|previous| !same_audio_application(previous, &applied))
+            .then_some(applied))
     }
 
     pub fn test_output(
@@ -294,31 +309,40 @@ impl AudioManager {
                 accessory.accessory_id == endpoint_id && accessory.paired && accessory.connected
             })
         };
-        let output_address = connected(&self.desired.routes.media_output_id)
-            .or_else(|| connected(&self.desired.routes.communication_output_id))
+        let media_accessory = connected(&self.desired.routes.media_output_id);
+        let communication_output_accessory =
+            connected(&self.desired.routes.communication_output_id)
+                .filter(|accessory| accessory.capabilities.hands_free);
+        let communication_input_accessory = connected(&self.desired.routes.communication_input_id)
+            .filter(|accessory| accessory.capabilities.microphone);
+        let media_address =
+            media_accessory.and_then(|accessory| bluetooth.raw_address(&accessory.accessory_id));
+        let communication_output_address = communication_output_accessory
             .and_then(|accessory| bluetooth.raw_address(&accessory.accessory_id));
-        let input_address = connected(&self.desired.routes.communication_input_id)
+        let communication_input_address = communication_input_accessory
             .and_then(|accessory| bluetooth.raw_address(&accessory.accessory_id));
-        write_asound_config(
-            &self.asound_path,
-            output_address.as_deref(),
-            input_address.as_deref(),
-        )?;
+        let output_address = media_address
+            .as_deref()
+            .or(communication_output_address.as_deref());
+        let input_address = communication_input_address
+            .as_deref()
+            .or(communication_output_address.as_deref());
+        write_asound_config(&self.asound_path, output_address, input_address)?;
 
         let media_fallback = !self.desired.routes.media_output_id.starts_with("builtin-")
-            && output_address.is_none();
+            && media_accessory.is_none();
         let communication_output_fallback = !self
             .desired
             .routes
             .communication_output_id
             .starts_with("builtin-")
-            && connected(&self.desired.routes.communication_output_id).is_none();
+            && communication_output_accessory.is_none();
         let communication_input_fallback = !self
             .desired
             .routes
             .communication_input_id
             .starts_with("builtin-")
-            && input_address.is_none();
+            && communication_input_accessory.is_none();
         let fallback =
             media_fallback || communication_output_fallback || communication_input_fallback;
         let route = AudioRouteLocal {
@@ -374,7 +398,7 @@ impl AudioManager {
             communication_output_fallback,
             communication_input_fallback,
         );
-        Ok(AppliedAudio {
+        let applied = AppliedAudio {
             state: AudioState {
                 schema_version: 1,
                 status: if bluetooth_state.status == "unavailable" {
@@ -396,7 +420,9 @@ impl AudioManager {
                 reported_at: epoch_seconds(),
             },
             route,
-        })
+        };
+        self.last_resolved = Some(applied.clone());
+        Ok(applied)
     }
 
     fn persist(&self) -> Result<(), AudioOperationError> {
@@ -507,8 +533,19 @@ fn write_asound_config(
 pcm.yoyopod_bt_a2dp {{\n  type bluealsa\n  device \"{output}\"\n  profile \"a2dp\"\n}}\n\
 pcm.yoyopod_bt_sco {{\n  type bluealsa\n  device \"{input}\"\n  profile \"sco\"\n}}\n"
     );
+    if fs::read(path).is_ok_and(|existing| existing == config.as_bytes()) {
+        return Ok(());
+    }
     atomic_write(path, config.as_bytes())
         .map_err(|_| AudioOperationError::failed("The local audio route could not be configured"))
+}
+
+fn same_audio_application(left: &AppliedAudio, right: &AppliedAudio) -> bool {
+    let mut left_state = left.state.clone();
+    let mut right_state = right.state.clone();
+    left_state.reported_at = 0;
+    right_state.reported_at = 0;
+    left.route == right.route && left_state == right_state
 }
 
 fn local_alsa_device(device: &str) -> &str {
@@ -593,6 +630,74 @@ mod tests {
         );
         assert_eq!(applied.state.status, "degraded");
         assert_eq!(applied.state.applied_revision, 2);
+    }
+
+    #[test]
+    fn a2dp_only_communication_output_falls_back_to_builtin() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let mut manager = AudioManager::open_at(
+            directory.path().join("settings.json"),
+            directory.path().join("asoundrc"),
+        );
+        let accessory_id = "9b0692e3-a07a-42f0-9fa7-a7704bbcf778".to_string();
+        let state = BluetoothState {
+            schema_version: 1,
+            status: "ready".to_string(),
+            radio_enabled: true,
+            scanning: false,
+            accessories: vec![BluetoothAccessory {
+                accessory_id: accessory_id.clone(),
+                name: "Speaker".to_string(),
+                kind: "speaker".to_string(),
+                paired: true,
+                connected: true,
+                trusted: true,
+                auto_connect: true,
+                capabilities: BluetoothCapabilities {
+                    output: true,
+                    microphone: false,
+                    stereo: true,
+                    hands_free: false,
+                },
+                battery_percent: None,
+                signal_percent: None,
+                last_seen_at: 1,
+            }],
+            scanned_at: None,
+            reported_at: 1,
+        };
+        let mut settings = AudioSettings::default();
+        settings.routes.communication_output_id = accessory_id;
+
+        let applied = manager
+            .apply(2, settings, &UnavailableBluetoothController, &state)
+            .expect("apply");
+
+        assert_eq!(applied.route.voip_playback_device, "ALSA: default");
+        assert_eq!(
+            applied.state.applied.routes.communication_output_id,
+            "builtin-speaker"
+        );
+        assert_eq!(applied.state.status, "degraded");
+    }
+
+    #[test]
+    fn unchanged_periodic_audio_state_is_not_reapplied() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let mut manager = AudioManager::open_at(
+            directory.path().join("settings.json"),
+            directory.path().join("asoundrc"),
+        );
+        let state = BluetoothState::unavailable();
+
+        manager
+            .current(&UnavailableBluetoothController, &state)
+            .expect("initial state");
+        let unchanged = manager
+            .current_if_changed(&UnavailableBluetoothController, &state)
+            .expect("periodic state");
+
+        assert!(unchanged.is_none());
     }
 
     #[test]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -446,12 +446,12 @@ impl AudioManager {
         } else {
             "yoyopod_bt_a2dp"
         };
-        let output_address = media_address
-            .as_deref()
-            .or(communication_output_address.as_deref());
-        let input_address = communication_input_address
-            .as_deref()
-            .or(communication_output_address.as_deref());
+        let (output_address, input_address) = bluetooth_pcm_addresses(
+            media_address.as_deref(),
+            communication_output_address.as_deref(),
+            communication_input_address.as_deref(),
+            media_uses_sco,
+        );
         write_asound_config(
             &self.asound_path,
             output_address,
@@ -719,6 +719,19 @@ pcm.yoyopod_alert_mirror {{\n\
         .map_err(|_| AudioOperationError::failed("The local audio route could not be configured"))
 }
 
+fn bluetooth_pcm_addresses<'a>(
+    media_address: Option<&'a str>,
+    communication_output_address: Option<&'a str>,
+    communication_input_address: Option<&'a str>,
+    media_uses_sco: bool,
+) -> (Option<&'a str>, Option<&'a str>) {
+    let output = media_address.or(communication_output_address);
+    let input = communication_input_address
+        .or(communication_output_address)
+        .or(if media_uses_sco { media_address } else { None });
+    (output, input)
+}
+
 fn escape_alsa_string(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
@@ -956,6 +969,21 @@ mod tests {
         assert_eq!(applied.route.media_device, "alsa/yoyopod_bt_sco");
         assert_eq!(applied.state.applied.routes.media_output_id, accessory_id);
         assert_eq!(applied.state.status, "ready");
+    }
+
+    #[test]
+    fn media_only_sco_route_uses_the_media_address_for_both_pcms() {
+        let address = "AA:BB:CC:DD:EE:FF";
+        let (output, input) = bluetooth_pcm_addresses(Some(address), None, None, true);
+        assert_eq!(output, Some(address));
+        assert_eq!(input, Some(address));
+
+        let directory = tempfile::tempdir().expect("tempdir");
+        let asound_path = directory.path().join("asoundrc");
+        write_asound_config(&asound_path, output, input, "default", "yoyopod_bt_sco")
+            .expect("asound config");
+        let config = fs::read_to_string(asound_path).expect("read asound config");
+        assert_eq!(config.matches("device \"AA:BB:CC:DD:EE:FF\"").count(), 2);
     }
 
     #[test]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -271,9 +271,9 @@ impl AudioManager {
                 "A newer or locally changed audio configuration is already active",
             ));
         }
+        self.persist_candidate(revision, &settings)?;
         self.desired_revision = revision;
         self.desired = settings;
-        self.persist()?;
         self.resolve(bluetooth, bluetooth_state)
     }
 
@@ -285,10 +285,12 @@ impl AudioManager {
     ) -> Result<AppliedAudio, AudioOperationError> {
         let max_output = self.desired.levels.max_output.clamp(20, 100);
         let level = level.min(max_output);
-        self.desired.levels.media = level;
-        self.desired.levels.communication = level;
-        self.desired.levels.alerts = level.max(20).min(max_output);
-        self.persist()?;
+        let mut desired = self.desired.clone();
+        desired.levels.media = level;
+        desired.levels.communication = level;
+        desired.levels.alerts = level.max(20).min(max_output);
+        self.persist_candidate(self.desired_revision, &desired)?;
+        self.desired = desired;
         self.resolve(bluetooth, bluetooth_state)
     }
 
@@ -563,10 +565,14 @@ impl AudioManager {
         Ok(applied)
     }
 
-    fn persist(&self) -> Result<(), AudioOperationError> {
+    fn persist_candidate(
+        &self,
+        revision: u64,
+        settings: &AudioSettings,
+    ) -> Result<(), AudioOperationError> {
         let stored = StoredAudioSettings {
-            revision: self.desired_revision,
-            settings: self.desired.clone(),
+            revision,
+            settings: settings.clone(),
         };
         atomic_json_write(&self.settings_path, &stored)
             .map_err(|_| AudioOperationError::failed("Audio settings could not be saved"))
@@ -669,7 +675,24 @@ fn write_asound_config(
     let output = output_address.unwrap_or("00:00:00:00:00:00");
     let input = input_address.unwrap_or(output);
     let builtin_ringer = escape_alsa_string(builtin_ringer);
+    let selected_alert_is_mono = selected_alert_pcm == "yoyopod_bt_sco";
     let selected_alert_pcm = escape_alsa_string(selected_alert_pcm);
+    let (selected_channels, selected_bindings, mirror_channels, selected_ttable) =
+        if selected_alert_is_mono {
+            (
+                1,
+                "  bindings.2.slave selected\n  bindings.2.channel 0\n",
+                3,
+                "  ttable.0.2 0.5\n  ttable.1.2 0.5\n",
+            )
+        } else {
+            (
+                2,
+                "  bindings.2.slave selected\n  bindings.2.channel 0\n  bindings.3.slave selected\n  bindings.3.channel 1\n",
+                4,
+                "  ttable.0.2 1\n  ttable.1.3 1\n",
+            )
+        };
     let config = format!(
         concat!(
             "# Managed by YoYoPod. Bluetooth addresses stay on-device.\n\
@@ -681,30 +704,30 @@ pcm.yoyopod_bt_sco {{\n  type bluealsa\n  device \"{input}\"\n  profile \"sco\"\
   slaves.builtin.pcm \"plug:{builtin_ringer}\"\n\
   slaves.builtin.channels 2\n\
   slaves.selected.pcm \"plug:{selected_alert_pcm}\"\n\
-  slaves.selected.channels 2\n\
+  slaves.selected.channels {selected_channels}\n\
   bindings.0.slave builtin\n\
   bindings.0.channel 0\n\
   bindings.1.slave builtin\n\
   bindings.1.channel 1\n\
-  bindings.2.slave selected\n\
-  bindings.2.channel 0\n\
-  bindings.3.slave selected\n\
-  bindings.3.channel 1\n\
+{selected_bindings}\
 }}\n\
 pcm.yoyopod_alert_mirror {{\n\
   type route\n\
   slave.pcm \"yoyopod_alert_multi\"\n\
-  slave.channels 4\n\
+  slave.channels {mirror_channels}\n\
   ttable.0.0 1\n\
   ttable.1.1 1\n\
-  ttable.0.2 1\n\
-  ttable.1.3 1\n\
+{selected_ttable}\
 }}\n"
         ),
         output = output,
         input = input,
         builtin_ringer = builtin_ringer,
         selected_alert_pcm = selected_alert_pcm,
+        selected_channels = selected_channels,
+        selected_bindings = selected_bindings,
+        mirror_channels = mirror_channels,
+        selected_ttable = selected_ttable,
     );
     if fs::read(path).is_ok_and(|existing| existing == config.as_bytes()) {
         return Ok(());
@@ -1073,6 +1096,11 @@ mod tests {
         assert!(config.contains("pcm.yoyopod_alert_mirror"));
         assert!(config.contains("plug:default"));
         assert!(config.contains("plug:yoyopod_bt_sco"));
+        assert!(config.contains("slaves.selected.channels 1"));
+        assert!(config.contains("slave.channels 3"));
+        assert!(config.contains("ttable.0.2 0.5"));
+        assert!(config.contains("ttable.1.2 0.5"));
+        assert!(!config.contains("bindings.3.slave selected"));
     }
 
     #[test]
@@ -1182,6 +1210,34 @@ mod tests {
     }
 
     #[test]
+    fn persistence_failures_preserve_the_active_audio_configuration() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let blocked_parent = directory.path().join("not-a-directory");
+        fs::write(&blocked_parent, b"blocked").expect("block settings directory");
+        let mut manager = AudioManager::open_at(
+            blocked_parent.join("settings.json"),
+            directory.path().join("asoundrc"),
+        );
+        let state = BluetoothState::unavailable();
+        let mut settings = AudioSettings::default();
+        settings.levels.media = 80;
+
+        let apply_error = manager
+            .apply(2, settings, &UnavailableBluetoothController, &state)
+            .expect_err("settings write must fail");
+        assert_eq!(apply_error.code, "audio_operation_failed");
+        assert_eq!(manager.desired_revision, 0);
+        assert_eq!(manager.desired, AudioSettings::default());
+
+        let level_error = manager
+            .set_output_level(90, &UnavailableBluetoothController, &state)
+            .expect_err("volume write must fail");
+        assert_eq!(level_error.code, "audio_operation_failed");
+        assert_eq!(manager.desired_revision, 0);
+        assert_eq!(manager.desired, AudioSettings::default());
+    }
+
+    #[test]
     fn local_output_level_preserves_the_configured_safety_cap() {
         let directory = tempfile::tempdir().expect("tempdir");
         let settings_path = directory.path().join("settings.json");
@@ -1266,6 +1322,9 @@ mod tests {
         assert!(config.contains("pcm.yoyopod_bt_a2dp"));
         assert!(config.contains("pcm.yoyopod_bt_sco"));
         assert!(config.contains("pcm.yoyopod_alert_mirror"));
+        assert!(config.contains("slaves.selected.channels 2"));
+        assert!(config.contains("slave.channels 4"));
+        assert!(config.contains("bindings.3.slave selected"));
     }
 
     #[allow(dead_code)]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -460,19 +460,13 @@ impl AudioManager {
             alert_pcm,
         )?;
 
-        let media_fallback = !self.desired.routes.media_output_id.starts_with("builtin-")
-            && media_accessory.is_none();
-        let communication_output_fallback = !self
-            .desired
-            .routes
-            .communication_output_id
-            .starts_with("builtin-")
+        let media_fallback =
+            self.desired.routes.media_output_id != "builtin-speaker" && media_accessory.is_none();
+        let communication_output_fallback = self.desired.routes.communication_output_id
+            != "builtin-speaker"
             && communication_output_accessory.is_none();
-        let communication_input_fallback = !self
-            .desired
-            .routes
-            .communication_input_id
-            .starts_with("builtin-")
+        let communication_input_fallback = self.desired.routes.communication_input_id
+            != "builtin-microphone"
             && communication_input_accessory.is_none();
         let fallback =
             media_fallback || communication_output_fallback || communication_input_fallback;
@@ -874,6 +868,49 @@ mod tests {
         );
         assert_eq!(applied.state.status, "degraded");
         assert_eq!(applied.state.applied_revision, 2);
+    }
+
+    #[test]
+    fn unknown_builtin_prefixed_routes_fall_back_to_exact_builtin_endpoints() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let mut manager = AudioManager::open_at(
+            directory.path().join("settings.json"),
+            directory.path().join("asoundrc"),
+        );
+        let state = BluetoothState {
+            schema_version: 1,
+            status: "ready".to_string(),
+            radio_enabled: true,
+            scanning: false,
+            accessories: Vec::new(),
+            scanned_at: None,
+            reported_at: 1,
+        };
+        let mut settings = AudioSettings::default();
+        settings.routes.media_output_id = "builtin-old-speaker".to_string();
+        settings.routes.communication_output_id = "builtin-old-speaker".to_string();
+        settings.routes.communication_input_id = "builtin-old-microphone".to_string();
+
+        let applied = manager
+            .apply(2, settings, &UnavailableBluetoothController, &state)
+            .expect("apply");
+
+        assert_eq!(
+            applied.state.applied.routes.media_output_id,
+            "builtin-speaker"
+        );
+        assert_eq!(
+            applied.state.applied.routes.communication_output_id,
+            "builtin-speaker"
+        );
+        assert_eq!(
+            applied.state.applied.routes.communication_input_id,
+            "builtin-microphone"
+        );
+        assert_eq!(applied.route.media_device, "alsa/default");
+        assert_eq!(applied.route.voip_playback_device, "ALSA: wm8960-soundcard");
+        assert_eq!(applied.route.voip_capture_device, "ALSA: wm8960-soundcard");
+        assert_eq!(applied.state.status, "degraded");
     }
 
     #[test]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -163,6 +163,7 @@ pub struct AudioRouteLocal {
     pub voip_capture_device: String,
     pub voip_media_device: String,
     pub communication_volume: u8,
+    pub alert_volume: u8,
     pub microphone_gain: u8,
 }
 
@@ -311,13 +312,7 @@ impl AudioManager {
                 route.voip_playback_device.as_str(),
                 route.communication_volume,
             ),
-            "alerts" => (
-                route.voip_ringer_device.as_str(),
-                self.desired
-                    .levels
-                    .alerts
-                    .min(self.desired.levels.max_output),
-            ),
+            "alerts" => (route.voip_ringer_device.as_str(), route.alert_volume),
             _ => return Err(AudioOperationError::invalid("Unknown audio test target")),
         };
         let sample = [
@@ -418,13 +413,25 @@ impl AudioManager {
             .and_then(|accessory| bluetooth.raw_address(&accessory.accessory_id));
         let communication_input_address = communication_input_accessory
             .and_then(|accessory| bluetooth.raw_address(&accessory.accessory_id));
+        let alert_accessory = communication_output_accessory.or(media_accessory);
+        let alert_pcm = if communication_output_accessory.is_some() || media_uses_sco {
+            "yoyopod_bt_sco"
+        } else {
+            "yoyopod_bt_a2dp"
+        };
         let output_address = media_address
             .as_deref()
             .or(communication_output_address.as_deref());
         let input_address = communication_input_address
             .as_deref()
             .or(communication_output_address.as_deref());
-        write_asound_config(&self.asound_path, output_address, input_address)?;
+        write_asound_config(
+            &self.asound_path,
+            output_address,
+            input_address,
+            local_alsa_device(&self.builtin.voip_ringer),
+            alert_pcm,
+        )?;
 
         let media_fallback = !self.desired.routes.media_output_id.starts_with("builtin-")
             && media_accessory.is_none();
@@ -468,8 +475,12 @@ impl AudioManager {
                 "ALSA: yoyopod_bt_sco"
             }
             .to_string(),
-            // Safety alerts/ringing always retain the built-in route.
-            voip_ringer_device: self.builtin.voip_ringer.clone(),
+            voip_ringer_device: if alert_accessory.is_some() {
+                "ALSA: yoyopod_alert_mirror"
+            } else {
+                self.builtin.voip_ringer.as_str()
+            }
+            .to_string(),
             voip_capture_device: if communication_input_fallback
                 || self.desired.routes.communication_input_id == "builtin-microphone"
             {
@@ -490,6 +501,11 @@ impl AudioManager {
                 .desired
                 .levels
                 .communication
+                .min(self.desired.levels.max_output),
+            alert_volume: self
+                .desired
+                .levels
+                .alerts
                 .min(self.desired.levels.max_output),
             microphone_gain: self.desired.levels.microphone_gain,
         };
@@ -626,20 +642,58 @@ fn write_asound_config(
     path: &Path,
     output_address: Option<&str>,
     input_address: Option<&str>,
+    builtin_ringer: &str,
+    selected_alert_pcm: &str,
 ) -> Result<(), AudioOperationError> {
     let output = output_address.unwrap_or("00:00:00:00:00:00");
     let input = input_address.unwrap_or(output);
+    let builtin_ringer = escape_alsa_string(builtin_ringer);
+    let selected_alert_pcm = escape_alsa_string(selected_alert_pcm);
     let config = format!(
-        "# Managed by YoYoPod. Bluetooth addresses stay on-device.\n\
+        concat!(
+            "# Managed by YoYoPod. Bluetooth addresses stay on-device.\n\
 </usr/share/alsa/alsa.conf>\n\
 pcm.yoyopod_bt_a2dp {{\n  type bluealsa\n  device \"{output}\"\n  profile \"a2dp\"\n}}\n\
-pcm.yoyopod_bt_sco {{\n  type bluealsa\n  device \"{input}\"\n  profile \"sco\"\n}}\n"
+pcm.yoyopod_bt_sco {{\n  type bluealsa\n  device \"{input}\"\n  profile \"sco\"\n}}\n",
+            "pcm.yoyopod_alert_multi {{\n\
+  type multi\n\
+  slaves.builtin.pcm \"plug:{builtin_ringer}\"\n\
+  slaves.builtin.channels 2\n\
+  slaves.selected.pcm \"plug:{selected_alert_pcm}\"\n\
+  slaves.selected.channels 2\n\
+  bindings.0.slave builtin\n\
+  bindings.0.channel 0\n\
+  bindings.1.slave builtin\n\
+  bindings.1.channel 1\n\
+  bindings.2.slave selected\n\
+  bindings.2.channel 0\n\
+  bindings.3.slave selected\n\
+  bindings.3.channel 1\n\
+}}\n\
+pcm.yoyopod_alert_mirror {{\n\
+  type route\n\
+  slave.pcm \"yoyopod_alert_multi\"\n\
+  slave.channels 4\n\
+  ttable.0.0 1\n\
+  ttable.1.1 1\n\
+  ttable.0.2 1\n\
+  ttable.1.3 1\n\
+}}\n"
+        ),
+        output = output,
+        input = input,
+        builtin_ringer = builtin_ringer,
+        selected_alert_pcm = selected_alert_pcm,
     );
     if fs::read(path).is_ok_and(|existing| existing == config.as_bytes()) {
         return Ok(());
     }
     atomic_write(path, config.as_bytes())
         .map_err(|_| AudioOperationError::failed("The local audio route could not be configured"))
+}
+
+fn escape_alsa_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 fn same_audio_application(left: &AppliedAudio, right: &AppliedAudio) -> bool {
@@ -866,6 +920,58 @@ mod tests {
     }
 
     #[test]
+    fn hands_free_output_mirrors_alerts_and_applies_the_alert_level() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let asound_path = directory.path().join("asoundrc");
+        let mut manager =
+            AudioManager::open_at(directory.path().join("settings.json"), asound_path.clone());
+        let accessory_id = "9b0692e3-a07a-42f0-9fa7-a7704bbcf779".to_string();
+        let state = BluetoothState {
+            schema_version: 1,
+            status: "ready".to_string(),
+            radio_enabled: true,
+            scanning: false,
+            accessories: vec![BluetoothAccessory {
+                accessory_id: accessory_id.clone(),
+                name: "Hands-free headset".to_string(),
+                kind: "headset".to_string(),
+                paired: true,
+                connected: true,
+                trusted: true,
+                auto_connect: true,
+                capabilities: BluetoothCapabilities {
+                    output: true,
+                    microphone: true,
+                    stereo: false,
+                    hands_free: true,
+                },
+                battery_percent: None,
+                signal_percent: None,
+                last_seen_at: 1,
+            }],
+            scanned_at: None,
+            reported_at: 1,
+        };
+        let mut settings = AudioSettings::default();
+        settings.routes.communication_output_id = accessory_id;
+        settings.levels.alerts = 54;
+
+        let applied = manager
+            .apply(2, settings, &UnavailableBluetoothController, &state)
+            .expect("apply");
+
+        assert_eq!(
+            applied.route.voip_ringer_device,
+            "ALSA: yoyopod_alert_mirror"
+        );
+        assert_eq!(applied.route.alert_volume, 54);
+        let config = fs::read_to_string(asound_path).expect("asound config");
+        assert!(config.contains("pcm.yoyopod_alert_mirror"));
+        assert!(config.contains("plug:wm8960-soundcard"));
+        assert!(config.contains("plug:yoyopod_bt_sco"));
+    }
+
+    #[test]
     fn unchanged_periodic_audio_state_is_not_reapplied() {
         let directory = tempfile::tempdir().expect("tempdir");
         let mut manager = AudioManager::open_at(
@@ -912,6 +1018,7 @@ mod tests {
         assert_eq!(applied.route.voip_ringer_device, "ALSA: custom-ringer");
         assert_eq!(applied.route.voip_capture_device, "ALSA: custom-capture");
         assert_eq!(applied.route.voip_media_device, "ALSA: custom-media");
+        assert_eq!(applied.route.alert_volume, 70);
     }
 
     #[test]
@@ -1021,12 +1128,20 @@ mod tests {
         let directory = tempfile::tempdir().expect("tempdir");
         let path = directory.path().join("asoundrc");
 
-        write_asound_config(&path, Some("00:11:22:33:44:55"), None).expect("write asound config");
+        write_asound_config(
+            &path,
+            Some("00:11:22:33:44:55"),
+            None,
+            "wm8960-soundcard",
+            "yoyopod_bt_a2dp",
+        )
+        .expect("write asound config");
 
         let config = fs::read_to_string(path).expect("asound config");
         assert!(config.contains("</usr/share/alsa/alsa.conf>"));
         assert!(config.contains("pcm.yoyopod_bt_a2dp"));
         assert!(config.contains("pcm.yoyopod_bt_sco"));
+        assert!(config.contains("pcm.yoyopod_alert_mirror"));
     }
 
     #[allow(dead_code)]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -268,11 +268,11 @@ impl AudioManager {
         bluetooth: &dyn BluetoothController,
         bluetooth_state: &BluetoothState,
     ) -> Result<AppliedAudio, AudioOperationError> {
-        let level = level.min(100);
+        let max_output = self.desired.levels.max_output.clamp(20, 100);
+        let level = level.min(max_output);
         self.desired.levels.media = level;
         self.desired.levels.communication = level;
-        self.desired.levels.alerts = level.max(20);
-        self.desired.levels.max_output = 100;
+        self.desired.levels.alerts = level.max(20).min(max_output);
         self.persist()?;
         self.resolve(bluetooth, bluetooth_state)
     }
@@ -622,6 +622,7 @@ fn write_asound_config(
     let input = input_address.unwrap_or(output);
     let config = format!(
         "# Managed by YoYoPod. Bluetooth addresses stay on-device.\n\
+</usr/share/alsa/alsa.conf>\n\
 pcm.yoyopod_bt_a2dp {{\n  type bluealsa\n  device \"{output}\"\n  profile \"a2dp\"\n}}\n\
 pcm.yoyopod_bt_sco {{\n  type bluealsa\n  device \"{input}\"\n  profile \"sco\"\n}}\n"
     );
@@ -892,6 +893,49 @@ mod tests {
                 .expect("stored settings");
         assert_eq!(stored.settings.levels.media, 100);
         assert_eq!(stored.settings.levels.max_output, 100);
+    }
+
+    #[test]
+    fn local_output_level_preserves_the_configured_safety_cap() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let settings_path = directory.path().join("settings.json");
+        let mut manager =
+            AudioManager::open_at(settings_path.clone(), directory.path().join("asoundrc"));
+        let state = BluetoothState::unavailable();
+        let mut settings = AudioSettings::default();
+        settings.levels.max_output = 70;
+        settings.levels.media = 65;
+        settings.levels.communication = 70;
+        settings.levels.alerts = 70;
+        manager
+            .apply(2, settings, &UnavailableBluetoothController, &state)
+            .expect("apply capped settings");
+
+        let applied = manager
+            .set_output_level(90, &UnavailableBluetoothController, &state)
+            .expect("set capped output level");
+
+        assert_eq!(applied.state.applied.levels.media, 70);
+        assert_eq!(applied.state.applied.levels.communication, 70);
+        assert_eq!(applied.state.applied.levels.alerts, 70);
+        assert_eq!(applied.state.applied.levels.max_output, 70);
+        let stored: StoredAudioSettings =
+            serde_json::from_slice(&fs::read(settings_path).expect("settings file"))
+                .expect("stored settings");
+        assert_eq!(stored.settings.levels.max_output, 70);
+    }
+
+    #[test]
+    fn managed_asound_config_includes_the_system_alsa_configuration() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("asoundrc");
+
+        write_asound_config(&path, Some("00:11:22:33:44:55"), None).expect("write asound config");
+
+        let config = fs::read_to_string(path).expect("asound config");
+        assert!(config.contains("</usr/share/alsa/alsa.conf>"));
+        assert!(config.contains("pcm.yoyopod_bt_a2dp"));
+        assert!(config.contains("pcm.yoyopod_bt_sco"));
     }
 
     #[allow(dead_code)]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -251,9 +251,11 @@ impl AudioManager {
         bluetooth_state: &BluetoothState,
     ) -> Result<AppliedAudio, AudioOperationError> {
         validate_settings(&settings)?;
-        if revision < self.desired_revision {
+        if revision < self.desired_revision
+            || (revision == self.desired_revision && settings != self.desired)
+        {
             return Err(AudioOperationError::invalid(
-                "A newer audio configuration is already active",
+                "A newer or locally changed audio configuration is already active",
             ));
         }
         self.desired_revision = revision;
@@ -401,7 +403,10 @@ impl AudioManager {
                 accessory.accessory_id == endpoint_id && accessory.paired && accessory.connected
             })
         };
-        let media_accessory = connected(&self.desired.routes.media_output_id);
+        let media_accessory = connected(&self.desired.routes.media_output_id)
+            .filter(|accessory| accessory.capabilities.stereo || accessory.capabilities.hands_free);
+        let media_uses_sco =
+            media_accessory.is_some_and(|accessory| !accessory.capabilities.stereo);
         let communication_output_accessory =
             connected(&self.desired.routes.communication_output_id)
                 .filter(|accessory| accessory.capabilities.hands_free);
@@ -443,7 +448,11 @@ impl AudioManager {
             {
                 self.builtin.media.as_str()
             } else {
-                "alsa/yoyopod_bt_a2dp"
+                if media_uses_sco {
+                    "alsa/yoyopod_bt_sco"
+                } else {
+                    "alsa/yoyopod_bt_a2dp"
+                }
             }
             .to_string(),
             media_volume: self
@@ -811,6 +820,52 @@ mod tests {
     }
 
     #[test]
+    fn hands_free_only_media_output_uses_the_sco_profile() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let mut manager = AudioManager::open_at(
+            directory.path().join("settings.json"),
+            directory.path().join("asoundrc"),
+        );
+        let accessory_id = "9b0692e3-a07a-42f0-9fa7-a7704bbcf777".to_string();
+        let state = BluetoothState {
+            schema_version: 1,
+            status: "ready".to_string(),
+            radio_enabled: true,
+            scanning: false,
+            accessories: vec![BluetoothAccessory {
+                accessory_id: accessory_id.clone(),
+                name: "Hands-free headset".to_string(),
+                kind: "headset".to_string(),
+                paired: true,
+                connected: true,
+                trusted: true,
+                auto_connect: true,
+                capabilities: BluetoothCapabilities {
+                    output: true,
+                    microphone: true,
+                    stereo: false,
+                    hands_free: true,
+                },
+                battery_percent: None,
+                signal_percent: None,
+                last_seen_at: 1,
+            }],
+            scanned_at: None,
+            reported_at: 1,
+        };
+        let mut settings = AudioSettings::default();
+        settings.routes.media_output_id = accessory_id.clone();
+
+        let applied = manager
+            .apply(2, settings, &UnavailableBluetoothController, &state)
+            .expect("apply");
+
+        assert_eq!(applied.route.media_device, "alsa/yoyopod_bt_sco");
+        assert_eq!(applied.state.applied.routes.media_output_id, accessory_id);
+        assert_eq!(applied.state.status, "ready");
+    }
+
+    #[test]
     fn unchanged_periodic_audio_state_is_not_reapplied() {
         let directory = tempfile::tempdir().expect("tempdir");
         let mut manager = AudioManager::open_at(
@@ -923,6 +978,42 @@ mod tests {
             serde_json::from_slice(&fs::read(settings_path).expect("settings file"))
                 .expect("stored settings");
         assert_eq!(stored.settings.levels.max_output, 70);
+    }
+
+    #[test]
+    fn same_revision_replay_cannot_overwrite_a_local_volume_change() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let settings_path = directory.path().join("settings.json");
+        let mut manager =
+            AudioManager::open_at(settings_path.clone(), directory.path().join("asoundrc"));
+        let state = BluetoothState::unavailable();
+        let cloud_settings = AudioSettings::default();
+        manager
+            .apply(
+                2,
+                cloud_settings.clone(),
+                &UnavailableBluetoothController,
+                &state,
+            )
+            .expect("initial cloud settings");
+        manager
+            .set_output_level(55, &UnavailableBluetoothController, &state)
+            .expect("local volume");
+
+        let error = manager
+            .apply(2, cloud_settings, &UnavailableBluetoothController, &state)
+            .expect_err("same revision must not overwrite local volume");
+
+        assert_eq!(error.code, "audio_invalid_settings");
+        let current = manager
+            .current(&UnavailableBluetoothController, &state)
+            .expect("current settings");
+        assert_eq!(current.state.applied.levels.media, 55);
+        let stored: StoredAudioSettings =
+            serde_json::from_slice(&fs::read(settings_path).expect("settings file"))
+                .expect("stored settings");
+        assert_eq!(stored.settings.levels.media, 55);
+        assert_eq!(stored.revision, 2);
     }
 
     #[test]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -283,12 +283,12 @@ impl AudioManager {
         bluetooth: &dyn BluetoothController,
         bluetooth_state: &BluetoothState,
     ) -> Result<AppliedAudio, AudioOperationError> {
-        let max_output = self.desired.levels.max_output.clamp(20, 100);
+        let max_output = self.desired.levels.max_output.min(100);
         let level = level.min(max_output);
         let mut desired = self.desired.clone();
         desired.levels.media = level;
         desired.levels.communication = level;
-        desired.levels.alerts = level.max(20).min(max_output);
+        desired.levels.alerts = level;
         self.persist_candidate(self.desired_revision, &desired)?;
         self.desired = desired;
         self.resolve(bluetooth, bluetooth_state)
@@ -589,10 +589,8 @@ fn validate_settings(settings: &AudioSettings) -> Result<(), AudioOperationError
     let levels = &settings.levels;
     if settings.alert_policy != "mirror_builtin_and_selected"
         || settings.fallback_policy != "builtin"
-        || levels.max_output < 20
         || levels.max_output > 100
         || levels.microphone_gain > 100
-        || levels.alerts < 20
         || levels.media > levels.max_output
         || levels.communication > levels.max_output
         || levels.alerts > levels.max_output
@@ -1245,10 +1243,10 @@ mod tests {
             AudioManager::open_at(settings_path.clone(), directory.path().join("asoundrc"));
         let state = BluetoothState::unavailable();
         let mut settings = AudioSettings::default();
-        settings.levels.max_output = 70;
-        settings.levels.media = 65;
-        settings.levels.communication = 70;
-        settings.levels.alerts = 70;
+        settings.levels.max_output = 10;
+        settings.levels.media = 10;
+        settings.levels.communication = 10;
+        settings.levels.alerts = 10;
         manager
             .apply(2, settings, &UnavailableBluetoothController, &state)
             .expect("apply capped settings");
@@ -1257,14 +1255,14 @@ mod tests {
             .set_output_level(90, &UnavailableBluetoothController, &state)
             .expect("set capped output level");
 
-        assert_eq!(applied.state.applied.levels.media, 70);
-        assert_eq!(applied.state.applied.levels.communication, 70);
-        assert_eq!(applied.state.applied.levels.alerts, 70);
-        assert_eq!(applied.state.applied.levels.max_output, 70);
+        assert_eq!(applied.state.applied.levels.media, 10);
+        assert_eq!(applied.state.applied.levels.communication, 10);
+        assert_eq!(applied.state.applied.levels.alerts, 10);
+        assert_eq!(applied.state.applied.levels.max_output, 10);
         let stored: StoredAudioSettings =
             serde_json::from_slice(&fs::read(settings_path).expect("settings file"))
                 .expect("stored settings");
-        assert_eq!(stored.settings.levels.max_output, 70);
+        assert_eq!(stored.settings.levels.max_output, 10);
     }
 
     #[test]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -459,11 +459,11 @@ impl AudioManager {
             .and_then(|accessory| bluetooth.raw_address(&accessory.accessory_id));
         let alert_accessory = communication_output_accessory.or(media_accessory);
         let alert_pcm = if communication_output_accessory.is_some() || media_uses_sco {
-            "yoyopod_bt_sco"
+            "yoyopod_bt_sco_playback"
         } else {
             "yoyopod_bt_a2dp"
         };
-        let (output_address, input_address) = bluetooth_pcm_addresses(
+        let (a2dp_address, sco_playback_address, sco_capture_address) = bluetooth_pcm_addresses(
             media_address.as_deref(),
             communication_output_address.as_deref(),
             communication_input_address.as_deref(),
@@ -471,8 +471,9 @@ impl AudioManager {
         );
         write_asound_config(
             &self.asound_path,
-            output_address,
-            input_address,
+            a2dp_address,
+            sco_playback_address,
+            sco_capture_address,
             &self.builtin.local_playback,
             alert_pcm,
         )?;
@@ -494,7 +495,7 @@ impl AudioManager {
                 self.builtin.media.as_str()
             } else {
                 if media_uses_sco {
-                    "alsa/yoyopod_bt_sco"
+                    "alsa/yoyopod_bt_sco_playback"
                 } else {
                     "alsa/yoyopod_bt_a2dp"
                 }
@@ -510,7 +511,7 @@ impl AudioManager {
             {
                 self.builtin.voip_playback.as_str()
             } else {
-                "ALSA: yoyopod_bt_sco"
+                "ALSA: yoyopod_bt_sco_playback"
             }
             .to_string(),
             voip_ringer_device: if alert_accessory.is_some() {
@@ -524,7 +525,7 @@ impl AudioManager {
             {
                 self.builtin.voip_capture.as_str()
             } else {
-                "ALSA: yoyopod_bt_sco"
+                "ALSA: yoyopod_bt_sco_capture"
             }
             .to_string(),
             voip_media_device: if communication_output_fallback
@@ -532,7 +533,7 @@ impl AudioManager {
             {
                 self.builtin.voip_media.as_str()
             } else {
-                "ALSA: yoyopod_bt_sco"
+                "ALSA: yoyopod_bt_sco_playback"
             }
             .to_string(),
             communication_volume: self
@@ -680,15 +681,19 @@ fn endpoints(bluetooth: &BluetoothState) -> AudioEndpoints {
 
 fn write_asound_config(
     path: &Path,
-    output_address: Option<&str>,
-    input_address: Option<&str>,
+    a2dp_address: Option<&str>,
+    sco_playback_address: Option<&str>,
+    sco_capture_address: Option<&str>,
     builtin_ringer: &str,
     selected_alert_pcm: &str,
 ) -> Result<(), AudioOperationError> {
-    let output = output_address.unwrap_or("00:00:00:00:00:00");
-    let input = input_address.unwrap_or(output);
+    let a2dp = a2dp_address.unwrap_or("00:00:00:00:00:00");
+    let sco_playback = sco_playback_address
+        .or(sco_capture_address)
+        .unwrap_or("00:00:00:00:00:00");
+    let sco_capture = sco_capture_address.unwrap_or(sco_playback);
     let builtin_ringer = escape_alsa_string(builtin_ringer);
-    let selected_alert_is_mono = selected_alert_pcm == "yoyopod_bt_sco";
+    let selected_alert_is_mono = selected_alert_pcm == "yoyopod_bt_sco_playback";
     let selected_alert_pcm = escape_alsa_string(selected_alert_pcm);
     let (selected_channels, selected_bindings, mirror_channels, selected_ttable) =
         if selected_alert_is_mono {
@@ -711,7 +716,8 @@ fn write_asound_config(
             "# Managed by YoYoPod. Bluetooth addresses stay on-device.\n\
 </usr/share/alsa/alsa.conf>\n\
 pcm.yoyopod_bt_a2dp {{\n  type bluealsa\n  device \"{output}\"\n  profile \"a2dp\"\n}}\n\
-pcm.yoyopod_bt_sco {{\n  type bluealsa\n  device \"{input}\"\n  profile \"sco\"\n}}\n",
+pcm.yoyopod_bt_sco_playback {{\n  type bluealsa\n  device \"{sco_playback}\"\n  profile \"sco\"\n}}\n\
+pcm.yoyopod_bt_sco_capture {{\n  type bluealsa\n  device \"{sco_capture}\"\n  profile \"sco\"\n}}\n",
             "pcm.yoyopod_alert_multi {{\n\
   type multi\n\
   slaves.builtin.pcm \"plug:{builtin_ringer}\"\n\
@@ -733,8 +739,9 @@ pcm.yoyopod_alert_mirror {{\n\
 {selected_ttable}\
 }}\n"
         ),
-        output = output,
-        input = input,
+        output = a2dp,
+        sco_playback = sco_playback,
+        sco_capture = sco_capture,
         builtin_ringer = builtin_ringer,
         selected_alert_pcm = selected_alert_pcm,
         selected_channels = selected_channels,
@@ -754,12 +761,13 @@ fn bluetooth_pcm_addresses<'a>(
     communication_output_address: Option<&'a str>,
     communication_input_address: Option<&'a str>,
     media_uses_sco: bool,
-) -> (Option<&'a str>, Option<&'a str>) {
-    let output = media_address.or(communication_output_address);
-    let input = communication_input_address
-        .or(communication_output_address)
-        .or(if media_uses_sco { media_address } else { None });
-    (output, input)
+) -> (Option<&'a str>, Option<&'a str>, Option<&'a str>) {
+    let a2dp = if media_uses_sco { None } else { media_address }.or(communication_output_address);
+    let sco_playback = communication_output_address
+        .or(if media_uses_sco { media_address } else { None })
+        .or(communication_input_address);
+    let sco_capture = communication_input_address.or(sco_playback);
+    (a2dp, sco_playback, sco_capture)
 }
 
 fn escape_alsa_string(value: &str) -> String {
@@ -1039,7 +1047,7 @@ mod tests {
             .apply(2, settings, &UnavailableBluetoothController, &state)
             .expect("apply");
 
-        assert_eq!(applied.route.media_device, "alsa/yoyopod_bt_sco");
+        assert_eq!(applied.route.media_device, "alsa/yoyopod_bt_sco_playback");
         assert_eq!(applied.state.applied.routes.media_output_id, accessory_id);
         assert_eq!(applied.state.status, "ready");
     }
@@ -1047,16 +1055,53 @@ mod tests {
     #[test]
     fn media_only_sco_route_uses_the_media_address_for_both_pcms() {
         let address = "AA:BB:CC:DD:EE:FF";
-        let (output, input) = bluetooth_pcm_addresses(Some(address), None, None, true);
-        assert_eq!(output, Some(address));
-        assert_eq!(input, Some(address));
+        let (a2dp, playback, capture) = bluetooth_pcm_addresses(Some(address), None, None, true);
+        assert_eq!(a2dp, None);
+        assert_eq!(playback, Some(address));
+        assert_eq!(capture, Some(address));
 
         let directory = tempfile::tempdir().expect("tempdir");
         let asound_path = directory.path().join("asoundrc");
-        write_asound_config(&asound_path, output, input, "default", "yoyopod_bt_sco")
-            .expect("asound config");
+        write_asound_config(
+            &asound_path,
+            a2dp,
+            playback,
+            capture,
+            "default",
+            "yoyopod_bt_sco_playback",
+        )
+        .expect("asound config");
         let config = fs::read_to_string(asound_path).expect("read asound config");
         assert_eq!(config.matches("device \"AA:BB:CC:DD:EE:FF\"").count(), 2);
+    }
+
+    #[test]
+    fn split_communication_routes_use_distinct_sco_pcms() {
+        let playback_address = "AA:BB:CC:DD:EE:01";
+        let capture_address = "AA:BB:CC:DD:EE:02";
+        let (a2dp, playback, capture) =
+            bluetooth_pcm_addresses(None, Some(playback_address), Some(capture_address), false);
+        assert_eq!(playback, Some(playback_address));
+        assert_eq!(capture, Some(capture_address));
+
+        let directory = tempfile::tempdir().expect("tempdir");
+        let asound_path = directory.path().join("asoundrc");
+        write_asound_config(
+            &asound_path,
+            a2dp,
+            playback,
+            capture,
+            "default",
+            "yoyopod_bt_sco_playback",
+        )
+        .expect("asound config");
+        let config = fs::read_to_string(asound_path).expect("read asound config");
+        assert!(config.contains(
+            "pcm.yoyopod_bt_sco_playback {\n  type bluealsa\n  device \"AA:BB:CC:DD:EE:01\""
+        ));
+        assert!(config.contains(
+            "pcm.yoyopod_bt_sco_capture {\n  type bluealsa\n  device \"AA:BB:CC:DD:EE:02\""
+        ));
     }
 
     #[test]
@@ -1108,7 +1153,7 @@ mod tests {
         let config = fs::read_to_string(asound_path).expect("asound config");
         assert!(config.contains("pcm.yoyopod_alert_mirror"));
         assert!(config.contains("plug:default"));
-        assert!(config.contains("plug:yoyopod_bt_sco"));
+        assert!(config.contains("plug:yoyopod_bt_sco_playback"));
         assert!(config.contains("slaves.selected.channels 1"));
         assert!(config.contains("slave.channels 3"));
         assert!(config.contains("ttable.0.2 0.5"));
@@ -1191,8 +1236,12 @@ mod tests {
             "default"
         );
         assert_eq!(
-            local_pcm_for_route("ALSA: yoyopod_bt_sco", "ALSA: wm8960-soundcard", "default"),
-            "yoyopod_bt_sco"
+            local_pcm_for_route(
+                "ALSA: yoyopod_bt_sco_playback",
+                "ALSA: wm8960-soundcard",
+                "default"
+            ),
+            "yoyopod_bt_sco_playback"
         );
     }
 
@@ -1353,6 +1402,7 @@ mod tests {
             &path,
             Some("00:11:22:33:44:55"),
             None,
+            None,
             "wm8960-soundcard",
             "yoyopod_bt_a2dp",
         )
@@ -1361,7 +1411,8 @@ mod tests {
         let config = fs::read_to_string(path).expect("asound config");
         assert!(config.contains("</usr/share/alsa/alsa.conf>"));
         assert!(config.contains("pcm.yoyopod_bt_a2dp"));
-        assert!(config.contains("pcm.yoyopod_bt_sco"));
+        assert!(config.contains("pcm.yoyopod_bt_sco_playback"));
+        assert!(config.contains("pcm.yoyopod_bt_sco_capture"));
         assert!(config.contains("pcm.yoyopod_alert_mirror"));
         assert!(config.contains("slaves.selected.channels 2"));
         assert!(config.contains("slave.channels 4"));

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::io::Read;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -843,8 +843,10 @@ fn atomic_json_write(path: &Path, value: &impl Serialize) -> Result<(), std::io:
 
 fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), std::io::Error> {
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-        fs::set_permissions(parent, fs::Permissions::from_mode(0o750))?;
+        let mut builder = fs::DirBuilder::new();
+        builder.recursive(true);
+        builder.mode(0o750);
+        builder.create(parent)?;
     }
     let temporary = path.with_extension("tmp");
     fs::write(&temporary, bytes)?;
@@ -1417,6 +1419,24 @@ mod tests {
         assert!(config.contains("slaves.selected.channels 2"));
         assert!(config.contains("slave.channels 4"));
         assert!(config.contains("bindings.3.slave selected"));
+    }
+
+    #[test]
+    fn atomic_writes_preserve_existing_parent_directory_permissions() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let shared_parent = directory.path().join("shared");
+        fs::create_dir(&shared_parent).expect("shared directory");
+        fs::set_permissions(&shared_parent, fs::Permissions::from_mode(0o1777))
+            .expect("shared permissions");
+
+        atomic_write(&shared_parent.join("settings.json"), b"{}").expect("atomic write");
+
+        let parent_mode = fs::metadata(&shared_parent)
+            .expect("shared metadata")
+            .permissions()
+            .mode()
+            & 0o7777;
+        assert_eq!(parent_mode, 0o1777);
     }
 
     #[allow(dead_code)]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -15,6 +15,8 @@ const DEFAULT_ASOUND_CONFIG_PATH: &str = "/var/lib/yoyopod/audio/asoundrc";
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct BuiltinAudioDevices {
     media: String,
+    local_playback: String,
+    local_capture: String,
     voip_playback: String,
     voip_ringer: String,
     voip_capture: String,
@@ -25,6 +27,8 @@ impl Default for BuiltinAudioDevices {
     fn default() -> Self {
         Self {
             media: "alsa/default".to_string(),
+            local_playback: "default".to_string(),
+            local_capture: "capture".to_string(),
             voip_playback: "ALSA: wm8960-soundcard".to_string(),
             voip_ringer: "ALSA: wm8960-soundcard".to_string(),
             voip_capture: "ALSA: wm8960-soundcard".to_string(),
@@ -46,12 +50,20 @@ impl BuiltinAudioDevices {
                 .or_else(|| yaml_string(&hardware, path))
                 .unwrap_or_else(|| fallback.to_string())
         };
+        let local_playback = configured(
+            &["media_audio", "alsa_device"],
+            "YOYOPOD_ALSA_DEVICE",
+            "default",
+        );
+        let local_capture = configured(
+            &["voice_audio", "capture_device_id"],
+            "YOYOPOD_LOCAL_CAPTURE_DEVICE",
+            "capture",
+        );
         Self {
-            media: mpv_alsa_device(&configured(
-                &["media_audio", "alsa_device"],
-                "YOYOPOD_ALSA_DEVICE",
-                "default",
-            )),
+            media: mpv_alsa_device(&local_playback),
+            local_playback,
+            local_capture,
             voip_playback: configured(
                 &["communication_audio", "playback_device_id"],
                 "YOYOPOD_PLAYBACK_DEVICE",
@@ -309,10 +321,21 @@ impl AudioManager {
         let (device, volume): (&str, u8) = match target {
             "media" => (route.media_device.as_str(), route.media_volume),
             "communication" => (
-                route.voip_playback_device.as_str(),
+                local_pcm_for_route(
+                    &route.voip_playback_device,
+                    &self.builtin.voip_playback,
+                    &self.builtin.local_playback,
+                ),
                 route.communication_volume,
             ),
-            "alerts" => (route.voip_ringer_device.as_str(), route.alert_volume),
+            "alerts" => (
+                local_pcm_for_route(
+                    &route.voip_ringer_device,
+                    &self.builtin.voip_ringer,
+                    &self.builtin.local_playback,
+                ),
+                route.alert_volume,
+            ),
             _ => return Err(AudioOperationError::invalid("Unknown audio test target")),
         };
         let sample = [
@@ -343,7 +366,11 @@ impl AudioManager {
         route: &AudioRouteLocal,
         duration_seconds: u64,
     ) -> Result<AudioInputMeter, AudioOperationError> {
-        let device = local_alsa_device(&route.voip_capture_device);
+        let device = local_pcm_for_route(
+            &route.voip_capture_device,
+            &self.builtin.voip_capture,
+            &self.builtin.local_capture,
+        );
         let duration = duration_seconds.clamp(1, 10).to_string();
         let mut child = Command::new("arecord")
             .args([
@@ -429,7 +456,7 @@ impl AudioManager {
             &self.asound_path,
             output_address,
             input_address,
-            local_alsa_device(&self.builtin.voip_ringer),
+            &self.builtin.local_playback,
             alert_pcm,
         )?;
 
@@ -747,6 +774,18 @@ fn local_alsa_device(device: &str) -> &str {
         .unwrap_or(device)
 }
 
+fn local_pcm_for_route<'a>(
+    route_device: &'a str,
+    builtin_route_device: &str,
+    builtin_local_pcm: &'a str,
+) -> &'a str {
+    if route_device == builtin_route_device {
+        builtin_local_pcm
+    } else {
+        local_alsa_device(route_device)
+    }
+}
+
 fn atomic_json_write(path: &Path, value: &impl Serialize) -> Result<(), std::io::Error> {
     atomic_write(path, &serde_json::to_vec_pretty(value)?)
 }
@@ -967,7 +1006,7 @@ mod tests {
         assert_eq!(applied.route.alert_volume, 54);
         let config = fs::read_to_string(asound_path).expect("asound config");
         assert!(config.contains("pcm.yoyopod_alert_mirror"));
-        assert!(config.contains("plug:wm8960-soundcard"));
+        assert!(config.contains("plug:default"));
         assert!(config.contains("plug:yoyopod_bt_sco"));
     }
 
@@ -995,6 +1034,8 @@ mod tests {
         let directory = tempfile::tempdir().expect("tempdir");
         let builtin = BuiltinAudioDevices {
             media: "alsa/custom-speaker".to_string(),
+            local_playback: "custom-playback-pcm".to_string(),
+            local_capture: "custom-capture-pcm".to_string(),
             voip_playback: "ALSA: custom-playback".to_string(),
             voip_ringer: "ALSA: custom-ringer".to_string(),
             voip_capture: "ALSA: custom-capture".to_string(),
@@ -1019,6 +1060,8 @@ mod tests {
         assert_eq!(applied.route.voip_capture_device, "ALSA: custom-capture");
         assert_eq!(applied.route.voip_media_device, "ALSA: custom-media");
         assert_eq!(applied.route.alert_volume, 70);
+        let config = fs::read_to_string(directory.path().join("asoundrc")).expect("asound config");
+        assert!(config.contains("plug:custom-playback-pcm"));
     }
 
     #[test]
@@ -1029,6 +1072,22 @@ mod tests {
         assert!(args.contains(&"--volume=86".to_string()));
         assert!(args.contains(&"--volume-max=100".to_string()));
         assert_eq!(args.last().map(String::as_str), Some("/tmp/test.wav"));
+    }
+
+    #[test]
+    fn local_operations_use_real_pcm_names_for_builtin_liblinphone_routes() {
+        assert_eq!(
+            local_pcm_for_route(
+                "ALSA: wm8960-soundcard",
+                "ALSA: wm8960-soundcard",
+                "default"
+            ),
+            "default"
+        );
+        assert_eq!(
+            local_pcm_for_route("ALSA: yoyopod_bt_sco", "ALSA: wm8960-soundcard", "default"),
+            "yoyopod_bt_sco"
+        );
     }
 
     #[test]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -294,6 +294,21 @@ impl AudioManager {
         self.resolve(bluetooth, bluetooth_state)
     }
 
+    pub fn step_output_level(
+        &mut self,
+        bluetooth: &dyn BluetoothController,
+        bluetooth_state: &BluetoothState,
+    ) -> Result<AppliedAudio, AudioOperationError> {
+        let max_output = self.desired.levels.max_output.min(100);
+        let current = self.desired.levels.media.min(max_output);
+        let next = if current >= max_output {
+            max_output.min(10)
+        } else {
+            current.saturating_add(10).min(max_output)
+        };
+        self.set_output_level(next, bluetooth, bluetooth_state)
+    }
+
     pub fn current(
         &mut self,
         bluetooth: &dyn BluetoothController,
@@ -1263,6 +1278,34 @@ mod tests {
             serde_json::from_slice(&fs::read(settings_path).expect("settings file"))
                 .expect("stored settings");
         assert_eq!(stored.settings.levels.max_output, 10);
+    }
+
+    #[test]
+    fn local_output_step_wraps_at_the_configured_safety_cap() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let settings_path = directory.path().join("settings.json");
+        let mut manager =
+            AudioManager::open_at(settings_path.clone(), directory.path().join("asoundrc"));
+        let state = BluetoothState::unavailable();
+        let mut settings = AudioSettings::default();
+        settings.levels.max_output = 70;
+        settings.levels.media = 70;
+        settings.levels.communication = 70;
+        settings.levels.alerts = 70;
+        manager
+            .apply(2, settings, &UnavailableBluetoothController, &state)
+            .expect("apply capped settings");
+
+        let wrapped = manager
+            .step_output_level(&UnavailableBluetoothController, &state)
+            .expect("wrap output level");
+        assert_eq!(wrapped.state.applied.levels.media, 10);
+
+        let stepped = manager
+            .step_output_level(&UnavailableBluetoothController, &state)
+            .expect("step output level");
+        assert_eq!(stepped.state.applied.levels.media, 20);
+        assert_eq!(stepped.state.applied.levels.max_output, 70);
     }
 
     #[test]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -32,7 +32,7 @@ impl Default for AudioSettings {
                 communication: 70,
                 alerts: 70,
                 microphone_gain: 60,
-                max_output: 85,
+                max_output: 100,
             },
             alert_policy: "mirror_builtin_and_selected".to_string(),
             fallback_policy: "builtin".to_string(),
@@ -177,6 +177,21 @@ impl AudioManager {
         }
         self.desired_revision = revision;
         self.desired = settings;
+        self.persist()?;
+        self.resolve(bluetooth, bluetooth_state)
+    }
+
+    pub fn set_output_level(
+        &mut self,
+        level: u8,
+        bluetooth: &dyn BluetoothController,
+        bluetooth_state: &BluetoothState,
+    ) -> Result<AppliedAudio, AudioOperationError> {
+        let level = level.min(100);
+        self.desired.levels.media = level;
+        self.desired.levels.communication = level;
+        self.desired.levels.alerts = level.max(20);
+        self.desired.levels.max_output = 100;
         self.persist()?;
         self.resolve(bluetooth, bluetooth_state)
     }
@@ -405,6 +420,8 @@ fn validate_settings(settings: &AudioSettings) -> Result<(), AudioOperationError
     if settings.alert_policy != "mirror_builtin_and_selected"
         || settings.fallback_policy != "builtin"
         || levels.max_output < 20
+        || levels.max_output > 100
+        || levels.microphone_gain > 100
         || levels.alerts < 20
         || levels.media > levels.max_output
         || levels.communication > levels.max_output
@@ -576,6 +593,32 @@ mod tests {
         );
         assert_eq!(applied.state.status, "degraded");
         assert_eq!(applied.state.applied_revision, 2);
+    }
+
+    #[test]
+    fn local_output_level_updates_all_output_domains_and_persists() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let settings_path = directory.path().join("settings.json");
+        let mut manager =
+            AudioManager::open_at(settings_path.clone(), directory.path().join("asoundrc"));
+        let state = BluetoothState::unavailable();
+
+        let applied = manager
+            .set_output_level(100, &UnavailableBluetoothController, &state)
+            .expect("set output level");
+
+        assert_eq!(applied.route.media_volume, 100);
+        assert_eq!(applied.route.communication_volume, 100);
+        assert_eq!(applied.state.applied.levels.media, 100);
+        assert_eq!(applied.state.applied.levels.communication, 100);
+        assert_eq!(applied.state.applied.levels.alerts, 100);
+        assert_eq!(applied.state.applied.levels.max_output, 100);
+
+        let stored: StoredAudioSettings =
+            serde_json::from_slice(&fs::read(settings_path).expect("settings file"))
+                .expect("stored settings");
+        assert_eq!(stored.settings.levels.media, 100);
+        assert_eq!(stored.settings.levels.max_output, 100);
     }
 
     #[allow(dead_code)]

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -1,0 +1,585 @@
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::bluetooth::{BluetoothController, BluetoothState};
+
+const DEFAULT_SETTINGS_PATH: &str = "/var/lib/yoyopod/audio/settings.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AudioSettings {
+    pub routes: AudioRoutes,
+    pub levels: AudioLevels,
+    pub alert_policy: String,
+    pub fallback_policy: String,
+}
+
+impl Default for AudioSettings {
+    fn default() -> Self {
+        Self {
+            routes: AudioRoutes {
+                media_output_id: "builtin-speaker".to_string(),
+                communication_output_id: "builtin-speaker".to_string(),
+                communication_input_id: "builtin-microphone".to_string(),
+            },
+            levels: AudioLevels {
+                media: 65,
+                communication: 70,
+                alerts: 70,
+                microphone_gain: 60,
+                max_output: 85,
+            },
+            alert_policy: "mirror_builtin_and_selected".to_string(),
+            fallback_policy: "builtin".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AudioRoutes {
+    pub media_output_id: String,
+    pub communication_output_id: String,
+    pub communication_input_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AudioLevels {
+    pub media: u8,
+    pub communication: u8,
+    pub alerts: u8,
+    pub microphone_gain: u8,
+    pub max_output: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AudioState {
+    pub schema_version: u8,
+    pub status: String,
+    pub applied_revision: u64,
+    pub applied: AudioSettings,
+    pub endpoints: AudioEndpoints,
+    pub fallback_reason: Option<String>,
+    pub input_meter: Option<AudioInputMeter>,
+    pub reported_at: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AudioEndpoints {
+    pub outputs: Vec<AudioEndpoint>,
+    pub inputs: Vec<AudioEndpoint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AudioEndpoint {
+    pub endpoint_id: String,
+    pub name: String,
+    pub kind: String,
+    pub accessory_id: Option<String>,
+    pub available: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AudioInputMeter {
+    pub level_percent: u8,
+    pub expires_at: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AudioRouteLocal {
+    pub media_device: String,
+    pub media_volume: u8,
+    pub voip_playback_device: String,
+    pub voip_ringer_device: String,
+    pub voip_capture_device: String,
+    pub voip_media_device: String,
+    pub communication_volume: u8,
+    pub microphone_gain: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AudioOperationError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl AudioOperationError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            code: "audio_invalid_settings",
+            message: message.into(),
+        }
+    }
+
+    fn failed(message: impl Into<String>) -> Self {
+        Self {
+            code: "audio_operation_failed",
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AppliedAudio {
+    pub state: AudioState,
+    pub route: AudioRouteLocal,
+}
+
+pub struct AudioManager {
+    settings_path: PathBuf,
+    asound_path: PathBuf,
+    desired_revision: u64,
+    desired: AudioSettings,
+    input_meter: Option<AudioInputMeter>,
+}
+
+impl AudioManager {
+    pub fn open() -> Self {
+        let settings_path = std::env::var_os("YOYOPOD_AUDIO_SETTINGS_FILE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_SETTINGS_PATH));
+        let asound_path = std::env::var_os("YOYOPOD_ASOUND_CONFIG")
+            .map(PathBuf::from)
+            .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".asoundrc")))
+            .unwrap_or_else(|| PathBuf::from("/home/raouf/.asoundrc"));
+        Self::open_at(settings_path, asound_path)
+    }
+
+    fn open_at(settings_path: PathBuf, asound_path: PathBuf) -> Self {
+        let stored = fs::read(&settings_path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<StoredAudioSettings>(&bytes).ok());
+        Self {
+            settings_path,
+            asound_path,
+            desired_revision: stored.as_ref().map_or(0, |stored| stored.revision),
+            desired: stored.map_or_else(AudioSettings::default, |stored| stored.settings),
+            input_meter: None,
+        }
+    }
+
+    pub fn apply(
+        &mut self,
+        revision: u64,
+        settings: AudioSettings,
+        bluetooth: &dyn BluetoothController,
+        bluetooth_state: &BluetoothState,
+    ) -> Result<AppliedAudio, AudioOperationError> {
+        validate_settings(&settings)?;
+        if revision < self.desired_revision {
+            return Err(AudioOperationError::invalid(
+                "A newer audio configuration is already active",
+            ));
+        }
+        self.desired_revision = revision;
+        self.desired = settings;
+        self.persist()?;
+        self.resolve(bluetooth, bluetooth_state)
+    }
+
+    pub fn current(
+        &mut self,
+        bluetooth: &dyn BluetoothController,
+        bluetooth_state: &BluetoothState,
+    ) -> Result<AppliedAudio, AudioOperationError> {
+        self.resolve(bluetooth, bluetooth_state)
+    }
+
+    pub fn test_output(
+        &self,
+        target: &str,
+        route: &AudioRouteLocal,
+    ) -> Result<(), AudioOperationError> {
+        let (device, volume): (&str, u8) = match target {
+            "media" => (route.media_device.as_str(), self.desired.levels.media),
+            "communication" => (
+                route.voip_playback_device.as_str(),
+                self.desired.levels.communication,
+            ),
+            "alerts" => ("alsa/default", self.desired.levels.alerts),
+            _ => return Err(AudioOperationError::invalid("Unknown audio test target")),
+        };
+        let sample = [
+            "/usr/share/sounds/alsa/Front_Center.wav",
+            "/usr/share/sounds/freedesktop/stereo/audio-volume-change.oga",
+        ]
+        .into_iter()
+        .find(|path| Path::new(path).exists())
+        .ok_or_else(|| AudioOperationError::failed("No audio test sound is installed"))?;
+        let alsa_device = local_alsa_device(device);
+        let _ = volume;
+        Command::new("aplay")
+            .args(["-q", "-D", alsa_device, sample])
+            .spawn()
+            .map_err(|_| AudioOperationError::failed("The test sound could not be played"))?;
+        Ok(())
+    }
+
+    pub fn test_input(
+        &mut self,
+        route: &AudioRouteLocal,
+        duration_seconds: u64,
+    ) -> Result<AudioInputMeter, AudioOperationError> {
+        let device = local_alsa_device(&route.voip_capture_device);
+        let duration = duration_seconds.clamp(1, 10).to_string();
+        let mut child = Command::new("arecord")
+            .args([
+                "-q", "-D", device, "-d", &duration, "-f", "S16_LE", "-c", "1", "-r", "8000", "-t",
+                "raw",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| AudioOperationError::failed("The microphone test could not start"))?;
+        let mut captured = Vec::new();
+        if let Some(mut stdout) = child.stdout.take() {
+            stdout.read_to_end(&mut captured).map_err(|_| {
+                AudioOperationError::failed("The microphone test could not be read")
+            })?;
+        }
+        let status = child
+            .wait()
+            .map_err(|_| AudioOperationError::failed("The microphone test did not finish"))?;
+        if !status.success() {
+            return Err(AudioOperationError::failed(
+                "The selected microphone is not currently available",
+            ));
+        }
+        let peak = captured
+            .chunks_exact(2)
+            .map(|bytes| i16::from_le_bytes([bytes[0], bytes[1]]).unsigned_abs())
+            .max()
+            .unwrap_or(0);
+        let meter = AudioInputMeter {
+            level_percent: ((u32::from(peak) * 100) / u32::from(i16::MAX as u16)).min(100) as u8,
+            expires_at: epoch_seconds() + 15,
+        };
+        self.input_meter = Some(meter.clone());
+        Ok(meter)
+    }
+
+    fn resolve(
+        &mut self,
+        bluetooth: &dyn BluetoothController,
+        bluetooth_state: &BluetoothState,
+    ) -> Result<AppliedAudio, AudioOperationError> {
+        if self
+            .input_meter
+            .as_ref()
+            .is_some_and(|meter| meter.expires_at <= epoch_seconds())
+        {
+            self.input_meter = None;
+        }
+        let connected = |endpoint_id: &str| {
+            bluetooth_state.accessories.iter().find(|accessory| {
+                accessory.accessory_id == endpoint_id && accessory.paired && accessory.connected
+            })
+        };
+        let output_address = connected(&self.desired.routes.media_output_id)
+            .or_else(|| connected(&self.desired.routes.communication_output_id))
+            .and_then(|accessory| bluetooth.raw_address(&accessory.accessory_id));
+        let input_address = connected(&self.desired.routes.communication_input_id)
+            .and_then(|accessory| bluetooth.raw_address(&accessory.accessory_id));
+        write_asound_config(
+            &self.asound_path,
+            output_address.as_deref(),
+            input_address.as_deref(),
+        )?;
+
+        let media_fallback = !self.desired.routes.media_output_id.starts_with("builtin-")
+            && output_address.is_none();
+        let communication_output_fallback = !self
+            .desired
+            .routes
+            .communication_output_id
+            .starts_with("builtin-")
+            && connected(&self.desired.routes.communication_output_id).is_none();
+        let communication_input_fallback = !self
+            .desired
+            .routes
+            .communication_input_id
+            .starts_with("builtin-")
+            && input_address.is_none();
+        let fallback =
+            media_fallback || communication_output_fallback || communication_input_fallback;
+        let route = AudioRouteLocal {
+            media_device: if media_fallback
+                || self.desired.routes.media_output_id == "builtin-speaker"
+            {
+                "alsa/default"
+            } else {
+                "alsa/yoyopod_bt_a2dp"
+            }
+            .to_string(),
+            media_volume: self
+                .desired
+                .levels
+                .media
+                .min(self.desired.levels.max_output),
+            voip_playback_device: if communication_output_fallback
+                || self.desired.routes.communication_output_id == "builtin-speaker"
+            {
+                "ALSA: default"
+            } else {
+                "ALSA: yoyopod_bt_sco"
+            }
+            .to_string(),
+            // Safety alerts/ringing always retain the built-in route.
+            voip_ringer_device: "ALSA: default".to_string(),
+            voip_capture_device: if communication_input_fallback
+                || self.desired.routes.communication_input_id == "builtin-microphone"
+            {
+                "ALSA: default"
+            } else {
+                "ALSA: yoyopod_bt_sco"
+            }
+            .to_string(),
+            voip_media_device: if communication_output_fallback
+                || self.desired.routes.communication_output_id == "builtin-speaker"
+            {
+                "ALSA: default"
+            } else {
+                "ALSA: yoyopod_bt_sco"
+            }
+            .to_string(),
+            communication_volume: self
+                .desired
+                .levels
+                .communication
+                .min(self.desired.levels.max_output),
+            microphone_gain: self.desired.levels.microphone_gain,
+        };
+        let applied = applied_settings(
+            &self.desired,
+            media_fallback,
+            communication_output_fallback,
+            communication_input_fallback,
+        );
+        Ok(AppliedAudio {
+            state: AudioState {
+                schema_version: 1,
+                status: if bluetooth_state.status == "unavailable" {
+                    "degraded"
+                } else if fallback {
+                    "degraded"
+                } else {
+                    "ready"
+                }
+                .to_string(),
+                applied_revision: self.desired_revision,
+                applied,
+                endpoints: endpoints(bluetooth_state),
+                fallback_reason: fallback.then(|| {
+                    "A selected Bluetooth route is disconnected; built-in audio is active"
+                        .to_string()
+                }),
+                input_meter: self.input_meter.clone(),
+                reported_at: epoch_seconds(),
+            },
+            route,
+        })
+    }
+
+    fn persist(&self) -> Result<(), AudioOperationError> {
+        let stored = StoredAudioSettings {
+            revision: self.desired_revision,
+            settings: self.desired.clone(),
+        };
+        atomic_json_write(&self.settings_path, &stored)
+            .map_err(|_| AudioOperationError::failed("Audio settings could not be saved"))
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct StoredAudioSettings {
+    revision: u64,
+    settings: AudioSettings,
+}
+
+fn validate_settings(settings: &AudioSettings) -> Result<(), AudioOperationError> {
+    let levels = &settings.levels;
+    if settings.alert_policy != "mirror_builtin_and_selected"
+        || settings.fallback_policy != "builtin"
+        || levels.max_output < 20
+        || levels.alerts < 20
+        || levels.media > levels.max_output
+        || levels.communication > levels.max_output
+        || levels.alerts > levels.max_output
+    {
+        return Err(AudioOperationError::invalid(
+            "Audio settings are outside the supported safe range",
+        ));
+    }
+    Ok(())
+}
+
+fn applied_settings(
+    desired: &AudioSettings,
+    media_fallback: bool,
+    communication_output_fallback: bool,
+    communication_input_fallback: bool,
+) -> AudioSettings {
+    let mut applied = desired.clone();
+    if media_fallback {
+        applied.routes.media_output_id = "builtin-speaker".to_string();
+    }
+    if communication_output_fallback {
+        applied.routes.communication_output_id = "builtin-speaker".to_string();
+    }
+    if communication_input_fallback {
+        applied.routes.communication_input_id = "builtin-microphone".to_string();
+    }
+    applied
+}
+
+fn endpoints(bluetooth: &BluetoothState) -> AudioEndpoints {
+    let mut outputs = vec![AudioEndpoint {
+        endpoint_id: "builtin-speaker".to_string(),
+        name: "YoYoPod speaker".to_string(),
+        kind: "builtin".to_string(),
+        accessory_id: None,
+        available: true,
+    }];
+    let mut inputs = vec![AudioEndpoint {
+        endpoint_id: "builtin-microphone".to_string(),
+        name: "YoYoPod microphone".to_string(),
+        kind: "builtin".to_string(),
+        accessory_id: None,
+        available: true,
+    }];
+    for accessory in bluetooth
+        .accessories
+        .iter()
+        .filter(|accessory| accessory.paired)
+    {
+        if accessory.capabilities.output {
+            outputs.push(AudioEndpoint {
+                endpoint_id: accessory.accessory_id.clone(),
+                name: accessory.name.clone(),
+                kind: "bluetooth".to_string(),
+                accessory_id: Some(accessory.accessory_id.clone()),
+                available: accessory.connected,
+            });
+        }
+        if accessory.capabilities.microphone {
+            inputs.push(AudioEndpoint {
+                endpoint_id: accessory.accessory_id.clone(),
+                name: accessory.name.clone(),
+                kind: "bluetooth".to_string(),
+                accessory_id: Some(accessory.accessory_id.clone()),
+                available: accessory.connected,
+            });
+        }
+    }
+    AudioEndpoints { outputs, inputs }
+}
+
+fn write_asound_config(
+    path: &Path,
+    output_address: Option<&str>,
+    input_address: Option<&str>,
+) -> Result<(), AudioOperationError> {
+    let output = output_address.unwrap_or("00:00:00:00:00:00");
+    let input = input_address.unwrap_or(output);
+    let config = format!(
+        "# Managed by YoYoPod. Bluetooth addresses stay on-device.\n\
+pcm.yoyopod_bt_a2dp {{\n  type bluealsa\n  device \"{output}\"\n  profile \"a2dp\"\n}}\n\
+pcm.yoyopod_bt_sco {{\n  type bluealsa\n  device \"{input}\"\n  profile \"sco\"\n}}\n"
+    );
+    atomic_write(path, config.as_bytes())
+        .map_err(|_| AudioOperationError::failed("The local audio route could not be configured"))
+}
+
+fn local_alsa_device(device: &str) -> &str {
+    device
+        .strip_prefix("alsa/")
+        .or_else(|| device.strip_prefix("ALSA: "))
+        .unwrap_or(device)
+}
+
+fn atomic_json_write(path: &Path, value: &impl Serialize) -> Result<(), std::io::Error> {
+    atomic_write(path, &serde_json::to_vec_pretty(value)?)
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+        fs::set_permissions(parent, fs::Permissions::from_mode(0o750))?;
+    }
+    let temporary = path.with_extension("tmp");
+    fs::write(&temporary, bytes)?;
+    fs::set_permissions(&temporary, fs::Permissions::from_mode(0o600))?;
+    fs::rename(temporary, path)
+}
+
+fn epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bluetooth::{
+        BluetoothAccessory, BluetoothCapabilities, BluetoothOperationError,
+        UnavailableBluetoothController,
+    };
+
+    #[test]
+    fn disconnected_selected_accessory_falls_back_without_losing_desired_setting() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let mut manager = AudioManager::open_at(
+            directory.path().join("settings.json"),
+            directory.path().join("asoundrc"),
+        );
+        let state = BluetoothState {
+            schema_version: 1,
+            status: "ready".to_string(),
+            radio_enabled: true,
+            scanning: false,
+            accessories: vec![BluetoothAccessory {
+                accessory_id: "9b0692e3-a07a-42f0-9fa7-a7704bbcf777".to_string(),
+                name: "Headset".to_string(),
+                kind: "headset".to_string(),
+                paired: true,
+                connected: false,
+                trusted: true,
+                auto_connect: true,
+                capabilities: BluetoothCapabilities {
+                    output: true,
+                    microphone: true,
+                    stereo: true,
+                    hands_free: true,
+                },
+                battery_percent: None,
+                signal_percent: None,
+                last_seen_at: 1,
+            }],
+            scanned_at: None,
+            reported_at: 1,
+        };
+        let id = state.accessories[0].accessory_id.clone();
+        let mut settings = AudioSettings::default();
+        settings.routes.media_output_id = id;
+        let applied = manager
+            .apply(2, settings, &UnavailableBluetoothController, &state)
+            .expect("apply");
+        assert_eq!(
+            applied.state.applied.routes.media_output_id,
+            "builtin-speaker"
+        );
+        assert_eq!(applied.state.status, "degraded");
+        assert_eq!(applied.state.applied_revision, 2);
+    }
+
+    #[allow(dead_code)]
+    fn error_type_is_public(error: BluetoothOperationError) -> &'static str {
+        error.code
+    }
+}

--- a/device/network/src/bluetooth.rs
+++ b/device/network/src/bluetooth.rs
@@ -1,0 +1,685 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use zbus::blocking::{Connection, Proxy};
+use zbus::fdo::ManagedObjects;
+use zvariant::OwnedObjectPath;
+
+const BLUEZ_DESTINATION: &str = "org.bluez";
+const AUDIO_SINK_UUID: &str = "0000110b-0000-1000-8000-00805f9b34fb";
+const HANDSFREE_UUID: &str = "0000111e-0000-1000-8000-00805f9b34fb";
+const HEADSET_UUID: &str = "00001108-0000-1000-8000-00805f9b34fb";
+const DEFAULT_REGISTRY_PATH: &str = "/var/lib/yoyopod/bluetooth/accessories.json";
+const SCAN_DURATION: Duration = Duration::from_secs(20);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BluetoothState {
+    pub schema_version: u8,
+    pub status: String,
+    pub radio_enabled: bool,
+    pub scanning: bool,
+    pub accessories: Vec<BluetoothAccessory>,
+    pub scanned_at: Option<u64>,
+    pub reported_at: u64,
+}
+
+impl BluetoothState {
+    pub fn unavailable() -> Self {
+        Self {
+            schema_version: 1,
+            status: "unavailable".to_string(),
+            radio_enabled: false,
+            scanning: false,
+            accessories: Vec::new(),
+            scanned_at: None,
+            reported_at: epoch_seconds(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BluetoothAccessory {
+    pub accessory_id: String,
+    pub name: String,
+    pub kind: String,
+    pub paired: bool,
+    pub connected: bool,
+    pub trusted: bool,
+    pub auto_connect: bool,
+    pub capabilities: BluetoothCapabilities,
+    pub battery_percent: Option<u8>,
+    pub signal_percent: Option<u8>,
+    pub last_seen_at: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BluetoothCapabilities {
+    pub output: bool,
+    pub microphone: bool,
+    pub stereo: bool,
+    pub hands_free: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BluetoothOperationError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl BluetoothOperationError {
+    fn unavailable() -> Self {
+        Self {
+            code: "bluetooth_unavailable",
+            message: "Bluetooth is not available on this YoYoPod".to_string(),
+        }
+    }
+
+    fn failed(message: impl Into<String>) -> Self {
+        Self {
+            code: "bluetooth_operation_failed",
+            message: message.into(),
+        }
+    }
+
+    fn invalid_accessory() -> Self {
+        Self {
+            code: "bluetooth_accessory_not_found",
+            message: "The Bluetooth accessory is no longer available".to_string(),
+        }
+    }
+}
+
+pub trait BluetoothController {
+    fn refresh(&mut self) -> Result<BluetoothState, BluetoothOperationError>;
+    fn set_radio(&mut self, enabled: bool) -> Result<BluetoothState, BluetoothOperationError>;
+    fn start_scan(&mut self) -> Result<BluetoothState, BluetoothOperationError>;
+    fn stop_scan(&mut self) -> Result<BluetoothState, BluetoothOperationError>;
+    fn pair(&mut self, accessory_id: &str) -> Result<BluetoothState, BluetoothOperationError>;
+    fn connect(&mut self, accessory_id: &str) -> Result<BluetoothState, BluetoothOperationError>;
+    fn disconnect(&mut self, accessory_id: &str)
+        -> Result<BluetoothState, BluetoothOperationError>;
+    fn forget(&mut self, accessory_id: &str) -> Result<BluetoothState, BluetoothOperationError>;
+    fn update_accessory(
+        &mut self,
+        accessory_id: &str,
+        alias: Option<&str>,
+        auto_connect: Option<bool>,
+    ) -> Result<BluetoothState, BluetoothOperationError>;
+    fn raw_address(&self, accessory_id: &str) -> Option<String>;
+    fn tick(&mut self) -> Option<BluetoothState>;
+}
+
+pub struct UnavailableBluetoothController;
+
+impl BluetoothController for UnavailableBluetoothController {
+    fn refresh(&mut self) -> Result<BluetoothState, BluetoothOperationError> {
+        Ok(BluetoothState::unavailable())
+    }
+
+    fn set_radio(&mut self, _: bool) -> Result<BluetoothState, BluetoothOperationError> {
+        Err(BluetoothOperationError::unavailable())
+    }
+
+    fn start_scan(&mut self) -> Result<BluetoothState, BluetoothOperationError> {
+        Err(BluetoothOperationError::unavailable())
+    }
+
+    fn stop_scan(&mut self) -> Result<BluetoothState, BluetoothOperationError> {
+        Err(BluetoothOperationError::unavailable())
+    }
+
+    fn pair(&mut self, _: &str) -> Result<BluetoothState, BluetoothOperationError> {
+        Err(BluetoothOperationError::unavailable())
+    }
+
+    fn connect(&mut self, _: &str) -> Result<BluetoothState, BluetoothOperationError> {
+        Err(BluetoothOperationError::unavailable())
+    }
+
+    fn disconnect(&mut self, _: &str) -> Result<BluetoothState, BluetoothOperationError> {
+        Err(BluetoothOperationError::unavailable())
+    }
+
+    fn forget(&mut self, _: &str) -> Result<BluetoothState, BluetoothOperationError> {
+        Err(BluetoothOperationError::unavailable())
+    }
+
+    fn update_accessory(
+        &mut self,
+        _: &str,
+        _: Option<&str>,
+        _: Option<bool>,
+    ) -> Result<BluetoothState, BluetoothOperationError> {
+        Err(BluetoothOperationError::unavailable())
+    }
+
+    fn raw_address(&self, _: &str) -> Option<String> {
+        None
+    }
+
+    fn tick(&mut self) -> Option<BluetoothState> {
+        None
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct AccessoryRegistry {
+    accessories: Vec<RegistryEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RegistryEntry {
+    accessory_id: String,
+    address: String,
+    #[serde(default)]
+    alias: String,
+    #[serde(default)]
+    auto_connect: bool,
+    #[serde(default)]
+    last_seen_at: u64,
+}
+
+pub struct BluezBluetoothController {
+    connection: Connection,
+    adapter_path: OwnedObjectPath,
+    registry_path: PathBuf,
+    registry: AccessoryRegistry,
+    scan_deadline: Option<Instant>,
+    scanned_at: Option<u64>,
+}
+
+impl BluezBluetoothController {
+    pub fn connect() -> Result<Self, BluetoothOperationError> {
+        Self::connect_with_registry(PathBuf::from(DEFAULT_REGISTRY_PATH))
+    }
+
+    fn connect_with_registry(registry_path: PathBuf) -> Result<Self, BluetoothOperationError> {
+        let connection =
+            Connection::system().map_err(|_| BluetoothOperationError::unavailable())?;
+        let objects = managed_objects(&connection)?;
+        let adapter_path = objects
+            .iter()
+            .find(|(_, interfaces)| interfaces.contains_key("org.bluez.Adapter1"))
+            .map(|(path, _)| path.clone())
+            .ok_or_else(BluetoothOperationError::unavailable)?;
+        let registry = load_registry(&registry_path).unwrap_or_default();
+        Ok(Self {
+            connection,
+            adapter_path,
+            registry_path,
+            registry,
+            scan_deadline: None,
+            scanned_at: None,
+        })
+    }
+
+    fn adapter_proxy(&self) -> Result<Proxy<'_>, BluetoothOperationError> {
+        Proxy::new(
+            &self.connection,
+            BLUEZ_DESTINATION,
+            self.adapter_path.as_str(),
+            "org.bluez.Adapter1",
+        )
+        .map_err(|_| BluetoothOperationError::unavailable())
+    }
+
+    fn device_path(&self, accessory_id: &str) -> Option<OwnedObjectPath> {
+        let address = self
+            .registry
+            .accessories
+            .iter()
+            .find(|entry| entry.accessory_id == accessory_id)?
+            .address
+            .clone();
+        managed_objects(&self.connection)
+            .ok()?
+            .into_iter()
+            .find(|(path, interfaces)| {
+                interfaces.contains_key("org.bluez.Device1")
+                    && device_property::<String>(&self.connection, path, "Address")
+                        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(&address))
+            })
+            .map(|(path, _)| path)
+    }
+
+    fn address_for_id(&self, accessory_id: &str) -> Option<String> {
+        self.registry
+            .accessories
+            .iter()
+            .find(|entry| entry.accessory_id == accessory_id)
+            .map(|entry| entry.address.clone())
+    }
+
+    fn device_proxy<'a>(
+        &'a self,
+        path: &'a OwnedObjectPath,
+    ) -> Result<Proxy<'a>, BluetoothOperationError> {
+        Proxy::new(
+            &self.connection,
+            BLUEZ_DESTINATION,
+            path.as_str(),
+            "org.bluez.Device1",
+        )
+        .map_err(|_| BluetoothOperationError::invalid_accessory())
+    }
+
+    fn save_registry(&self) -> Result<(), BluetoothOperationError> {
+        save_registry(&self.registry_path, &self.registry)
+            .map_err(|_| BluetoothOperationError::failed("Bluetooth settings could not be saved"))
+    }
+
+    fn refresh_inner(&mut self) -> Result<BluetoothState, BluetoothOperationError> {
+        let radio_enabled = self
+            .adapter_proxy()?
+            .get_property::<bool>("Powered")
+            .unwrap_or(false);
+        let scanning = self
+            .adapter_proxy()?
+            .get_property::<bool>("Discovering")
+            .unwrap_or(false);
+        let now = epoch_seconds();
+        let objects = managed_objects(&self.connection)?;
+        let mut accessories = Vec::new();
+        let mut registry_changed = false;
+
+        for (path, interfaces) in &objects {
+            if !interfaces.contains_key("org.bluez.Device1") {
+                continue;
+            }
+            let uuids =
+                device_property::<Vec<String>>(&self.connection, path, "UUIDs").unwrap_or_default();
+            let capabilities = capabilities_for(&uuids);
+            if !capabilities.output {
+                continue;
+            }
+            let Some(address) = device_property::<String>(&self.connection, path, "Address") else {
+                continue;
+            };
+            let entry_index = if let Some(index) = self
+                .registry
+                .accessories
+                .iter()
+                .position(|entry| entry.address.eq_ignore_ascii_case(&address))
+            {
+                index
+            } else {
+                self.registry.accessories.push(RegistryEntry {
+                    accessory_id: Uuid::new_v4().to_string(),
+                    address: address.clone(),
+                    alias: String::new(),
+                    auto_connect: false,
+                    last_seen_at: now,
+                });
+                registry_changed = true;
+                self.registry.accessories.len() - 1
+            };
+            let entry = &mut self.registry.accessories[entry_index];
+            if entry.last_seen_at != now {
+                entry.last_seen_at = now;
+                registry_changed = true;
+            }
+            let system_name = device_property::<String>(&self.connection, path, "Alias")
+                .or_else(|| device_property::<String>(&self.connection, path, "Name"))
+                .unwrap_or_else(|| "Bluetooth audio".to_string());
+            let name = if entry.alias.trim().is_empty() {
+                system_name
+            } else {
+                entry.alias.clone()
+            };
+            let rssi = device_property::<i16>(&self.connection, path, "RSSI");
+            accessories.push(BluetoothAccessory {
+                accessory_id: entry.accessory_id.clone(),
+                name: clean_name(&name),
+                kind: accessory_kind(&name, &capabilities),
+                paired: device_property::<bool>(&self.connection, path, "Paired").unwrap_or(false),
+                connected: device_property::<bool>(&self.connection, path, "Connected")
+                    .unwrap_or(false),
+                trusted: device_property::<bool>(&self.connection, path, "Trusted")
+                    .unwrap_or(false),
+                auto_connect: entry.auto_connect,
+                capabilities,
+                battery_percent: battery_percent(&self.connection, path),
+                signal_percent: rssi.map(rssi_percent),
+                last_seen_at: entry.last_seen_at,
+            });
+        }
+        accessories.sort_by(|left, right| {
+            right
+                .connected
+                .cmp(&left.connected)
+                .then_with(|| right.paired.cmp(&left.paired))
+                .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
+        });
+        if registry_changed {
+            self.save_registry()?;
+        }
+        Ok(BluetoothState {
+            schema_version: 1,
+            status: "ready".to_string(),
+            radio_enabled,
+            scanning,
+            accessories,
+            scanned_at: self.scanned_at,
+            reported_at: now,
+        })
+    }
+
+    fn call_device(
+        &mut self,
+        accessory_id: &str,
+        method: &str,
+    ) -> Result<BluetoothState, BluetoothOperationError> {
+        let path = self
+            .device_path(accessory_id)
+            .ok_or_else(BluetoothOperationError::invalid_accessory)?;
+        self.device_proxy(&path)?
+            .call::<_, _, ()>(method, &())
+            .map_err(|_| {
+                BluetoothOperationError::failed(format!(
+                    "The accessory could not be {}",
+                    method.to_lowercase()
+                ))
+            })?;
+        self.refresh_inner()
+    }
+}
+
+impl BluetoothController for BluezBluetoothController {
+    fn refresh(&mut self) -> Result<BluetoothState, BluetoothOperationError> {
+        self.refresh_inner()
+    }
+
+    fn set_radio(&mut self, enabled: bool) -> Result<BluetoothState, BluetoothOperationError> {
+        self.adapter_proxy()?
+            .set_property("Powered", enabled)
+            .map_err(|_| BluetoothOperationError::failed("Bluetooth radio could not be changed"))?;
+        if !enabled {
+            self.scan_deadline = None;
+        }
+        self.refresh_inner()
+    }
+
+    fn start_scan(&mut self) -> Result<BluetoothState, BluetoothOperationError> {
+        let adapter = self.adapter_proxy()?;
+        if !adapter.get_property::<bool>("Powered").unwrap_or(false) {
+            adapter.set_property("Powered", true).map_err(|_| {
+                BluetoothOperationError::failed("Bluetooth radio could not be enabled")
+            })?;
+        }
+        adapter
+            .call::<_, _, ()>("StartDiscovery", &())
+            .map_err(|_| BluetoothOperationError::failed("Bluetooth scan could not be started"))?;
+        drop(adapter);
+        self.scan_deadline = Some(Instant::now() + SCAN_DURATION);
+        self.refresh_inner()
+    }
+
+    fn stop_scan(&mut self) -> Result<BluetoothState, BluetoothOperationError> {
+        let adapter = self.adapter_proxy()?;
+        if adapter.get_property::<bool>("Discovering").unwrap_or(false) {
+            adapter
+                .call::<_, _, ()>("StopDiscovery", &())
+                .map_err(|_| {
+                    BluetoothOperationError::failed("Bluetooth scan could not be stopped")
+                })?;
+        }
+        drop(adapter);
+        self.scan_deadline = None;
+        self.scanned_at = Some(epoch_seconds());
+        self.refresh_inner()
+    }
+
+    fn pair(&mut self, accessory_id: &str) -> Result<BluetoothState, BluetoothOperationError> {
+        let address = self
+            .address_for_id(accessory_id)
+            .ok_or_else(BluetoothOperationError::invalid_accessory)?;
+        let output = Command::new("bluetoothctl")
+            .args(["--agent", "NoInputNoOutput", "pair", &address])
+            .output()
+            .map_err(|_| BluetoothOperationError::failed("Bluetooth pairing could not start"))?;
+        if !output.status.success() {
+            return Err(BluetoothOperationError {
+                code: "bluetooth_pairing_rejected",
+                message:
+                    "Pairing was not accepted. Put the accessory in pairing mode and try again."
+                        .to_string(),
+            });
+        }
+        let path = self
+            .device_path(accessory_id)
+            .ok_or_else(BluetoothOperationError::invalid_accessory)?;
+        {
+            let device = self.device_proxy(&path)?;
+            let _ = device.set_property("Trusted", true);
+        }
+        self.refresh_inner()
+    }
+
+    fn connect(&mut self, accessory_id: &str) -> Result<BluetoothState, BluetoothOperationError> {
+        if let Ok(state) = self.refresh_inner() {
+            for connected in state
+                .accessories
+                .into_iter()
+                .filter(|accessory| accessory.connected && accessory.accessory_id != accessory_id)
+            {
+                let _ = self.disconnect(&connected.accessory_id);
+            }
+        }
+        self.call_device(accessory_id, "Connect")
+    }
+
+    fn disconnect(
+        &mut self,
+        accessory_id: &str,
+    ) -> Result<BluetoothState, BluetoothOperationError> {
+        self.call_device(accessory_id, "Disconnect")
+    }
+
+    fn forget(&mut self, accessory_id: &str) -> Result<BluetoothState, BluetoothOperationError> {
+        let path = self
+            .device_path(accessory_id)
+            .ok_or_else(BluetoothOperationError::invalid_accessory)?;
+        self.adapter_proxy()?
+            .call::<_, _, ()>("RemoveDevice", &(path,))
+            .map_err(|_| BluetoothOperationError::failed("The accessory could not be forgotten"))?;
+        self.registry
+            .accessories
+            .retain(|entry| entry.accessory_id != accessory_id);
+        self.save_registry()?;
+        self.refresh_inner()
+    }
+
+    fn update_accessory(
+        &mut self,
+        accessory_id: &str,
+        alias: Option<&str>,
+        auto_connect: Option<bool>,
+    ) -> Result<BluetoothState, BluetoothOperationError> {
+        let entry = self
+            .registry
+            .accessories
+            .iter_mut()
+            .find(|entry| entry.accessory_id == accessory_id)
+            .ok_or_else(BluetoothOperationError::invalid_accessory)?;
+        if let Some(alias) = alias {
+            entry.alias = clean_name(alias);
+        }
+        if let Some(auto_connect) = auto_connect {
+            entry.auto_connect = auto_connect;
+        }
+        self.save_registry()?;
+        self.refresh_inner()
+    }
+
+    fn raw_address(&self, accessory_id: &str) -> Option<String> {
+        self.address_for_id(accessory_id)
+    }
+
+    fn tick(&mut self) -> Option<BluetoothState> {
+        if self
+            .scan_deadline
+            .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            return self.stop_scan().ok();
+        }
+        None
+    }
+}
+
+fn managed_objects(connection: &Connection) -> Result<ManagedObjects, BluetoothOperationError> {
+    Proxy::new(
+        connection,
+        BLUEZ_DESTINATION,
+        "/",
+        "org.freedesktop.DBus.ObjectManager",
+    )
+    .and_then(|proxy| proxy.call("GetManagedObjects", &()))
+    .map_err(|_| BluetoothOperationError::unavailable())
+}
+
+fn device_property<T>(connection: &Connection, path: &OwnedObjectPath, property: &str) -> Option<T>
+where
+    T: TryFrom<zvariant::OwnedValue>,
+    T::Error: Into<zbus::Error>,
+{
+    Proxy::new(
+        connection,
+        BLUEZ_DESTINATION,
+        path.as_str(),
+        "org.bluez.Device1",
+    )
+    .ok()?
+    .get_property::<T>(property)
+    .ok()
+}
+
+fn battery_percent(connection: &Connection, path: &OwnedObjectPath) -> Option<u8> {
+    Proxy::new(
+        connection,
+        BLUEZ_DESTINATION,
+        path.as_str(),
+        "org.bluez.Battery1",
+    )
+    .ok()?
+    .get_property::<u8>("Percentage")
+    .ok()
+}
+
+fn capabilities_for(uuids: &[String]) -> BluetoothCapabilities {
+    let has = |uuid: &str| {
+        uuids
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(uuid))
+    };
+    let stereo = has(AUDIO_SINK_UUID);
+    let hands_free = has(HANDSFREE_UUID) || has(HEADSET_UUID);
+    BluetoothCapabilities {
+        output: stereo || hands_free,
+        microphone: hands_free,
+        stereo,
+        hands_free,
+    }
+}
+
+fn accessory_kind(name: &str, capabilities: &BluetoothCapabilities) -> String {
+    let normalized = name.to_lowercase();
+    if normalized.contains("earbud") || normalized.contains("airpod") || normalized.contains("buds")
+    {
+        "earbuds"
+    } else if capabilities.microphone
+        && (normalized.contains("headset") || normalized.contains("headphone"))
+    {
+        "headset"
+    } else if normalized.contains("speaker") {
+        "speaker"
+    } else if normalized.contains("headphone") {
+        "headphones"
+    } else {
+        "unknown_audio"
+    }
+    .to_string()
+}
+
+fn clean_name(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| !character.is_control())
+        .collect::<String>()
+        .trim()
+        .chars()
+        .take(80)
+        .collect()
+}
+
+fn rssi_percent(rssi: i16) -> u8 {
+    (((rssi.clamp(-100, -40) + 100) * 100) / 60) as u8
+}
+
+fn load_registry(path: &Path) -> Result<AccessoryRegistry, std::io::Error> {
+    let bytes = fs::read(path)?;
+    serde_json::from_slice(&bytes)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+fn save_registry(path: &Path, registry: &AccessoryRegistry) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+        fs::set_permissions(parent, fs::Permissions::from_mode(0o750))?;
+    }
+    let temporary = path.with_extension("tmp");
+    fs::write(&temporary, serde_json::to_vec_pretty(registry)?)?;
+    fs::set_permissions(&temporary, fs::Permissions::from_mode(0o600))?;
+    fs::rename(temporary, path)
+}
+
+fn epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capabilities_only_allow_audio_profiles() {
+        assert!(!capabilities_for(&["0000180f-0000-1000-8000-00805f9b34fb".to_string()]).output);
+        let capabilities =
+            capabilities_for(&[AUDIO_SINK_UUID.to_string(), HANDSFREE_UUID.to_string()]);
+        assert!(capabilities.output);
+        assert!(capabilities.stereo);
+        assert!(capabilities.microphone);
+    }
+
+    #[test]
+    fn registry_is_private_and_round_trips_opaque_ids() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let path = directory.path().join("accessories.json");
+        let registry = AccessoryRegistry {
+            accessories: vec![RegistryEntry {
+                accessory_id: Uuid::new_v4().to_string(),
+                address: "AA:BB:CC:DD:EE:FF".to_string(),
+                alias: "Kitchen headset".to_string(),
+                auto_connect: true,
+                last_seen_at: 10,
+            }],
+        };
+        save_registry(&path, &registry).expect("save");
+        let loaded = load_registry(&path).expect("load");
+        assert_eq!(
+            loaded.accessories[0].accessory_id,
+            registry.accessories[0].accessory_id
+        );
+        assert_eq!(
+            fs::metadata(path).expect("metadata").permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}

--- a/device/network/src/bluetooth.rs
+++ b/device/network/src/bluetooth.rs
@@ -554,7 +554,15 @@ impl BluetoothController for BluezBluetoothController {
     fn tick(&mut self) -> Option<BluetoothState> {
         let now = Instant::now();
         if self.scan_deadline.is_some_and(|deadline| now >= deadline) {
-            return self.stop_scan().ok();
+            return Some(match self.stop_scan() {
+                Ok(state) => state,
+                Err(_) => {
+                    self.scan_deadline = None;
+                    self.scan_refresh_deadline = None;
+                    self.state_refresh_deadline = now + STATE_REFRESH_INTERVAL;
+                    BluetoothState::unavailable()
+                }
+            });
         }
         if self.scan_deadline.is_some()
             && self
@@ -562,10 +570,16 @@ impl BluetoothController for BluezBluetoothController {
                 .is_some_and(|deadline| now >= deadline)
         {
             self.scan_refresh_deadline = Some(now + SCAN_REFRESH_INTERVAL);
-            return self.refresh_inner().ok();
+            return Some(
+                self.refresh_inner()
+                    .unwrap_or_else(|_| BluetoothState::unavailable()),
+            );
         }
         if now >= self.state_refresh_deadline {
-            return self.refresh_inner().ok();
+            return Some(
+                self.refresh_inner()
+                    .unwrap_or_else(|_| BluetoothState::unavailable()),
+            );
         }
         None
     }

--- a/device/network/src/bluetooth.rs
+++ b/device/network/src/bluetooth.rs
@@ -17,6 +17,7 @@ const HEADSET_UUID: &str = "00001108-0000-1000-8000-00805f9b34fb";
 const DEFAULT_REGISTRY_PATH: &str = "/var/lib/yoyopod/bluetooth/accessories.json";
 const SCAN_DURATION: Duration = Duration::from_secs(12);
 const SCAN_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const STATE_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BluetoothState {
@@ -192,6 +193,7 @@ pub struct BluezBluetoothController {
     registry: AccessoryRegistry,
     scan_deadline: Option<Instant>,
     scan_refresh_deadline: Option<Instant>,
+    state_refresh_deadline: Instant,
     scanned_at: Option<u64>,
 }
 
@@ -217,6 +219,7 @@ impl BluezBluetoothController {
             registry,
             scan_deadline: None,
             scan_refresh_deadline: None,
+            state_refresh_deadline: Instant::now() + STATE_REFRESH_INTERVAL,
             scanned_at: None,
         })
     }
@@ -277,6 +280,7 @@ impl BluezBluetoothController {
     }
 
     fn refresh_inner(&mut self) -> Result<BluetoothState, BluetoothOperationError> {
+        self.state_refresh_deadline = Instant::now() + STATE_REFRESH_INTERVAL;
         let radio_enabled = self
             .adapter_proxy()?
             .get_property::<bool>("Powered")
@@ -480,18 +484,13 @@ impl BluetoothController for BluezBluetoothController {
         let path = self
             .device_path(accessory_id)
             .ok_or_else(BluetoothOperationError::invalid_accessory)?;
-        if device_property::<bool>(&self.connection, &path, "Connected").unwrap_or(false) {
-            return self.refresh_inner();
-        }
         let uuids =
             device_property::<Vec<String>>(&self.connection, &path, "UUIDs").unwrap_or_default();
-        let profile = preferred_output_profile(&uuids).ok_or_else(|| BluetoothOperationError {
+        preferred_output_profile(&uuids).ok_or_else(|| BluetoothOperationError {
             code: "bluetooth_audio_profile_unavailable",
             message: "The accessory does not offer a compatible playback profile".to_string(),
         })?;
-        let connect_result = self
-            .device_proxy(&path)?
-            .call::<_, _, ()>("ConnectProfile", &(profile,));
+        let connect_result = self.device_proxy(&path)?.call::<_, _, ()>("Connect", &());
         if connect_result.is_err()
             && !device_property::<bool>(&self.connection, &path, "Connected").unwrap_or(false)
         {
@@ -563,6 +562,9 @@ impl BluetoothController for BluezBluetoothController {
                 .is_some_and(|deadline| now >= deadline)
         {
             self.scan_refresh_deadline = Some(now + SCAN_REFRESH_INTERVAL);
+            return self.refresh_inner().ok();
+        }
+        if now >= self.state_refresh_deadline {
             return self.refresh_inner().ok();
         }
         None
@@ -735,7 +737,9 @@ mod tests {
     fn scan_window_is_short_and_refreshes_incrementally() {
         assert_eq!(SCAN_DURATION, Duration::from_secs(12));
         assert_eq!(SCAN_REFRESH_INTERVAL, Duration::from_secs(1));
+        assert_eq!(STATE_REFRESH_INTERVAL, Duration::from_secs(3));
         assert!(SCAN_REFRESH_INTERVAL < SCAN_DURATION);
+        assert!(SCAN_DURATION > STATE_REFRESH_INTERVAL);
     }
 
     #[test]

--- a/device/network/src/bluetooth.rs
+++ b/device/network/src/bluetooth.rs
@@ -635,19 +635,6 @@ impl BluetoothController for BluezBluetoothController {
     }
 
     fn connect(&mut self, accessory_id: &str) -> Result<BluetoothState, BluetoothOperationError> {
-        let previously_connected = self
-            .refresh_inner()
-            .map(|state| {
-                state
-                    .accessories
-                    .into_iter()
-                    .filter(|accessory| {
-                        accessory.connected && accessory.accessory_id != accessory_id
-                    })
-                    .map(|accessory| accessory.accessory_id)
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
         let path = self
             .device_path(accessory_id)
             .ok_or_else(BluetoothOperationError::invalid_accessory)?;
@@ -668,12 +655,8 @@ impl BluetoothController for BluezBluetoothController {
                         .to_string(),
             });
         }
-        // Keep the active route working until its replacement has accepted the
-        // connection. This also preserves the old accessory when validation or
-        // the BlueZ connection attempt fails.
-        for connected_id in previously_connected {
-            let _ = self.disconnect(&connected_id);
-        }
+        // Keep other accessories connected: media, call playback, and call
+        // capture may intentionally use different selected routes.
         self.refresh_inner()
     }
 

--- a/device/network/src/bluetooth.rs
+++ b/device/network/src/bluetooth.rs
@@ -484,15 +484,19 @@ impl BluetoothController for BluezBluetoothController {
     }
 
     fn connect(&mut self, accessory_id: &str) -> Result<BluetoothState, BluetoothOperationError> {
-        if let Ok(state) = self.refresh_inner() {
-            for connected in state
-                .accessories
-                .into_iter()
-                .filter(|accessory| accessory.connected && accessory.accessory_id != accessory_id)
-            {
-                let _ = self.disconnect(&connected.accessory_id);
-            }
-        }
+        let previously_connected = self
+            .refresh_inner()
+            .map(|state| {
+                state
+                    .accessories
+                    .into_iter()
+                    .filter(|accessory| {
+                        accessory.connected && accessory.accessory_id != accessory_id
+                    })
+                    .map(|accessory| accessory.accessory_id)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
         let path = self
             .device_path(accessory_id)
             .ok_or_else(BluetoothOperationError::invalid_accessory)?;
@@ -512,6 +516,12 @@ impl BluetoothController for BluezBluetoothController {
                     "The accessory rejected the audio connection. Put it in pairing mode and try again."
                         .to_string(),
             });
+        }
+        // Keep the active route working until its replacement has accepted the
+        // connection. This also preserves the old accessory when validation or
+        // the BlueZ connection attempt fails.
+        for connected_id in previously_connected {
+            let _ = self.disconnect(&connected_id);
         }
         self.refresh_inner()
     }

--- a/device/network/src/bluetooth.rs
+++ b/device/network/src/bluetooth.rs
@@ -15,7 +15,8 @@ const AUDIO_SINK_UUID: &str = "0000110b-0000-1000-8000-00805f9b34fb";
 const HANDSFREE_UUID: &str = "0000111e-0000-1000-8000-00805f9b34fb";
 const HEADSET_UUID: &str = "00001108-0000-1000-8000-00805f9b34fb";
 const DEFAULT_REGISTRY_PATH: &str = "/var/lib/yoyopod/bluetooth/accessories.json";
-const SCAN_DURATION: Duration = Duration::from_secs(20);
+const SCAN_DURATION: Duration = Duration::from_secs(12);
+const SCAN_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BluetoothState {
@@ -190,6 +191,7 @@ pub struct BluezBluetoothController {
     registry_path: PathBuf,
     registry: AccessoryRegistry,
     scan_deadline: Option<Instant>,
+    scan_refresh_deadline: Option<Instant>,
     scanned_at: Option<u64>,
 }
 
@@ -214,6 +216,7 @@ impl BluezBluetoothController {
             registry_path,
             registry,
             scan_deadline: None,
+            scan_refresh_deadline: None,
             scanned_at: None,
         })
     }
@@ -400,6 +403,7 @@ impl BluetoothController for BluezBluetoothController {
             .map_err(|_| BluetoothOperationError::failed("Bluetooth radio could not be changed"))?;
         if !enabled {
             self.scan_deadline = None;
+            self.scan_refresh_deadline = None;
         }
         self.refresh_inner()
     }
@@ -415,7 +419,9 @@ impl BluetoothController for BluezBluetoothController {
             .call::<_, _, ()>("StartDiscovery", &())
             .map_err(|_| BluetoothOperationError::failed("Bluetooth scan could not be started"))?;
         drop(adapter);
-        self.scan_deadline = Some(Instant::now() + SCAN_DURATION);
+        let now = Instant::now();
+        self.scan_deadline = Some(now + SCAN_DURATION);
+        self.scan_refresh_deadline = Some(now + SCAN_REFRESH_INTERVAL);
         self.refresh_inner()
     }
 
@@ -430,6 +436,7 @@ impl BluetoothController for BluezBluetoothController {
         }
         drop(adapter);
         self.scan_deadline = None;
+        self.scan_refresh_deadline = None;
         self.scanned_at = Some(epoch_seconds());
         self.refresh_inner()
     }
@@ -521,11 +528,17 @@ impl BluetoothController for BluezBluetoothController {
     }
 
     fn tick(&mut self) -> Option<BluetoothState> {
-        if self
-            .scan_deadline
-            .is_some_and(|deadline| Instant::now() >= deadline)
-        {
+        let now = Instant::now();
+        if self.scan_deadline.is_some_and(|deadline| now >= deadline) {
             return self.stop_scan().ok();
+        }
+        if self.scan_deadline.is_some()
+            && self
+                .scan_refresh_deadline
+                .is_some_and(|deadline| now >= deadline)
+        {
+            self.scan_refresh_deadline = Some(now + SCAN_REFRESH_INTERVAL);
+            return self.refresh_inner().ok();
         }
         None
     }
@@ -656,6 +669,13 @@ mod tests {
         assert!(capabilities.output);
         assert!(capabilities.stereo);
         assert!(capabilities.microphone);
+    }
+
+    #[test]
+    fn scan_window_is_short_and_refreshes_incrementally() {
+        assert_eq!(SCAN_DURATION, Duration::from_secs(12));
+        assert_eq!(SCAN_REFRESH_INTERVAL, Duration::from_secs(1));
+        assert!(SCAN_REFRESH_INTERVAL < SCAN_DURATION);
     }
 
     #[test]

--- a/device/network/src/bluetooth.rs
+++ b/device/network/src/bluetooth.rs
@@ -477,7 +477,32 @@ impl BluetoothController for BluezBluetoothController {
                 let _ = self.disconnect(&connected.accessory_id);
             }
         }
-        self.call_device(accessory_id, "Connect")
+        let path = self
+            .device_path(accessory_id)
+            .ok_or_else(BluetoothOperationError::invalid_accessory)?;
+        if device_property::<bool>(&self.connection, &path, "Connected").unwrap_or(false) {
+            return self.refresh_inner();
+        }
+        let uuids =
+            device_property::<Vec<String>>(&self.connection, &path, "UUIDs").unwrap_or_default();
+        let profile = preferred_output_profile(&uuids).ok_or_else(|| BluetoothOperationError {
+            code: "bluetooth_audio_profile_unavailable",
+            message: "The accessory does not offer a compatible playback profile".to_string(),
+        })?;
+        let connect_result = self
+            .device_proxy(&path)?
+            .call::<_, _, ()>("ConnectProfile", &(profile,));
+        if connect_result.is_err()
+            && !device_property::<bool>(&self.connection, &path, "Connected").unwrap_or(false)
+        {
+            return Err(BluetoothOperationError {
+                code: "bluetooth_connection_rejected",
+                message:
+                    "The accessory rejected the audio connection. Put it in pairing mode and try again."
+                        .to_string(),
+            });
+        }
+        self.refresh_inner()
     }
 
     fn disconnect(
@@ -599,6 +624,23 @@ fn capabilities_for(uuids: &[String]) -> BluetoothCapabilities {
     }
 }
 
+fn preferred_output_profile(uuids: &[String]) -> Option<&'static str> {
+    let has = |uuid: &str| {
+        uuids
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(uuid))
+    };
+    if has(AUDIO_SINK_UUID) {
+        Some(AUDIO_SINK_UUID)
+    } else if has(HANDSFREE_UUID) {
+        Some(HANDSFREE_UUID)
+    } else if has(HEADSET_UUID) {
+        Some(HEADSET_UUID)
+    } else {
+        None
+    }
+}
+
 fn accessory_kind(name: &str, capabilities: &BluetoothCapabilities) -> String {
     let normalized = name.to_lowercase();
     if normalized.contains("earbud") || normalized.contains("airpod") || normalized.contains("buds")
@@ -669,6 +711,24 @@ mod tests {
         assert!(capabilities.output);
         assert!(capabilities.stereo);
         assert!(capabilities.microphone);
+    }
+
+    #[test]
+    fn connection_prefers_remote_playback_profile() {
+        assert_eq!(
+            preferred_output_profile(
+                &[HANDSFREE_UUID.to_string(), AUDIO_SINK_UUID.to_uppercase(),]
+            ),
+            Some(AUDIO_SINK_UUID)
+        );
+        assert_eq!(
+            preferred_output_profile(&[HANDSFREE_UUID.to_string()]),
+            Some(HANDSFREE_UUID)
+        );
+        assert_eq!(
+            preferred_output_profile(&["0000180f-0000-1000-8000-00805f9b34fb".to_string()]),
+            None
+        );
     }
 
     #[test]

--- a/device/network/src/bluetooth.rs
+++ b/device/network/src/bluetooth.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -195,6 +196,7 @@ pub struct BluezBluetoothController {
     scan_refresh_deadline: Option<Instant>,
     state_refresh_deadline: Instant,
     scanned_at: Option<u64>,
+    connected_accessories: HashSet<String>,
 }
 
 impl BluezBluetoothController {
@@ -221,6 +223,7 @@ impl BluezBluetoothController {
             scan_refresh_deadline: None,
             state_refresh_deadline: Instant::now() + STATE_REFRESH_INTERVAL,
             scanned_at: None,
+            connected_accessories: HashSet::new(),
         })
     }
 
@@ -293,6 +296,7 @@ impl BluezBluetoothController {
         let objects = managed_objects(&self.connection)?;
         let mut accessories = Vec::new();
         let mut registry_changed = false;
+        let mut connected_accessories = HashSet::new();
 
         for (path, interfaces) in &objects {
             if !interfaces.contains_key("org.bluez.Device1") {
@@ -307,6 +311,9 @@ impl BluezBluetoothController {
             let Some(address) = device_property::<String>(&self.connection, path, "Address") else {
                 continue;
             };
+            let connected =
+                device_property::<bool>(&self.connection, path, "Connected").unwrap_or(false);
+            let rssi = device_property::<i16>(&self.connection, path, "RSSI");
             let entry_index = if let Some(index) = self
                 .registry
                 .accessories
@@ -326,9 +333,15 @@ impl BluezBluetoothController {
                 self.registry.accessories.len() - 1
             };
             let entry = &mut self.registry.accessories[entry_index];
-            if entry.last_seen_at != now {
+            let was_connected = self.connected_accessories.contains(&entry.accessory_id);
+            if should_refresh_last_seen(scanning, rssi.is_some(), connected, was_connected)
+                && entry.last_seen_at != now
+            {
                 entry.last_seen_at = now;
                 registry_changed = true;
+            }
+            if connected {
+                connected_accessories.insert(entry.accessory_id.clone());
             }
             let system_name = device_property::<String>(&self.connection, path, "Alias")
                 .or_else(|| device_property::<String>(&self.connection, path, "Name"))
@@ -338,14 +351,12 @@ impl BluezBluetoothController {
             } else {
                 entry.alias.clone()
             };
-            let rssi = device_property::<i16>(&self.connection, path, "RSSI");
             accessories.push(BluetoothAccessory {
                 accessory_id: entry.accessory_id.clone(),
                 name: clean_name(&name),
                 kind: accessory_kind(&name, &capabilities),
                 paired: device_property::<bool>(&self.connection, path, "Paired").unwrap_or(false),
-                connected: device_property::<bool>(&self.connection, path, "Connected")
-                    .unwrap_or(false),
+                connected,
                 trusted: device_property::<bool>(&self.connection, path, "Trusted")
                     .unwrap_or(false),
                 auto_connect: entry.auto_connect,
@@ -365,6 +376,7 @@ impl BluezBluetoothController {
         if registry_changed {
             self.save_registry()?;
         }
+        self.connected_accessories = connected_accessories;
         Ok(BluetoothState {
             schema_version: 1,
             status: "ready".to_string(),
@@ -691,6 +703,15 @@ fn rssi_percent(rssi: i16) -> u8 {
     (((rssi.clamp(-100, -40) + 100) * 100) / 60) as u8
 }
 
+fn should_refresh_last_seen(
+    scanning: bool,
+    has_rssi: bool,
+    connected: bool,
+    was_connected: bool,
+) -> bool {
+    (scanning && has_rssi) || (connected && !was_connected)
+}
+
 fn load_registry(path: &Path) -> Result<AccessoryRegistry, std::io::Error> {
     let bytes = fs::read(path)?;
     serde_json::from_slice(&bytes)
@@ -754,6 +775,15 @@ mod tests {
         assert_eq!(STATE_REFRESH_INTERVAL, Duration::from_secs(3));
         assert!(SCAN_REFRESH_INTERVAL < SCAN_DURATION);
         assert!(SCAN_DURATION > STATE_REFRESH_INTERVAL);
+    }
+
+    #[test]
+    fn cached_devices_do_not_look_fresh_without_discovery_or_connection() {
+        assert!(!should_refresh_last_seen(false, false, false, false));
+        assert!(!should_refresh_last_seen(false, true, false, false));
+        assert!(!should_refresh_last_seen(false, false, true, true));
+        assert!(should_refresh_last_seen(true, true, false, false));
+        assert!(should_refresh_last_seen(false, false, true, false));
     }
 
     #[test]

--- a/device/network/src/bluetooth.rs
+++ b/device/network/src/bluetooth.rs
@@ -19,6 +19,7 @@ const DEFAULT_REGISTRY_PATH: &str = "/var/lib/yoyopod/bluetooth/accessories.json
 const SCAN_DURATION: Duration = Duration::from_secs(12);
 const SCAN_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const STATE_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
+const BLUETOOTH_RECONNECT_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BluetoothState {
@@ -167,6 +168,156 @@ impl BluetoothController for UnavailableBluetoothController {
 
     fn tick(&mut self) -> Option<BluetoothState> {
         None
+    }
+}
+
+pub struct RecoveringBluetoothController {
+    controller: Option<BluezBluetoothController>,
+    next_reconnect_at: Instant,
+}
+
+impl RecoveringBluetoothController {
+    pub fn new() -> Self {
+        let mut recovering = Self {
+            controller: None,
+            next_reconnect_at: Instant::now(),
+        };
+        let _ = recovering.reconnect();
+        recovering
+    }
+
+    fn reconnect(&mut self) -> Result<(), BluetoothOperationError> {
+        match BluezBluetoothController::connect() {
+            Ok(controller) => {
+                self.controller = Some(controller);
+                Ok(())
+            }
+            Err(error) => {
+                self.controller = None;
+                self.next_reconnect_at = Instant::now() + BLUETOOTH_RECONNECT_INTERVAL;
+                Err(error)
+            }
+        }
+    }
+
+    fn ensure_controller(
+        &mut self,
+    ) -> Result<&mut BluezBluetoothController, BluetoothOperationError> {
+        if self.controller.is_none() {
+            if Instant::now() < self.next_reconnect_at {
+                return Err(BluetoothOperationError::unavailable());
+            }
+            self.reconnect()?;
+        }
+        self.controller
+            .as_mut()
+            .ok_or_else(BluetoothOperationError::unavailable)
+    }
+
+    fn with_controller<T>(
+        &mut self,
+        operation: impl FnOnce(&mut BluezBluetoothController) -> Result<T, BluetoothOperationError>,
+    ) -> Result<T, BluetoothOperationError> {
+        let result = operation(self.ensure_controller()?);
+        if result
+            .as_ref()
+            .err()
+            .is_some_and(|error| error.code == "bluetooth_unavailable")
+        {
+            self.controller = None;
+            self.next_reconnect_at = Instant::now() + BLUETOOTH_RECONNECT_INTERVAL;
+        }
+        result
+    }
+}
+
+impl Default for RecoveringBluetoothController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BluetoothController for RecoveringBluetoothController {
+    fn refresh(&mut self) -> Result<BluetoothState, BluetoothOperationError> {
+        self.with_controller(|controller| controller.refresh())
+    }
+
+    fn set_radio(&mut self, enabled: bool) -> Result<BluetoothState, BluetoothOperationError> {
+        self.with_controller(|controller| controller.set_radio(enabled))
+    }
+
+    fn start_scan(&mut self) -> Result<BluetoothState, BluetoothOperationError> {
+        self.with_controller(|controller| controller.start_scan())
+    }
+
+    fn stop_scan(&mut self) -> Result<BluetoothState, BluetoothOperationError> {
+        self.with_controller(|controller| controller.stop_scan())
+    }
+
+    fn pair(&mut self, accessory_id: &str) -> Result<BluetoothState, BluetoothOperationError> {
+        self.with_controller(|controller| controller.pair(accessory_id))
+    }
+
+    fn connect(&mut self, accessory_id: &str) -> Result<BluetoothState, BluetoothOperationError> {
+        self.with_controller(|controller| controller.connect(accessory_id))
+    }
+
+    fn disconnect(
+        &mut self,
+        accessory_id: &str,
+    ) -> Result<BluetoothState, BluetoothOperationError> {
+        self.with_controller(|controller| controller.disconnect(accessory_id))
+    }
+
+    fn forget(&mut self, accessory_id: &str) -> Result<BluetoothState, BluetoothOperationError> {
+        self.with_controller(|controller| controller.forget(accessory_id))
+    }
+
+    fn update_accessory(
+        &mut self,
+        accessory_id: &str,
+        alias: Option<&str>,
+        auto_connect: Option<bool>,
+    ) -> Result<BluetoothState, BluetoothOperationError> {
+        self.with_controller(|controller| {
+            controller.update_accessory(accessory_id, alias, auto_connect)
+        })
+    }
+
+    fn raw_address(&self, accessory_id: &str) -> Option<String> {
+        self.controller
+            .as_ref()
+            .and_then(|controller| controller.raw_address(accessory_id))
+    }
+
+    fn tick(&mut self) -> Option<BluetoothState> {
+        if self.controller.is_none() {
+            if Instant::now() < self.next_reconnect_at || self.reconnect().is_err() {
+                return None;
+            }
+            let state = self
+                .controller
+                .as_mut()
+                .and_then(|controller| controller.refresh().ok());
+            if state.is_none() {
+                self.controller = None;
+                self.next_reconnect_at = Instant::now() + BLUETOOTH_RECONNECT_INTERVAL;
+            }
+            return Some(state.unwrap_or_else(BluetoothState::unavailable));
+        }
+
+        let state = self
+            .controller
+            .as_mut()
+            .and_then(|controller| controller.tick());
+        if state
+            .as_ref()
+            .is_some_and(|state| state.status == "unavailable")
+        {
+            self.controller = None;
+            self.next_reconnect_at = Instant::now() + BLUETOOTH_RECONNECT_INTERVAL;
+        }
+        state
     }
 }
 

--- a/device/network/src/lib.rs
+++ b/device/network/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod at;
+pub mod audio;
+pub mod bluetooth;
 pub mod config;
 pub mod gps;
 pub mod modem;

--- a/device/network/src/protocol.rs
+++ b/device/network/src/protocol.rs
@@ -2,6 +2,10 @@ use serde_json::json;
 
 use crate::snapshot::NetworkRuntimeSnapshot;
 use crate::wifi::{WifiChangeOperation, WifiState};
+use crate::{
+    audio::{AudioRouteLocal, AudioState},
+    bluetooth::BluetoothState,
+};
 
 pub use yoyopod_protocol::{EnvelopeKind, ProtocolError, WorkerEnvelope, SUPPORTED_SCHEMA_VERSION};
 
@@ -39,6 +43,38 @@ pub fn wifi_state_result(request_id: Option<String>, state: &WifiState) -> Worke
         json!({
             "state": state,
         }),
+    )
+}
+
+pub fn bluetooth_state_event(state: &BluetoothState) -> WorkerEnvelope {
+    WorkerEnvelope::event(
+        "bluetooth_state",
+        serde_json::to_value(state).expect("Bluetooth state should serialize"),
+    )
+}
+
+pub fn bluetooth_state_result(
+    request_id: Option<String>,
+    state: &BluetoothState,
+) -> WorkerEnvelope {
+    WorkerEnvelope::result("bluetooth_state", request_id, json!({ "state": state }))
+}
+
+pub fn audio_state_event(state: &AudioState) -> WorkerEnvelope {
+    WorkerEnvelope::event(
+        "audio_state",
+        serde_json::to_value(state).expect("audio state should serialize"),
+    )
+}
+
+pub fn audio_state_result(request_id: Option<String>, state: &AudioState) -> WorkerEnvelope {
+    WorkerEnvelope::result("audio_state", request_id, json!({ "state": state }))
+}
+
+pub fn audio_route_local_event(route: &AudioRouteLocal) -> WorkerEnvelope {
+    WorkerEnvelope::event(
+        "audio_route_local",
+        serde_json::to_value(route).expect("local audio route should serialize"),
     )
 }
 

--- a/device/network/src/worker.rs
+++ b/device/network/src/worker.rs
@@ -324,6 +324,7 @@ where
     }
 
     if pending_wifi_change.is_some()
+        && envelope.message_type.starts_with("wifi_")
         && !matches!(
             envelope.message_type.as_str(),
             "wifi_refresh" | "wifi_confirm_change" | "network.shutdown" | "worker.stop"
@@ -1353,6 +1354,40 @@ mod tests {
             envelope.kind == EnvelopeKind::Result
                 && envelope.message_type == "wifi_state"
                 && envelope.request_id.as_deref() == Some(activation_id)
+        }));
+    }
+
+    #[test]
+    fn bluetooth_commands_continue_during_pending_wifi_changes() {
+        let activation_id = "77777777-7777-4777-8777-777777777777";
+        let bluetooth_id = "88888888-8888-4888-8888-888888888888";
+        let envelopes = run_wifi_commands(
+            vec![
+                WorkerEnvelope::command(
+                    "wifi_activate_profile",
+                    Some(activation_id.to_string()),
+                    serde_json::json!({
+                        "profile_id": "22222222-2222-4222-8222-222222222222",
+                        "preference": "preferred",
+                    }),
+                ),
+                WorkerEnvelope::command(
+                    "bluetooth_refresh",
+                    Some(bluetooth_id.to_string()),
+                    serde_json::json!({}),
+                ),
+            ],
+            false,
+        );
+
+        assert!(!envelopes.iter().any(|envelope| {
+            envelope.request_id.as_deref() == Some(bluetooth_id)
+                && envelope.payload["code"] == "wifi_change_in_progress"
+        }));
+        assert!(envelopes.iter().any(|envelope| {
+            envelope.request_id.as_deref() == Some(bluetooth_id)
+                && envelope.kind == EnvelopeKind::Result
+                && envelope.message_type == "bluetooth_state"
         }));
     }
 

--- a/device/network/src/worker.rs
+++ b/device/network/src/worker.rs
@@ -30,6 +30,8 @@ const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 // wait. Keep the cloud-confirmation phase below the remaining checkpoint time.
 const WIFI_CHANGE_TIMEOUT: Duration = Duration::from_secs(60);
 const WIFI_CANDIDATE_INTERVAL: Duration = Duration::from_secs(5);
+const BLUETOOTH_AUTO_CONNECT_MIN_BACKOFF: Duration = Duration::from_secs(15);
+const BLUETOOTH_AUTO_CONNECT_MAX_BACKOFF: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Debug)]
 struct PendingWifiChange {
@@ -39,6 +41,64 @@ struct PendingWifiChange {
     deadline: Instant,
     next_candidate_at: Instant,
     candidate_attempt: u8,
+}
+
+#[derive(Debug, Default)]
+struct BluetoothAutoConnectBackoff {
+    accessory_id: Option<String>,
+    failed_attempts: u32,
+    retry_at: Option<Instant>,
+}
+
+impl BluetoothAutoConnectBackoff {
+    fn candidate(&mut self, state: &BluetoothState, now: Instant) -> Option<String> {
+        if !state.radio_enabled
+            || state
+                .accessories
+                .iter()
+                .any(|accessory| accessory.connected)
+        {
+            self.reset();
+            return None;
+        }
+        let Some(accessory_id) = state
+            .accessories
+            .iter()
+            .find(|accessory| accessory.paired && accessory.auto_connect)
+            .map(|accessory| accessory.accessory_id.clone())
+        else {
+            self.reset();
+            return None;
+        };
+        if self.accessory_id.as_deref() != Some(accessory_id.as_str()) {
+            self.reset();
+            self.accessory_id = Some(accessory_id.clone());
+        }
+        if self.retry_at.is_some_and(|retry_at| now < retry_at) {
+            return None;
+        }
+        Some(accessory_id)
+    }
+
+    fn record_failure(&mut self, accessory_id: String, now: Instant) {
+        if self.accessory_id.as_deref() != Some(accessory_id.as_str()) {
+            self.reset();
+            self.accessory_id = Some(accessory_id);
+        }
+        self.failed_attempts = self.failed_attempts.saturating_add(1);
+        let exponent = self.failed_attempts.saturating_sub(1).min(5);
+        let multiplier = 1_u32 << exponent;
+        let delay = BLUETOOTH_AUTO_CONNECT_MIN_BACKOFF
+            .saturating_mul(multiplier)
+            .min(BLUETOOTH_AUTO_CONNECT_MAX_BACKOFF);
+        self.retry_at = now.checked_add(delay);
+    }
+
+    fn reset(&mut self) {
+        self.accessory_id = None;
+        self.failed_attempts = 0;
+        self.retry_at = None;
+    }
 }
 
 pub fn run(config_dir: &str) -> Result<()> {
@@ -188,7 +248,13 @@ where
     let mut bluetooth_state = bluetooth
         .refresh()
         .unwrap_or_else(|_| BluetoothState::unavailable());
-    bluetooth_state = auto_connect_saved_accessory(bluetooth.as_mut(), bluetooth_state);
+    let mut bluetooth_auto_connect = BluetoothAutoConnectBackoff::default();
+    bluetooth_state = auto_connect_saved_accessory(
+        bluetooth.as_mut(),
+        bluetooth_state,
+        &mut bluetooth_auto_connect,
+        Instant::now(),
+    );
     emit_bluetooth_state(output, &bluetooth_state)?;
     if let Ok(applied) = audio.current(bluetooth.as_ref(), &bluetooth_state) {
         emit_applied_audio(output, &applied)?;
@@ -244,6 +310,7 @@ where
                     output,
                     bluetooth.as_mut(),
                     &mut bluetooth_state,
+                    &mut bluetooth_auto_connect,
                     &mut audio,
                 )?;
             }
@@ -269,6 +336,7 @@ where
                     output,
                     bluetooth.as_mut(),
                     &mut bluetooth_state,
+                    &mut bluetooth_auto_connect,
                     &mut audio,
                 )?;
             }
@@ -913,12 +981,14 @@ fn service_bluetooth_and_audio(
     output: &mut dyn Write,
     bluetooth: &mut dyn BluetoothController,
     bluetooth_state: &mut BluetoothState,
+    bluetooth_auto_connect: &mut BluetoothAutoConnectBackoff,
     audio: &mut AudioManager,
 ) -> Result<()> {
     let Some(state) = bluetooth.tick() else {
         return Ok(());
     };
-    *bluetooth_state = auto_connect_saved_accessory(bluetooth, state);
+    *bluetooth_state =
+        auto_connect_saved_accessory(bluetooth, state, bluetooth_auto_connect, Instant::now());
     emit_bluetooth_state(output, bluetooth_state)?;
     if let Ok(Some(applied)) = audio.current_if_changed(bluetooth, bluetooth_state) {
         emit_applied_audio(output, &applied)?;
@@ -929,24 +999,22 @@ fn service_bluetooth_and_audio(
 fn auto_connect_saved_accessory(
     bluetooth: &mut dyn BluetoothController,
     state: BluetoothState,
+    backoff: &mut BluetoothAutoConnectBackoff,
+    now: Instant,
 ) -> BluetoothState {
-    if !state.radio_enabled
-        || state
-            .accessories
-            .iter()
-            .any(|accessory| accessory.connected)
-    {
-        return state;
-    }
-    let Some(accessory_id) = state
-        .accessories
-        .iter()
-        .find(|accessory| accessory.paired && accessory.auto_connect)
-        .map(|accessory| accessory.accessory_id.clone())
-    else {
+    let Some(accessory_id) = backoff.candidate(&state, now) else {
         return state;
     };
-    bluetooth.connect(&accessory_id).unwrap_or(state)
+    match bluetooth.connect(&accessory_id) {
+        Ok(connected) => {
+            backoff.reset();
+            connected
+        }
+        Err(_) => {
+            backoff.record_failure(accessory_id, now);
+            state
+        }
+    }
 }
 
 fn emit_bluetooth_state(output: &mut dyn Write, state: &BluetoothState) -> Result<()> {
@@ -1097,6 +1165,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bluetooth::{BluetoothAccessory, BluetoothCapabilities};
     use crate::wifi::{
         WifiActivationPreference, WifiActiveNetwork, WifiNearbyNetwork, WifiSavedProfile,
         WifiSecurity, WifiState, WifiStateStatus,
@@ -1222,6 +1291,84 @@ mod tests {
             scanned_at: Some(1_700_000_000),
             reported_at: 1_700_000_001,
         }
+    }
+
+    fn auto_connect_state(accessory_id: &str) -> BluetoothState {
+        BluetoothState {
+            schema_version: 1,
+            status: "ready".to_string(),
+            radio_enabled: true,
+            scanning: false,
+            accessories: vec![BluetoothAccessory {
+                accessory_id: accessory_id.to_string(),
+                name: "Family headset".to_string(),
+                kind: "headset".to_string(),
+                paired: true,
+                connected: false,
+                trusted: true,
+                auto_connect: true,
+                capabilities: BluetoothCapabilities {
+                    output: true,
+                    microphone: true,
+                    stereo: true,
+                    hands_free: true,
+                },
+                battery_percent: None,
+                signal_percent: None,
+                last_seen_at: 1,
+            }],
+            scanned_at: None,
+            reported_at: 1,
+        }
+    }
+
+    #[test]
+    fn failed_bluetooth_auto_connects_back_off_per_accessory() {
+        let mut bluetooth = UnavailableBluetoothController;
+        let mut backoff = BluetoothAutoConnectBackoff::default();
+        let first_attempt_at = Instant::now();
+        let state = auto_connect_state("accessory-a");
+
+        let retained = auto_connect_saved_accessory(
+            &mut bluetooth,
+            state.clone(),
+            &mut backoff,
+            first_attempt_at,
+        );
+        assert_eq!(retained, state);
+        assert_eq!(backoff.failed_attempts, 1);
+        let first_retry_at = backoff.retry_at.expect("retry deadline");
+        assert_eq!(
+            first_retry_at.duration_since(first_attempt_at),
+            BLUETOOTH_AUTO_CONNECT_MIN_BACKOFF
+        );
+
+        auto_connect_saved_accessory(
+            &mut bluetooth,
+            state.clone(),
+            &mut backoff,
+            first_retry_at - Duration::from_millis(1),
+        );
+        assert_eq!(backoff.failed_attempts, 1);
+
+        auto_connect_saved_accessory(&mut bluetooth, state, &mut backoff, first_retry_at);
+        assert_eq!(backoff.failed_attempts, 2);
+        assert_eq!(
+            backoff
+                .retry_at
+                .expect("second retry deadline")
+                .duration_since(first_retry_at),
+            BLUETOOTH_AUTO_CONNECT_MIN_BACKOFF.saturating_mul(2)
+        );
+
+        auto_connect_saved_accessory(
+            &mut bluetooth,
+            auto_connect_state("accessory-b"),
+            &mut backoff,
+            first_retry_at,
+        );
+        assert_eq!(backoff.accessory_id.as_deref(), Some("accessory-b"));
+        assert_eq!(backoff.failed_attempts, 1);
     }
 
     fn run_wifi_command(command: WorkerEnvelope, fail_scan: bool) -> Vec<WorkerEnvelope> {

--- a/device/network/src/worker.rs
+++ b/device/network/src/worker.rs
@@ -4,12 +4,18 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
 
+use crate::audio::{AppliedAudio, AudioManager, AudioSettings};
+use crate::bluetooth::{
+    BluetoothController, BluetoothOperationError, BluetoothState, BluezBluetoothController,
+    UnavailableBluetoothController,
+};
 use crate::config::NetworkHostConfig;
 use crate::modem::{ModemController, Sim7600ModemController};
 use crate::protocol::{
-    health_result, ready_event, snapshot_event, snapshot_result, stopped_event, stopped_result,
-    wifi_change_candidate_event, wifi_provisioning_state_event, wifi_state_event,
-    wifi_state_result, EnvelopeKind, WorkerEnvelope,
+    audio_route_local_event, audio_state_event, audio_state_result, bluetooth_state_event,
+    bluetooth_state_result, health_result, ready_event, snapshot_event, snapshot_result,
+    stopped_event, stopped_result, wifi_change_candidate_event, wifi_provisioning_state_event,
+    wifi_state_event, wifi_state_result, EnvelopeKind, WorkerEnvelope,
 };
 use crate::provisioning::{WifiProvisioner, WifiProvisioningState};
 use crate::runtime::{NetworkRuntime, RuntimeCommandError};
@@ -45,6 +51,9 @@ pub fn run(config_dir: &str) -> Result<()> {
     let wifi: Box<dyn WifiController> = NetworkManagerWifiController::connect()
         .map(|controller| Box::new(controller) as Box<dyn WifiController>)
         .unwrap_or_else(|_| Box::new(UnavailableWifiController));
+    let bluetooth: Box<dyn BluetoothController> = BluezBluetoothController::connect()
+        .map(|controller| Box::new(controller) as Box<dyn BluetoothController>)
+        .unwrap_or_else(|_| Box::new(UnavailableBluetoothController));
     match NetworkHostConfig::load(config_dir) {
         Ok(config) => run_with_runtime_loop(
             NetworkRuntime::new(
@@ -56,6 +65,8 @@ pub fn run(config_dir: &str) -> Result<()> {
             &mut stdout,
             DEFAULT_POLL_INTERVAL,
             wifi,
+            bluetooth,
+            AudioManager::open(),
         ),
         Err(error) => run_with_runtime_loop(
             NetworkRuntime::degraded_config(config_dir, error.to_string()),
@@ -63,6 +74,8 @@ pub fn run(config_dir: &str) -> Result<()> {
             &mut stdout,
             DEFAULT_POLL_INTERVAL,
             wifi,
+            bluetooth,
+            AudioManager::open(),
         ),
     }
 }
@@ -120,6 +133,8 @@ where
         output,
         poll_interval,
         Box::new(UnavailableWifiController),
+        Box::new(UnavailableBluetoothController),
+        AudioManager::open(),
     )
 }
 
@@ -135,7 +150,15 @@ where
     R: Read + Send + 'static,
     W: Write,
 {
-    run_with_runtime_loop(runtime, reader_channel(input), output, poll_interval, wifi)
+    run_with_runtime_loop(
+        runtime,
+        reader_channel(input),
+        output,
+        poll_interval,
+        wifi,
+        Box::new(UnavailableBluetoothController),
+        AudioManager::open(),
+    )
 }
 
 fn run_with_runtime_loop<C, W>(
@@ -144,6 +167,8 @@ fn run_with_runtime_loop<C, W>(
     output: &mut W,
     poll_interval: Duration,
     mut wifi: Box<dyn WifiController>,
+    mut bluetooth: Box<dyn BluetoothController>,
+    mut audio: AudioManager,
 ) -> Result<()>
 where
     C: ModemController,
@@ -158,6 +183,14 @@ where
         wifi.refresh()
             .unwrap_or_else(|_| crate::wifi::WifiState::unavailable()),
     )?;
+    let mut bluetooth_state = bluetooth
+        .refresh()
+        .unwrap_or_else(|_| BluetoothState::unavailable());
+    bluetooth_state = auto_connect_saved_accessory(bluetooth.as_mut(), bluetooth_state);
+    emit_bluetooth_state(output, &bluetooth_state)?;
+    if let Ok(applied) = audio.current(bluetooth.as_ref(), &bluetooth_state) {
+        emit_applied_audio(output, &applied)?;
+    }
     if should_boot_runtime(runtime.snapshot()) {
         runtime.start();
     }
@@ -194,6 +227,9 @@ where
                     wifi.as_mut(),
                     &mut pending_wifi_change,
                     &mut provisioning,
+                    bluetooth.as_mut(),
+                    &mut bluetooth_state,
+                    &mut audio,
                     envelope,
                     output,
                 )? {
@@ -202,6 +238,12 @@ where
                 }
                 service_pending_wifi_change(output, wifi.as_mut(), &mut pending_wifi_change)?;
                 service_provisioning(output, &mut provisioning)?;
+                service_bluetooth_and_audio(
+                    output,
+                    bluetooth.as_mut(),
+                    &mut bluetooth_state,
+                    &mut audio,
+                )?;
             }
             Ok(Err(error)) => {
                 write_envelope(
@@ -221,6 +263,12 @@ where
                 emit_pending_snapshots(output, &mut runtime)?;
                 service_pending_wifi_change(output, wifi.as_mut(), &mut pending_wifi_change)?;
                 service_provisioning(output, &mut provisioning)?;
+                service_bluetooth_and_audio(
+                    output,
+                    bluetooth.as_mut(),
+                    &mut bluetooth_state,
+                    &mut audio,
+                )?;
             }
             Err(RecvTimeoutError::Disconnected) => {
                 shutdown_for_implicit_exit(output, &mut runtime, "input_closed")?;
@@ -242,6 +290,9 @@ fn handle_command<C, W>(
     wifi: &mut dyn WifiController,
     pending_wifi_change: &mut Option<PendingWifiChange>,
     provisioning: &mut Option<WifiProvisioner>,
+    bluetooth: &mut dyn BluetoothController,
+    bluetooth_state: &mut BluetoothState,
+    audio: &mut AudioManager,
     envelope: WorkerEnvelope,
     output: &mut W,
 ) -> Result<LoopControl>
@@ -464,6 +515,194 @@ where
                 emit_provisioning_state(output, &WifiProvisioningState::idle())?;
             }
         }
+        "bluetooth_refresh" => {
+            handle_bluetooth_operation(
+                output,
+                envelope.request_id,
+                bluetooth.refresh(),
+                bluetooth,
+                bluetooth_state,
+                audio,
+            )?;
+        }
+        "bluetooth_set_radio" => {
+            let enabled = envelope
+                .payload
+                .get("enabled")
+                .and_then(serde_json::Value::as_bool)
+                .ok_or_else(|| BluetoothOperationError {
+                    code: "bluetooth_invalid_request",
+                    message: "Bluetooth power setting is invalid".to_string(),
+                });
+            let result = enabled.and_then(|enabled| bluetooth.set_radio(enabled));
+            handle_bluetooth_operation(
+                output,
+                envelope.request_id,
+                result,
+                bluetooth,
+                bluetooth_state,
+                audio,
+            )?;
+        }
+        "bluetooth_scan_start" => {
+            let result = bluetooth.start_scan();
+            handle_bluetooth_operation(
+                output,
+                envelope.request_id,
+                result,
+                bluetooth,
+                bluetooth_state,
+                audio,
+            )?;
+        }
+        "bluetooth_scan_stop" => {
+            let result = bluetooth.stop_scan();
+            handle_bluetooth_operation(
+                output,
+                envelope.request_id,
+                result,
+                bluetooth,
+                bluetooth_state,
+                audio,
+            )?;
+        }
+        "bluetooth_pair" | "bluetooth_connect" | "bluetooth_disconnect" | "bluetooth_forget" => {
+            let accessory_id = envelope
+                .payload
+                .get("accessory_id")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_owned)
+                .ok_or_else(|| BluetoothOperationError {
+                    code: "bluetooth_invalid_request",
+                    message: "Bluetooth accessory reference is invalid".to_string(),
+                });
+            let result =
+                accessory_id.and_then(|accessory_id| match envelope.message_type.as_str() {
+                    "bluetooth_pair" => bluetooth.pair(&accessory_id),
+                    "bluetooth_connect" => bluetooth.connect(&accessory_id),
+                    "bluetooth_disconnect" => bluetooth.disconnect(&accessory_id),
+                    _ => bluetooth.forget(&accessory_id),
+                });
+            handle_bluetooth_operation(
+                output,
+                envelope.request_id,
+                result,
+                bluetooth,
+                bluetooth_state,
+                audio,
+            )?;
+        }
+        "bluetooth_update_accessory" => {
+            let accessory_id = envelope
+                .payload
+                .get("accessory_id")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_owned)
+                .ok_or_else(|| BluetoothOperationError {
+                    code: "bluetooth_invalid_request",
+                    message: "Bluetooth accessory reference is invalid".to_string(),
+                });
+            let alias = envelope
+                .payload
+                .get("alias")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned);
+            let auto_connect = envelope
+                .payload
+                .get("auto_connect")
+                .and_then(serde_json::Value::as_bool);
+            let result = accessory_id.and_then(|accessory_id| {
+                bluetooth.update_accessory(&accessory_id, alias.as_deref(), auto_connect)
+            });
+            handle_bluetooth_operation(
+                output,
+                envelope.request_id,
+                result,
+                bluetooth,
+                bluetooth_state,
+                audio,
+            )?;
+        }
+        "audio_apply_settings" => {
+            let revision = envelope
+                .payload
+                .get("revision")
+                .and_then(serde_json::Value::as_u64);
+            let settings = envelope
+                .payload
+                .get("settings")
+                .cloned()
+                .and_then(|value| serde_json::from_value::<AudioSettings>(value).ok());
+            match revision.zip(settings) {
+                Some((revision, settings)) => {
+                    match audio.apply(revision, settings, bluetooth, bluetooth_state) {
+                        Ok(applied) => {
+                            write_envelope(
+                                output,
+                                &audio_state_result(envelope.request_id, &applied.state),
+                            )?;
+                            emit_applied_audio(output, &applied)?;
+                        }
+                        Err(error) => emit_audio_error(output, envelope.request_id, error)?,
+                    }
+                }
+                None => emit_audio_error(
+                    output,
+                    envelope.request_id,
+                    crate::audio::AudioOperationError {
+                        code: "audio_invalid_settings",
+                        message: "Audio settings payload is invalid".to_string(),
+                    },
+                )?,
+            }
+        }
+        "audio_test_output" => {
+            let target = envelope
+                .payload
+                .get("target")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+            match audio
+                .current(bluetooth, bluetooth_state)
+                .and_then(|applied| {
+                    audio.test_output(target, &applied.route)?;
+                    Ok(applied)
+                }) {
+                Ok(applied) => {
+                    write_envelope(
+                        output,
+                        &audio_state_result(envelope.request_id, &applied.state),
+                    )?;
+                    emit_applied_audio(output, &applied)?;
+                }
+                Err(error) => emit_audio_error(output, envelope.request_id, error)?,
+            }
+        }
+        "audio_test_input" => {
+            let duration = envelope
+                .payload
+                .get("duration_seconds")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(10);
+            let result = audio
+                .current(bluetooth, bluetooth_state)
+                .and_then(|applied| {
+                    audio.test_input(&applied.route, duration)?;
+                    audio.current(bluetooth, bluetooth_state)
+                });
+            match result {
+                Ok(applied) => {
+                    write_envelope(
+                        output,
+                        &audio_state_result(envelope.request_id, &applied.state),
+                    )?;
+                    emit_applied_audio(output, &applied)?;
+                }
+                Err(error) => emit_audio_error(output, envelope.request_id, error)?,
+            }
+        }
         "network.shutdown" | "worker.stop" => {
             if let Some(worker) = provisioning.take() {
                 let _ = worker.stop();
@@ -610,6 +849,93 @@ fn handle_wifi_operation(
 
 fn emit_wifi_state(output: &mut dyn Write, state: crate::wifi::WifiState) -> Result<()> {
     write_envelope(output, &wifi_state_event(&state))
+}
+
+fn handle_bluetooth_operation(
+    output: &mut dyn Write,
+    request_id: Option<String>,
+    result: Result<BluetoothState, BluetoothOperationError>,
+    bluetooth: &dyn BluetoothController,
+    bluetooth_state: &mut BluetoothState,
+    audio: &mut AudioManager,
+) -> Result<()> {
+    match result {
+        Ok(state) => {
+            *bluetooth_state = state;
+            write_envelope(output, &bluetooth_state_result(request_id, bluetooth_state))?;
+            emit_bluetooth_state(output, bluetooth_state)?;
+            if let Ok(applied) = audio.current(bluetooth, bluetooth_state) {
+                emit_applied_audio(output, &applied)?;
+            }
+        }
+        Err(error) => {
+            write_envelope(
+                output,
+                &WorkerEnvelope::error("bluetooth_error", request_id, error.code, error.message),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn service_bluetooth_and_audio(
+    output: &mut dyn Write,
+    bluetooth: &mut dyn BluetoothController,
+    bluetooth_state: &mut BluetoothState,
+    audio: &mut AudioManager,
+) -> Result<()> {
+    let Some(state) = bluetooth.tick() else {
+        return Ok(());
+    };
+    *bluetooth_state = auto_connect_saved_accessory(bluetooth, state);
+    emit_bluetooth_state(output, bluetooth_state)?;
+    if let Ok(applied) = audio.current(bluetooth, bluetooth_state) {
+        emit_applied_audio(output, &applied)?;
+    }
+    Ok(())
+}
+
+fn auto_connect_saved_accessory(
+    bluetooth: &mut dyn BluetoothController,
+    state: BluetoothState,
+) -> BluetoothState {
+    if !state.radio_enabled
+        || state
+            .accessories
+            .iter()
+            .any(|accessory| accessory.connected)
+    {
+        return state;
+    }
+    let Some(accessory_id) = state
+        .accessories
+        .iter()
+        .find(|accessory| accessory.paired && accessory.auto_connect)
+        .map(|accessory| accessory.accessory_id.clone())
+    else {
+        return state;
+    };
+    bluetooth.connect(&accessory_id).unwrap_or(state)
+}
+
+fn emit_bluetooth_state(output: &mut dyn Write, state: &BluetoothState) -> Result<()> {
+    write_envelope(output, &bluetooth_state_event(state))
+}
+
+fn emit_applied_audio(output: &mut dyn Write, applied: &AppliedAudio) -> Result<()> {
+    write_envelope(output, &audio_state_event(&applied.state))?;
+    write_envelope(output, &audio_route_local_event(&applied.route))
+}
+
+fn emit_audio_error(
+    output: &mut dyn Write,
+    request_id: Option<String>,
+    error: crate::audio::AudioOperationError,
+) -> Result<()> {
+    write_envelope(
+        output,
+        &WorkerEnvelope::error("audio_error", request_id, error.code, error.message),
+    )
 }
 
 fn emit_provisioning_state(output: &mut dyn Write, state: &WifiProvisioningState) -> Result<()> {

--- a/device/network/src/worker.rs
+++ b/device/network/src/worker.rs
@@ -917,7 +917,7 @@ fn service_bluetooth_and_audio(
     };
     *bluetooth_state = auto_connect_saved_accessory(bluetooth, state);
     emit_bluetooth_state(output, bluetooth_state)?;
-    if let Ok(applied) = audio.current(bluetooth, bluetooth_state) {
+    if let Ok(Some(applied)) = audio.current_if_changed(bluetooth, bluetooth_state) {
         emit_applied_audio(output, &applied)?;
     }
     Ok(())

--- a/device/network/src/worker.rs
+++ b/device/network/src/worker.rs
@@ -625,6 +625,34 @@ where
                 audio,
             )?;
         }
+        "audio_set_output_level" => {
+            let level = envelope
+                .payload
+                .get("level")
+                .and_then(serde_json::Value::as_u64)
+                .filter(|level| *level <= 100)
+                .map(|level| level as u8);
+            match level {
+                Some(level) => match audio.set_output_level(level, bluetooth, bluetooth_state) {
+                    Ok(applied) => {
+                        write_envelope(
+                            output,
+                            &audio_state_result(envelope.request_id, &applied.state),
+                        )?;
+                        emit_applied_audio(output, &applied)?;
+                    }
+                    Err(error) => emit_audio_error(output, envelope.request_id, error)?,
+                },
+                None => emit_audio_error(
+                    output,
+                    envelope.request_id,
+                    crate::audio::AudioOperationError {
+                        code: "audio_invalid_settings",
+                        message: "Audio output level must be between 0 and 100".to_string(),
+                    },
+                )?,
+            }
+        }
         "audio_apply_settings" => {
             let revision = envelope
                 .payload

--- a/device/network/src/worker.rs
+++ b/device/network/src/worker.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 
 use crate::audio::{AppliedAudio, AudioManager, AudioSettings};
 use crate::bluetooth::{
-    BluetoothController, BluetoothOperationError, BluetoothState, BluezBluetoothController,
+    BluetoothController, BluetoothOperationError, BluetoothState, RecoveringBluetoothController,
     UnavailableBluetoothController,
 };
 use crate::config::NetworkHostConfig;
@@ -113,9 +113,7 @@ pub fn run(config_dir: &str) -> Result<()> {
     let wifi: Box<dyn WifiController> = NetworkManagerWifiController::connect()
         .map(|controller| Box::new(controller) as Box<dyn WifiController>)
         .unwrap_or_else(|_| Box::new(UnavailableWifiController));
-    let bluetooth: Box<dyn BluetoothController> = BluezBluetoothController::connect()
-        .map(|controller| Box::new(controller) as Box<dyn BluetoothController>)
-        .unwrap_or_else(|_| Box::new(UnavailableBluetoothController));
+    let bluetooth: Box<dyn BluetoothController> = Box::new(RecoveringBluetoothController::new());
     match NetworkHostConfig::load(config_dir) {
         Ok(config) => run_with_runtime_loop(
             NetworkRuntime::new(
@@ -699,14 +697,24 @@ where
             )?;
         }
         "audio_set_output_level" => {
+            let cycle = envelope
+                .payload
+                .get("cycle")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true);
             let level = envelope
                 .payload
                 .get("level")
                 .and_then(serde_json::Value::as_u64)
                 .filter(|level| *level <= 100)
                 .map(|level| level as u8);
-            match level {
-                Some(level) => match audio.set_output_level(level, bluetooth, bluetooth_state) {
+            let result = if cycle && level.is_none() {
+                Some(audio.step_output_level(bluetooth, bluetooth_state))
+            } else {
+                level.map(|level| audio.set_output_level(level, bluetooth, bluetooth_state))
+            };
+            match result {
+                Some(result) => match result {
                     Ok(applied) => {
                         write_envelope(
                             output,
@@ -721,7 +729,8 @@ where
                     envelope.request_id,
                     crate::audio::AudioOperationError {
                         code: "audio_invalid_settings",
-                        message: "Audio output level must be between 0 and 100".to_string(),
+                        message: "Audio output level must be a 0 to 100 value or a cycle request"
+                            .to_string(),
                     },
                 )?,
             }

--- a/device/network/src/worker.rs
+++ b/device/network/src/worker.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::io::{self, BufRead, Read, Write};
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -44,10 +45,14 @@ struct PendingWifiChange {
 }
 
 #[derive(Debug, Default)]
-struct BluetoothAutoConnectBackoff {
-    accessory_id: Option<String>,
+struct BluetoothAutoConnectRetry {
     failed_attempts: u32,
     retry_at: Option<Instant>,
+}
+
+#[derive(Debug, Default)]
+struct BluetoothAutoConnectBackoff {
+    retries: HashMap<String, BluetoothAutoConnectRetry>,
 }
 
 impl BluetoothAutoConnectBackoff {
@@ -61,43 +66,40 @@ impl BluetoothAutoConnectBackoff {
             self.reset();
             return None;
         }
-        let Some(accessory_id) = state
+        self.retries.retain(|accessory_id, _| {
+            state.accessories.iter().any(|accessory| {
+                accessory.accessory_id == *accessory_id
+                    && accessory.paired
+                    && accessory.auto_connect
+            })
+        });
+        state
             .accessories
             .iter()
-            .find(|accessory| accessory.paired && accessory.auto_connect)
+            .filter(|accessory| accessory.paired && accessory.auto_connect)
+            .find(|accessory| {
+                self.retries
+                    .get(&accessory.accessory_id)
+                    .and_then(|retry| retry.retry_at)
+                    .map(|retry_at| now >= retry_at)
+                    .unwrap_or(true)
+            })
             .map(|accessory| accessory.accessory_id.clone())
-        else {
-            self.reset();
-            return None;
-        };
-        if self.accessory_id.as_deref() != Some(accessory_id.as_str()) {
-            self.reset();
-            self.accessory_id = Some(accessory_id.clone());
-        }
-        if self.retry_at.is_some_and(|retry_at| now < retry_at) {
-            return None;
-        }
-        Some(accessory_id)
     }
 
     fn record_failure(&mut self, accessory_id: String, now: Instant) {
-        if self.accessory_id.as_deref() != Some(accessory_id.as_str()) {
-            self.reset();
-            self.accessory_id = Some(accessory_id);
-        }
-        self.failed_attempts = self.failed_attempts.saturating_add(1);
-        let exponent = self.failed_attempts.saturating_sub(1).min(5);
+        let retry = self.retries.entry(accessory_id).or_default();
+        retry.failed_attempts = retry.failed_attempts.saturating_add(1);
+        let exponent = retry.failed_attempts.saturating_sub(1).min(5);
         let multiplier = 1_u32 << exponent;
         let delay = BLUETOOTH_AUTO_CONNECT_MIN_BACKOFF
             .saturating_mul(multiplier)
             .min(BLUETOOTH_AUTO_CONNECT_MAX_BACKOFF);
-        self.retry_at = now.checked_add(delay);
+        retry.retry_at = now.checked_add(delay);
     }
 
     fn reset(&mut self) {
-        self.accessory_id = None;
-        self.failed_attempts = 0;
-        self.retry_at = None;
+        self.retries.clear();
     }
 }
 
@@ -1336,8 +1338,9 @@ mod tests {
             first_attempt_at,
         );
         assert_eq!(retained, state);
-        assert_eq!(backoff.failed_attempts, 1);
-        let first_retry_at = backoff.retry_at.expect("retry deadline");
+        let retry = backoff.retries.get("accessory-a").expect("retry state");
+        assert_eq!(retry.failed_attempts, 1);
+        let first_retry_at = retry.retry_at.expect("retry deadline");
         assert_eq!(
             first_retry_at.duration_since(first_attempt_at),
             BLUETOOTH_AUTO_CONNECT_MIN_BACKOFF
@@ -1349,26 +1352,26 @@ mod tests {
             &mut backoff,
             first_retry_at - Duration::from_millis(1),
         );
-        assert_eq!(backoff.failed_attempts, 1);
+        assert_eq!(backoff.retries["accessory-a"].failed_attempts, 1);
 
         auto_connect_saved_accessory(&mut bluetooth, state, &mut backoff, first_retry_at);
-        assert_eq!(backoff.failed_attempts, 2);
+        assert_eq!(backoff.retries["accessory-a"].failed_attempts, 2);
         assert_eq!(
-            backoff
+            backoff.retries["accessory-a"]
                 .retry_at
                 .expect("second retry deadline")
                 .duration_since(first_retry_at),
             BLUETOOTH_AUTO_CONNECT_MIN_BACKOFF.saturating_mul(2)
         );
 
-        auto_connect_saved_accessory(
-            &mut bluetooth,
-            auto_connect_state("accessory-b"),
-            &mut backoff,
-            first_retry_at,
-        );
-        assert_eq!(backoff.accessory_id.as_deref(), Some("accessory-b"));
-        assert_eq!(backoff.failed_attempts, 1);
+        let mut multiple = auto_connect_state("accessory-a");
+        let mut second = multiple.accessories[0].clone();
+        second.accessory_id = "accessory-b".to_string();
+        second.name = "Second headset".to_string();
+        multiple.accessories.push(second);
+        auto_connect_saved_accessory(&mut bluetooth, multiple, &mut backoff, first_retry_at);
+        assert_eq!(backoff.retries["accessory-a"].failed_attempts, 2);
+        assert_eq!(backoff.retries["accessory-b"].failed_attempts, 1);
     }
 
     fn run_wifi_command(command: WorkerEnvelope, fail_scan: bool) -> Vec<WorkerEnvelope> {

--- a/device/network/src/worker.rs
+++ b/device/network/src/worker.rs
@@ -57,12 +57,7 @@ struct BluetoothAutoConnectBackoff {
 
 impl BluetoothAutoConnectBackoff {
     fn candidate(&mut self, state: &BluetoothState, now: Instant) -> Option<String> {
-        if !state.radio_enabled
-            || state
-                .accessories
-                .iter()
-                .any(|accessory| accessory.connected)
-        {
+        if !state.radio_enabled {
             self.reset();
             return None;
         }
@@ -71,12 +66,13 @@ impl BluetoothAutoConnectBackoff {
                 accessory.accessory_id == *accessory_id
                     && accessory.paired
                     && accessory.auto_connect
+                    && !accessory.connected
             })
         });
         state
             .accessories
             .iter()
-            .filter(|accessory| accessory.paired && accessory.auto_connect)
+            .filter(|accessory| accessory.paired && accessory.auto_connect && !accessory.connected)
             .find(|accessory| {
                 self.retries
                     .get(&accessory.accessory_id)
@@ -96,6 +92,10 @@ impl BluetoothAutoConnectBackoff {
             .saturating_mul(multiplier)
             .min(BLUETOOTH_AUTO_CONNECT_MAX_BACKOFF);
         retry.retry_at = now.checked_add(delay);
+    }
+
+    fn record_success(&mut self, accessory_id: &str) {
+        self.retries.remove(accessory_id);
     }
 
     fn reset(&mut self) {
@@ -1018,7 +1018,7 @@ fn auto_connect_saved_accessory(
     };
     match bluetooth.connect(&accessory_id) {
         Ok(connected) => {
-            backoff.reset();
+            backoff.record_success(&accessory_id);
             connected
         }
         Err(_) => {
@@ -1381,6 +1381,27 @@ mod tests {
         auto_connect_saved_accessory(&mut bluetooth, multiple, &mut backoff, first_retry_at);
         assert_eq!(backoff.retries["accessory-a"].failed_attempts, 2);
         assert_eq!(backoff.retries["accessory-b"].failed_attempts, 1);
+    }
+
+    #[test]
+    fn connected_auto_connect_accessories_do_not_block_remaining_routes() {
+        let now = Instant::now();
+        let mut state = auto_connect_state("accessory-a");
+        state.accessories[0].connected = true;
+        let mut second = state.accessories[0].clone();
+        second.accessory_id = "accessory-b".to_string();
+        second.name = "Second headset".to_string();
+        second.connected = false;
+        state.accessories.push(second);
+
+        let mut backoff = BluetoothAutoConnectBackoff::default();
+        backoff.record_failure("accessory-a".to_string(), now);
+
+        assert_eq!(
+            backoff.candidate(&state, now),
+            Some("accessory-b".to_string())
+        );
+        assert!(!backoff.retries.contains_key("accessory-a"));
     }
 
     fn run_wifi_command(command: WorkerEnvelope, fail_scan: bool) -> Vec<WorkerEnvelope> {

--- a/device/network/src/worker.rs
+++ b/device/network/src/worker.rs
@@ -66,7 +66,7 @@ pub fn run(config_dir: &str) -> Result<()> {
             DEFAULT_POLL_INTERVAL,
             wifi,
             bluetooth,
-            AudioManager::open(),
+            AudioManager::open(config_dir),
         ),
         Err(error) => run_with_runtime_loop(
             NetworkRuntime::degraded_config(config_dir, error.to_string()),
@@ -75,7 +75,7 @@ pub fn run(config_dir: &str) -> Result<()> {
             DEFAULT_POLL_INTERVAL,
             wifi,
             bluetooth,
-            AudioManager::open(),
+            AudioManager::open(config_dir),
         ),
     }
 }
@@ -127,6 +127,7 @@ where
     R: Read + Send + 'static,
     W: Write,
 {
+    let config_dir = runtime.snapshot().config_dir.clone();
     run_with_runtime_loop(
         runtime,
         reader_channel(input),
@@ -134,7 +135,7 @@ where
         poll_interval,
         Box::new(UnavailableWifiController),
         Box::new(UnavailableBluetoothController),
-        AudioManager::open(),
+        AudioManager::open(&config_dir),
     )
 }
 
@@ -150,6 +151,7 @@ where
     R: Read + Send + 'static,
     W: Write,
 {
+    let config_dir = runtime.snapshot().config_dir.clone();
     run_with_runtime_loop(
         runtime,
         reader_channel(input),
@@ -157,7 +159,7 @@ where
         poll_interval,
         wifi,
         Box::new(UnavailableBluetoothController),
-        AudioManager::open(),
+        AudioManager::open(&config_dir),
     )
 }
 

--- a/device/runtime/src/event.rs
+++ b/device/runtime/src/event.rs
@@ -685,20 +685,16 @@ fn system_speech_command(state: &RuntimeState, line: &str) -> Vec<RuntimeCommand
 }
 
 fn commands_for_settings_intent(
-    state: &RuntimeState,
+    _state: &RuntimeState,
     intent: &yoyopod_protocol::ui::SettingsIntent,
 ) -> Vec<RuntimeCommand> {
     use yoyopod_protocol::ui::SettingsIntent;
     match intent {
-        SettingsIntent::VolumeStep => {
-            let level = ((state.media.volume.clamp(0, 100) + 5) / 10).clamp(1, 10);
-            let next = if level >= 10 { 1 } else { level + 1 };
-            vec![worker_command(
-                WorkerDomain::Network,
-                "audio_set_output_level",
-                json!({"level": next * 10}),
-            )]
-        }
+        SettingsIntent::VolumeStep => vec![worker_command(
+            WorkerDomain::Network,
+            "audio_set_output_level",
+            json!({"cycle": true}),
+        )],
         SettingsIntent::WifiSetupStart => vec![worker_command(
             WorkerDomain::Network,
             "wifi_provisioning_start",
@@ -1906,11 +1902,11 @@ mod tests {
         };
         assert_eq!(*domain, WorkerDomain::Network);
         assert_eq!(envelope.message_type, "audio_set_output_level");
-        assert_eq!(envelope.payload["level"], 10);
+        assert_eq!(envelope.payload["cycle"], true);
 
         event.apply(&mut state);
-        assert_eq!(state.media.volume, 10);
-        assert_eq!(state.ui_snapshot().settings.volume_level, 1);
+        assert_eq!(state.media.volume, 100);
+        assert_eq!(state.ui_snapshot().settings.volume_level, 10);
     }
 
     #[test]

--- a/device/runtime/src/event.rs
+++ b/device/runtime/src/event.rs
@@ -1239,8 +1239,11 @@ fn commands_for_cloud_command(command: &Value) -> Vec<RuntimeCommand> {
             })
             .unwrap_or_default(),
         "bluetooth_refresh"
+        | "bluetooth_set_power"
         | "bluetooth_set_radio"
+        | "bluetooth_scan"
         | "bluetooth_scan_start"
+        | "bluetooth_stop_scan"
         | "bluetooth_scan_stop"
         | "bluetooth_pair"
         | "bluetooth_connect"
@@ -1252,6 +1255,12 @@ fn commands_for_cloud_command(command: &Value) -> Vec<RuntimeCommand> {
         | "audio_test_input" => command_id
             .map(|command_id| {
                 let command_type = normalized(&command_type);
+                let network_command_type = match command_type.as_str() {
+                    "bluetooth_set_power" => "bluetooth_set_radio",
+                    "bluetooth_scan" => "bluetooth_scan_start",
+                    "bluetooth_stop_scan" => "bluetooth_scan_stop",
+                    other => other,
+                };
                 let timeout_ms = match command_type.as_str() {
                     "bluetooth_pair" => 90_000,
                     "bluetooth_connect" => 30_000,
@@ -1261,7 +1270,7 @@ fn commands_for_cloud_command(command: &Value) -> Vec<RuntimeCommand> {
                 vec![RuntimeCommand::CorrelatedWorkerCommand {
                     domain: WorkerDomain::Network,
                     envelope: WorkerEnvelope::command(
-                        command_type.clone(),
+                        network_command_type,
                         Some(command_id.clone()),
                         command
                             .get("payload")
@@ -2341,14 +2350,15 @@ mod tests {
 
     #[test]
     fn bluetooth_and_audio_cloud_commands_are_correlated_to_network() {
-        for command_type in [
-            "bluetooth_set_radio",
-            "bluetooth_scan_start",
-            "bluetooth_pair",
-            "bluetooth_connect",
-            "audio_apply_settings",
-            "audio_test_output",
-            "audio_test_input",
+        for (command_type, network_command_type) in [
+            ("bluetooth_set_power", "bluetooth_set_radio"),
+            ("bluetooth_scan", "bluetooth_scan_start"),
+            ("bluetooth_stop_scan", "bluetooth_scan_stop"),
+            ("bluetooth_pair", "bluetooth_pair"),
+            ("bluetooth_connect", "bluetooth_connect"),
+            ("audio_apply_settings", "audio_apply_settings"),
+            ("audio_test_output", "audio_test_output"),
+            ("audio_test_input", "audio_test_input"),
         ] {
             let commands = commands_for_event(
                 &RuntimeState::default(),
@@ -2359,13 +2369,19 @@ mod tests {
                 })),
             );
             let RuntimeCommand::CorrelatedWorkerCommand {
-                domain, command_id, ..
+                domain,
+                envelope,
+                command_id,
+                command_type: correlated_command_type,
+                ..
             } = &commands[0]
             else {
                 panic!("expected correlated network command for {command_type}");
             };
             assert_eq!(*domain, WorkerDomain::Network);
+            assert_eq!(envelope.message_type, network_command_type);
             assert_eq!(command_id, "command-123");
+            assert_eq!(correlated_command_type, command_type);
         }
     }
 }

--- a/device/runtime/src/event.rs
+++ b/device/runtime/src/event.rs
@@ -2349,6 +2349,7 @@ mod tests {
                 "voip_capture_device": "ALSA: default",
                 "voip_media_device": "ALSA: default",
                 "communication_volume": 65,
+                "alert_volume": 58,
                 "microphone_gain": 55
             })),
         );

--- a/device/runtime/src/event.rs
+++ b/device/runtime/src/event.rs
@@ -26,6 +26,9 @@ pub enum RuntimeEvent {
     WifiState(Value),
     WifiChangeCandidate(Value),
     WifiProvisioningState(Value),
+    BluetoothState(Value),
+    AudioState(Value),
+    AudioRouteLocal(Value),
     PowerSnapshot(Value),
     VoiceTranscript(Value),
     VoiceAskResult(Value),
@@ -97,7 +100,11 @@ impl RuntimeEvent {
                 state.resolve_overlay_for(WorkerDomain::Network);
                 state.apply_network_snapshot(snapshot);
             }
-            Self::WifiState(_) | Self::WifiChangeCandidate(_) => {}
+            Self::WifiState(_)
+            | Self::WifiChangeCandidate(_)
+            | Self::BluetoothState(_)
+            | Self::AudioState(_)
+            | Self::AudioRouteLocal(_) => {}
             Self::WifiProvisioningState(payload) => state.apply_wifi_provisioning_state(payload),
             Self::PowerSnapshot(snapshot) => {
                 state.resolve_overlay_for(WorkerDomain::Power);
@@ -160,7 +167,14 @@ pub fn runtime_event_from_worker(
     } = envelope;
 
     match kind {
-        EnvelopeKind::Error if message_type == "wifi_error" => Some(RuntimeEvent::Ignored),
+        EnvelopeKind::Error
+            if matches!(
+                message_type.as_str(),
+                "wifi_error" | "bluetooth_error" | "audio_error"
+            ) =>
+        {
+            Some(RuntimeEvent::Ignored)
+        }
         EnvelopeKind::Error => Some(RuntimeEvent::WorkerError {
             domain,
             message: worker_error_message(&message_type, &payload),
@@ -257,6 +271,45 @@ pub fn commands_for_event(state: &RuntimeState, event: &RuntimeEvent) -> Vec<Run
                 "payload": candidate,
             }),
         )],
+        RuntimeEvent::BluetoothState(bluetooth) => vec![worker_command(
+            WorkerDomain::Cloud,
+            "cloud.publish_event",
+            json!({
+                "event_type": "bluetooth_state",
+                "payload": bluetooth,
+            }),
+        )],
+        RuntimeEvent::AudioState(audio) => vec![worker_command(
+            WorkerDomain::Cloud,
+            "cloud.publish_event",
+            json!({
+                "event_type": "audio_state",
+                "payload": audio,
+            }),
+        )],
+        RuntimeEvent::AudioRouteLocal(route) => {
+            let mut commands = Vec::new();
+            if let Some(device) = route.get("media_device").and_then(Value::as_str) {
+                commands.push(worker_command(
+                    WorkerDomain::Media,
+                    "media.set_audio_device",
+                    json!({ "device": device }),
+                ));
+            }
+            if let Some(volume) = route.get("media_volume").and_then(Value::as_u64) {
+                commands.push(worker_command(
+                    WorkerDomain::Media,
+                    "media.set_volume",
+                    json!({ "volume": volume }),
+                ));
+            }
+            commands.push(worker_command(
+                WorkerDomain::Voip,
+                "voip.set_audio_devices",
+                route.clone(),
+            ));
+            commands
+        }
         RuntimeEvent::WifiProvisioningState(provisioning) => {
             // The raw payload carries the hotspot password and the QR (which
             // embeds it). Never forward those to the cloud/MQTT — publish only
@@ -456,6 +509,9 @@ fn network_event_from_message(message_type: &str, payload: Value) -> RuntimeEven
         "wifi_state" => RuntimeEvent::WifiState(payload),
         "wifi_change_candidate" => RuntimeEvent::WifiChangeCandidate(payload),
         "wifi_provisioning_state" => RuntimeEvent::WifiProvisioningState(payload),
+        "bluetooth_state" => RuntimeEvent::BluetoothState(payload),
+        "audio_state" => RuntimeEvent::AudioState(payload),
+        "audio_route_local" => RuntimeEvent::AudioRouteLocal(payload),
         "network.error" => RuntimeEvent::WorkerError {
             domain: WorkerDomain::Network,
             message: worker_error_message(message_type, &payload),
@@ -1178,6 +1234,43 @@ fn commands_for_cloud_command(command: &Value) -> Vec<RuntimeCommand> {
                     ),
                     command_id,
                     command_type: normalized(&command_type),
+                    timeout_ms,
+                }]
+            })
+            .unwrap_or_default(),
+        "bluetooth_refresh"
+        | "bluetooth_set_radio"
+        | "bluetooth_scan_start"
+        | "bluetooth_scan_stop"
+        | "bluetooth_pair"
+        | "bluetooth_connect"
+        | "bluetooth_disconnect"
+        | "bluetooth_update_accessory"
+        | "bluetooth_forget"
+        | "audio_apply_settings"
+        | "audio_test_output"
+        | "audio_test_input" => command_id
+            .map(|command_id| {
+                let command_type = normalized(&command_type);
+                let timeout_ms = match command_type.as_str() {
+                    "bluetooth_pair" => 90_000,
+                    "bluetooth_connect" => 30_000,
+                    "audio_test_input" => 20_000,
+                    _ => 15_000,
+                };
+                vec![RuntimeCommand::CorrelatedWorkerCommand {
+                    domain: WorkerDomain::Network,
+                    envelope: WorkerEnvelope::command(
+                        command_type.clone(),
+                        Some(command_id.clone()),
+                        command
+                            .get("payload")
+                            .cloned()
+                            .filter(Value::is_object)
+                            .unwrap_or_else(empty_payload),
+                    ),
+                    command_id,
+                    command_type,
                     timeout_ms,
                 }]
             })
@@ -2192,5 +2285,87 @@ mod tests {
         assert_eq!(envelope.message_type, "cloud.publish_event");
         assert_eq!(envelope.payload["event_type"], "wifi_change_candidate");
         assert_eq!(envelope.payload["payload"]["command_id"], "command-123");
+    }
+
+    #[test]
+    fn bluetooth_and_audio_state_are_forwarded_without_local_route_details() {
+        for (event, expected_type) in [
+            (
+                RuntimeEvent::BluetoothState(json!({
+                    "schema_version": 1,
+                    "status": "ready",
+                    "accessories": []
+                })),
+                "bluetooth_state",
+            ),
+            (
+                RuntimeEvent::AudioState(json!({
+                    "schema_version": 1,
+                    "status": "ready",
+                    "applied_revision": 2
+                })),
+                "audio_state",
+            ),
+        ] {
+            let commands = commands_for_event(&RuntimeState::default(), &event);
+            let RuntimeCommand::WorkerCommand { domain, envelope } = &commands[0] else {
+                panic!("expected cloud publish command");
+            };
+            assert_eq!(*domain, WorkerDomain::Cloud);
+            assert_eq!(envelope.message_type, "cloud.publish_event");
+            assert_eq!(envelope.payload["event_type"], expected_type);
+        }
+
+        let route_commands = commands_for_event(
+            &RuntimeState::default(),
+            &RuntimeEvent::AudioRouteLocal(json!({
+                "media_device": "alsa/default",
+                "media_volume": 60,
+                "voip_playback_device": "ALSA: default",
+                "voip_ringer_device": "ALSA: default",
+                "voip_capture_device": "ALSA: default",
+                "voip_media_device": "ALSA: default",
+                "communication_volume": 65,
+                "microphone_gain": 55
+            })),
+        );
+        assert_eq!(route_commands.len(), 3);
+        assert!(route_commands.iter().all(|command| {
+            matches!(
+                command,
+                RuntimeCommand::WorkerCommand { domain, .. }
+                    if *domain != WorkerDomain::Cloud
+            )
+        }));
+    }
+
+    #[test]
+    fn bluetooth_and_audio_cloud_commands_are_correlated_to_network() {
+        for command_type in [
+            "bluetooth_set_radio",
+            "bluetooth_scan_start",
+            "bluetooth_pair",
+            "bluetooth_connect",
+            "audio_apply_settings",
+            "audio_test_output",
+            "audio_test_input",
+        ] {
+            let commands = commands_for_event(
+                &RuntimeState::default(),
+                &RuntimeEvent::CloudCommand(json!({
+                    "command": command_type,
+                    "commandId": "command-123",
+                    "payload": {}
+                })),
+            );
+            let RuntimeCommand::CorrelatedWorkerCommand {
+                domain, command_id, ..
+            } = &commands[0]
+            else {
+                panic!("expected correlated network command for {command_type}");
+            };
+            assert_eq!(*domain, WorkerDomain::Network);
+            assert_eq!(command_id, "command-123");
+        }
     }
 }

--- a/device/runtime/src/event.rs
+++ b/device/runtime/src/event.rs
@@ -103,8 +103,8 @@ impl RuntimeEvent {
             Self::WifiState(_)
             | Self::WifiChangeCandidate(_)
             | Self::BluetoothState(_)
-            | Self::AudioState(_)
-            | Self::AudioRouteLocal(_) => {}
+            | Self::AudioState(_) => {}
+            Self::AudioRouteLocal(route) => state.apply_audio_route_local(route),
             Self::WifiProvisioningState(payload) => state.apply_wifi_provisioning_state(payload),
             Self::PowerSnapshot(snapshot) => {
                 state.resolve_overlay_for(WorkerDomain::Power);
@@ -694,9 +694,9 @@ fn commands_for_settings_intent(
             let level = ((state.media.volume.clamp(0, 100) + 5) / 10).clamp(1, 10);
             let next = if level >= 10 { 1 } else { level + 1 };
             vec![worker_command(
-                WorkerDomain::Media,
-                "media.set_volume",
-                json!({"volume": next * 10}),
+                WorkerDomain::Network,
+                "audio_set_output_level",
+                json!({"level": next * 10}),
             )]
         }
         SettingsIntent::WifiSetupStart => vec![worker_command(
@@ -1109,14 +1109,14 @@ fn commands_for_voice_command(
             })
             .unwrap_or_default(),
         VoiceCommandIntent::VolumeUp => vec![worker_command(
-            WorkerDomain::Media,
-            "media.set_volume",
-            json!({"volume": adjusted_volume(state, 10)}),
+            WorkerDomain::Network,
+            "audio_set_output_level",
+            json!({"level": adjusted_volume(state, 10)}),
         )],
         VoiceCommandIntent::VolumeDown => vec![worker_command(
-            WorkerDomain::Media,
-            "media.set_volume",
-            json!({"volume": adjusted_volume(state, -10)}),
+            WorkerDomain::Network,
+            "audio_set_output_level",
+            json!({"level": adjusted_volume(state, -10)}),
         )],
         VoiceCommandIntent::ReadScreen
         | VoiceCommandIntent::MuteMic
@@ -1895,22 +1895,36 @@ mod tests {
     }
 
     #[test]
-    fn setup_volume_step_wraps_and_routes_to_media() {
+    fn setup_volume_step_wraps_and_routes_to_managed_audio() {
         let mut state = RuntimeState::default();
         state.media.volume = 100;
         let event = RuntimeEvent::UiIntent(UiIntent::Settings(SettingsIntent::VolumeStep));
         let commands = commands_for_event(&state, &event);
 
         let RuntimeCommand::WorkerCommand { domain, envelope } = &commands[0] else {
-            panic!("expected media command");
+            panic!("expected managed audio command");
         };
-        assert_eq!(*domain, WorkerDomain::Media);
-        assert_eq!(envelope.message_type, "media.set_volume");
-        assert_eq!(envelope.payload["volume"], 10);
+        assert_eq!(*domain, WorkerDomain::Network);
+        assert_eq!(envelope.message_type, "audio_set_output_level");
+        assert_eq!(envelope.payload["level"], 10);
 
         event.apply(&mut state);
         assert_eq!(state.media.volume, 10);
         assert_eq!(state.ui_snapshot().settings.volume_level, 1);
+    }
+
+    #[test]
+    fn voice_volume_routes_to_managed_audio() {
+        let mut state = RuntimeState::default();
+        state.media.volume = 90;
+        let commands = commands_for_voice_command(&state, VoiceCommandIntent::VolumeUp, "");
+
+        let RuntimeCommand::WorkerCommand { domain, envelope } = &commands[0] else {
+            panic!("expected managed audio command");
+        };
+        assert_eq!(*domain, WorkerDomain::Network);
+        assert_eq!(envelope.message_type, "audio_set_output_level");
+        assert_eq!(envelope.payload["level"], 100);
     }
 
     #[test]
@@ -2346,6 +2360,13 @@ mod tests {
                     if *domain != WorkerDomain::Cloud
             )
         }));
+
+        let mut state = RuntimeState::default();
+        RuntimeEvent::AudioRouteLocal(json!({
+            "media_volume": 100
+        }))
+        .apply(&mut state);
+        assert_eq!(state.media.volume, 100);
     }
 
     #[test]

--- a/device/runtime/src/state.rs
+++ b/device/runtime/src/state.rs
@@ -1077,6 +1077,12 @@ impl RuntimeState {
         }
     }
 
+    pub fn apply_audio_route_local(&mut self, route: &Value) {
+        if let Some(volume) = i32_field(route, "media_volume") {
+            self.media.volume = volume.clamp(0, 100);
+        }
+    }
+
     pub fn apply_voip_snapshot(&mut self, snapshot: &Value) {
         if let Some(registered) = snapshot.get("registered").and_then(Value::as_bool) {
             self.call.registered = registered;

--- a/device/runtime/src/state.rs
+++ b/device/runtime/src/state.rs
@@ -1246,11 +1246,9 @@ impl RuntimeState {
     fn apply_settings_intent(&mut self, intent: &yoyopod_protocol::ui::SettingsIntent) {
         use yoyopod_protocol::ui::SettingsIntent;
         match intent {
-            SettingsIntent::VolumeStep => {
-                let level = volume_level(self.media.volume);
-                let next = if level >= 10 { 1 } else { level + 1 };
-                self.media.volume = next * 10;
-            }
+            // The network worker owns the configured safety cap and publishes
+            // the applied level immediately after cycling it.
+            SettingsIntent::VolumeStep => {}
             SettingsIntent::CompanionSet(value) => self.settings.companion = value.clone(),
             SettingsIntent::ThemeSet(value) => self.settings.theme = value.clone(),
             SettingsIntent::SpeakNamesToggle => {

--- a/device/voip/src/host.rs
+++ b/device/voip/src/host.rs
@@ -33,6 +33,7 @@ pub trait VoipRuntimeBackend {
         _media_device: &str,
         _microphone_gain: u8,
         _output_volume: u8,
+        _alert_volume: u8,
     ) -> Result<(), String> {
         Ok(())
     }
@@ -316,6 +317,7 @@ impl VoipHost {
         media_device: &str,
         microphone_gain: u8,
         output_volume: u8,
+        alert_volume: u8,
     ) -> Result<(), String> {
         backend.set_audio_devices(
             playback_device,
@@ -324,6 +326,7 @@ impl VoipHost {
             media_device,
             microphone_gain,
             output_volume,
+            alert_volume,
         )
     }
 

--- a/device/voip/src/host.rs
+++ b/device/voip/src/host.rs
@@ -25,6 +25,17 @@ pub trait VoipRuntimeBackend {
     fn reject_call(&mut self) -> Result<(), String>;
     fn hangup(&mut self) -> Result<(), String>;
     fn set_muted(&mut self, muted: bool) -> Result<(), String>;
+    fn set_audio_devices(
+        &mut self,
+        _playback_device: &str,
+        _ringer_device: &str,
+        _capture_device: &str,
+        _media_device: &str,
+        _microphone_gain: u8,
+        _output_volume: u8,
+    ) -> Result<(), String> {
+        Ok(())
+    }
     fn send_text_message(&mut self, sip_address: &str, text: &str) -> Result<String, String>;
     fn start_voice_recording(&mut self, file_path: &str) -> Result<(), String>;
     fn voice_recording_metrics(&mut self) -> Result<VoiceRecordingMetrics, String>;
@@ -294,6 +305,26 @@ impl VoipHost {
         backend.set_muted(muted)?;
         self.call.set_muted(muted);
         Ok(())
+    }
+
+    pub fn set_audio_devices<B: VoipRuntimeBackend + ?Sized>(
+        &mut self,
+        backend: &mut B,
+        playback_device: &str,
+        ringer_device: &str,
+        capture_device: &str,
+        media_device: &str,
+        microphone_gain: u8,
+        output_volume: u8,
+    ) -> Result<(), String> {
+        backend.set_audio_devices(
+            playback_device,
+            ringer_device,
+            capture_device,
+            media_device,
+            microphone_gain,
+            output_volume,
+        )
     }
 
     pub fn send_text_message<B: VoipRuntimeBackend + ?Sized>(

--- a/device/voip/src/liblinphone/backend.rs
+++ b/device/voip/src/liblinphone/backend.rs
@@ -166,6 +166,7 @@ impl VoipRuntimeBackend for LiblinphoneBackend {
         media_device: &str,
         microphone_gain: u8,
         output_volume: u8,
+        alert_volume: u8,
     ) -> Result<(), String> {
         let playback = CString::new(playback_device).map_err(|error| error.to_string())?;
         let ringer = CString::new(ringer_device).map_err(|error| error.to_string())?;
@@ -179,6 +180,7 @@ impl VoipRuntimeBackend for LiblinphoneBackend {
                 media.as_ptr(),
                 microphone_gain.into(),
                 output_volume.into(),
+                alert_volume.into(),
             )
         })
         .map_err(|error| error.to_string())

--- a/device/voip/src/liblinphone/backend.rs
+++ b/device/voip/src/liblinphone/backend.rs
@@ -158,6 +158,32 @@ impl VoipRuntimeBackend for LiblinphoneBackend {
             .map_err(|error| error.to_string())
     }
 
+    fn set_audio_devices(
+        &mut self,
+        playback_device: &str,
+        ringer_device: &str,
+        capture_device: &str,
+        media_device: &str,
+        microphone_gain: u8,
+        output_volume: u8,
+    ) -> Result<(), String> {
+        let playback = CString::new(playback_device).map_err(|error| error.to_string())?;
+        let ringer = CString::new(ringer_device).map_err(|error| error.to_string())?;
+        let capture = CString::new(capture_device).map_err(|error| error.to_string())?;
+        let media = CString::new(media_device).map_err(|error| error.to_string())?;
+        check(unsafe {
+            runtime::yoyopod_liblinphone_set_audio_devices(
+                playback.as_ptr(),
+                ringer.as_ptr(),
+                capture.as_ptr(),
+                media.as_ptr(),
+                microphone_gain.into(),
+                output_volume.into(),
+            )
+        })
+        .map_err(|error| error.to_string())
+    }
+
     fn send_text_message(&mut self, sip_address: &str, text: &str) -> Result<String, String> {
         let sip_address = CString::new(sip_address).map_err(|error| error.to_string())?;
         let text = CString::new(text).map_err(|error| error.to_string())?;

--- a/device/voip/src/liblinphone/ffi.rs
+++ b/device/voip/src/liblinphone/ffi.rs
@@ -161,6 +161,7 @@ pub struct LinphoneApi {
     pub core_enable_echo_cancellation: unsafe extern "C" fn(*mut LinphoneCore, c_int),
     pub core_set_mic_gain_db: unsafe extern "C" fn(*mut LinphoneCore, c_float),
     pub core_set_playback_gain_db: unsafe extern "C" fn(*mut LinphoneCore, c_float),
+    pub core_set_ring_level: unsafe extern "C" fn(*mut LinphoneCore, c_int),
     pub core_set_audio_port_range: unsafe extern "C" fn(*mut LinphoneCore, c_int, c_int),
     pub core_set_video_port_range: unsafe extern "C" fn(*mut LinphoneCore, c_int, c_int),
     pub core_create_nat_policy: unsafe extern "C" fn(*mut LinphoneCore) -> *mut LinphoneNatPolicy,
@@ -364,6 +365,9 @@ impl LinphoneApi {
             },
             core_set_playback_gain_db: unsafe {
                 required_symbol(library, c"linphone_core_set_playback_gain_db")?
+            },
+            core_set_ring_level: unsafe {
+                required_symbol(library, c"linphone_core_set_ring_level")?
             },
             core_set_audio_port_range: unsafe {
                 required_symbol(library, c"linphone_core_set_audio_port_range")?

--- a/device/voip/src/liblinphone/runtime.rs
+++ b/device/voip/src/liblinphone/runtime.rs
@@ -186,6 +186,7 @@ pub unsafe extern "C" fn yoyopod_liblinphone_start(
         );
         (api.core_set_mic_gain_db)(state.core, (mic_gain as f32) * 0.3);
         (api.core_set_playback_gain_db)(state.core, ((output_volume as f32) * 0.12) - 6.0);
+        (api.core_set_ring_level)(state.core, output_volume.clamp(0, 100));
         (api.core_set_audio_port_range)(state.core, 7076, 7100);
         (api.core_set_video_port_range)(state.core, 9076, 9100);
         if let Some(set_aggregation) = api.core_set_chat_messages_aggregation_enabled {
@@ -377,6 +378,7 @@ pub unsafe extern "C" fn yoyopod_liblinphone_set_audio_devices(
     media_device_id: *const c_char,
     microphone_gain: c_int,
     output_volume: c_int,
+    alert_volume: c_int,
 ) -> c_int {
     let state = match STATE.lock() {
         Ok(state) => state,
@@ -419,6 +421,7 @@ pub unsafe extern "C" fn yoyopod_liblinphone_set_audio_devices(
             state.core,
             ((output_volume.clamp(0, 100) as f32) * 0.12) - 6.0,
         );
+        (api.core_set_ring_level)(state.core, alert_volume.clamp(0, 100));
     }
     error::clear_last_error();
     0

--- a/device/voip/src/liblinphone/runtime.rs
+++ b/device/voip/src/liblinphone/runtime.rs
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn yoyopod_liblinphone_start(
             if echo_cancellation != 0 { TRUE } else { FALSE },
         );
         (api.core_set_mic_gain_db)(state.core, (mic_gain as f32) * 0.3);
-        (api.core_set_playback_gain_db)(state.core, ((output_volume as f32) * 0.12) - 6.0);
+        (api.core_set_playback_gain_db)(state.core, playback_gain_db(output_volume));
         (api.core_set_ring_level)(state.core, output_volume.clamp(0, 100));
         (api.core_set_audio_port_range)(state.core, 7076, 7100);
         (api.core_set_video_port_range)(state.core, 9076, 9100);
@@ -417,14 +417,20 @@ pub unsafe extern "C" fn yoyopod_liblinphone_set_audio_devices(
         );
         set_device(&api, state.core, media_device_id, api.core_set_media_device);
         (api.core_set_mic_gain_db)(state.core, (microphone_gain.clamp(0, 100) as f32) * 0.3);
-        (api.core_set_playback_gain_db)(
-            state.core,
-            ((output_volume.clamp(0, 100) as f32) * 0.12) - 6.0,
-        );
+        (api.core_set_playback_gain_db)(state.core, playback_gain_db(output_volume));
         (api.core_set_ring_level)(state.core, alert_volume.clamp(0, 100));
     }
     error::clear_last_error();
     0
+}
+
+fn playback_gain_db(output_volume: c_int) -> f32 {
+    let fraction = output_volume.clamp(0, 100) as f32 / 100.0;
+    if fraction == 0.0 {
+        -120.0
+    } else {
+        20.0 * fraction.log10()
+    }
 }
 
 #[no_mangle]
@@ -1763,4 +1769,17 @@ fn copy_str_to_c_buffer(value: &str, out: *mut c_char, out_size: u32) -> bool {
         *out.add(count) = 0;
     }
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::playback_gain_db;
+
+    #[test]
+    fn playback_percentages_map_to_real_attenuation() {
+        assert_eq!(playback_gain_db(0), -120.0);
+        assert!((playback_gain_db(10) - -20.0).abs() < 0.01);
+        assert!((playback_gain_db(50) - -6.0206).abs() < 0.01);
+        assert_eq!(playback_gain_db(100), 0.0);
+    }
 }

--- a/device/voip/src/liblinphone/runtime.rs
+++ b/device/voip/src/liblinphone/runtime.rs
@@ -370,6 +370,61 @@ pub unsafe extern "C" fn yoyopod_liblinphone_set_muted(muted: i32) -> c_int {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn yoyopod_liblinphone_set_audio_devices(
+    playback_device_id: *const c_char,
+    ringer_device_id: *const c_char,
+    capture_device_id: *const c_char,
+    media_device_id: *const c_char,
+    microphone_gain: c_int,
+    output_volume: c_int,
+) -> c_int {
+    let state = match STATE.lock() {
+        Ok(state) => state,
+        Err(_) => {
+            error::set_last_error("liblinphone runtime state lock poisoned");
+            return -1;
+        }
+    };
+    if !state.started || state.core.is_null() {
+        // Audio preferences may arrive before SIP startup. The worker's config
+        // still applies them when the backend starts, so this is not an error.
+        return 0;
+    }
+    let Some(api) = state.api.clone() else {
+        error::set_last_error("Liblinphone API is not initialized");
+        return -1;
+    };
+    unsafe {
+        set_device(
+            &api,
+            state.core,
+            playback_device_id,
+            api.core_set_playback_device,
+        );
+        set_device(
+            &api,
+            state.core,
+            ringer_device_id,
+            api.core_set_ringer_device,
+        );
+        set_device(
+            &api,
+            state.core,
+            capture_device_id,
+            api.core_set_capture_device,
+        );
+        set_device(&api, state.core, media_device_id, api.core_set_media_device);
+        (api.core_set_mic_gain_db)(state.core, (microphone_gain.clamp(0, 100) as f32) * 0.3);
+        (api.core_set_playback_gain_db)(
+            state.core,
+            ((output_volume.clamp(0, 100) as f32) * 0.12) - 6.0,
+        );
+    }
+    error::clear_last_error();
+    0
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn yoyopod_liblinphone_send_text_message(
     sip_address: *const c_char,
     text: *const c_char,

--- a/device/voip/src/worker.rs
+++ b/device/voip/src/worker.rs
@@ -330,6 +330,12 @@ where
                 .and_then(serde_json::Value::as_u64)
                 .filter(|value| *value <= 100)
                 .map(|value| value as u8);
+            let alert_volume = envelope
+                .payload
+                .get("alert_volume")
+                .and_then(serde_json::Value::as_u64)
+                .filter(|value| *value <= 100)
+                .map(|value| value as u8);
             match (
                 playback,
                 ringer,
@@ -337,6 +343,7 @@ where
                 media,
                 microphone_gain,
                 output_volume,
+                alert_volume,
             ) {
                 (
                     Some(playback),
@@ -345,6 +352,7 @@ where
                     Some(media),
                     Some(microphone_gain),
                     Some(output_volume),
+                    Some(alert_volume),
                 ) => {
                     backend.with_backend(|backend_ref| {
                         host.set_audio_devices(
@@ -355,6 +363,7 @@ where
                             media,
                             microphone_gain,
                             output_volume,
+                            alert_volume,
                         )
                     })?;
                     write_envelope_to(

--- a/device/voip/src/worker.rs
+++ b/device/voip/src/worker.rs
@@ -306,6 +306,79 @@ where
             )?;
             write_session_snapshot(host, output)?;
         }
+        "voip.set_audio_devices" => {
+            let string = |key: &str| {
+                envelope
+                    .payload
+                    .get(key)
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|value| !value.trim().is_empty())
+            };
+            let playback = string("voip_playback_device");
+            let ringer = string("voip_ringer_device");
+            let capture = string("voip_capture_device");
+            let media = string("voip_media_device");
+            let microphone_gain = envelope
+                .payload
+                .get("microphone_gain")
+                .and_then(serde_json::Value::as_u64)
+                .filter(|value| *value <= 100)
+                .map(|value| value as u8);
+            let output_volume = envelope
+                .payload
+                .get("communication_volume")
+                .and_then(serde_json::Value::as_u64)
+                .filter(|value| *value <= 100)
+                .map(|value| value as u8);
+            match (
+                playback,
+                ringer,
+                capture,
+                media,
+                microphone_gain,
+                output_volume,
+            ) {
+                (
+                    Some(playback),
+                    Some(ringer),
+                    Some(capture),
+                    Some(media),
+                    Some(microphone_gain),
+                    Some(output_volume),
+                ) => {
+                    backend.with_backend(|backend_ref| {
+                        host.set_audio_devices(
+                            backend_ref,
+                            playback,
+                            ringer,
+                            capture,
+                            media,
+                            microphone_gain,
+                            output_volume,
+                        )
+                    })?;
+                    write_envelope_to(
+                        output,
+                        &WorkerEnvelope::result(
+                            "voip.set_audio_devices",
+                            envelope.request_id,
+                            json!({"applied": true}),
+                        ),
+                    )?;
+                }
+                _ => {
+                    write_envelope_to(
+                        output,
+                        &WorkerEnvelope::error(
+                            "voip.error",
+                            envelope.request_id,
+                            "invalid_command",
+                            "voip.set_audio_devices requires complete safe audio routing settings",
+                        ),
+                    )?;
+                }
+            }
+        }
         "voip.send_text_message" => {
             let uri = envelope.payload["uri"].as_str().unwrap_or("").trim();
             let text = envelope.payload["text"].as_str().unwrap_or("");


### PR DESCRIPTION
## What changed

- adds Bluetooth discovery, pairing, connection, trust, auto-connect, and local audio routing
- improves scan responsiveness and enforces outbound audio routing
- applies dashboard audio settings to media and VoIP workers
- adds a managed local output-level command used by device settings and voice volume controls
- persists local output changes and publishes sanitized audio state back to the cloud
- updates runtime media state from applied routes
- supports the full 0–100 output range

## Why

Local device volume actions bypassed the managed audio configuration and changed only MPV, so the backend and dashboard remained stale. Legacy desired settings also capped output below 100%.

## Coordinated integration

- Dashboard: https://github.com/eng-samanody/yoyo_dash/pull/644
- Backend: https://github.com/eng-samanody/yoyo_end/pull/1030
- YoYoPod Core: https://github.com/attmous/yoyopod/pull/477

Review and merge these as one contract-compatible set. Recommended merge order: backend, Core, dashboard.

## Validation

- 34 network tests passed
- 33 runtime tests passed
- locked ARM64 CI build and artifact upload passed
- exact artifact deployed to `piz`
- MPV reached 100% from the dashboard
- local managed change reconciled back to dashboard state at 70%

## Deployment status

Commit `9803a586a3f300dd9f4edf80afffb2857e36c02d` is deployed to `piz` for pre-merge testing. Do not merge independently of the companion dashboard and backend PRs.