### PR TITLE
brand: lowercase the yoyopod wordmark everywhere

### DIFF
--- a/.github/ISSUE_TEMPLATE/README.md
+++ b/.github/ISSUE_TEMPLATE/README.md
@@ -1,6 +1,6 @@
 # Review issue templates
 
-Four YAML issue forms for the YoYoPod codebase review workflow:
+Four YAML issue forms for the yoyopod codebase review workflow:
 
 | Template | Lens |
 |---|---|

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,5 +84,5 @@ jobs:
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             gh release upload "$RELEASE_TAG" dist/* --clobber
           else
-            gh release create "$RELEASE_TAG" dist/* --title "YoYoPod $RELEASE_TAG" --generate-notes
+            gh release create "$RELEASE_TAG" dist/* --title "yoyopod $RELEASE_TAG" --generate-notes
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# YoYoPod - Agent Instructions
+# yoyopod - Agent Instructions
 
 Last Updated: 2026-05-13
 Target Hardware: Raspberry Pi Zero 2W

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# YoYoPod
+# yoyopod
 
 <p align="center">
-  <img src="docs/assets/readme/yoyopod-device-tour.gif" alt="YoYoPod running on the current prototype hardware" width="320">
+  <img src="docs/assets/readme/yoyopod-device-tour.gif" alt="yoyopod running on the current prototype hardware" width="320">
 </p>
 
 <p align="center">
-  <strong>YoYoPod is a tiny Pi-powered music player and phone for kids aged 7-13.</strong>
+  <strong>yoyopod is a tiny Pi-powered music player and phone for kids aged 7-13.</strong>
 </p>
 
 <p align="center">
@@ -21,11 +21,11 @@
   <img alt="PiSugar" src="https://img.shields.io/badge/PiSugar-power%20integration-159957">
 </p>
 
-YoYoPod is being built by software-engineer fathers in Stuttgart, Germany. The idea is simple: give kids a dedicated little device for music, voice messages, and staying in touch, without throwing them into the chaos of a general-purpose phone.
+yoyopod is being built by software-engineer fathers in Stuttgart, Germany. The idea is simple: give kids a dedicated little device for music, voice messages, and staying in touch, without throwing them into the chaos of a general-purpose phone.
 
 The current prototype runs on a Raspberry Pi Zero 2W and uses the Whisplay HAT because it gives us a great bundle for fast iteration: screen, side push-to-talk button, microphone, and speaker. That is our prototype path, not a permanent promise about the final hardware. The long-term device may ship with its own display and driver.
 
-## What YoYoPod Can Do
+## What yoyopod Can Do
 
 - `Music playback` - local-first music, playlists, recent tracks, shuffle, and a simple now-playing flow.
 - `Calls and voice messages` - family-friendly calling, quick voice notes, and a contact-first Talk experience.
@@ -37,15 +37,15 @@ The current prototype runs on a Raspberry Pi Zero 2W and uses the Whisplay HAT b
 
 | Hub | Listen |
 | --- | --- |
-| ![YoYoPod hub screen](docs/assets/readme/hub.png) | ![YoYoPod listen screen](docs/assets/readme/listen.png) |
+| ![yoyopod hub screen](docs/assets/readme/hub.png) | ![yoyopod listen screen](docs/assets/readme/listen.png) |
 
 | Talk | Setup |
 | --- | --- |
-| ![YoYoPod talk screen](docs/assets/readme/talk.png) | ![YoYoPod setup screen](docs/assets/readme/setup.png) |
+| ![yoyopod talk screen](docs/assets/readme/talk.png) | ![yoyopod setup screen](docs/assets/readme/setup.png) |
 
 ## The Software Stack
 
-This repository contains the software that runs the current YoYoPod prototype:
+This repository contains the software that runs the current yoyopod prototype:
 
 - `device/runtime/` - Rust runtime for config, worker supervision, app state, event routing, and UI snapshots.
 - `device/{ui,media,voip,network,cloud,power,speech}/` - Rust domain sidecar hosts for UI, media, VoIP, network, cloud, power, and speech/Ask.
@@ -144,14 +144,14 @@ When docs disagree, trust current code and the most recently merged PRs. The [`d
 
 ## License
 
-YoYoPod is licensed under the **GNU Affero General Public License v3.0 or later** (AGPLv3+). See [LICENSE](LICENSE) for the full text.
+yoyopod is licensed under the **GNU Affero General Public License v3.0 or later** (AGPLv3+). See [LICENSE](LICENSE) for the full text.
 
-The project's own source could be permissively licensed in isolation, but YoYoPod's VoIP backend links [liblinphone](https://gitlab.linphone.org/BC/public/liblinphone), which is itself AGPLv3 (with a paid commercial-license alternative from Belledonne Communications). Distributed binaries that include the liblinphone link therefore fall under AGPLv3 as a combined work.
+The project's own source could be permissively licensed in isolation, but yoyopod's VoIP backend links [liblinphone](https://gitlab.linphone.org/BC/public/liblinphone), which is itself AGPLv3 (with a paid commercial-license alternative from Belledonne Communications). Distributed binaries that include the liblinphone link therefore fall under AGPLv3 as a combined work.
 
 In practical terms:
 
 - The full source is published in this repository.
-- Anyone receiving a YoYoPod device or firmware artifact is entitled to the corresponding source under the same license.
+- Anyone receiving a yoyopod device or firmware artifact is entitled to the corresponding source under the same license.
 - Modifications and derivative works must remain AGPLv3 and must publish their source.
 
-Section 13 of the AGPL ("network use") triggers source-disclosure for software that interacts with users remotely over a network. YoYoPod's typical use (a local user holding the device) does not trigger that clause; a hypothetical future cloud companion that exposes liblinphone functionality remotely would.
+Section 13 of the AGPL ("network use") triggers source-disclosure for software that interacts with users remotely over a network. yoyopod's typical use (a local user holding the device) does not trigger that clause; a hypothetical future cloud companion that exposes liblinphone functionality remotely would.

--- a/cli/yoyopod/Cargo.toml
+++ b/cli/yoyopod/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "YoYoPod operator CLI: dev-machine to Pi orchestration."
+description = "yoyopod operator CLI: dev-machine to Pi orchestration."
 
 [[bin]]
 name = "yoyopod"

--- a/cli/yoyopod/src/cli.rs
+++ b/cli/yoyopod/src/cli.rs
@@ -5,7 +5,7 @@ use clap::{Args, Parser, Subcommand};
 #[derive(Debug, Parser)]
 #[command(
     name = "yoyopod",
-    about = "YoYoPod operator CLI: dev-machine to Pi orchestration.",
+    about = "yoyopod operator CLI: dev-machine to Pi orchestration.",
     version
 )]
 pub struct Cli {
@@ -54,7 +54,7 @@ pub struct TargetArgs {
 pub enum TargetCommand {
     /// Show repo SHA, processes, and log tail on the Pi.
     Status,
-    /// Restart the YoYoPod dev runtime service on the Pi.
+    /// Restart the yoyopod dev runtime service on the Pi.
     Restart,
     /// Tail yoyopod logs on the Pi.
     Logs(LogsArgs),

--- a/cli/yoyopod/src/commands/target/deploy.rs
+++ b/cli/yoyopod/src/commands/target/deploy.rs
@@ -167,7 +167,7 @@ pub fn run(
          sudo -n install -d -m 0755 {dropin_dir} && \
          sudo -n install -d -m 0755 /var/lib/yoyopod/audio && \
          if ! sudo -n test -s /var/lib/yoyopod/audio/asoundrc; then \
-           printf '# Managed by YoYoPod.\\n</usr/share/alsa/alsa.conf>\\n' \
+           printf '# Managed by yoyopod.\\n</usr/share/alsa/alsa.conf>\\n' \
            | sudo -n tee /var/lib/yoyopod/audio/asoundrc >/dev/null; \
          fi && \
          printf '[Service]\\nAmbientCapabilities=CAP_NET_BIND_SERVICE\\n' \
@@ -193,7 +193,7 @@ pub fn run(
 
     // Bluetooth audio lives outside the artifact: BlueZ provides radio/device
     // management and BlueALSA exposes paired profiles through stable ALSA PCM
-    // aliases. YoYoPod must be the source/gateway so audio flows out to a
+    // aliases. yoyopod must be the source/gateway so audio flows out to a
     // speaker or headset; advertising a sink role reverses that direction.
     // Install the explicit role drop-in idempotently and restart BlueALSA only
     // when its configuration changed (or the service is not already active).

--- a/cli/yoyopod/src/paths.rs
+++ b/cli/yoyopod/src/paths.rs
@@ -27,7 +27,7 @@ impl Default for PiPaths {
             error_log_file: "logs/yoyopod_errors.log".to_string(),
             pid_file: "/opt/yoyopod-dev/state/yoyopod.pid".to_string(),
             screenshot_path: "/tmp/yoyopod_screenshot.png".to_string(),
-            startup_marker: "YoYoPod Rust runtime starting".to_string(),
+            startup_marker: "yoyopod Rust runtime starting".to_string(),
             kill_processes: vec!["yoyopod-runtime".to_string()],
             rsync_exclude: vec![
                 ".git/".to_string(),

--- a/config/app/core.yaml
+++ b/config/app/core.yaml
@@ -2,7 +2,7 @@
 # Board overlays follow this same relative path under config/boards/<board>/.
 
 app:
-  name: "YoYoPod"
+  name: "yoyopod"
   version: "1.0.0"
 
 ui:

--- a/config/boards/rpi-zero-2w/audio/music.yaml
+++ b/config/boards/rpi-zero-2w/audio/music.yaml
@@ -1,4 +1,4 @@
 # Raspberry Pi Zero 2W board overrides.
 #
 # Keep music_dir inherited from config/audio/music.yaml. The dev/prod lane
-# installer runs YoYoPod as the device owner and seeds shared music there.
+# installer runs yoyopod as the device owner and seeds shared music there.

--- a/config/communication/calling.yaml
+++ b/config/communication/calling.yaml
@@ -11,7 +11,7 @@ calling:
     sip_username: ""
     sip_identity: ""
     transport: "tcp"
-    display_name: "YoYoPod"
+    display_name: "yoyopod"
   network:
     stun_server: "stun.linphone.org"
     enable_ice: true

--- a/config/communication/integrations/liblinphone_factory.conf
+++ b/config/communication/integrations/liblinphone_factory.conf
@@ -16,7 +16,7 @@ verify_server_certs=1
 verify_server_cn=1
 auto_send_ringing=1
 supported=replaces, outbound, gruu, path
-user_agent=YoYoPod/1.0
+user_agent=yoyopod/1.0
 refresh_window=90-90
 linphone_specs=lime
 

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,8 +1,8 @@
 {
   "device": {
-    "name": "YoYoPod-001",
+    "name": "yoyopod-001",
     "device_id": "",
-    "model": "YoYoPod Connect"
+    "model": "yoyopod Connect"
   },
   "display": {
     "width": 320,

--- a/config/voice/assistant.yaml
+++ b/config/voice/assistant.yaml
@@ -32,7 +32,7 @@ worker:
   max_audio_seconds: 30.0
   stt_model: "gpt-4o-mini-transcribe"
   stt_language: "en"
-  stt_prompt: "Transcribe this YoYoPod voice command in English Latin letters. Do not output Arabic, Persian, Korean, or other non-Latin scripts. Preserve family names such as mama, baba, mom, dad, mommy, daddy, and papa."
+  stt_prompt: "Transcribe this yoyopod voice command in English Latin letters. Do not output Arabic, Persian, Korean, or other non-Latin scripts. Preserve family names such as mama, baba, mom, dad, mommy, daddy, and papa."
   tts_model: "gpt-4o-mini-tts"
   tts_voice: "coral"
   tts_instructions: "Speak warmly and calmly for a child. Use simple words, friendly pacing, and brief answers. Avoid scary emphasis."
@@ -40,7 +40,7 @@ worker:
   ask_timeout_seconds: 12.0
   ask_max_history_turns: 4
   ask_max_response_chars: 480
-  ask_instructions: "You are YoYoPod's friendly Ask helper for a child using a small handheld audio device. Answer in simple language a child can understand. Keep answers to 1-3 short sentences unless the child asks for a story. Be warm, calm, and encouraging. Do not use scary detail. Do not ask for private information. For medical, legal, safety, emergency, or adult topics, give a brief safe answer and say to ask a grown-up. If you are unsure, say so simply. Do not claim to browse the internet or know live facts."
+  ask_instructions: "You are yoyopod's friendly Ask helper for a child using a small handheld audio device. Answer in simple language a child can understand. Keep answers to 1-3 short sentences unless the child asks for a story. Be warm, calm, and encouraging. Do not use scary detail. Do not ask for private information. For medical, legal, safety, emergency, or adult topics, give a brief safe answer and say to ask a grown-up. If you are unsure, say so simply. Do not claim to browse the internet or know live facts."
   local_feedback_enabled: true
 
 trace:

--- a/deploy/pi-deploy.yaml
+++ b/deploy/pi-deploy.yaml
@@ -1,4 +1,4 @@
-# Raspberry Pi deploy contract for YoYoPod.
+# Raspberry Pi deploy contract for yoyopod.
 # This is the shared source of truth for `yoyopod target` (Rust CLI) and the Pi skills.
 # Dev lane checkouts live under /opt/yoyopod-dev; prod slots live under /opt/yoyopod-prod.
 # Machine-specific connection overrides belong in deploy/pi-deploy.local.yaml.
@@ -22,7 +22,7 @@ kill_processes:
 log_file: logs/yoyopod.log
 error_log_file: logs/yoyopod_errors.log
 pid_file: /opt/yoyopod-dev/state/yoyopod.pid
-startup_marker: "YoYoPod starting"
+startup_marker: "yoyopod starting"
 screenshot_path: /tmp/yoyopod_screenshot.png
 rsync_exclude:
   - .git/

--- a/deploy/scripts/bootstrap_pi.sh
+++ b/deploy/scripts/bootstrap_pi.sh
@@ -124,7 +124,7 @@ install -m 0644 -o root -g root \
 # during normal operation.
 install -d -m 0755 -o root -g root /etc/NetworkManager/dnsmasq-shared.d
 cat > "/etc/NetworkManager/dnsmasq-shared.d/010-yoyopod-captive.conf" <<'EOF'
-# Written by bootstrap_pi.sh - YoYoPod Wi-Fi setup captive portal.
+# Written by bootstrap_pi.sh - yoyopod Wi-Fi setup captive portal.
 address=/#/10.42.0.1
 EOF
 
@@ -139,7 +139,7 @@ EOF
 # user (the units are patched to run as ${INVOKING_USER}), since that user is not
 # necessarily a member of netdev; keep the netdev group as a fallback.
 cat > "/etc/polkit-1/rules.d/50-yoyopod-wifi-share.rules" <<EOF
-// Written by bootstrap_pi.sh - YoYoPod Wi-Fi setup authorization.
+// Written by bootstrap_pi.sh - yoyopod Wi-Fi setup authorization.
 polkit.addRule(function(action, subject) {
     if ((subject.user == "${INVOKING_USER}" || subject.isInGroup("netdev")) &&
         (action.id == "org.freedesktop.NetworkManager.wifi.scan" ||

--- a/deploy/scripts/install_pi.sh
+++ b/deploy/scripts/install_pi.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # deploy/scripts/install_pi.sh
 #
-# Curl-friendly Raspberry Pi installer for the YoYoPod dev/prod lane layout.
+# Curl-friendly Raspberry Pi installer for the yoyopod dev/prod lane layout.
 #
 # Canonical fresh-board command:
 #   curl -fsSL https://raw.githubusercontent.com/moustafattia/yoyopod-core/main/deploy/scripts/install_pi.sh | sudo -E bash -s --
@@ -19,7 +19,7 @@ SOURCE_URL="${YOYOPOD_INSTALL_SOURCE_URL:-https://codeload.github.com/${REPO}/ta
 
 usage() {
     cat <<EOF
-YoYoPod Pi installer
+yoyopod Pi installer
 
 Usage:
   curl -fsSL https://raw.githubusercontent.com/moustafattia/yoyopod-core/main/deploy/scripts/install_pi.sh | sudo -E bash -s -- [bootstrap args]
@@ -67,7 +67,7 @@ archive="${workdir}/source.tar.gz"
 source_dir="${workdir}/source"
 mkdir -p "${source_dir}"
 
-echo "install-pi: downloading YoYoPod source from ${SOURCE_URL}"
+echo "install-pi: downloading yoyopod source from ${SOURCE_URL}"
 curl -fsSL "${SOURCE_URL}" -o "${archive}"
 
 echo "install-pi: extracting installer payload"

--- a/deploy/systemd/bluealsa-yoyopod.conf
+++ b/deploy/systemd/bluealsa-yoyopod.conf
@@ -1,7 +1,7 @@
 [Service]
-# YoYoPod is the audio source/gateway. It sends media and call audio to paired
+# yoyopod is the audio source/gateway. It sends media and call audio to paired
 # speakers/headsets and may receive a headset microphone over HFP/HSP. Do not
 # advertise sink/target roles: those make phones and smart speakers stream
-# their audio into YoYoPod in the wrong direction.
+# their audio into yoyopod in the wrong direction.
 ExecStart=
 ExecStart=/usr/bin/bluealsa -S -p a2dp-source -p hfp-ag -p hsp-ag

--- a/deploy/systemd/yoyopod-dev.service
+++ b/deploy/systemd/yoyopod-dev.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=YoyoPod dev lane (mutable checkout)
+Description=yoyopod dev lane (mutable checkout)
 After=network-online.target sound.target bluetooth.service bluealsa.service pisugar-server.service
 Wants=network-online.target bluetooth.service bluealsa.service
 Conflicts=yoyopod-prod.service
@@ -13,7 +13,7 @@ EnvironmentFile=-/etc/default/yoyopod-dev
 Environment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc
 Environment=ALSA_CONFIG_PATH=/var/lib/yoyopod/audio/asoundrc
 WorkingDirectory=/
-ExecStartPre=/usr/bin/env bash -lc 'install -d -m 0755 /var/lib/yoyopod/audio; test -s /var/lib/yoyopod/audio/asoundrc || printf "# Managed by YoYoPod.\n</usr/share/alsa/alsa.conf>\n" > /var/lib/yoyopod/audio/asoundrc'
+ExecStartPre=/usr/bin/env bash -lc 'install -d -m 0755 /var/lib/yoyopod/audio; test -s /var/lib/yoyopod/audio/asoundrc || printf "# Managed by yoyopod.\n</usr/share/alsa/alsa.conf>\n" > /var/lib/yoyopod/audio/asoundrc'
 ExecStartPre=/usr/bin/env bash -lc 'HOME="$${HOME:-/root}"; DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; install -d -m 700 "$$HOME/.local/share/linphone" "$$HOME/.config/linphone"; install -d -m 755 "$$STATE_DIR"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; test -d "$$CHECKOUT/config"; test -x "$$CHECKOUT/device/runtime/build/yoyopod-runtime"; test -x "$$CHECKOUT/device/ui/build/yoyopod-ui-host"'
 ExecStart=/usr/bin/env bash -lc 'DEV_ROOT="$${YOYOPOD_DEV_ROOT:-/opt/yoyopod-dev}"; STATE_DIR="$${YOYOPOD_STATE_DIR:-$$DEV_ROOT/state}"; export YOYOPOD_PID_FILE="$${YOYOPOD_PID_FILE:-$$STATE_DIR/yoyopod.pid}"; CHECKOUT="$${YOYOPOD_DEV_CHECKOUT:-$$DEV_ROOT/checkout}"; cd "$$CHECKOUT"; exec "$$CHECKOUT/device/runtime/build/yoyopod-runtime" --config-dir "$$CHECKOUT/config" --hardware whisplay'
 Restart=on-failure

--- a/deploy/systemd/yoyopod-prod-rollback.service
+++ b/deploy/systemd/yoyopod-prod-rollback.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=YoyoPod prod rollback after repeated slot failures
+Description=yoyopod prod rollback after repeated slot failures
 StartLimitIntervalSec=3600
 StartLimitBurst=2
 

--- a/deploy/systemd/yoyopod-prod.service
+++ b/deploy/systemd/yoyopod-prod.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=YoyoPod prod lane (slot deploy, OTA-ready)
+Description=yoyopod prod lane (slot deploy, OTA-ready)
 After=network-online.target sound.target bluetooth.service bluealsa.service pisugar-server.service
 Wants=network-online.target bluetooth.service bluealsa.service
 Conflicts=yoyopod-dev.service
@@ -17,7 +17,7 @@ Environment=PYTHONUNBUFFERED=1
 Environment=YOYOPOD_ASOUND_CONFIG=/var/lib/yoyopod/audio/asoundrc
 Environment=ALSA_CONFIG_PATH=/var/lib/yoyopod/audio/asoundrc
 WorkingDirectory=/
-ExecStartPre=/usr/bin/env bash -lc 'install -d -m 0755 /var/lib/yoyopod/audio; test -s /var/lib/yoyopod/audio/asoundrc || printf "# Managed by YoYoPod.\n</usr/share/alsa/alsa.conf>\n" > /var/lib/yoyopod/audio/asoundrc'
+ExecStartPre=/usr/bin/env bash -lc 'install -d -m 0755 /var/lib/yoyopod/audio; test -s /var/lib/yoyopod/audio/asoundrc || printf "# Managed by yoyopod.\n</usr/share/alsa/alsa.conf>\n" > /var/lib/yoyopod/audio/asoundrc'
 ExecStart=/usr/bin/env bash -lc 'exec "$${YOYOPOD_ROOT:-/opt/yoyopod-prod}/current/bin/launch"'
 Restart=on-failure
 RestartSec=5

--- a/device/cloud/src/main.rs
+++ b/device/cloud/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 
 #[derive(Debug, Parser)]
 #[command(name = "yoyopod-cloud-host")]
-#[command(about = "YoYoPod Rust Cloud Host")]
+#[command(about = "yoyopod Rust Cloud Host")]
 struct Args {
     #[arg(long, default_value = "config")]
     config_dir: String,

--- a/device/media/src/main.rs
+++ b/device/media/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 
 #[derive(Debug, Parser)]
 #[command(name = "yoyopod-media-host")]
-#[command(about = "YoYoPod Rust media host")]
+#[command(about = "yoyopod Rust media host")]
 struct Args {}
 
 fn main() -> Result<()> {

--- a/device/media/src/remote_cache.rs
+++ b/device/media/src/remote_cache.rs
@@ -35,7 +35,7 @@ impl RemoteAssetDownloader for HttpRemoteAssetDownloader {
         if let Some(parent) = target_path.parent() {
             fs::create_dir_all(parent).map_err(|error| error.to_string())?;
         }
-        let request = ureq::get(media_url).set("User-Agent", "YoYoPod/remote-playback-cache");
+        let request = ureq::get(media_url).set("User-Agent", "yoyopod/remote-playback-cache");
         let response = request.call().map_err(|error| error.to_string())?;
         let mut reader = response.into_reader();
         let mut handle = fs::File::create(target_path).map_err(|error| error.to_string())?;

--- a/device/network/src/audio.rs
+++ b/device/network/src/audio.rs
@@ -640,14 +640,14 @@ fn applied_settings(
 fn endpoints(bluetooth: &BluetoothState) -> AudioEndpoints {
     let mut outputs = vec![AudioEndpoint {
         endpoint_id: "builtin-speaker".to_string(),
-        name: "YoYoPod speaker".to_string(),
+        name: "yoyopod speaker".to_string(),
         kind: "builtin".to_string(),
         accessory_id: None,
         available: true,
     }];
     let mut inputs = vec![AudioEndpoint {
         endpoint_id: "builtin-microphone".to_string(),
-        name: "YoYoPod microphone".to_string(),
+        name: "yoyopod microphone".to_string(),
         kind: "builtin".to_string(),
         accessory_id: None,
         available: true,
@@ -713,7 +713,7 @@ fn write_asound_config(
         };
     let config = format!(
         concat!(
-            "# Managed by YoYoPod. Bluetooth addresses stay on-device.\n\
+            "# Managed by yoyopod. Bluetooth addresses stay on-device.\n\
 </usr/share/alsa/alsa.conf>\n\
 pcm.yoyopod_bt_a2dp {{\n  type bluealsa\n  device \"{output}\"\n  profile \"a2dp\"\n}}\n\
 pcm.yoyopod_bt_sco_playback {{\n  type bluealsa\n  device \"{sco_playback}\"\n  profile \"sco\"\n}}\n\

--- a/device/network/src/bluetooth.rs
+++ b/device/network/src/bluetooth.rs
@@ -79,7 +79,7 @@ impl BluetoothOperationError {
     fn unavailable() -> Self {
         Self {
             code: "bluetooth_unavailable",
-            message: "Bluetooth is not available on this YoYoPod".to_string(),
+            message: "Bluetooth is not available on this yoyopod".to_string(),
         }
     }
 

--- a/device/network/src/main.rs
+++ b/device/network/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 
 #[derive(Debug, Parser)]
 #[command(name = "yoyopod-network-host")]
-#[command(about = "YoYoPod Rust Network Host")]
+#[command(about = "yoyopod Rust Network Host")]
 struct Args {
     #[arg(long, default_value = "config")]
     config_dir: String,

--- a/device/network/src/portal.html
+++ b/device/network/src/portal.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<title>YoYoPod Wi‑Fi Setup</title>
+<title>yoyopod Wi‑Fi Setup</title>
 <style>
   :root { color-scheme: light; }
   * { box-sizing: border-box; }
@@ -45,7 +45,7 @@
 </head>
 <body>
   <main class="card">
-    <h1>Connect your YoYoPod</h1>
+    <h1>Connect your yoyopod</h1>
     <p class="lead">Choose your home Wi‑Fi network and enter the password.</p>
 
     <div class="list" id="list"><p class="muted">Looking for networks…</p></div>
@@ -63,7 +63,7 @@
     </form>
 
     <div class="status" id="status" role="status" aria-live="polite"></div>
-    <p class="muted">After you tap Connect, the YoYoPod leaves this hotspot to join your network — check its screen.</p>
+    <p class="muted">After you tap Connect, the yoyopod leaves this hotspot to join your network — check its screen.</p>
   </main>
 
 <script>
@@ -182,7 +182,7 @@
       .then(function (res) {
         if (res.ok) {
           statusEl.className = "status ok";
-          statusEl.textContent = "Connecting… you can close this page and watch your YoYoPod.";
+          statusEl.textContent = "Connecting… you can close this page and watch your yoyopod.";
         } else {
           statusEl.className = "status err";
           statusEl.textContent = (res.body && res.body.error) || "Could not connect.";
@@ -192,7 +192,7 @@
       .catch(function () {
         // Tearing down the hotspot drops this connection — that's the success path.
         statusEl.className = "status ok";
-        statusEl.textContent = "Connecting… you can close this page and watch your YoYoPod.";
+        statusEl.textContent = "Connecting… you can close this page and watch your yoyopod.";
       });
   });
 </script>

--- a/device/network/src/provisioning.rs
+++ b/device/network/src/provisioning.rs
@@ -57,7 +57,7 @@ const PORTAL_BIND: &str = "10.42.0.1:80";
 /// The shared-mode gateway address can take a moment to appear on the interface
 /// after activation, so retry the bind briefly rather than failing immediately.
 const PORTAL_BIND_TIMEOUT: Duration = Duration::from_secs(10);
-const AP_CONNECTION_ID: &str = "YoYoPod Setup";
+const AP_CONNECTION_ID: &str = "yoyopod Setup";
 const PORTAL_POLL: Duration = Duration::from_millis(250);
 /// Hard cap on the `/connect` request body. An SSID (<=32) plus a PSK (<=64) in
 /// JSON is well under 1 KiB; 8 KiB leaves generous headroom while bounding what a
@@ -772,7 +772,7 @@ fn delete_profile(connection: &Connection, path: &OwnedObjectPath) {
 /// Delete any leftover setup-AP profile (`AP_CONNECTION_ID`) from a previous run.
 /// Call this on network-worker startup: if an earlier run terminated ungracefully
 /// (crash / SIGKILL / power loss) while the hotspot was up, NetworkManager can
-/// keep the "YoYoPod Setup" connection saved and active, leaving the device
+/// keep the "yoyopod Setup" connection saved and active, leaving the device
 /// broadcasting the onboarding AP and holding the radio. Deleting the profile
 /// also deactivates it. Best-effort; if NM is unreachable there is nothing to do.
 pub fn cleanup_stale_setup_ap() {
@@ -926,7 +926,7 @@ impl Hotspot {
                 }
                 // Don't leave the AP profile behind if it cannot be brought up
                 // (e.g. a missing polkit "share" grant): delete it before failing
-                // so repeated attempts don't accumulate orphaned "YoYoPod Setup"
+                // so repeated attempts don't accumulate orphaned "yoyopod Setup"
                 // connections.
                 ActiveWait::Deactivated => {
                     delete_profile(&connection, &path);
@@ -971,7 +971,7 @@ impl ApCredentials {
             .map(|byte| ALPHABET[(*byte as usize) % ALPHABET.len()] as char)
             .collect();
         Self {
-            ssid: format!("YoYoPod-{suffix}"),
+            ssid: format!("yoyopod-{suffix}"),
             password,
         }
     }
@@ -1050,7 +1050,7 @@ fn build_station_settings(request: &ConnectRequest) -> Result<NmSettings, String
         HashMap::from([
             (
                 "id".to_string(),
-                owned(format!("YoYoPod {}", request.ssid))?,
+                owned(format!("yoyopod {}", request.ssid))?,
             ),
             ("type".to_string(), owned("802-11-wireless".to_string())?),
             ("autoconnect".to_string(), owned(true)?),
@@ -1202,12 +1202,12 @@ mod tests {
     #[test]
     fn qr_payload_is_a_wifi_join_uri_with_escaping() {
         let credentials = ApCredentials {
-            ssid: "YoYoPod-1A2B".to_string(),
+            ssid: "yoyopod-1A2B".to_string(),
             password: "ABCD2345".to_string(),
         };
         assert_eq!(
             credentials.qr_payload(),
-            "WIFI:S:YoYoPod-1A2B;T:WPA;P:ABCD2345;;"
+            "WIFI:S:yoyopod-1A2B;T:WPA;P:ABCD2345;;"
         );
         assert_eq!(escape_qr("a;b:c"), "a\\;b\\:c");
     }
@@ -1215,7 +1215,7 @@ mod tests {
     #[test]
     fn generated_credentials_are_typeable_and_unique_enough() {
         let credentials = ApCredentials::generate();
-        assert!(credentials.ssid.starts_with("YoYoPod-"));
+        assert!(credentials.ssid.starts_with("yoyopod-"));
         assert_eq!(credentials.password.len(), 8);
         assert!((8..=63).contains(&credentials.password.len()));
     }

--- a/device/network/src/wifi.rs
+++ b/device/network/src/wifi.rs
@@ -227,7 +227,7 @@ impl WifiOperationError {
     fn unavailable() -> Self {
         Self::new(
             "wifi_unavailable",
-            "Wi-Fi management is not available on this YoYoPod",
+            "Wi-Fi management is not available on this yoyopod",
         )
     }
 
@@ -958,7 +958,7 @@ impl WifiController for NetworkManagerWifiController {
             settings
                 .entry("connection".to_string())
                 .or_default()
-                .insert("id".to_string(), owned(format!("YoYoPod {ssid}"))?);
+                .insert("id".to_string(), owned(format!("yoyopod {ssid}"))?);
             settings
                 .entry("802-11-wireless".to_string())
                 .or_default()
@@ -1392,7 +1392,7 @@ fn build_profile_settings(
         HashMap::from([
             (
                 "id".to_string(),
-                owned(format!("YoYoPod {}", request.ssid))?,
+                owned(format!("yoyopod {}", request.ssid))?,
             ),
             ("type".to_string(), owned("802-11-wireless".to_string())?),
             ("autoconnect".to_string(), owned(autoconnect)?),

--- a/device/network/src/worker.rs
+++ b/device/network/src/worker.rs
@@ -106,7 +106,7 @@ impl BluetoothAutoConnectBackoff {
 pub fn run(config_dir: &str) -> Result<()> {
     let mut stdout = io::stdout().lock();
     // A previous run that died ungracefully (crash / SIGKILL / power loss) while
-    // the setup hotspot was up can leave the "YoYoPod Setup" AP profile behind in
+    // the setup hotspot was up can leave the "yoyopod Setup" AP profile behind in
     // NetworkManager, keeping the device broadcasting and holding the radio. Clear
     // any such stale profile on startup, before the runtime loop begins.
     crate::provisioning::cleanup_stale_setup_ap();

--- a/device/onpi/src/main.rs
+++ b/device/onpi/src/main.rs
@@ -18,7 +18,7 @@ mod ui_host;
 #[derive(Debug, Parser)]
 #[command(
     name = "yoyopod-on-pi",
-    about = "YoYoPod on-Pi companion: staged hardware validation.",
+    about = "yoyopod on-Pi companion: staged hardware validation.",
     version
 )]
 struct Cli {

--- a/device/onpi/src/report.rs
+++ b/device/onpi/src/report.rs
@@ -61,7 +61,7 @@ impl CheckResult {
 /// Print the compact summary table for one validation stage.
 pub fn print_summary(stage: &str, results: &[CheckResult]) {
     println!();
-    println!("YoYoPod target validation summary: {stage}");
+    println!("yoyopod target validation summary: {stage}");
     println!("{}", "=".repeat(48));
     for result in results {
         println!("[{}] {}: {}", result.status, result.name, result.details);

--- a/device/power/src/main.rs
+++ b/device/power/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 
 #[derive(Debug, Parser)]
 #[command(name = "yoyopod-power-host")]
-#[command(about = "YoYoPod Rust Power Host")]
+#[command(about = "yoyopod Rust Power Host")]
 struct Args {
     #[arg(long, default_value = "config")]
     config_dir: String,

--- a/device/runtime/src/cli.rs
+++ b/device/runtime/src/cli.rs
@@ -24,7 +24,7 @@ const SCREENSHOT_FILE: &str = "/tmp/yoyopod_screenshot.png";
 
 #[derive(Debug, Clone, Parser)]
 #[command(name = "yoyopod-runtime")]
-#[command(about = "YoYoPod Rust top-level runtime host")]
+#[command(about = "yoyopod Rust top-level runtime host")]
 pub struct Args {
     #[arg(long, default_value = "config")]
     pub config_dir: PathBuf,

--- a/device/runtime/src/logging.rs
+++ b/device/runtime/src/logging.rs
@@ -6,11 +6,11 @@ use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 pub fn startup_marker(version: &str, pid: u32) -> String {
-    format!("===== YoYoPod starting (version={version}, pid={pid}) =====")
+    format!("===== yoyopod starting (version={version}, pid={pid}) =====")
 }
 
 pub fn shutdown_marker(pid: u32) -> String {
-    format!("===== YoYoPod shutting down (pid={pid}) =====")
+    format!("===== yoyopod shutting down (pid={pid}) =====")
 }
 
 pub fn log_info(message: impl AsRef<str>) {

--- a/device/runtime/src/voice.rs
+++ b/device/runtime/src/voice.rs
@@ -181,8 +181,8 @@ pub struct VoiceActivationResult {
     pub stripped_prefix: String,
 }
 
-const DEFAULT_ASK_INSTRUCTIONS: &str = "You are YoYoPod's friendly Ask helper for a child using a small handheld audio device. Answer in simple language a child can understand. Keep answers to 1-3 short sentences unless the child asks for a story. Be warm, calm, and encouraging. Do not use scary detail. Do not ask for private information. For medical, legal, safety, emergency, or adult topics, give a brief safe answer and say to ask a grown-up. If you are unsure, say so simply. Do not claim to browse the internet or know live facts.";
-const DEFAULT_STT_PROMPT: &str = "Transcribe this YoYoPod voice command in English Latin letters. Do not output Arabic, Persian, Korean, or other non-Latin scripts. Preserve family names such as mama, baba, mom, dad, mommy, daddy, and papa.";
+const DEFAULT_ASK_INSTRUCTIONS: &str = "You are yoyopod's friendly Ask helper for a child using a small handheld audio device. Answer in simple language a child can understand. Keep answers to 1-3 short sentences unless the child asks for a story. Be warm, calm, and encouraging. Do not use scary detail. Do not ask for private information. For medical, legal, safety, emergency, or adult topics, give a brief safe answer and say to ask a grown-up. If you are unsure, say so simply. Do not claim to browse the internet or know live facts.";
+const DEFAULT_STT_PROMPT: &str = "Transcribe this yoyopod voice command in English Latin letters. Do not output Arabic, Persian, Korean, or other non-Latin scripts. Preserve family names such as mama, baba, mom, dad, mommy, daddy, and papa.";
 const DEFAULT_TTS_INSTRUCTIONS: &str = "Speak warmly and calmly for a child. Use simple words, friendly pacing, and brief answers. Avoid scary emphasis.";
 
 const POLITE_PREFIX_TOKENS: &[&str] = &[

--- a/device/ui/UI_ARCH_SKELETON.html
+++ b/device/ui/UI_ARCH_SKELETON.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>YoyoPod UI — Architecture Skeleton</title>
+<title>yoyopod UI — Architecture Skeleton</title>
 <style>
   :root {
     --bg: #0f1218;
@@ -89,7 +89,7 @@
 <body>
 <div class="container">
 
-<h1>YoyoPod UI — Architecture Skeleton
+<h1>yoyopod UI — Architecture Skeleton
   <span class="sub">A buildable design that combines the web-framework structure lens with the game-engine aesthetics lens. This is the blueprint: layers, folder tree, struct shapes, enum definitions, scene construction, deck contracts, and the hard limits the SPI panel imposes on what the system can do per frame.</span>
 </h1>
 

--- a/device/ui/assets/ui/HANDOFF.md
+++ b/device/ui/assets/ui/HANDOFF.md
@@ -1,4 +1,4 @@
-# YoyoPod Device UI — Implementation Handoff
+# yoyopod Device UI — Implementation Handoff
 
 For the agent (or human) implementing this design in `device/ui/`. The mockups
 in this folder are **final** as of 2026-07-15. This document is the entry

--- a/device/ui/assets/ui/README.md
+++ b/device/ui/assets/ui/README.md
@@ -1,4 +1,4 @@
-# YoyoPod Device UI — Mockups & Design Specs
+# yoyopod Device UI — Mockups & Design Specs
 
 Static HTML design specs for the 240 × 280 Whisplay panel UI. Nothing in this
 folder is compiled into the device binary — these are the canonical design

--- a/device/ui/assets/ui/mockup_ask.html
+++ b/device/ui/assets/ui/mockup_ask.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Ask Flow · Implementation Spec · Flat</title>
+<title>yoyopod — Ask Flow · Implementation Spec · Flat</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800;900&display=swap');
 
@@ -295,7 +295,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Ask Flow · Implementation Spec · Flat</h1>
+<h1>yoyopod — Ask Flow · Implementation Spec · Flat</h1>
 <p class="muted">Ask is voice Q&amp;A with the AI: hold the side button, ask a question, let go, hear the answer. (Hardware note: this is the device's single button — on Ask the runtime's passthrough policy remaps its hold to PTT, see <code>mockup_input_model.html</code> §1.) It is a <b>single stateful surface</b> — no tabs, no list, no sub-routes, nothing to focus. The screen exists only to show <i>which phase of the conversation the device is in</i>: IDLE → LISTENING → THINKING → ANSWERING → IDLE. The stage tints full-bleed butter (<code>bg_stage_butter #FFF0CC</code>) — the v1 pale-butter inner card is retired with the flat pass, same full-bleed move as Listen v2's lime and Talk v5's peri. Everything on this screen is also spoken aloud — text is for grown-ups, never a requirement. Input model lives in its own doc: <code>mockup_input_model.html</code>.</p>
 
 <div class="legend">

--- a/device/ui/assets/ui/mockup_companions.html
+++ b/device/ui/assets/ui/mockup_companions.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Companion Variants · Owl / Cat / Bunny / Robot</title>
+<title>yoyopod — Companion Variants · Owl / Cat / Bunny / Robot</title>
 <style>
   :root {
     --panel-w: 240px;
@@ -220,7 +220,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Companion Variants</h1>
+<h1>yoyopod — Companion Variants</h1>
 <p class="muted">Three swappable animal companions for the Home stage, drawn in the same flat UI, outlined character style as the original Blob: thick 2px ink outlines, flat fills, breathing scale animation, blinking eyes. Body fill is a single token per variant — easy to recolor or swap on themes/events. The Blob remains available as a fourth fallback.</p>
 
 <!-- ============================================================ -->

--- a/device/ui/assets/ui/mockup_companions_dark.html
+++ b/device/ui/assets/ui/mockup_companions_dark.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Companion Variants · Dark Theme · Owl / Cat / Bunny / Robot</title>
+<title>yoyopod — Companion Variants · Dark Theme · Owl / Cat / Bunny / Robot</title>
 <style>
   :root {
     --panel-w: 240px;
@@ -227,7 +227,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Companion Variants · Dark Theme</h1>
+<h1>yoyopod — Companion Variants · Dark Theme</h1>
 <p class="muted">Dark-theme variant of the companion spec. <b>Owl and Bunny fills stay unchanged</b> — they already read well on either surface. <b>Cat and Robot get re-tuned</b>: cat butter washes out on dark (→ deep amber), and robot light-grey reads like white plastic (→ slate blue). What flips:</p>
 <ul class="muted" style="max-width: 760px; font-size: 13px; line-height: 1.55; margin-top: 6px;">
   <li><b>Outlines</b> (the 3 px stroke that wraps every body) flip from ink (near-black) to <code>ink</code> = warm off-white <code>#F2E8DA</code>, so the silhouettes show against the dark surface. Characters keep their ink outlines (illustrations, not UI); no drop-shadow.</li>

--- a/device/ui/assets/ui/mockup_home.html
+++ b/device/ui/assets/ui/mockup_home.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Home Screen · Implementation Spec</title>
+<title>yoyopod — Home Screen · Implementation Spec</title>
 <style>
   :root {
     /* ─── Panel ─── */
@@ -309,7 +309,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Home Screen · Implementation Spec</h1>
+<h1>yoyopod — Home Screen · Implementation Spec</h1>
 <p class="muted">Canonical mockup of the <b>Home</b> screen: the landing surface the device returns to on long-press from any category root. Five states are documented — idle (no slot focused) and one focused state per deck slot (Listen, Talk, Ask, Setup). The companion <b>Blob</b> lives only on Home; no other screen renders it. Panel canvas is 240 × 280 px.</p>
 <p class="muted"><b>2026-07-15 · flat pass</b> — borders + hard shadows removed (Blob keeps its character outline), deck focused slot = inset pill, neutral bezel replaces the orange prototype frame. Matches Listen v2.1 / Talk v5.1.</p>
 

--- a/device/ui/assets/ui/mockup_input_model.html
+++ b/device/ui/assets/ui/mockup_input_model.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Input Model · Gesture Contract</title>
+<title>yoyopod — Input Model · Gesture Contract</title>
 <style>
   :root {
     --panel-w: 240px;
@@ -252,7 +252,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Input Model</h1>
+<h1>yoyopod — Input Model</h1>
 <p class="muted">three-gesture contract · main button today, whole-surface touch tomorrow · single source of truth</p>
 
 <p style="background:#2a2025; border:1px solid #4a3a30; border-radius:8px; padding:10px 14px; font-size:13px; color:#c9b9a3; max-width:760px;">

--- a/device/ui/assets/ui/mockup_listen.html
+++ b/device/ui/assets/ui/mockup_listen.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Listen Flow · v2 · Wheel + Arc Hero · Implementation Spec</title>
+<title>yoyopod — Listen Flow · v2 · Wheel + Arc Hero · Implementation Spec</title>
 <style>
   :root {
     /* ─── Panel ─── */
@@ -435,7 +435,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Listen Flow · v2 · Wheel + Arc Hero · Implementation Spec</h1>
+<h1>yoyopod — Listen Flow · v2 · Wheel + Arc Hero · Implementation Spec</h1>
 <p class="muted">Canonical mockup of the <b>Listen</b> category, redesigned around two primitives: the <b>wheel</b> (carousel menu — the focused tile is a flat, accent-filled card) and the <b>arc hero</b> (ring-progress NowPlaying). Chrome is <b>flat, color-first</b> (v2.1): no borders, no shadows anywhere — the one surviving stroke is the transient focus ring on transport targets. Tab strip, card, and rows are retired. <b>This file owns both primitives</b> — <code>mockup_talk.html</code> references them. Every pixel in the renders is sourced from the §3/§4 tables — no magic numbers. Panel canvas is 240 × 280 px: status bar y 0–22 · stage y 22–228 · deck y 228–280. One hardware button (press = roll · double-press = open · long-press ≥ 400 ms = Home; on capture screens the hold remaps to PTT — none in this flow); a voice prompt speaks every focused label.</p>
 
 <div class="legend">

--- a/device/ui/assets/ui/mockup_listen_dark.html
+++ b/device/ui/assets/ui/mockup_listen_dark.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Listen Flow · v2 · Wheel + Arc Hero · Dark Theme · Implementation Spec</title>
+<title>yoyopod — Listen Flow · v2 · Wheel + Arc Hero · Dark Theme · Implementation Spec</title>
 <style>
   :root {
     /* ─── Panel ─── */
@@ -442,7 +442,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Listen Flow · v2 · Wheel + Arc Hero · Dark Theme</h1>
+<h1>yoyopod — Listen Flow · v2 · Wheel + Arc Hero · Dark Theme</h1>
 <p class="muted">Dark-theme variant of the canonical Listen spec (<code>mockup_listen.html</code> · "Listen Flow · v2.1", flat wheel + arc hero). <b>Strict token swap:</b> page structure, geometry, behavior, and renders are identical to the light file — only the surface/ink color tokens change, plus one dark-only token, <code>ink_on_accent</code>, for content sitting on a bright accent fill. Chrome stays <b>flat, color-first</b> (v2.1): no borders, no shadows — the one surviving stroke is the transient focus ring on transport targets, drawn in dark <code>ink</code> (warm off-white). <b>The light file is normative for everything except color</b> — every pixel in the renders below is sourced from its §3/§4 tables. Panel canvas is 240 × 280 px: status bar y 0–22 · stage y 22–228 · deck y 228–280. One hardware button (press = roll · double-press = open · long-press ≥ 400 ms = Home; on capture screens the hold remaps to PTT — none in this flow); a voice prompt speaks every focused label.</p>
 
 <div class="legend">

--- a/device/ui/assets/ui/mockup_setup.html
+++ b/device/ui/assets/ui/mockup_setup.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Setup Flow · Implementation Spec (v2 · wheel + flat)</title>
+<title>yoyopod — Setup Flow · Implementation Spec (v2 · wheel + flat)</title>
 <style>
   :root {
     --panel-w: 240px;
@@ -292,7 +292,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Setup Flow · Implementation Spec <span style="color:#8a7c6c">· v2 wheel + flat</span></h1>
+<h1>yoyopod — Setup Flow · Implementation Spec <span style="color:#8a7c6c">· v2 wheel + flat</span></h1>
 <p class="muted">Setup is the grown-up corner of the device, re-presented on the system-wide pattern: <b>wheel navigation + fully flat chrome + neutral bezel</b>. One hardware button, three gestures (<b>press</b> = roll the wheel one step · <b>double-press</b> = open / activate · <b>long-press ≥ 400 ms</b> = Home; see <code>mockup_input_model.html</code>), plus the side PTT which Setup never remaps. Every roll speaks the newly focused label (the Speak-names accessibility feature, §6). Setup's accent is <code>c_coral</code>; the whole stage is tinted full-bleed <code>bg_stage_coral</code> — the user reads "I'm in Setup" from the surface itself, no card, no label. The wheel's normative spec lives in <code>mockup_listen.html §3</code>; the values used here are restated in §8. This spec replaces and extends the shipped runtime's <code>Power</code> screen (§11).</p>
 
 <div class="legend">

--- a/device/ui/assets/ui/mockup_system.html
+++ b/device/ui/assets/ui/mockup_system.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — System Overlays · Loading + Error · Implementation Spec</title>
+<title>yoyopod — System Overlays · Loading + Error · Implementation Spec</title>
 <style>
   :root {
     --panel-w: 240px;
@@ -215,7 +215,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — System Overlays · Loading + Error · Implementation Spec</h1>
+<h1>yoyopod — System Overlays · Loading + Error · Implementation Spec</h1>
 <p class="muted">The last two runtime routes with no design: <code>UiScreen::Loading</code> and <code>UiScreen::Error</code>. Both are <b>overlays</b> (<code>NavigationPolicy::Overlay</code>, <code>Persistence::Singleton</code>) — they float over whatever screen was active, never replace it, and there is exactly one instance of each. Small and friendly: a kid aged 3–7 sees a gentle pause or a butter "oops", never a hang and never a stack trace. Voice speaks everything important — pre-readers complete both flows without decoding a word. Frames below sit over a plain cream stage for clarity; frame 2 shows real overlay semantics with a dimmed wheel behind. Flat system: no UI borders, no drop shadows — fills + radius only. Input model lives in <code>mockup_input_model.html</code>.</p>
 
 <!-- ============================================================ -->

--- a/device/ui/assets/ui/mockup_talk.html
+++ b/device/ui/assets/ui/mockup_talk.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Talk Flow · v5.1 · Contact Wheel + De-boxed Calls · Flat</title>
+<title>yoyopod — Talk Flow · v5.1 · Contact Wheel + De-boxed Calls · Flat</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800&display=swap');
 
@@ -430,7 +430,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Talk Flow · v5.1 · Contact Wheel + De-boxed Calls · Flat</h1>
+<h1>yoyopod — Talk Flow · v5.1 · Contact Wheel + De-boxed Calls · Flat</h1>
 <p class="muted">De-boxing pass, now fully <b>flat, color-first</b> (v5.1): no borders, no hard shadows anywhere — the 2&nbsp;px ink focus ring on call buttons and Replay transport is the one surviving stroke; focus elsewhere = fill + size + spoken label. <b>(1)</b> The peri card + 28&nbsp;px rows become a 3-slot <b>contact wheel</b> — the focused tile is the only plate on screen. <b>(2)</b> The tab strip retires; depth ≥&nbsp;2 gets one 12&nbsp;px uppercase <b>context label</b>, no box. <b>(3)</b> The card tint becomes a <b>full-bleed stage tint</b> (<code>bg_stage_peri</code>). <b>(4)</b> Call overlays lose the cream card and pill buttons entirely. <b>(5)</b> Recording is a full-bleed tomato state. PTT contract, stuck semantics, per-contact replay, and the route inventory are all unchanged from v4.</p>
 <p><b>Wheel and Arc-Hero primitive geometry, animation, and FFI tables are normative in <code>mockup_listen.html</code> §3/§4/§7; this file specifies only Talk's variants and deltas.</b></p>
 

--- a/device/ui/build.rs
+++ b/device/ui/build.rs
@@ -16,7 +16,7 @@ fn main() {
         manifest_dir
             .join("native/lvgl")
             .canonicalize()
-            .expect("canonicalize YoYoPod LVGL build directory"),
+            .expect("canonicalize yoyopod LVGL build directory"),
     );
     let lvgl_source_dir = env::var("YOYOPOD_LVGL_SOURCE_DIR")
         .or_else(|_| env::var("LVGL_SOURCE_DIR"))

--- a/device/ui/native/lvgl/CMakeLists.txt
+++ b/device/ui/native/lvgl/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT LVGL_SOURCE_DIR)
   message(FATAL_ERROR "LVGL_SOURCE_DIR must point to an LVGL checkout")
 endif()
 
-# YoYoPod does not use LVGL vector graphics or Lottie, so keep ThorVG off
+# yoyopod does not use LVGL vector graphics or Lottie, so keep ThorVG off
 # even if upstream desktop defaults enable it.
 set(CONFIG_LV_USE_THORVG_INTERNAL OFF CACHE BOOL "Disable LVGL ThorVG integration" FORCE)
 set(CONFIG_LV_BUILD_EXAMPLES OFF CACHE BOOL "Disable LVGL examples" FORCE)

--- a/device/voip/src/main.rs
+++ b/device/voip/src/main.rs
@@ -7,7 +7,7 @@ fn main() -> Result<()> {
 
     #[derive(Debug, Parser)]
     #[command(name = "yoyopod-voip-host")]
-    #[command(about = "YoYoPod Rust VoIP host")]
+    #[command(about = "yoyopod Rust VoIP host")]
     struct Args {}
 
     let _args = Args::parse();

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# YoYoPod Documentation
+# yoyopod Documentation
 
 This page is the entry point for repo documentation.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,4 @@
-# YoYoPod Roadmap
+# yoyopod Roadmap
 
 This is the project's living roadmap. It tracks the rounds of the Rust
 CLI rebuild — what's done, what's paused, when each gap closes.

--- a/docs/architecture/CANONICAL_STRUCTURE.md
+++ b/docs/architecture/CANONICAL_STRUCTURE.md
@@ -84,7 +84,7 @@ overlay shapes.
 
 ## Canonical Package Ownership
 
-YoYoPod uses a hybrid ownership model:
+yoyopod uses a hybrid ownership model:
 
 - domain packages own domain behavior and models
 - app/runtime composition owns app wiring and lifecycle

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,7 +1,7 @@
 # Architecture Docs
 
 Runtime topology, package/config ownership, event flow, and the
-cross-cutting structural contracts that define how YoYoPod is composed.
+cross-cutting structural contracts that define how yoyopod is composed.
 
 - [`SYSTEM_ARCHITECTURE.md`](SYSTEM_ARCHITECTURE.md) - current runtime
   shape: the Rust runtime, the worker hosts, and the operator CLI

--- a/docs/architecture/SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM_ARCHITECTURE.md
@@ -1,9 +1,9 @@
-# YoYoPod System Architecture
+# yoyopod System Architecture
 
 **Last updated:** 2026-05-06
 **Status:** Current implementation
 
-YoYoPod is now Rust-first. The supported app runtime is the Rust
+yoyopod is now Rust-first. The supported app runtime is the Rust
 `yoyopod-runtime` binary in `device/runtime`; Python is operations tooling only.
 
 ## Runtime Owner

--- a/docs/architecture/WORK_AREAS.md
+++ b/docs/architecture/WORK_AREAS.md
@@ -1,6 +1,6 @@
 # Repo Work Areas
 
-YoYoPod is now Rust-first for the device runtime. Use this map when deciding
+yoyopod is now Rust-first for the device runtime. Use this map when deciding
 where a change belongs.
 
 ## Primary Runtime

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,6 +1,6 @@
 # Design Docs
 
-UI design targets and visual references for YoYoPod on Whisplay
+UI design targets and visual references for yoyopod on Whisplay
 (240x280 portrait, single side button).
 
 - [`previews/`](previews/) - static HTML visual references for each

--- a/docs/design/previews/field-notes.html
+++ b/docs/design/previews/field-notes.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>YoYoPod Design Preview - Field Notes</title>
+  <title>yoyopod Design Preview - Field Notes</title>
   <style>
     :root {
       --bg: #f6f1e7;

--- a/docs/design/previews/graffiti-buddy.html
+++ b/docs/design/previews/graffiti-buddy.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>YoYoPod Design Preview - Graffiti Buddy</title>
+  <title>yoyopod Design Preview - Graffiti Buddy</title>
   <style>
     :root {
       --shell: #ffde3a;

--- a/docs/design/previews/index.html
+++ b/docs/design/previews/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>YoYoPod Design Previews</title>
+  <title>yoyopod Design Previews</title>
   <style>
     :root {
       --paper: #f4efe6;
@@ -142,7 +142,7 @@
 <body>
   <main>
     <section class="hero">
-      <span class="eyebrow">YoYoPod Visual Directions</span>
+      <span class="eyebrow">yoyopod Visual Directions</span>
       <h1>Three small HTML previews for the next production look.</h1>
       <p>
         Each concept uses the same device moments so you can compare feel rather than layout changes:

--- a/docs/design/previews/pocket-arcade.html
+++ b/docs/design/previews/pocket-arcade.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>YoYoPod Design Preview - Pocket Arcade</title>
+  <title>yoyopod Design Preview - Pocket Arcade</title>
   <style>
     :root {
       --shell: #3551ff;

--- a/docs/design/previews/round-two.html
+++ b/docs/design/previews/round-two.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>YoYoPod Design Previews - Round Two</title>
+  <title>yoyopod Design Previews - Round Two</title>
   <style>
     :root {
       --ink: #1f2430;

--- a/docs/design/previews/safety-badge.html
+++ b/docs/design/previews/safety-badge.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>YoYoPod Design Preview - Safety Badge</title>
+  <title>yoyopod Design Preview - Safety Badge</title>
   <style>
     :root {
       --bg: #e9eef0;

--- a/docs/design/previews/sticker-glow.html
+++ b/docs/design/previews/sticker-glow.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>YoYoPod Design Preview - Sticker Glow</title>
+  <title>yoyopod Design Preview - Sticker Glow</title>
   <style>
     :root {
       --paper: #fff8ea;

--- a/docs/design/previews/toy-radio.html
+++ b/docs/design/previews/toy-radio.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>YoYoPod Design Preview - Toy Radio</title>
+  <title>yoyopod Design Preview - Toy Radio</title>
   <style>
     :root {
       --bg: #fff6e8;

--- a/docs/features/CLOUD_PROVISIONING_AND_BACKEND.md
+++ b/docs/features/CLOUD_PROVISIONING_AND_BACKEND.md
@@ -1,6 +1,6 @@
 # Cloud Provisioning, Backend Connection, And MQTT Telemetry
 
-This document is the device/runtime-side reference for how YoYoPod talks to the
+This document is the device/runtime-side reference for how yoyopod talks to the
 backend.
 
 It covers:
@@ -93,7 +93,7 @@ Host events include:
 
 ## MQTT Topics
 
-The backend topic contract still uses the YoYoPod device namespace:
+The backend topic contract still uses the yoyopod device namespace:
 
 - publish device events to `yoyopod/{device_id}/evt`
 - subscribe for backend commands on `yoyopod/{device_id}/cmd`

--- a/docs/features/CLOUD_VOICE_WORKER.md
+++ b/docs/features/CLOUD_VOICE_WORKER.md
@@ -37,7 +37,7 @@ YOYOPOD_CLOUD_ASK_MAX_RESPONSE_CHARS=480
 
 For the prod lane, use `/etc/default/yoyopod-prod` instead.
 
-OpenAI requires disclosure that TTS output is AI-generated. YoYoPod should be
+OpenAI requires disclosure that TTS output is AI-generated. yoyopod should be
 treated as an AI voice device whenever cloud TTS is enabled.
 
 The file is group-readable because the remote dev workflow sources lane

--- a/docs/features/LOCAL_FIRST_MUSIC_PLAN.md
+++ b/docs/features/LOCAL_FIRST_MUSIC_PLAN.md
@@ -4,7 +4,7 @@
 
 ## Decision
 
-YoYoPod's `Listen` experience is now local-first and local-only.
+yoyopod's `Listen` experience is now local-first and local-only.
 
 The product no longer treats Spotify, Amazon Music, or other providers as active `Listen` sources. `Listen` now means on-device music managed through an app-owned mpv backend and filesystem library.
 
@@ -20,10 +20,10 @@ The `Listen` root mode opens a small local library menu:
 
 ## Backend Contract
 
-YoYoPod now uses an app-managed mpv backend plus filesystem scanning:
+yoyopod now uses an app-managed mpv backend plus filesystem scanning:
 
 - local playlists are discovered from `.m3u` files under `audio.music_dir`
-- recent tracks are stored by YoYoPod from mpv track-change events
+- recent tracks are stored by yoyopod from mpv track-change events
 - shuffle builds a queue from filesystem track paths
 - metadata falls back to local tag reads when mpv metadata is sparse
 

--- a/docs/features/MPV_DEPENDENCIES.md
+++ b/docs/features/MPV_DEPENDENCIES.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-YoYoPod uses an app-managed mpv process as a local-only music backend.
+yoyopod uses an app-managed mpv process as a local-only music backend.
 
 This means:
 
@@ -16,7 +16,7 @@ This means:
 
 It does not mean Spotify or Amazon Music support in the current product.
 
-## Runtime Role In YoYoPod
+## Runtime Role In yoyopod
 
 mpv currently provides:
 
@@ -80,12 +80,12 @@ Expected checks:
 - mpv starts cleanly under app control
 - local playlists are visible
 - local tracks play through the configured ALSA device
-- YoYoPod can reach mpv over the configured IPC socket
+- yoyopod can reach mpv over the configured IPC socket
 
 ## Current Product Guidance
 
 - Keep mpv as the local playback engine
-- keep the YoYoPod product local-first
+- keep the yoyopod product local-first
 - do not treat streaming providers as active product sources unless that becomes a separate approved project decision
 
 ## References

--- a/docs/features/REMOTE_PLAYBACK.md
+++ b/docs/features/REMOTE_PLAYBACK.md
@@ -1,4 +1,4 @@
-# YoYoPod Remote Playback On Device
+# yoyopod Remote Playback On Device
 
 This document describes the current device-side playback and media-import behavior for `yoyo-py`.
 

--- a/docs/features/WIFI_ONBOARDING.md
+++ b/docs/features/WIFI_ONBOARDING.md
@@ -1,6 +1,6 @@
 # On-Device Wi-Fi Onboarding
 
-Connect a YoYoPod to home Wi-Fi with no companion app and no keyboard: on the
+Connect a yoyopod to home Wi-Fi with no companion app and no keyboard: on the
 device pick **Settings → Wi-Fi**, and it turns its own radio into a temporary
 Access Point, shows a QR code, and serves a captive-portal web page where a
 phone selects the network and enters the password.

--- a/docs/hardware/AUDIO_STACK.md
+++ b/docs/hardware/AUDIO_STACK.md
@@ -1,11 +1,11 @@
-# YoYoPod Audio Stack
+# yoyopod Audio Stack
 
 **Last Verified:** 2026-04-08
 **Verified Against:** `origin/main` plus live `rpi-zero` runtime
 
 ## Overview
 
-YoYoPod now uses an app-managed `mpv` process for music playback and Liblinphone for call audio.
+yoyopod now uses an app-managed `mpv` process for music playback and Liblinphone for call audio.
 
 For music playback, the runtime path is:
 
@@ -141,7 +141,7 @@ Verified live on `rpi-zero`:
 So the effective music loudness comes from:
 
 ```text
-YoYoPod shared volume
+yoyopod shared volume
   -> ALSA mixer controls
   -> mpv volume property
   -> WM8960 analog output stage
@@ -165,7 +165,7 @@ mpv
   -> speaker / headphone analog output
 ```
 
-There is also HDMI audio on card 1, but the current YoYoPod music runtime is using the WM8960 path, not HDMI.
+There is also HDMI audio on card 1, but the current yoyopod music runtime is using the WM8960 path, not HDMI.
 
 ## Call Audio Relationship
 
@@ -191,7 +191,7 @@ They are separate software paths that meet at the same codec/hardware.
 - There is no Mopidy or GStreamer dependency in the current production music path.
 - `mpv` is spawned by the app and dies with the app.
 - If music works but is quiet, check both:
-  - YoYoPod shared volume
+  - yoyopod shared volume
   - ALSA `Speaker` / `Headphone` mixer levels
 - If `Now Playing` is wrong, inspect the Rust media host snapshot and mpv IPC logs.
 

--- a/docs/hardware/POWER_MODULE.md
+++ b/docs/hardware/POWER_MODULE.md
@@ -1,6 +1,6 @@
 # Power Module
 
-This document is the dedicated source of truth for YoYoPod's PiSugar-backed power subsystem.
+This document is the dedicated source of truth for yoyopod's PiSugar-backed power subsystem.
 
 Current target hardware:
 - Raspberry Pi Zero 2W
@@ -232,7 +232,7 @@ Required system package:
 - `i2c-tools`
 
 Important expectation:
-- YoYoPod should be started by `systemd` on boot when watchdog mode is used
+- yoyopod should be started by `systemd` on boot when watchdog mode is used
 
 Current production unit:
 - `deploy/systemd/yoyopod-prod.service`

--- a/docs/hardware/README.md
+++ b/docs/hardware/README.md
@@ -1,7 +1,7 @@
 # Hardware Docs
 
 Device-specific runtime dependencies and audio/power behaviour for
-YoYoPod, plus enclosure design directions.
+yoyopod, plus enclosure design directions.
 
 - [`AUDIO_STACK.md`](AUDIO_STACK.md) - ALSA routing, WM8960 headroom,
   and mpv output behaviour

--- a/docs/hardware/enclosure/README.md
+++ b/docs/hardware/enclosure/README.md
@@ -1,6 +1,6 @@
 # Enclosure Wireframes
 
-Industrial-design wireframes for the YoYoPod handheld shell — flat
+Industrial-design wireframes for the yoyopod handheld shell — flat
 orthographic views (top, front, right, back, bottom) plus a depth
 section. These are design directions, not a released mechanical
 contract: no CAD, no tooling drawings, no tolerance sign-off.

--- a/docs/operations/CONTRIBUTOR_WORKFLOW.md
+++ b/docs/operations/CONTRIBUTOR_WORKFLOW.md
@@ -1,6 +1,6 @@
 # Contributor Workflow
 
-This guide is the shortest path from fresh checkout to a credible YoYoPod contribution.
+This guide is the shortest path from fresh checkout to a credible yoyopod contribution.
 
 It is not a full architecture document and it is not a board bringup manual.
 
@@ -132,7 +132,7 @@ in the PR instead of pretending CI covered more than it did.
 
 ## What a good PR looks like here
 
-A good YoYoPod PR:
+A good yoyopod PR:
 
 - stays within one coherent problem slice
 - updates docs when the contract changes

--- a/docs/operations/DEV_PROD_LANES.md
+++ b/docs/operations/DEV_PROD_LANES.md
@@ -1,6 +1,6 @@
 # Dev and Prod Lane Contract
 
-YoYoPod boards can keep two deployment lanes installed at the same time:
+yoyopod boards can keep two deployment lanes installed at the same time:
 
 - **Dev lane**: mutable checkout for fast hardware testing from a PR branch.
 - **Prod lane**: immutable slot/OTA runtime for packaged releases.

--- a/docs/operations/PI_DEV_WORKFLOW.md
+++ b/docs/operations/PI_DEV_WORKFLOW.md
@@ -1,6 +1,6 @@
 # Raspberry Pi Dev Workflow
 
-This guide covers the normal dev-machine-to-board loop for YoYoPod.
+This guide covers the normal dev-machine-to-board loop for yoyopod.
 
 For fresh-board bootstrap, lane structure, and rollback, read:
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,6 +1,6 @@
 # Operations Docs
 
-Setup, deploy, and daily-workflow operations for YoYoPod on the Pi.
+Setup, deploy, and daily-workflow operations for yoyopod on the Pi.
 
 For the current state of the operator CLI and which capabilities are
 temporarily paused, read [`../ROADMAP.md`](../ROADMAP.md) first.

--- a/docs/operations/SETUP_CONTRACT.md
+++ b/docs/operations/SETUP_CONTRACT.md
@@ -1,6 +1,6 @@
 # Setup and System Dependency Contract
 
-This document defines the baseline setup contract for YoYoPod Core. As
+This document defines the baseline setup contract for yoyopod Core. As
 of 2026-05-13, automated setup commands (`yoyopod setup …`,
 `yoyopod target setup …`) were deleted in Round 0 of the CLI rebuild;
 see [`../ROADMAP.md`](../ROADMAP.md). Until the

--- a/docs/product/LANDING_PAGE_POSITIONING.md
+++ b/docs/product/LANDING_PAGE_POSITIONING.md
@@ -14,7 +14,7 @@ Best choice:
 The first device before a smartphone
 
 ## Subheadline
-YoYoPod is a parent-managed companion device for kids ages 7–14, built for safe communication, live location, and everyday audio without the distraction, complexity, or screen addiction of a smartphone.
+yoyopod is a parent-managed companion device for kids ages 7–14, built for safe communication, live location, and everyday audio without the distraction, complexity, or screen addiction of a smartphone.
 
 ## Primary CTA ideas
 - Join the waitlist
@@ -44,13 +44,13 @@ See your child’s live-ish location when they’re out in the world, without ha
 A tiny screen, simple controls, and a focused experience help kids feel grown-up without pulling them into endless apps and notifications.
 
 4. Music and audio they actually enjoy
-At home, YoYoPod is a simple everyday audio companion for music, stories, and listening.
+At home, yoyopod is a simple everyday audio companion for music, stories, and listening.
 
 5. Parent-managed from a mobile app
 Contacts, settings, and device controls stay in the parent’s hands, where they belong.
 
 ## Three-line positioning block
-For kids, YoYoPod feels like freedom.
+For kids, yoyopod feels like freedom.
 For parents, it feels like reassurance.
 For both, it’s a better step before the smartphone years.
 
@@ -59,7 +59,7 @@ Step 1
 Parents set up approved contacts and device settings in the mobile app.
 
 Step 2
-Kids carry YoYoPod as their simple, everyday companion for listening, calling, and getting around independently.
+Kids carry yoyopod as their simple, everyday companion for listening, calling, and getting around independently.
 
 Step 3
 Parents can reach them, hear from them, and check their location when it matters.
@@ -67,7 +67,7 @@ Parents can reach them, hear from them, and check their location when it matters
 ## Why not just give them a phone?
 Because most kids don’t need the internet in their pocket before they need independence.
 
-YoYoPod is built for the stage before a smartphone:
+yoyopod is built for the stage before a smartphone:
 - communication without app overload
 - location without social media
 - independence without endless distraction
@@ -79,7 +79,7 @@ What parents actually need is simple:
 - Can they reach me?
 - Can I see where they are?
 
-YoYoPod is built around those questions first.
+yoyopod is built around those questions first.
 
 ## Kid/parent dual-sided section
 For kids:
@@ -95,7 +95,7 @@ For parents:
 - More confidence when kids are out on their own
 
 ## Anti-positioning
-YoYoPod is not:
+yoyopod is not:
 - a smartphone replacement
 - a toy
 - a screen-first device
@@ -109,7 +109,7 @@ Headline:
 The first device before a smartphone
 
 Subheadline:
-YoYoPod is a parent-managed companion device for kids ages 7–14, built for safe communication, live location, and everyday audio without the distraction, complexity, or screen addiction of a smartphone.
+yoyopod is a parent-managed companion device for kids ages 7–14, built for safe communication, live location, and everyday audio without the distraction, complexity, or screen addiction of a smartphone.
 
 CTA:
 Join the waitlist
@@ -122,7 +122,7 @@ Parents want their kids to have independence, communication, and safety.
 They don’t want to hand over distraction, social media, and addictive screens to get it.
 
 3. Solution section
-YoYoPod gives kids a focused device for communication, audio, and mobility, while giving parents the confidence to stay connected.
+yoyopod gives kids a focused device for communication, audio, and mobility, while giving parents the confidence to stay connected.
 
 4. Value props
 - Safe communication
@@ -149,7 +149,7 @@ Headline:
 The first device before a smartphone
 
 Subheadline:
-YoYoPod helps kids stay connected, independent, and easy to reach with simple calling, voice messages, live location, and everyday audio — all under parent control.
+yoyopod helps kids stay connected, independent, and easy to reach with simple calling, voice messages, live location, and everyday audio — all under parent control.
 
 CTA:
 Join the waitlist
@@ -165,7 +165,7 @@ Headline:
 Give them independence. Not a smartphone.
 
 Subheadline:
-YoYoPod is a simple connected device for kids ages 7–14 that gives families safe communication, location visibility, and peace of mind before the smartphone years.
+yoyopod is a simple connected device for kids ages 7–14 that gives families safe communication, location visibility, and peace of mind before the smartphone years.
 
 CTA:
 Join the waitlist

--- a/docs/product/PRODUCT_DEFINITION.md
+++ b/docs/product/PRODUCT_DEFINITION.md
@@ -1,10 +1,10 @@
-# YoYoPod Product Definition
+# yoyopod Product Definition
 
-YoYoPod is a parent-managed first independent device for kids ages 7–14, built for the gap before a smartphone. It gives children a focused sense of independence through simple communication, music, and mobility, while giving parents peace of mind through reliable calling and live location visibility, without the distraction, complexity, and screen addiction of a full smartphone.
+yoyopod is a parent-managed first independent device for kids ages 7–14, built for the gap before a smartphone. It gives children a focused sense of independence through simple communication, music, and mobility, while giving parents peace of mind through reliable calling and live location visibility, without the distraction, complexity, and screen addiction of a full smartphone.
 
 Short version:
 
-YoYoPod is the first device before a smartphone: a simple, walkie-talkie-like companion for kids that enables safe communication, music, and location sharing under parent control.
+yoyopod is the first device before a smartphone: a simple, walkie-talkie-like companion for kids that enables safe communication, music, and location sharing under parent control.
 
 Positioning line:
 

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -1,6 +1,6 @@
 # Product Docs
 
-Product-definition artefacts for YoYoPod V1.
+Product-definition artefacts for yoyopod V1.
 
 - [`PRODUCT_DEFINITION.md`](PRODUCT_DEFINITION.md) - crisp product
   definition and positioning core

--- a/docsite/website-vision/src/content/docs/company/mission.md
+++ b/docsite/website-vision/src/content/docs/company/mission.md
@@ -49,7 +49,7 @@ reachability** and **trustworthy location**. Everything else is
 secondary — including everything the answer refuses to be
 ([What yoyopod Is Not](/company/what-we-are-not/)).
 
-> For kids, YoYoPod feels like freedom.
+> For kids, yoyopod feels like freedom.
 > For parents, it feels like reassurance.
 > For both, it's a better step before the smartphone years.
 

--- a/docsite/website/public/mockups/mockup_ask.html
+++ b/docsite/website/public/mockups/mockup_ask.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Ask Flow · Implementation Spec · Flat</title>
+<title>yoyopod — Ask Flow · Implementation Spec · Flat</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800;900&display=swap');
 
@@ -295,7 +295,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Ask Flow · Implementation Spec · Flat</h1>
+<h1>yoyopod — Ask Flow · Implementation Spec · Flat</h1>
 <p class="muted">Ask is voice Q&amp;A with the AI: hold the side button, ask a question, let go, hear the answer. (Hardware note: this is the device's single button — on Ask the runtime's passthrough policy remaps its hold to PTT, see <code>mockup_input_model.html</code> §1.) It is a <b>single stateful surface</b> — no tabs, no list, no sub-routes, nothing to focus. The screen exists only to show <i>which phase of the conversation the device is in</i>: IDLE → LISTENING → THINKING → ANSWERING → IDLE. The stage tints full-bleed butter (<code>bg_stage_butter #FFF0CC</code>) — the v1 pale-butter inner card is retired with the flat pass, same full-bleed move as Listen v2's lime and Talk v5's peri. Everything on this screen is also spoken aloud — text is for grown-ups, never a requirement. Input model lives in its own doc: <code>mockup_input_model.html</code>.</p>
 
 <div class="legend">

--- a/docsite/website/public/mockups/mockup_companions.html
+++ b/docsite/website/public/mockups/mockup_companions.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Companion Variants · Owl / Cat / Bunny / Robot</title>
+<title>yoyopod — Companion Variants · Owl / Cat / Bunny / Robot</title>
 <style>
   :root {
     --panel-w: 240px;
@@ -220,7 +220,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Companion Variants</h1>
+<h1>yoyopod — Companion Variants</h1>
 <p class="muted">Three swappable animal companions for the Home stage, drawn in the same flat UI, outlined character style as the original Blob: thick 2px ink outlines, flat fills, breathing scale animation, blinking eyes. Body fill is a single token per variant — easy to recolor or swap on themes/events. The Blob remains available as a fourth fallback.</p>
 
 <!-- ============================================================ -->

--- a/docsite/website/public/mockups/mockup_companions_dark.html
+++ b/docsite/website/public/mockups/mockup_companions_dark.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Companion Variants · Dark Theme · Owl / Cat / Bunny / Robot</title>
+<title>yoyopod — Companion Variants · Dark Theme · Owl / Cat / Bunny / Robot</title>
 <style>
   :root {
     --panel-w: 240px;
@@ -227,7 +227,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Companion Variants · Dark Theme</h1>
+<h1>yoyopod — Companion Variants · Dark Theme</h1>
 <p class="muted">Dark-theme variant of the companion spec. <b>Owl and Bunny fills stay unchanged</b> — they already read well on either surface. <b>Cat and Robot get re-tuned</b>: cat butter washes out on dark (→ deep amber), and robot light-grey reads like white plastic (→ slate blue). What flips:</p>
 <ul class="muted" style="max-width: 760px; font-size: 13px; line-height: 1.55; margin-top: 6px;">
   <li><b>Outlines</b> (the 3 px stroke that wraps every body) flip from ink (near-black) to <code>ink</code> = warm off-white <code>#F2E8DA</code>, so the silhouettes show against the dark surface. Characters keep their ink outlines (illustrations, not UI); no drop-shadow.</li>

--- a/docsite/website/public/mockups/mockup_home.html
+++ b/docsite/website/public/mockups/mockup_home.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Home Screen · Implementation Spec</title>
+<title>yoyopod — Home Screen · Implementation Spec</title>
 <style>
   :root {
     /* ─── Panel ─── */
@@ -309,7 +309,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Home Screen · Implementation Spec</h1>
+<h1>yoyopod — Home Screen · Implementation Spec</h1>
 <p class="muted">Canonical mockup of the <b>Home</b> screen: the landing surface the device returns to on long-press from any category root. Five states are documented — idle (no slot focused) and one focused state per deck slot (Listen, Talk, Ask, Setup). The companion <b>Blob</b> lives only on Home; no other screen renders it. Panel canvas is 240 × 280 px.</p>
 <p class="muted"><b>2026-07-15 · flat pass</b> — borders + hard shadows removed (Blob keeps its character outline), deck focused slot = inset pill, neutral bezel replaces the orange prototype frame. Matches Listen v2.1 / Talk v5.1.</p>
 

--- a/docsite/website/public/mockups/mockup_input_model.html
+++ b/docsite/website/public/mockups/mockup_input_model.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Input Model · Gesture Contract</title>
+<title>yoyopod — Input Model · Gesture Contract</title>
 <style>
   :root {
     --panel-w: 240px;
@@ -252,7 +252,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Input Model</h1>
+<h1>yoyopod — Input Model</h1>
 <p class="muted">three-gesture contract · main button today, whole-surface touch tomorrow · single source of truth</p>
 
 <p style="background:#2a2025; border:1px solid #4a3a30; border-radius:8px; padding:10px 14px; font-size:13px; color:#c9b9a3; max-width:760px;">

--- a/docsite/website/public/mockups/mockup_listen.html
+++ b/docsite/website/public/mockups/mockup_listen.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Listen Flow · v2 · Wheel + Arc Hero · Implementation Spec</title>
+<title>yoyopod — Listen Flow · v2 · Wheel + Arc Hero · Implementation Spec</title>
 <style>
   :root {
     /* ─── Panel ─── */
@@ -435,7 +435,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Listen Flow · v2 · Wheel + Arc Hero · Implementation Spec</h1>
+<h1>yoyopod — Listen Flow · v2 · Wheel + Arc Hero · Implementation Spec</h1>
 <p class="muted">Canonical mockup of the <b>Listen</b> category, redesigned around two primitives: the <b>wheel</b> (carousel menu — the focused tile is a flat, accent-filled card) and the <b>arc hero</b> (ring-progress NowPlaying). Chrome is <b>flat, color-first</b> (v2.1): no borders, no shadows anywhere — the one surviving stroke is the transient focus ring on transport targets. Tab strip, card, and rows are retired. <b>This file owns both primitives</b> — <code>mockup_talk.html</code> references them. Every pixel in the renders is sourced from the §3/§4 tables — no magic numbers. Panel canvas is 240 × 280 px: status bar y 0–22 · stage y 22–228 · deck y 228–280. One hardware button (press = roll · double-press = open · long-press ≥ 400 ms = Home; on capture screens the hold remaps to PTT — none in this flow); a voice prompt speaks every focused label.</p>
 
 <div class="legend">

--- a/docsite/website/public/mockups/mockup_listen_dark.html
+++ b/docsite/website/public/mockups/mockup_listen_dark.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Listen Flow · v2 · Wheel + Arc Hero · Dark Theme · Implementation Spec</title>
+<title>yoyopod — Listen Flow · v2 · Wheel + Arc Hero · Dark Theme · Implementation Spec</title>
 <style>
   :root {
     /* ─── Panel ─── */
@@ -442,7 +442,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Listen Flow · v2 · Wheel + Arc Hero · Dark Theme</h1>
+<h1>yoyopod — Listen Flow · v2 · Wheel + Arc Hero · Dark Theme</h1>
 <p class="muted">Dark-theme variant of the canonical Listen spec (<code>mockup_listen.html</code> · "Listen Flow · v2.1", flat wheel + arc hero). <b>Strict token swap:</b> page structure, geometry, behavior, and renders are identical to the light file — only the surface/ink color tokens change, plus one dark-only token, <code>ink_on_accent</code>, for content sitting on a bright accent fill. Chrome stays <b>flat, color-first</b> (v2.1): no borders, no shadows — the one surviving stroke is the transient focus ring on transport targets, drawn in dark <code>ink</code> (warm off-white). <b>The light file is normative for everything except color</b> — every pixel in the renders below is sourced from its §3/§4 tables. Panel canvas is 240 × 280 px: status bar y 0–22 · stage y 22–228 · deck y 228–280. One hardware button (press = roll · double-press = open · long-press ≥ 400 ms = Home; on capture screens the hold remaps to PTT — none in this flow); a voice prompt speaks every focused label.</p>
 
 <div class="legend">

--- a/docsite/website/public/mockups/mockup_setup.html
+++ b/docsite/website/public/mockups/mockup_setup.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Setup Flow · Implementation Spec (v2 · wheel + flat)</title>
+<title>yoyopod — Setup Flow · Implementation Spec (v2 · wheel + flat)</title>
 <style>
   :root {
     --panel-w: 240px;
@@ -292,7 +292,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Setup Flow · Implementation Spec <span style="color:#8a7c6c">· v2 wheel + flat</span></h1>
+<h1>yoyopod — Setup Flow · Implementation Spec <span style="color:#8a7c6c">· v2 wheel + flat</span></h1>
 <p class="muted">Setup is the grown-up corner of the device, re-presented on the system-wide pattern: <b>wheel navigation + fully flat chrome + neutral bezel</b>. One hardware button, three gestures (<b>press</b> = roll the wheel one step · <b>double-press</b> = open / activate · <b>long-press ≥ 400 ms</b> = Home; see <code>mockup_input_model.html</code>), plus the side PTT which Setup never remaps. Every roll speaks the newly focused label (the Speak-names accessibility feature, §6). Setup's accent is <code>c_coral</code>; the whole stage is tinted full-bleed <code>bg_stage_coral</code> — the user reads "I'm in Setup" from the surface itself, no card, no label. The wheel's normative spec lives in <code>mockup_listen.html §3</code>; the values used here are restated in §8. This spec replaces and extends the shipped runtime's <code>Power</code> screen (§11).</p>
 
 <div class="legend">

--- a/docsite/website/public/mockups/mockup_system.html
+++ b/docsite/website/public/mockups/mockup_system.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — System Overlays · Loading + Error · Implementation Spec</title>
+<title>yoyopod — System Overlays · Loading + Error · Implementation Spec</title>
 <style>
   :root {
     --panel-w: 240px;
@@ -214,7 +214,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — System Overlays · Loading + Error · Implementation Spec</h1>
+<h1>yoyopod — System Overlays · Loading + Error · Implementation Spec</h1>
 <p class="muted">The last two runtime routes with no design: <code>UiScreen::Loading</code> and <code>UiScreen::Error</code>. Both are <b>overlays</b> (<code>NavigationPolicy::Overlay</code>, <code>Persistence::Singleton</code>) — they float over whatever screen was active, never replace it, and there is exactly one instance of each. Small and friendly: a kid aged 3–7 sees a gentle pause or a butter "oops", never a hang and never a stack trace. Voice speaks everything important — pre-readers complete both flows without decoding a word. Frames below sit over a plain cream stage for clarity; frame 2 shows real overlay semantics with a dimmed wheel behind. Flat system: no UI borders, no drop shadows — fills + radius only. Input model lives in <code>mockup_input_model.html</code>.</p>
 
 <!-- ============================================================ -->

--- a/docsite/website/public/mockups/mockup_talk.html
+++ b/docsite/website/public/mockups/mockup_talk.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>YoyoPod — Talk Flow · v5.1 · Contact Wheel + De-boxed Calls · Flat</title>
+<title>yoyopod — Talk Flow · v5.1 · Contact Wheel + De-boxed Calls · Flat</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800&display=swap');
 
@@ -430,7 +430,7 @@
 </head>
 <body>
 
-<h1>YoyoPod — Talk Flow · v5.1 · Contact Wheel + De-boxed Calls · Flat</h1>
+<h1>yoyopod — Talk Flow · v5.1 · Contact Wheel + De-boxed Calls · Flat</h1>
 <p class="muted">De-boxing pass, now fully <b>flat, color-first</b> (v5.1): no borders, no hard shadows anywhere — the 2&nbsp;px ink focus ring on call buttons and Replay transport is the one surviving stroke; focus elsewhere = fill + size + spoken label. <b>(1)</b> The peri card + 28&nbsp;px rows become a 3-slot <b>contact wheel</b> — the focused tile is the only plate on screen. <b>(2)</b> The tab strip retires; depth ≥&nbsp;2 gets one 12&nbsp;px uppercase <b>context label</b>, no box. <b>(3)</b> The card tint becomes a <b>full-bleed stage tint</b> (<code>bg_stage_peri</code>). <b>(4)</b> Call overlays lose the cream card and pill buttons entirely. <b>(5)</b> Recording is a full-bleed tomato state. PTT contract, stuck semantics, per-contact replay, and the route inventory are all unchanged from v4.</p>
 <p><b>Wheel and Arc-Hero primitive geometry, animation, and FFI tables are normative in <code>mockup_listen.html</code> §3/§4/§7; this file specifies only Talk's variants and deltas.</b></p>
 

--- a/docsite/website/src/content/docs/product/positioning.md
+++ b/docsite/website/src/content/docs/product/positioning.md
@@ -11,14 +11,14 @@ anything public about yoyopod, start here.
 | Element | Decision |
 | --- | --- |
 | Hero headline | **"The first device before a smartphone"** |
-| Subheadline | "YoYoPod is a parent-managed companion device for kids ages 7–14, built for safe communication, live location, and everyday audio without the distraction, complexity, or screen addiction of a smartphone." |
+| Subheadline | "yoyopod is a parent-managed companion device for kids ages 7–14, built for safe communication, live location, and everyday audio without the distraction, complexity, or screen addiction of a smartphone." |
 | Primary CTA | "Join the waitlist" |
 | Secondary CTA | "See how it works" |
 | Emotional alternative | "Give them independence. Not a smartphone." |
 
 The three-line positioning block:
 
-> For kids, YoYoPod feels like freedom.
+> For kids, yoyopod feels like freedom.
 > For parents, it feels like reassurance.
 > For both, it's a better step before the smartphone years.
 
@@ -38,7 +38,7 @@ Built around three questions, in this order:
 
 > Can I reach my child? · Can they reach me? · Can I see where they are?
 >
-> YoYoPod is built around those questions first.
+> yoyopod is built around those questions first.
 
 And the contrast list: *communication without app overload · location
 without social media · independence without endless distraction ·

--- a/rules/architecture.md
+++ b/rules/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-YoYoPod is Rust-only. The runtime, the workers, and the operator CLI
+yoyopod is Rust-only. The runtime, the workers, and the operator CLI
 are all Rust. The Python operator CLI was retired in Round 0 of the
 CLI rebuild (`docs/ROADMAP.md`); active code must
 not depend on it.

--- a/rules/design-fidelity.md
+++ b/rules/design-fidelity.md
@@ -20,7 +20,7 @@ match the design as closely as possible on actual hardware.
 
 - Prefer standard Figma Design links with `node-id=...`. A Figma Make link is acceptable only as a loose concept preview.
 - Extract one runtime screen at a time. Do not try to reproduce an entire board as a single device screen.
-- Map each Figma frame onto the existing YoYoPod information architecture and routes before changing code.
+- Map each Figma frame onto the existing yoyopod information architecture and routes before changing code.
 - Reuse the current navigation model. Do not introduce a second navigation system just because the Figma board is organized differently.
 - If the Figma hint text conflicts with the real one-button behavior, keep the real behavior and update the copy to match the hardware interaction.
 
@@ -59,7 +59,7 @@ match the design as closely as possible on actual hardware.
   - status chips
   - footer or hint bars
   - page dots
-- Normalize those primitives into YoYoPod theme helpers instead of duplicating one-off measurements in every screen.
+- Normalize those primitives into yoyopod theme helpers instead of duplicating one-off measurements in every screen.
 - Use the Figma design language, but compress it aggressively for `240x280`.
 - Prefer one strong focal element per screen. Avoid dashboard-style compositions on Whisplay.
 

--- a/rules/logging.md
+++ b/rules/logging.md
@@ -42,8 +42,8 @@ and `yoyopod target ...` CLI on the same path. Do not use `/tmp/yoyopod.pid`;
 ## Startup/Shutdown Markers
 
 ```
-===== YoYoPod starting (version=X, pid=Y) =====
-===== YoYoPod shutting down (pid=Y) =====
+===== yoyopod starting (version=X, pid=Y) =====
+===== yoyopod shutting down (pid=Y) =====
 ```
 
 Used by deploy commands to verify the app started successfully.

--- a/rules/lvgl.md
+++ b/rules/lvgl.md
@@ -38,7 +38,7 @@ upstream LVGL itself, built from the pinned 9.5.0 source using
 
 ## lv_conf.h
 
-Minimal config enabling only what YoYoPod uses:
+Minimal config enabling only what yoyopod uses:
 - `LV_COLOR_DEPTH 16` (RGB565)
 - `LV_USE_SNAPSHOT 1` (for screenshot readback)
 - Montserrat fonts 12-40

--- a/rules/project.md
+++ b/rules/project.md
@@ -1,6 +1,6 @@
 # Project Overview
 
-YoYoPod is an iPod-inspired Raspberry Pi application combining SIP
+yoyopod is an iPod-inspired Raspberry Pi application combining SIP
 calling and mpv-based local music playback behind a small-screen,
 button-driven UI.
 

--- a/skills/yoyopod-logs/SKILL.md
+++ b/skills/yoyopod-logs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoyopod-logs
-description: Tail YoYoPod runtime/service logs from Raspberry Pi
+description: Tail yoyopod runtime/service logs from Raspberry Pi
 disable-model-invocation: true
 allowed-tools:
   - Read

--- a/skills/yoyopod-restart/SKILL.md
+++ b/skills/yoyopod-restart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoyopod-restart
-description: Restart the active YoYoPod dev lane service on Raspberry Pi
+description: Restart the active yoyopod dev lane service on Raspberry Pi
 disable-model-invocation: true
 allowed-tools:
   - Read

--- a/skills/yoyopod-screenshot/SKILL.md
+++ b/skills/yoyopod-screenshot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoyopod-screenshot
-description: Capture a screenshot of the active YoYoPod display from Raspberry Pi
+description: Capture a screenshot of the active yoyopod display from Raspberry Pi
 disable-model-invocation: true
 allowed-tools:
   - Read


### PR DESCRIPTION
`yoyopod` is now the brand type mark. This lowercases every `YoYoPod`
and `YoyoPod` in prose, UI copy, log text, and config display strings —
**196 replacements across 106 files**.

The v2 enclosure drawings and the product one-pager already used the
lowercase mark, so this brings the repo in line with the design work
rather than the other way round.

## What was deliberately left alone

`YoyoPodRuntimeConfig` and `YoyoPodApp` in
`docs/architecture/CANONICAL_STRUCTURE.md`. Those name real symbols from
the retired Python runtime, not the brand — lowercasing them would make
the doc wrong about the code it describes. They are the only two
CamelCase spellings left in the tree.

## Strings with behaviour attached

Most of the diff is prose, but several occurrences are runtime
identifiers. Each was renamed on **both** sides in this commit, so
nothing is left half-renamed:

| Identifier | Producer | Consumer |
| --- | --- | --- |
| startup marker | `device/runtime/src/logging.rs` | `deploy/pi-deploy.yaml` → `cli/…/target/ops.rs` (`grep -aF`) |
| setup AP profile | `AP_CONNECTION_ID` in `provisioning.rs` | matched back in `remove_stale_ap_profile` |
| setup hotspot SSID | `format!("yoyopod-{suffix}")` | tests asserting `starts_with("yoyopod-")` and the QR payload |
| saved Wi-Fi conn ids | `wifi.rs`, `provisioning.rs` | nothing reads them by prefix |
| asoundrc header | systemd units | `cli/…/target/deploy.rs` |

Also changed, all externally visible: SIP `user_agent=yoyopod/1.0`, the
HTTP `User-Agent` in `remote_cache.rs`, the GitHub release title, and
the `stt_prompt` / `ask_instructions` model prompts.

### One rollout note

`ops.rs` verifies startup with a case-sensitive `grep -aF`. A Pi still
running an **old** binary logs `YoYoPod starting` and a **new** CLI
greps for `yoyopod starting`, so startup verification would fail against
a stale device. Deploying the runtime — which the CLI does in the same
operation — resolves it. Worth knowing before anyone points a fresh CLI
at an un-updated Pi.

## Verification

- `cli/`: `cargo check --workspace --locked` clean, `cargo test
  --workspace --locked` **50 passed / 0 failed**
- `device/`: `cargo check -p yoyopod-runtime -p yoyopod-media -p
  yoyopod-protocol --locked` clean
- `yoyopod-network`, `yoyopod-ui`, `yoyopod-voip` **could not be built
  locally** — `network` uses Unix-only `PermissionsExt`, and `ui`/`voip`
  need LVGL and liblinphone. I confirmed `network` fails identically on
  an unmodified tree, so the failure is the Windows dev box, not this
  change. CI's `rust-device-arm64` job covers all three.
- Since `network` holds the SSID assertions and could not be run here, I
  checked the diff mechanically instead: **all 35 changed lines in `.rs`
  files sit inside a string literal or a comment**, so no identifier
  moved and compilation cannot break. The one line the checker flagged
  was a false positive — a continuation inside a multi-line string in
  `deploy.rs:170`.

Please glance at the SSID and SIP `user_agent` changes specifically —
those are visible outside the repo, and they're the two most likely to
want a different call than a blanket lowercase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
